### PR TITLE
Add Mistral Vibe CLI agent to L2 container

### DIFF
--- a/src/codexctl/cli/main.py
+++ b/src/codexctl/cli/main.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 
 import argparse
 
-from ..lib.auth import codex_auth
+from ..lib.auth import codex_auth, mistral_auth
 from ..lib.config import (
     build_root as _build_root,
     config_root as _config_root,
@@ -115,12 +115,23 @@ def main() -> None:
         pass
     p_cache.add_argument("--force", action="store_true", help="Recreate the mirror from scratch")
 
-    # auth
+    # auth (codex)
     p_auth = sub.add_parser(
         "auth",
-        help="Authenticate Codex CLI by running 'codex login' inside an L3 container with port forwarding",
+        help="Authenticate Codex CLI by running 'codex login' inside an L2 container with port forwarding",
     )
     _a = p_auth.add_argument("project_id")
+    try:
+        _a.completer = _complete_project_ids  # type: ignore[attr-defined]
+    except Exception:
+        pass
+
+    # mistral-auth
+    p_mistral_auth = sub.add_parser(
+        "mistral-auth",
+        help="Set up Mistral API key for Vibe CLI inside an L2 container",
+    )
+    _a = p_mistral_auth.add_argument("project_id")
     try:
         _a.completer = _complete_project_ids  # type: ignore[attr-defined]
     except Exception:
@@ -205,6 +216,8 @@ def main() -> None:
         print(f"Cache ready at {res['path']} (upstream: {res['upstream_url']}; created: {res['created']})")
     elif args.cmd == "auth":
         codex_auth(args.project_id)
+    elif args.cmd == "mistral-auth":
+        mistral_auth(args.project_id)
     elif args.cmd == "config":
         # READ PATHS
         print("Configuration (read):")

--- a/src/codexctl/lib/auth.py
+++ b/src/codexctl/lib/auth.py
@@ -11,32 +11,14 @@ from .projects import load_project
 
 # ---------- Codex authentication ----------
 
-def codex_auth(project_id: str) -> None:
-    """Run codex login inside the L2 container to authenticate the Codex CLI.
-
-    This command:
-    - Spins up a temporary L2 container for the project (L2 has the codex CLI)
-    - Mounts the shared codex config directory (/home/dev/.codex)
-    - Forwards port 1455 from the container to localhost for OAuth callback
-    - Runs `codex login` interactively
-    - The authentication persists in the shared .codex folder
-
-    The user can press Ctrl+C to stop the container after authentication is complete.
-    """
-    # Verify podman is available before proceeding
+def _check_podman() -> None:
+    """Verify podman is available."""
     if shutil.which("podman") is None:
         raise SystemExit("podman not found; please install podman")
 
-    project = load_project(project_id)
 
-    # Shared env mounts - we only need the codex config directory
-    envs_base = get_envs_base_dir()
-    codex_host_dir = envs_base / "_codex-config"
-    _ensure_dir_writable(codex_host_dir, "Codex config")
-
-    container_name = f"{project.id}-auth"
-
-    # Check if a container with the same name is already running
+def _cleanup_existing_container(container_name: str) -> None:
+    """Remove an existing container if it exists."""
     result = subprocess.run(
         ["podman", "container", "exists", container_name],
         stdout=subprocess.DEVNULL,
@@ -49,6 +31,31 @@ def codex_auth(project_id: str) -> None:
             stdout=subprocess.DEVNULL,
             stderr=subprocess.DEVNULL,
         )
+
+
+def codex_auth(project_id: str) -> None:
+    """Run codex login inside the L2 container to authenticate the Codex CLI.
+
+    This command:
+    - Spins up a temporary L2 container for the project (L2 has the codex CLI)
+    - Mounts the shared codex config directory (/home/dev/.codex)
+    - Forwards port 1455 from the container to localhost for OAuth callback
+    - Runs `codex login` interactively
+    - The authentication persists in the shared .codex folder
+
+    The user can press Ctrl+C to stop the container after authentication is complete.
+    """
+    _check_podman()
+
+    project = load_project(project_id)
+
+    # Shared env mounts - we only need the codex config directory
+    envs_base = get_envs_base_dir()
+    codex_host_dir = envs_base / "_codex-config"
+    _ensure_dir_writable(codex_host_dir, "Codex config")
+
+    container_name = f"{project.id}-codex-auth"
+    _cleanup_existing_container(container_name)
 
     # Build the podman run command
     # - Interactive with TTY for codex login
@@ -86,6 +93,78 @@ def codex_auth(project_id: str) -> None:
     except KeyboardInterrupt:
         print("\nAuthentication interrupted.")
         # Best-effort cleanup
+        subprocess.run(
+            ["podman", "rm", "-f", container_name],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            check=False,
+        )
+
+
+# ---------- Mistral Vibe authentication ----------
+
+def mistral_auth(project_id: str) -> None:
+    """Set up Mistral API key for Vibe CLI inside the L2 container.
+
+    This command:
+    - Spins up a temporary L2 container for the project (L2 has mistral-vibe)
+    - Mounts the shared vibe config directory (/home/dev/.vibe)
+    - Runs an interactive shell where the user can run `vibe` to trigger
+      the API key prompt, or manually create ~/.vibe/.env
+    - The API key persists in the shared .vibe folder
+
+    Mistral Vibe stores the API key in ~/.vibe/.env as MISTRAL_API_KEY=<key>.
+    """
+    _check_podman()
+
+    project = load_project(project_id)
+
+    # Shared env mounts - we only need the vibe config directory
+    envs_base = get_envs_base_dir()
+    vibe_host_dir = envs_base / "_vibe-config"
+    _ensure_dir_writable(vibe_host_dir, "Vibe config")
+
+    container_name = f"{project.id}-mistral-auth"
+    _cleanup_existing_container(container_name)
+
+    # Build the podman run command
+    # - Interactive with TTY for API key entry
+    # - Mount vibe config dir for persistent auth
+    # - Use L2 image (which has mistral-vibe installed)
+    cmd = [
+        "podman", "run",
+        "--rm",
+        "-it",
+        "-v", f"{vibe_host_dir}:/home/dev/.vibe:Z",
+        "--name", container_name,
+        f"{project.id}:l2",
+        "bash", "-c",
+        "echo 'Enter your Mistral API key (get one at https://console.mistral.ai/api-keys):' && "
+        "read -r -p 'MISTRAL_API_KEY=' api_key && "
+        "mkdir -p ~/.vibe && "
+        "echo \"MISTRAL_API_KEY=$api_key\" > ~/.vibe/.env && "
+        "echo && echo 'API key saved to ~/.vibe/.env' && "
+        "echo 'You can now use vibe in task containers.'",
+    ]
+    cmd[3:3] = _podman_userns_args()
+
+    print("Authenticating Mistral Vibe for project:", project.id)
+    print()
+    print("You will be prompted to enter your Mistral API key.")
+    print("Get your API key at: https://console.mistral.ai/api-keys")
+    print()
+    print("$", " ".join(map(str, cmd)))
+    print()
+
+    try:
+        subprocess.run(cmd, check=True)
+    except subprocess.CalledProcessError as e:
+        if e.returncode == 130:
+            print("\nAuthentication container stopped.")
+        else:
+            raise SystemExit(f"Auth failed: {e}")
+    except KeyboardInterrupt:
+        print("\nAuthentication interrupted.")
         subprocess.run(
             ["podman", "rm", "-f", container_name],
             stdout=subprocess.DEVNULL,

--- a/src/codexctl/lib/tasks.py
+++ b/src/codexctl/lib/tasks.py
@@ -211,10 +211,12 @@ def _build_task_env_and_volumes(project: Project, task_id: str) -> tuple[dict, l
     envs_base = get_envs_base_dir()
     codex_host_dir = envs_base / "_codex-config"
     claude_host_dir = envs_base / "_claude-config"
+    vibe_host_dir = envs_base / "_vibe-config"
     # Prefer project-configured SSH host dir if set
     ssh_host_dir = project.ssh_host_dir or (envs_base / f"_ssh-config-{project.id}")
     _ensure_dir_writable(codex_host_dir, "Codex config")
     _ensure_dir_writable(claude_host_dir, "Claude config")
+    _ensure_dir_writable(vibe_host_dir, "Vibe config")
 
     env = {
         "PROJECT_ID": project.id,
@@ -235,6 +237,8 @@ def _build_task_env_and_volumes(project: Project, task_id: str) -> tuple[dict, l
     volumes.append(f"{codex_host_dir}:/home/dev/.codex:Z")
     # Shared Claude credentials/config
     volumes.append(f"{claude_host_dir}:/home/dev/.claude:Z")
+    # Shared Mistral Vibe credentials/config
+    volumes.append(f"{vibe_host_dir}:/home/dev/.vibe:Z")
 
     # Security mode specific wiring
     cache_repo = project.cache_path

--- a/src/codexctl/resources/templates/l2.codex-agent.Dockerfile.template
+++ b/src/codexctl/resources/templates/l2.codex-agent.Dockerfile.template
@@ -7,18 +7,30 @@ ENV DEBIAN_FRONTEND=noninteractive
 USER root
 RUN set -eux; \
     apt-get update; \
-    apt-get install -y --no-install-recommends curl ca-certificates gnupg; \
+    apt-get install -y --no-install-recommends curl ca-certificates gnupg python3 python3-pip python3-venv; \
     curl -fsSL https://deb.nodesource.com/setup_22.x | bash -; \
     apt-get install -y --no-install-recommends nodejs ripgrep; \
     npm install -g @openai/codex; \
     npm install -g @anthropic-ai/claude-code; \
     npm cache clean --force; \
+    pip3 install --break-system-packages mistral-vibe; \
     rm -rf /var/lib/apt/lists/*
 
 RUN set -eux; \
     printf '%s\n' \
       'alias codex="codex --dangerously-bypass-approvals-and-sandbox"' \
       'alias claude="claude --dangerously-skip-permissions"' \
+      'alias vibe="vibe --yes"' \
+      '' \
+      '# Print available agents on interactive login' \
+      'if [ -t 1 ] && [ -z "$_CODEXCTL_AGENTS_SHOWN" ]; then' \
+      '  export _CODEXCTL_AGENTS_SHOWN=1' \
+      '  printf "\\n\\033[1mAvailable AI agents:\\033[0m\\n"' \
+      '  printf "  \\033[36mcodex\\033[0m  - OpenAI Codex CLI (auto-approve enabled)\\n"' \
+      '  printf "  \\033[36mclaude\\033[0m - Claude Code CLI (permissions skipped)\\n"' \
+      '  printf "  \\033[36mvibe\\033[0m   - Mistral Vibe CLI (auto-approve enabled)\\n"' \
+      '  printf "\\n"' \
+      'fi' \
       > /etc/profile.d/codexctl-agent-aliases.sh; \
     if [ -f /etc/bash.bashrc ]; then \
       printf '\n# codexctl agent aliases\n. /etc/profile.d/codexctl-agent-aliases.sh\n' >> /etc/bash.bashrc; \


### PR DESCRIPTION
- Install mistral-vibe via pip in L2 Dockerfile template
- Add vibe alias with --yes flag for auto-approval
- Mount ~/.vibe config directory for API key persistence
- Add mistral-auth CLI command for API key setup
- Display available agents on interactive container login

🤖 Generated with [Claude Code](https://claude.com/claude-code)