### PR TITLE
Fix container initialization issues

### DIFF
--- a/src/codexctl/lib/tasks.py
+++ b/src/codexctl/lib/tasks.py
@@ -440,7 +440,7 @@ def task_run_cli(project_id: str, task_id: str) -> None:
         f"{project.id}:l2",
         # Ensure init runs and then keep the container alive even without a TTY
         # init-ssh-and-repo.sh now prints a readiness marker we can watch for
-        "bash", "-lc", "init-ssh-and-repo.sh; echo __CLI_READY__; tail -f /dev/null",
+        "bash", "-lc", "init-ssh-and-repo.sh && echo __CLI_READY__; tail -f /dev/null",
     ]
     print("$", " ".join(map(str, cmd)))
     try:


### PR DESCRIPTION
- Remove .new-task-marker before git clone so directory is empty
- Hard reset to latest HEAD after cloning from cache (cache may be stale)
- Only emit __CLI_READY__ on successful init (use && instead of ;)

🤖 Generated with [Claude Code](https://claude.com/claude-code)