### PR TITLE
Replace .new-task-marker file with NEW_TASK env var

### DIFF
--- a/src/codexctl/resources/templates/l2.codex-agent.Dockerfile.template
+++ b/src/codexctl/resources/templates/l2.codex-agent.Dockerfile.template
@@ -18,6 +18,7 @@ RUN set -eux; \
     printf '%s\n' \
       'alias codex="codex --dangerously-bypass-approvals-and-sandbox"' \
       'alias claude="claude --dangerously-skip-permissions"' \
+      'alias vibe="vibe --auto-approve"' \
       > /etc/profile.d/codexctl-agent-aliases.sh; \
     if [ -f /etc/bash.bashrc ]; then \
       printf '\n# codexctl agent aliases\n. /etc/profile.d/codexctl-agent-aliases.sh\n' >> /etc/bash.bashrc; \

--- a/src/codexctl/resources/templates/l3.codexui.Dockerfile.template
+++ b/src/codexctl/resources/templates/l3.codexui.Dockerfile.template
@@ -15,6 +15,7 @@ RUN set -eux; \
     printf '%s\n' \
       'alias codex="codex --dangerously-bypass-approvals-and-sandbox"' \
       'alias claude="claude --dangerously-skip-permissions"' \
+      'alias vibe="vibe --auto-approve"' \
       > /etc/profile.d/codexctl-agent-aliases.sh; \
     if [ -f /etc/bash.bashrc ]; then \
       printf '\n# codexctl agent aliases\n. /etc/profile.d/codexctl-agent-aliases.sh\n' >> /etc/bash.bashrc; \


### PR DESCRIPTION
- Add needs_reset field to task meta, set on task creation
- Pass NEW_TASK=1 env var to container when needs_reset is true
- Clear needs_reset after successful container start
- Update init-ssh-and-repo.sh to handle NEW_TASK for fresh clone/reset
- Add vibe alias with --auto-approve flag to L2/L3 templates
- Fix __CLI_READY__ to only echo on init success (use && not ;)

This avoids the issue where a marker file in /workspace prevented git clone from succeeding because the directory was not empty.

🤖 Generated with [Claude Code](https://claude.com/claude-code)