### PR TITLE
Add cache information display to TUI

### DIFF
--- a/src/codexctl/lib/projects.py
+++ b/src/codexctl/lib/projects.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import subprocess
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Optional
+from typing import Optional, Dict, Any
 
 import yaml  # pip install pyyaml
 
@@ -173,6 +173,7 @@ def get_project_state(project_id: str) -> dict:
     - ``ssh`` - True if the project SSH directory exists and contains
       a ``config`` file.
     - ``cache`` - True if the project's cache directory exists.
+    - ``cache_last_commit`` - Dict with commit info if cache exists, None otherwise.
     """
 
     project = load_project(project_id)
@@ -215,10 +216,18 @@ def get_project_state(project_id: str) -> dict:
     # treat existence of the directory as "cache present".
     cache_dir = project.cache_path
     has_cache = cache_dir.is_dir()
+    
+    # Get cache commit info if cache exists
+    cache_last_commit = None
+    if has_cache:
+        # Import here to avoid circular import
+        from .git_cache import get_cache_last_commit
+        cache_last_commit = get_cache_last_commit(project_id)
 
     return {
         "dockerfiles": has_dockerfiles,
         "images": has_images,
         "ssh": has_ssh,
         "cache": has_cache,
+        "cache_last_commit": cache_last_commit,
     }

--- a/src/codexctl/tui/widgets.py
+++ b/src/codexctl/tui/widgets.py
@@ -235,6 +235,16 @@ class ProjectState(Static):
             tasks_line,
         ]
 
+        # Add cache commit info if available
+        cache_commit = state.get("cache_last_commit")
+        if cache_commit:
+            lines.append("")
+            lines.append("Cache info:")
+            lines.append(f"  Commit:   {cache_commit.get('commit_hash', 'unknown')[:8]}")
+            lines.append(f"  Date:     {cache_commit.get('commit_date', 'unknown')}")
+            lines.append(f"  Author:   {cache_commit.get('commit_author', 'unknown')}")
+            lines.append(f"  Message:  {cache_commit.get('commit_message', 'unknown')[:50]}{'...' if len(cache_commit.get('commit_message', '')) > 50 else ''}")
+
         self.update("\n".join(lines))
 
 


### PR DESCRIPTION
This implementation adds a feature to show the last commit information from cached git repositories in the TUI. It helps users decide whether a manual cache update is needed by displaying:

- Commit hash (shortened)
- Commit date and time
- Commit author
- Commit message (truncated if long)

The implementation is cheap (uses git log without updating) and gracefully handles cases where cache doesn't exist or git operations fail.

Changes:
- Added get_cache_last_commit() function to git_cache.py
- Updated get_project_state() to include cache commit info
- Enhanced ProjectState widget to display cache information
- Added comprehensive tests

Generated by Mistral Vibe.