### PR TITLE
docs: reorganize documentation by audience

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,256 +1,111 @@
-# Quick start
+# codexctl
 
-> **Future plans and design documents** are collected in [`docs/brainstorming/`](docs/brainstorming/).
+A tool for managing containerized AI coding agent projects using Podman. Provides both a CLI (`codexctl`) and a Textual TUI (`codextui`).
 
- * pre-requisites
-   * set up podman (e.g. `~/.config/containers/storage.conf`)
- * install to venv
-   * clone the repo `git clone git@github.com:sliwowitz/codexctl.git`
-   * create a venv `mkvirtualenv codexctl`
-   * in the venv, install from the repo clone `pip install ./codexctl/`
- * configure codexctl
-   * set up codexctl (e.g. `~/.config/codexctl/config.yml`)
- * start a project
-   * check paths `codexctl config`
-   * copy example project into *User projects root*
-   * initialize project
-     * generate dockerfile
-     * build images
-     * initialize ssh keys
-     * initialize cache
- * run a project
-   * create a task
-   * assign task to cli or ui
+> **Future plans and design documents** are in [`docs/brainstorming/`](docs/brainstorming/).
 
-Quick answers to common questions
+## Documentation
 
-- How do I run a quick session from within PyCharm?
-  1) Open the repo in PyCharm and set up a Python interpreter (3.9+).
-  2) Set environment variables so the app sees the example projects:
-     - CODEXCTL_CONFIG_DIR = /path/to/this/repo/examples
-       (the examples/ directory contains per-project folders with project.yml)
-     - Optional: CODEXCTL_STATE_DIR to a writable path (defaults to ~/.local/share/codexctl)
-  3) Create a Run/Debug configuration:
-     - For CLI: Module name = codexctl.cli, Parameters = projects (or other subcommands)
-       Example to list projects: Run module codexctl.cli with args: projects
-       Example to create a task:  Run module codexctl.cli with args: task new uc
-     - For the TUI: Module name = codexctl.tui (no args). You can also run the installed console script codexctl-tui or codextui.
-     - Ensure the Environment variables are set in the Run config (see step 2).
+| Document | Description |
+|----------|-------------|
+| [Full Usage Guide](docs/USAGE.md) | Complete user documentation |
+| [Developer Guide](docs/DEVELOPER.md) | Internal architecture and contributor docs |
+| [Shared Directories](docs/SHARED_DIRS.md) | Volume mounts and SSH configuration |
+| [Container Layers](docs/CONTAINER_LAYERS.md) | Docker image architecture |
+| [Security Modes](docs/GIT_CACHE_AND_SECURITY_MODES.md) | Online vs gatekeeping modes |
+| [Packaging](docs/PACKAGING.md) | pip, deb, and rpm packaging |
 
-- How do I package and install via pip?
-  - From a clean checkout, build an sdist and wheel:
-    - python -m pip install --upgrade build
-    - python -m build
-    - Artifacts appear under dist/ (codexctl-<ver>.tar.gz and codexctl-<ver>-py3-none-any.whl)
-  - Install directly from source (editable) for development:
-    - python -m pip install -e .
-  - Or install the built wheel:
-    - python -m pip install dist/codexctl-<ver>-py3-none-any.whl
-    - After install, you should have console scripts:
-      - codexctl, codexctl-tui, codextui
+## Quick Start
 
-- How do I enable Bash completion for codexctl?
-  - Bash completion is powered by argcomplete.
-  - If your system has bash-completion installed (common on most distros), completion is enabled automatically after installing codexctl: the package ships a loader at share/bash-completion/completions/codexctl that Bash autoloads.
-  - If completion does not work (e.g., custom env/venv or no bash-completion package), you can enable it manually:
-    - One-time system-wide: sudo activate-global-python-argcomplete
-    - Per-shell (current session): eval "$(register-python-argcomplete codexctl)"
-    - Per-user (all new shells): add to ~/.bashrc
-      - eval "$(register-python-argcomplete codexctl)"
-  - Zsh users can use bashcompinit:
-    - autoload -U bashcompinit && bashcompinit
-    - eval "$(register-python-argcomplete --shell zsh codexctl)"
+### Prerequisites
 
-– How do I install into a custom path, e.g. /usr/local?
-  - User-local (no root):
-    - python -m pip install --user .
-    - Binaries go to ~/.local/bin (ensure it’s on PATH).
-  - Custom prefix (Debian/Ubuntu note about “local”):
-    - On Debian/Ubuntu, pip uses the posix_local install scheme which inserts a
-      trailing "/local" segment under the chosen prefix.
-    - Therefore, pick the parent directory as your prefix and let pip add
-      "/local" for you.
-    - Example (recommended):
-      - python -m pip install --prefix=/virt/podman .
-      - Resulting layout: /virt/podman/local/bin/codexctl and
-        /virt/podman/local/lib/pythonX.Y/dist-packages/...
-    - Do NOT append "/local" yourself, or you’ll get a nested path like
-      /virt/podman/local/local.
-      - Wrong: python -m pip install --prefix=/virt/podman/local .
-    - If you want the TUI as well, install the extra:
-      - python -m pip install --prefix=/virt/podman '.[tui]'
-  - Alternatively, use a virtual environment:
-    - python -m venv .venv && . .venv/bin/activate && pip install .
+- Podman installed and configured
+- Python 3.9+
+- OpenSSH client (for private git repos)
 
-Runtime locations (FHS/XDG)
+### Installation
 
-- Config/projects:
-  - Root: /etc/codexctl/projects
-  - User: ~/.config/codexctl/projects
-  - Override: CODEXCTL_CONFIG_DIR=/path/to/config (if this points directly to a folder containing project subfolders, that’s accepted; if it contains a projects/ subfolder, that is used).
-- State (writable: tasks, build, cache):
-  - Root: /var/lib/codexctl
-  - User: ${XDG_DATA_HOME:-~/.local/share}/codexctl
-  - Override: CODEXCTL_STATE_DIR=/path/to/state
+```bash
+# Clone and install
+git clone git@github.com:sliwowitz/codexctl.git
+cd codexctl
+pip install .
 
-Global configuration file
+# With TUI support
+pip install '.[tui]'
+```
 
-- The tool looks for a global config file in this order (first found wins):
-  - ${XDG_CONFIG_HOME:-~/.config}/codexctl/config.yml (user override)
-  - sys.prefix/etc/codexctl/config.yml (pip/venv installs)
-  - /etc/codexctl/config.yml (system default)
-- An example config is provided at examples/codexctl-config.yml. Copy and edit:
-  - mkdir -p ~/.config/codexctl && cp examples/codexctl-config.yml ~/.config/codexctl/config.yml
-- Minimum global settings include:
-  - ui.base_port: default first task port for UI mode
-  - paths.user_projects_root: per-user projects directory
-  - paths.state_root: writable state root
-  - paths.build_root: directory for generated files (renamed from legacy "stage")
+### Basic Workflow
 
-FHS note
+```bash
+# 1. Create project directory
+mkdir -p ~/.config/codexctl/projects/myproj
 
-- /usr/share is read-only and should not be used for writable data. codexctl writes under /var/lib/codexctl (for root installs) or ~/.local/share/codexctl (for users). Templates are read from the Python package resources.
-
-Examples for development
-
-- Use the included examples/ as your config:
-  - export CODEXCTL_CONFIG_DIR=$PWD/examples
-  - Optionally: export CODEXCTL_STATE_DIR=$PWD/tmp/dev-runtime/var-lib-codexctl
-  - Now run:
-    - python -m codexctl.cli projects
-    - python -m codexctl.cli task new uc
-    - python -m codexctl.cli task list uc
-    - python -m codexctl.cli generate uc
-    - python -m codexctl.cli build uc
-
-From zero to first run (new project)
-
-This is the end‑to‑end sequence to start a new project from a user‑provided directory that contains a project.yml and, optionally, a Docker include snippet.
-
-Prerequisites
-- Podman installed and working.
-- OpenSSH client tools (ssh, ssh-keygen) if you plan to use private Git over SSH.
-
-1) Create your per‑user projects root (once)
-- mkdir -p ~/.config/codexctl/projects
-
-2) Create your project directory and project.yml
-- Example layout:
-  - ~/.config/codexctl/projects/myproj/project.yml
-  - Optional snippet: ~/.config/codexctl/projects/myproj/user.dockerinclude
-
-Minimal project.yml example
-```yaml
+# 2. Create project.yml (see docs/USAGE.md for full schema)
+cat > ~/.config/codexctl/projects/myproj/project.yml << 'EOF'
 project:
   id: myproj
   security_class: online
 git:
-  upstream_url: git@github.com:yourorg/yourrepo.git   # or https://... for public
+  upstream_url: https://github.com/yourorg/yourrepo.git
   default_branch: main
-# Optional SSH hints for containers (recommended):
-ssh:
-  key_name: id_ed25519_myproj  # matches the key created by ssh-init
-# Optional: reference your Docker include snippet used at image build time
-docker:
-  user_snippet_file: user.dockerinclude
+EOF
+
+# 3. Generate and build images
+codexctl generate myproj
+codexctl build myproj
+
+# 4. (Optional) Set up SSH for private repos
+codexctl ssh-init myproj
+
+# 5. Create and run a task
+codexctl task new myproj
+codexctl task run-cli myproj 1    # CLI mode
+# or
+codexctl task run-ui myproj 1     # Web UI mode
 ```
 
-Optional Docker include snippet (user.dockerinclude)
-- This text is pasted near the end of your project image (L2) Dockerfile.
-- Example lines you might add:
+### Common Commands
+
+```bash
+codexctl projects              # List projects
+codexctl config                # Show resolved paths
+codexctl task list <project>   # List tasks
+codexctl task delete <project> <task_id>  # Delete a task
 ```
-RUN apt-get update && apt-get install -y ripgrep jq && rm -rf /var/lib/apt/lists/*
+
+## Configuration
+
+### Global Config
+
+Location: `~/.config/codexctl/config.yml`
+
+```yaml
+ui:
+  base_port: 7860
+
+paths:
+  user_projects_root: ~/.config/codexctl/projects
+  state_root: ~/.local/share/codexctl
+
+git:
+  human_name: "Your Name"
+  human_email: "your@email.com"
 ```
 
-3) Generate Dockerfiles
-- codexctl generate myproj
+### Environment Overrides
 
-4) Build images
-- codexctl build myproj
-- Optional: codexctl build myproj --dev
+| Variable | Purpose |
+|----------|---------|
+| `CODEXCTL_CONFIG_DIR` | Projects directory |
+| `CODEXCTL_STATE_DIR` | Writable state root |
+| `CODEXCTL_CONFIG_FILE` | Global config file path |
 
-5) Initialize the shared SSH directory and generate a keypair (only if using private Git over SSH)
-- codexctl ssh-init myproj
-  - By default creates an ed25519 keypair named id_ed25519_myproj and a default SSH config with:
-    - Global defaults:
-      - IdentitiesOnly yes
-      - StrictHostKeyChecking accept-new (avoids interactive prompts in agents)
-      - IdentityFile <generated_private_key> (applies to all hosts by default)
-    - Host github.com section with User git (inherits IdentityFile)
-  - If your project.yml contains ssh.host_dir, that directory is used; otherwise the default path is <envs_base>/_ssh-config-myproj.
-  - Use the printed .pub key to add a deploy key or authorize it on your Git host.
-  - Advanced: You can customize the SSH config via a template. In project.yml set:
-    ```yaml
-    ssh:
-      config_template: ssh_config.template  # path relative to the project root or absolute
-    ```
-    The template supports tokens: {{IDENTITY_FILE}}, {{KEY_NAME}}, {{PROJECT_ID}}.
-    If not set, a built‑in template is used (see src/codexctl/resources/templates/ssh_config.template).
+## Requirements
 
-6) Create a task (per‑run workspace)
-- codexctl task new myproj
-  - The command prints the new task ID. You can list tasks with: codexctl task list myproj
+- **Podman** is required for build/run commands
+- **TUI** is optional: `pip install 'codexctl[tui]'`
 
-7) Run the task
-- CLI agent mode (headless; Codex, Claude Code, or Mistral Vibe):
-  - codexctl task run-cli myproj <task_id>
-- UI (web) mode (Codex UI, Claude, or Mistral):
-  - codexctl task run-ui myproj <task_id> [--backend codex|claude|mistral]
-  - For Claude, set one of: CODEXUI_CLAUDE_API_KEY / ANTHROPIC_API_KEY / CLAUDE_API_KEY
-  - Optional: CODEXUI_CLAUDE_MODEL=claude-3-5-sonnet-20240620
-  - For Mistral, set one of: CODEXUI_MISTRAL_API_KEY / MISTRAL_API_KEY
-  - Optional: CODEXUI_MISTRAL_MODEL=mistral-large-latest
+## License
 
-Tips
-- Show resolved paths and configuration:
-  - codexctl config
-- Where envs (SSH, Codex, Claude, and Mistral config) live by default:
-  - /var/lib/codexctl/envs (root) or as configured in examples/codexctl-config.yml under envs.base_dir
-- Details on shared directories and SSH mounts:
-  - docs/SHARED_DIRS.md
-
-Notes
-
-- Podman is required at runtime for build/run commands.
-- The TUI is optional. Install it with: pip install 'codexctl[tui]'.
-- For system packaging (deb/rpm), install the wheel and create /etc/codexctl and /var/lib/codexctl with suitable permissions; the app will locate them automatically.
-
-Container readiness and initial log streaming (important for developers)
-
-- codexctl shows the initial container logs to the user when starting task containers and then automatically detaches once a "ready" condition is met (or after a short timeout). This improves UX but introduces dependencies that developers must be aware of when changing entry scripts or server behavior.
-
-- CLI (task run-cli):
-  - Readiness is determined from log output. The container initialization script emits a marker line:
-    - ">> init complete" (from resources/scripts/init-ssh-and-repo.sh)
-  - Additionally, the run command echoes "__CLI_READY__" just before keeping the container alive. The host follows logs and detaches when either of these markers appears.
-  - If you modify the init script or change its output, ensure that a stable readiness line is preserved, or update the detection in src/codexctl/lib/tasks.py (task_run_cli and _stream_initial_logs).
-
-- UI (task run-ui):
-  - Readiness is currently determined by probing the bound localhost port (127.0.0.1:<assigned_port> → container port 7860). The host follows the container logs for a short time and detaches as soon as the TCP port is reachable, or after a timeout.
-  - This implies a dependency on the UI process actually listening on PORT (default 7860) and binding to 0.0.0.0 inside the container. The default entry script is resources/scripts/codexui-entry.sh which runs `server.ts` via `tsx`/`ts-node` (or `server.js` if present) from the CodexUI repo.
-  - If the UI server changes its port, bind address, or startup behavior (e.g., delays listening until after long asset builds), you may need to adjust:
-    - The exposed/internal port, and the host port mapping in src/codexctl/lib/tasks.py (task_run_ui).
-    - The readiness timeout in src/codexctl/lib/tasks.py.
-    - Optionally, implement log-marker-based readiness if port probing is insufficient, and then add/guarantee a stable log line in the UI server’s startup output.
-
-- Timeouts and detaching behavior:
-  - CLI: detaches after readiness marker or 60s.
-  - UI: detaches after port becomes reachable or 30s.
-  - Even on timeout, containers remain running in the background. Users can continue watching logs with `podman logs -f <container>`.
-
-- Where to change things:
-  - Host-side logic: src/codexctl/lib/tasks.py (task_run_cli, task_run_ui, _stream_initial_logs)
-  - CLI init marker: src/codexctl/resources/scripts/init-ssh-and-repo.sh
-  - UI entry: src/codexctl/resources/scripts/codexui-entry.sh (runs the UI server)
-
-- Important dependency note:
-  - Because initial log streaming detaches on a specific readiness condition, changes to the UI or CLI startup output or listening port can affect the host-side readiness detection. When altering the UI server or init scripts, please keep the readiness semantics stable or adjust codexctl’s detection accordingly to avoid regressions where the tool either never detaches or detaches too early.
-
-GPU passthrough configuration (per-project only)
-
-- codexctl can request NVIDIA GPU devices for containers (Podman + nvidia-container-toolkit), but this is a per-project opt-in only. The default is disabled.
-- To enable for a project, edit <project>/project.yml and add:
-  run:
-    gpus: all   # or true
-- Important: GPU-enabled projects often require a CUDA/NVIDIA-capable base image (e.g., images built with NVIDIA HPC SDK or CUDA). Choose an appropriate base image in the project's docker.base_image.
-- When enabled, codexctl adds flags like --device nvidia.com/gpu=all and NVIDIA_* env vars; ensure the host has NVIDIA drivers and nvidia-container-toolkit with Podman integration.
+See [LICENSE](LICENSE) file.

--- a/docs/DEVELOPER.md
+++ b/docs/DEVELOPER.md
@@ -1,0 +1,175 @@
+# Developer Guide
+
+This document covers internal architecture and implementation details for contributors and maintainers of codexctl.
+
+## Container Readiness and Log Streaming
+
+codexctl shows the initial container logs to the user when starting task containers and then automatically detaches once a "ready" condition is met. This improves UX but introduces dependencies that developers must be aware of when changing entry scripts or server behavior.
+
+### CLI Mode (task run-cli)
+
+Readiness is determined from log output. The container initialization script emits marker lines:
+- `">> init complete"` (from `resources/scripts/init-ssh-and-repo.sh`)
+- `"__CLI_READY__"` (echoed by the run command just before keeping the container alive)
+
+The host follows logs and detaches when either of these markers appears, or after 60 seconds timeout.
+
+**If you modify the init script**, ensure a stable readiness line is preserved, or update the detection in `src/codexctl/lib/tasks.py` (`task_run_cli` and `_stream_initial_logs`).
+
+### UI Mode (task run-ui)
+
+Readiness is determined by log markers, not port probing. The host follows container logs and detaches when it sees specific startup markers from Codex UI:
+- Primary marker: `"Codex UI ("` (the main startup banner when HTTP server is ready)
+- Secondary marker: `"Logging Codex UI activity"` (log redirection message)
+
+This approach avoids false positives from port binding before actual server readiness. The default entry script is `resources/scripts/codexui-entry.sh` which runs `server.ts` via `tsx` or `ts-node` from the CodexUI repo.
+
+**If the UI server changes its startup behavior or output format**, you may need to adjust:
+- The readiness markers in `src/codexctl/lib/tasks.py` (`_ui_ready` function)
+- The exposed/internal port and host port mapping in `src/codexctl/lib/tasks.py` (`task_run_ui`)
+
+### Timeout Behavior
+
+- **CLI**: detaches after readiness marker or 60s timeout
+- **UI**: detaches after readiness marker (no timeout by default; follows logs until ready)
+- Even on timeout, containers remain running in the background. Users can continue watching logs with `podman logs -f <container>`.
+
+### Key Source Files
+
+| File | Purpose |
+|------|---------|
+| `src/codexctl/lib/tasks.py` | Host-side logic: `task_run_cli`, `task_run_ui`, `_stream_initial_logs`, `_ui_ready` |
+| `src/codexctl/resources/scripts/init-ssh-and-repo.sh` | CLI init marker, SSH setup, repo sync |
+| `src/codexctl/resources/scripts/codexui-entry.sh` | UI entry script (runs the UI server) |
+
+**Important**: Changes to startup output or listening ports can affect readiness detection. Keep the readiness semantics stable or adjust codexctl's detection accordingly.
+
+---
+
+## Container Layer Architecture
+
+codexctl builds project containers in three logical layers:
+
+| Layer | Image Name | Purpose |
+|-------|------------|---------|
+| L0 | `codexctl-l0:<base-tag>` | Development base (Ubuntu 24.04, git, ssh, dev user) |
+| L1-CLI | `codexctl-l1-cli:<base-tag>` | Agent tools (Codex, Claude Code, Mistral Vibe) |
+| L1-UI | `codexctl-l1-ui:<base-tag>` | UI dependencies and entry script |
+| L2 | `<project>:l2-cli`, `<project>:l2-ui` | Project-specific config and user snippets |
+
+L0 and L1 are project-agnostic and cache well; L2 is project-specific.
+
+See [CONTAINER_LAYERS.md](CONTAINER_LAYERS.md) for detailed documentation.
+
+---
+
+## Volume Mounts at Runtime
+
+When a task container starts, codexctl mounts:
+
+| Container Path | Host Source | Purpose |
+|----------------|-------------|---------|
+| `/workspace` | `<state_root>/tasks/<project>/<task>/workspace` | Per-task workspace |
+| `/home/dev/.codex` | `<envs_base>/_codex-config` | Codex credentials |
+| `/home/dev/.claude` | `<envs_base>/_claude-config` | Claude Code credentials |
+| `/home/dev/.vibe` | `<envs_base>/_vibe-config` | Mistral Vibe credentials |
+| `/home/dev/.blablador` | `<envs_base>/_blablador-config` | Blablador credentials |
+| `/home/dev/.ssh` (optional) | `<envs_base>/_ssh-config-<project>` | SSH keys/config |
+
+See [SHARED_DIRS.md](SHARED_DIRS.md) for detailed documentation.
+
+---
+
+## Environment Variables Set by codexctl
+
+### Core Variables (always set)
+
+| Variable | Value | Purpose |
+|----------|-------|---------|
+| `PROJECT_ID` | Project ID from config | Identify current project |
+| `TASK_ID` | Numeric task ID | Identify current task |
+| `REPO_ROOT` | `/workspace` | Init script clone target |
+| `CLAUDE_CONFIG_DIR` | `/home/dev/.claude` | Claude Code config location |
+| `GIT_RESET_MODE` | `none` (default) | Controls workspace reset behavior |
+| `HUMAN_GIT_NAME` | From config or "Nobody" | Git committer name |
+| `HUMAN_GIT_EMAIL` | From config or "nobody@localhost" | Git committer email |
+
+### Conditional Variables (based on security mode)
+
+| Variable | When Set | Purpose |
+|----------|----------|---------|
+| `CODE_REPO` | Always | Git URL (upstream or gate depending on mode) |
+| `GIT_BRANCH` | Always | Target branch name |
+| `CLONE_FROM` | Online mode with gate | Alternate clone source for faster init |
+| `EXTERNAL_REMOTE_URL` | Relaxed gatekeeping | Upstream URL for "external" remote |
+
+---
+
+## Security Modes
+
+### Online Mode
+- `CODE_REPO` points to upstream URL
+- Container can push directly to upstream
+- Git gate (if present) is used as read-only clone accelerator
+
+### Gatekeeping Mode
+- `CODE_REPO` points to `file:///git-gate/gate.git`
+- Container cannot access upstream directly
+- Human review required before changes reach upstream
+
+See [GIT_CACHE_AND_SECURITY_MODES.md](GIT_CACHE_AND_SECURITY_MODES.md) for detailed documentation.
+
+---
+
+## Development Workflow
+
+### Running from Source
+
+```bash
+# Set up environment to use example projects
+export CODEXCTL_CONFIG_DIR=$PWD/examples
+export CODEXCTL_STATE_DIR=$PWD/tmp/dev-runtime/var-lib-codexctl
+
+# Run CLI commands
+python -m codexctl.cli projects
+python -m codexctl.cli task new uc
+python -m codexctl.cli generate uc
+python -m codexctl.cli build uc
+
+# Run TUI
+python -m codexctl.tui
+```
+
+### PyCharm Setup
+
+1. Open the repo and set up a Python interpreter (3.9+)
+2. Set environment variables:
+   - `CODEXCTL_CONFIG_DIR` = `/path/to/this/repo/examples`
+   - Optional: `CODEXCTL_STATE_DIR` = writable path
+3. Create Run/Debug configuration:
+   - For CLI: Module name = `codexctl.cli`, Parameters = `projects` (or other subcommands)
+   - For TUI: Module name = `codexctl.tui` (no args)
+
+### Building and Testing
+
+```bash
+# Build wheel
+python -m pip install --upgrade build
+python -m build
+
+# Install in development mode
+python -m pip install -e .
+
+# Install with TUI
+python -m pip install -e '.[tui]'
+```
+
+---
+
+## Packaging
+
+See [PACKAGING.md](PACKAGING.md) for details on:
+- Python packaging (pip/Poetry)
+- Distribution packages (deb/rpm)
+- FHS compliance
+- Runtime lookup strategy

--- a/docs/SHARED_DIRS.md
+++ b/docs/SHARED_DIRS.md
@@ -6,6 +6,7 @@ Overview
   - Shared credentials/config for Codex under /home/dev/.codex
   - Shared credentials/config for Claude Code under /home/dev/.claude
   - Shared credentials/config for Mistral Vibe under /home/dev/.vibe
+  - Shared credentials/config for Blablador (OpenCode) under /home/dev/.blablador
   - Optional per‑project SSH configuration under /home/dev/.ssh (read‑write)
 
 Per‑task workspace (required)
@@ -30,7 +31,10 @@ Shared envs base directory (configurable)
   3) _vibe-config (required; created automatically if missing)
      - Mounted as: <base_dir>/_vibe-config → /home/dev/.vibe:Z (read‑write)
      - Purpose: Shared credentials/config used by Mistral Vibe (CLI + UI).
-  4) _ssh-config-<project_id> (optional)
+  4) _blablador-config (required; created automatically if missing)
+     - Mounted as: <base_dir>/_blablador-config → /home/dev/.blablador:Z (read‑write)
+     - Purpose: Shared credentials/config used by Blablador (OpenCode wrapper) inside the containers.
+  5) _ssh-config-<project_id> (optional)
      - Mounted as: <base_dir>/_ssh-config-<project_id> → /home/dev/.ssh:Z (read‑write)
      - Purpose: If your project uses private git URLs (e.g. git@github.com:...), provide SSH keys and config here so the container can fetch the repository.
 
@@ -88,10 +92,11 @@ Git identity configuration
 - This approach ensures commits show both the AI agent (author) and the human supervisor (committer).
 
 Quick reference (runtime mounts)
-- /workspace          ← <state_root>/tasks/<project>/<task>/workspace:Z
+- /workspace              ← <state_root>/tasks/<project>/<task>/workspace:Z
 - /home/dev/.codex        ← <envs_base>/_codex-config:Z
 - /home/dev/.claude       ← <envs_base>/_claude-config:Z
 - /home/dev/.vibe         ← <envs_base>/_vibe-config:Z
+- /home/dev/.blablador    ← <envs_base>/_blablador-config:Z
 - /home/dev/.ssh (optional) ← <envs_base>/_ssh-config-<project>:Z
 
 How codexctl discovers these paths
@@ -100,10 +105,11 @@ How codexctl discovers these paths
 
 Minimal setup to run tasks
 1) Ensure codexctl can write to the state root (or set CODEXCTL_STATE_DIR accordingly).
-2) Optionally create the envs base dir (codexctl will create _codex-config, _claude-config, and _vibe-config automatically if missing):
+2) Optionally create the envs base dir (codexctl will create these directories automatically if missing):
    - sudo mkdir -p /var/lib/codexctl/envs/_codex-config
    - sudo mkdir -p /var/lib/codexctl/envs/_claude-config
    - sudo mkdir -p /var/lib/codexctl/envs/_vibe-config
+   - sudo mkdir -p /var/lib/codexctl/envs/_blablador-config
 3) If using private git repositories for a project <proj>:
    - sudo mkdir -p /var/lib/codexctl/envs/_ssh-config-<proj>
    - Place SSH keys and config there (see above). Keys must match your repo host.
@@ -111,8 +117,9 @@ Minimal setup to run tasks
 Notes
 - The SSH directory is optional. Public HTTPS repos do not require it.
 - The .codex directory is mounted read‑write and should contain any credentials/config required by Codex tooling.
-- The .claude directory is mounted read‑write and should contain any credentials/config required by Claude Code (CLI only).
+- The .claude directory is mounted read‑write and should contain any credentials/config required by Claude Code.
 - The .vibe directory is mounted read‑write and should contain any credentials/config required by Mistral Vibe.
+- The .blablador directory is mounted read‑write and should contain any credentials/config required by Blablador (OpenCode).
 - Both CLI and UI containers mount the same paths and start with the working directory set to /workspace.
 
 See also

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -1,236 +1,310 @@
-codexctl
-Simple, prefix-/XDG-aware tool to manage containerized projects and per-run tasks using Podman. Provides a CLI (codexctl) and a Textual TUI (codexctl-tui / codextui).
+# codexctl User Guide
 
-Quick answers to common questions
+A prefix-/XDG-aware tool to manage containerized AI agent projects using Podman. Provides a CLI (`codexctl`) and a Textual TUI (`codextui`).
 
-- How do I run a quick session from within PyCharm?
-  1) Open the repo in PyCharm and set up a Python interpreter (3.9+).
-  2) Set environment variables so the app sees the example projects:
-     - CODEXCTL_CONFIG_DIR = /path/to/this/repo/examples
-       (the examples/ directory contains per-project folders with project.yml)
-     - Optional: CODEXCTL_STATE_DIR to a writable path (defaults to ~/.local/share/codexctl)
-  3) Create a Run/Debug configuration:
-     - For CLI: Module name = codexctl.cli, Parameters = projects (or other subcommands)
-       Example to list projects: Run module codexctl.cli with args: projects
-       Example to create a task:  Run module codexctl.cli with args: task new uc
-     - For the TUI: Module name = codexctl.tui (no args). You can also run the installed console script codexctl-tui or codextui.
-     - Ensure the Environment variables are set in the Run config (see step 2).
+## Table of Contents
 
-- How do I package and install via pip?
-  - From a clean checkout, build an sdist and wheel:
-    - python -m pip install --upgrade build
-    - python -m build
-    - Artifacts appear under dist/ (codexctl-<ver>.tar.gz and codexctl-<ver>-py3-none-any.whl)
-  - Install directly from source (editable) for development:
-    - python -m pip install -e .
-  - Or install the built wheel:
-    - python -m pip install dist/codexctl-<ver>-py3-none-any.whl
-    - After install, you should have console scripts:
-      - codexctl, codexctl-tui, codextui
+- [Installation](#installation)
+- [Runtime Locations](#runtime-locations)
+- [Global Configuration](#global-configuration)
+- [From Zero to First Run](#from-zero-to-first-run)
+- [GPU Passthrough](#gpu-passthrough)
+- [Tips](#tips)
+- [FAQ](#faq)
 
-- How do I enable Bash completion for codexctl?
-  - Bash completion is powered by argcomplete.
-  - If your system has bash-completion installed (common on most distros), completion is enabled automatically after installing codexctl: the package ships a loader at share/bash-completion/completions/codexctl that Bash autoloads.
-  - If completion does not work (e.g., custom env/venv or no bash-completion package), you can enable it manually:
-    - One-time system-wide: sudo activate-global-python-argcomplete
-    - Per-shell (current session): eval "$(register-python-argcomplete codexctl)"
-    - Per-user (all new shells): add to ~/.bashrc
-      - eval "$(register-python-argcomplete codexctl)"
-  - Zsh users can use bashcompinit:
-    - autoload -U bashcompinit && bashcompinit
-    - eval "$(register-python-argcomplete --shell zsh codexctl)"
+---
 
-– How do I install into a custom path, e.g. /usr/local?
-  - User-local (no root):
-    - python -m pip install --user .
-    - Binaries go to ~/.local/bin (ensure it’s on PATH).
-  - Custom prefix (Debian/Ubuntu note about “local”):
-    - On Debian/Ubuntu, pip uses the posix_local install scheme which inserts a
-      trailing "/local" segment under the chosen prefix.
-    - Therefore, pick the parent directory as your prefix and let pip add
-      "/local" for you.
-    - Example (recommended):
-      - python -m pip install --prefix=/virt/podman .
-      - Resulting layout: /virt/podman/local/bin/codexctl and
-        /virt/podman/local/lib/pythonX.Y/dist-packages/...
-    - Do NOT append "/local" yourself, or you’ll get a nested path like
-      /virt/podman/local/local.
-      - Wrong: python -m pip install --prefix=/virt/podman/local .
-    - If you want the TUI as well, install the extra:
-      - python -m pip install --prefix=/virt/podman '.[tui]'
-  - Alternatively, use a virtual environment:
-    - python -m venv .venv && . .venv/bin/activate && pip install .
+## Installation
 
-Runtime locations (FHS/XDG)
+### Via pip
 
-- Config/projects:
-  - Root: /etc/codexctl/projects
-  - User: ~/.config/codexctl/projects
-  - Override: CODEXCTL_CONFIG_DIR=/path/to/config (if this points directly to a folder containing project subfolders, that’s accepted; if it contains a projects/ subfolder, that is used).
-- State (writable: tasks, build, cache):
-  - Root: /var/lib/codexctl
-  - User: ${XDG_DATA_HOME:-~/.local/share}/codexctl
-  - Override: CODEXCTL_STATE_DIR=/path/to/state
+```bash
+# Build from source
+python -m pip install --upgrade build
+python -m build
+pip install dist/codexctl-*.whl
 
-Global configuration file
+# Or install directly (editable for development)
+pip install -e .
 
-- The tool looks for a global config file in this order (first found wins):
-  - ${XDG_CONFIG_HOME:-~/.config}/codexctl/config.yml (user override)
-  - sys.prefix/etc/codexctl/config.yml (pip/venv installs)
-  - /etc/codexctl/config.yml (system default)
-- An example config is provided at examples/codexctl-config.yml. Copy and edit:
-  - mkdir -p ~/.config/codexctl && cp examples/codexctl-config.yml ~/.config/codexctl/config.yml
-- Minimum global settings include:
-  - ui.base_port: default first task port for UI mode
-  - paths.user_projects_root: per-user projects directory
-  - paths.state_root: writable state root
-  - paths.build_root: directory for generated files (renamed from legacy "stage")
+# With TUI support
+pip install '.[tui]'
+```
 
-FHS note
+After install, you should have console scripts: `codexctl`, `codexctl-tui`, `codextui`
 
-- /usr/share is read-only and should not be used for writable data. codexctl writes under /var/lib/codexctl (for root installs) or ~/.local/share/codexctl (for users). Templates are read from the Python package resources.
+### Bash Completion
 
-Examples for development
+Bash completion is powered by argcomplete.
 
-- Use the included examples/ as your config:
-  - export CODEXCTL_CONFIG_DIR=$PWD/examples
-  - Optionally: export CODEXCTL_STATE_DIR=$PWD/tmp/dev-runtime/var-lib-codexctl
-  - Now run:
-    - python -m codexctl.cli projects
-    - python -m codexctl.cli task new uc
-    - python -m codexctl.cli task list uc
-    - python -m codexctl.cli generate uc
-    - python -m codexctl.cli build uc
+- If your system has bash-completion installed (common on most distros), completion is enabled automatically
+- Manual setup:
+  - One-time system-wide: `sudo activate-global-python-argcomplete`
+  - Per-shell: `eval "$(register-python-argcomplete codexctl)"`
+  - Per-user: add to `~/.bashrc`: `eval "$(register-python-argcomplete codexctl)"`
+- Zsh users:
+  ```bash
+  autoload -U bashcompinit && bashcompinit
+  eval "$(register-python-argcomplete --shell zsh codexctl)"
+  ```
 
-From zero to first run (new project)
+### Custom Install Paths
 
-This is the end‑to‑end sequence to start a new project from a user‑provided directory that contains a project.yml and, optionally, a Docker include snippet.
+**User-local (no root):**
+```bash
+pip install --user .
+# Binaries go to ~/.local/bin (ensure it's on PATH)
+```
 
-Prerequisites
-- Podman installed and working.
-- OpenSSH client tools (ssh, ssh-keygen) if you plan to use private Git over SSH.
+**Custom prefix (Debian/Ubuntu):**
 
-1) Create your per‑user projects root (once)
-- mkdir -p ~/.config/codexctl/projects
+On Debian/Ubuntu, pip uses the `posix_local` scheme which inserts `/local` under the prefix.
 
-2) Create your project directory and project.yml
-- Example layout:
-  - ~/.config/codexctl/projects/myproj/project.yml
-  - Optional snippet: ~/.config/codexctl/projects/myproj/user.dockerinclude
+```bash
+# Correct - let pip add /local:
+pip install --prefix=/virt/podman .
+# Result: /virt/podman/local/bin/codexctl
 
-Minimal project.yml example
+# Wrong - don't add /local yourself:
+pip install --prefix=/virt/podman/local .
+# Result: /virt/podman/local/local/bin/codexctl
+```
+
+**Virtual environment (recommended):**
+```bash
+python -m venv .venv && . .venv/bin/activate && pip install .
+```
+
+---
+
+## Runtime Locations
+
+### Config/Projects
+
+| Install Type | Path |
+|--------------|------|
+| Root | `/etc/codexctl/projects` |
+| User | `~/.config/codexctl/projects` |
+| Override | `CODEXCTL_CONFIG_DIR=/path/to/config` |
+
+### State (writable: tasks, build, gate)
+
+| Install Type | Path |
+|--------------|------|
+| Root | `/var/lib/codexctl` |
+| User | `${XDG_DATA_HOME:-~/.local/share}/codexctl` |
+| Override | `CODEXCTL_STATE_DIR=/path/to/state` |
+
+---
+
+## Global Configuration
+
+The tool looks for a global config file in this order (first found wins):
+
+1. `${XDG_CONFIG_HOME:-~/.config}/codexctl/config.yml` (user override)
+2. `sys.prefix/etc/codexctl/config.yml` (pip/venv installs)
+3. `/etc/codexctl/config.yml` (system default)
+
+### Example Config
+
+Copy from `examples/codexctl-config.yml`:
+```bash
+mkdir -p ~/.config/codexctl
+cp examples/codexctl-config.yml ~/.config/codexctl/config.yml
+```
+
+### Minimum Settings
+
 ```yaml
+ui:
+  base_port: 7860           # Default port for UI mode
+
+paths:
+  user_projects_root: ~/.config/codexctl/projects
+  state_root: ~/.local/share/codexctl
+  build_root: ~/.local/share/codexctl/build
+
+git:
+  human_name: "Your Name"
+  human_email: "your@email.com"
+```
+
+---
+
+## From Zero to First Run
+
+### Prerequisites
+
+- Podman installed and working
+- OpenSSH client tools (ssh, ssh-keygen) for private Git over SSH
+
+### Step 1: Create Project Directory
+
+```bash
+mkdir -p ~/.config/codexctl/projects/myproj
+```
+
+### Step 2: Create project.yml
+
+```yaml
+# ~/.config/codexctl/projects/myproj/project.yml
 project:
   id: myproj
-  security_class: online
+  security_class: online    # or "gatekeeping" for restricted mode
+
 git:
-  upstream_url: git@github.com:yourorg/yourrepo.git   # or https://... for public
+  upstream_url: git@github.com:yourorg/yourrepo.git  # or https://...
   default_branch: main
-# Optional SSH hints for containers (recommended):
+
+# Optional: SSH hints for containers
 ssh:
-  key_name: id_ed25519_myproj  # matches the key created by ssh-init
-# Optional: reference your Docker include snippet used at image build time
+  key_name: id_ed25519_myproj  # matches key created by ssh-init
+
+# Optional: Docker include snippet
 docker:
   user_snippet_file: user.dockerinclude
 ```
 
-Optional Docker include snippet (user.dockerinclude)
-- This text is pasted near the end of your project image (L2) Dockerfile.
-- Example lines you might add:
-```
+### Step 3: (Optional) Docker Include Snippet
+
+Create `~/.config/codexctl/projects/myproj/user.dockerinclude`:
+```dockerfile
 RUN apt-get update && apt-get install -y ripgrep jq && rm -rf /var/lib/apt/lists/*
 ```
 
-3) Generate Dockerfiles
-- codexctl generate myproj
+This text is pasted near the end of your project image (L2) Dockerfile.
 
-4) Build images
-- codexctl build myproj
-- Optional: build a manual dev image from L0 as well:
-  - codexctl build myproj --dev
+### Step 4: Generate Dockerfiles
 
-5) Initialize the shared SSH directory and generate a keypair (only if using private Git over SSH)
-- codexctl ssh-init myproj
-  - By default creates an ed25519 keypair named id_ed25519_myproj and a default SSH config with:
-    - Global defaults:
-      - IdentitiesOnly yes
-      - StrictHostKeyChecking accept-new (avoids interactive prompts in agents)
-      - IdentityFile <generated_private_key> (applies to all hosts by default)
-    - Host github.com section with User git (inherits IdentityFile)
-  - If your project.yml contains ssh.host_dir, that directory is used; otherwise the default path is <envs_base>/_ssh-config-myproj.
-  - Use the printed .pub key to add a deploy key or authorize it on your Git host.
-  - Advanced: You can customize the SSH config via a template. In project.yml set:
-    ```yaml
-    ssh:
-      config_template: ssh_config.template  # path relative to the project root or absolute
-    ```
-    The template supports tokens: {{IDENTITY_FILE}}, {{KEY_NAME}}, {{PROJECT_ID}}.
-    If not set, a built‑in template is used (see src/codexctl/resources/templates/ssh_config.template).
+```bash
+codexctl generate myproj
+```
 
-6) Create a task (per‑run workspace)
-- codexctl task new myproj
-  - The command prints the new task ID. You can list tasks with: codexctl task list myproj
+### Step 5: Build Images
 
-7) Run the task
-- CLI agent mode (headless; Codex, Claude Code, or Mistral Vibe):
-  - codexctl task run-cli myproj <task_id>
-- UI (web) mode (Codex UI, Claude, or Mistral):
-  - codexctl task run-ui myproj <task_id> [--backend codex|claude|mistral]
-  - For Claude, set one of: CODEXUI_CLAUDE_API_KEY / ANTHROPIC_API_KEY / CLAUDE_API_KEY
-  - Optional: CODEXUI_CLAUDE_MODEL=claude-3-5-sonnet-20240620
-  - For Mistral, set one of: CODEXUI_MISTRAL_API_KEY / MISTRAL_API_KEY
-  - Optional: CODEXUI_MISTRAL_MODEL=mistral-large-latest
+```bash
+codexctl build myproj
 
-Tips
-- Show resolved paths and configuration:
-  - codexctl config
-- Where envs (SSH, Codex, Claude, and Mistral config) live by default:
-  - /var/lib/codexctl/envs (root) or as configured in examples/codexctl-config.yml under envs.base_dir
-- Details on shared directories and SSH mounts:
-  - docs/SHARED_DIRS.md
+# Optional: build a dev image from L0 as well
+codexctl build myproj --dev
+```
 
-Notes
+### Step 6: Initialize SSH (for private repos)
 
-- Podman is required at runtime for build/run commands.
-- The TUI is optional. Install it with: pip install 'codexctl[tui]'.
-- For system packaging (deb/rpm), install the wheel and create /etc/codexctl and /var/lib/codexctl with suitable permissions; the app will locate them automatically.
+```bash
+codexctl ssh-init myproj
+```
 
-Container readiness and initial log streaming (important for developers)
+This creates:
+- An ed25519 keypair named `id_ed25519_myproj`
+- A default SSH config with:
+  - `IdentitiesOnly yes`
+  - `StrictHostKeyChecking accept-new` (avoids interactive prompts)
+  - `IdentityFile <generated_private_key>`
+  - Host github.com section with `User git`
 
-- codexctl shows the initial container logs to the user when starting task containers and then automatically detaches once a "ready" condition is met (or after a short timeout). This improves UX but introduces dependencies that developers must be aware of when changing entry scripts or server behavior.
+Use the printed `.pub` key to add a deploy key on your Git host.
 
-- CLI (task run-cli):
-  - Readiness is determined from log output. The container initialization script emits a marker line:
-    - ">> init complete" (from resources/scripts/init-ssh-and-repo.sh)
-  - Additionally, the run command echoes "__CLI_READY__" just before keeping the container alive. The host follows logs and detaches when either of these markers appears.
-  - If you modify the init script or change its output, ensure that a stable readiness line is preserved, or update the detection in src/codexctl/lib/tasks.py (task_run_cli and _stream_initial_logs).
+**Advanced:** Customize SSH config via template in `project.yml`:
+```yaml
+ssh:
+  config_template: ssh_config.template  # relative or absolute path
+```
+Supported tokens: `{{IDENTITY_FILE}}`, `{{KEY_NAME}}`, `{{PROJECT_ID}}`
 
-- UI (task run-ui):
-  - Readiness is currently determined by probing the bound localhost port (127.0.0.1:<assigned_port> → container port 7860). The host follows the container logs for a short time and detaches as soon as the TCP port is reachable, or after a timeout.
-  - This implies a dependency on the UI process actually listening on PORT (default 7860) and binding to 0.0.0.0 inside the container. The default entry script is resources/scripts/codexui-entry.sh which runs `server.ts` via `tsx` or `ts-node` (or `server.js` if present) from the CodexUI repo.
-  - If the UI server changes its port, bind address, or startup behavior (e.g., delays listening until after long asset builds), you may need to adjust:
-    - The exposed/internal port, and the host port mapping in src/codexctl/lib/tasks.py (task_run_ui).
-    - The readiness timeout in src/codexctl/lib/tasks.py.
-    - Optionally, implement log-marker-based readiness if port probing is insufficient, and then add/guarantee a stable log line in the UI server’s startup output.
+### Step 7: Create and Run a Task
 
-- Timeouts and detaching behavior:
-  - CLI: detaches after readiness marker or 60s.
-  - UI: detaches after port becomes reachable or 30s.
-  - Even on timeout, containers remain running in the background. Users can continue watching logs with `podman logs -f <container>`.
+```bash
+# Create a new task
+codexctl task new myproj
+# Output: Created task 1 for project myproj
 
-- Where to change things:
-  - Host-side logic: src/codexctl/lib/tasks.py (task_run_cli, task_run_ui, _stream_initial_logs)
-  - CLI init marker: src/codexctl/resources/scripts/init-ssh-and-repo.sh
-  - UI entry: src/codexctl/resources/scripts/codexui-entry.sh (runs the UI server)
+# List tasks
+codexctl task list myproj
 
-- Important dependency note:
-  - Because initial log streaming detaches on a specific readiness condition, changes to the UI or CLI startup output or listening port can affect the host-side readiness detection. When altering the UI server or init scripts, please keep the readiness semantics stable or adjust codexctl’s detection accordingly to avoid regressions where the tool either never detaches or detaches too early.
+# Run in CLI mode (headless agent)
+codexctl task run-cli myproj 1
 
-GPU passthrough configuration (per-project only)
+# Or run in UI mode (web interface)
+codexctl task run-ui myproj 1 --backend codex
+```
 
-- codexctl can request NVIDIA GPU devices for containers (Podman + nvidia-container-toolkit), but this is a per-project opt-in only. The default is disabled.
-- To enable for a project, edit <project>/project.yml and add:
-  run:
-    gpus: all   # or true
-- Important: GPU-enabled projects often require a CUDA/NVIDIA-capable base image (e.g., images built with NVIDIA HPC SDK or CUDA). Choose an appropriate base image in the project's docker.base_image.
-- When enabled, codexctl adds flags like --device nvidia.com/gpu=all and NVIDIA_* env vars; ensure the host has NVIDIA drivers and nvidia-container-toolkit with Podman integration.
+### UI Mode Configuration
+
+| Backend | API Key Environment Variable | Optional Model Variable |
+|---------|------------------------------|------------------------|
+| codex | (uses OpenAI from codex config) | - |
+| claude | `CODEXUI_CLAUDE_API_KEY` or `ANTHROPIC_API_KEY` or `CLAUDE_API_KEY` | `CODEXUI_CLAUDE_MODEL` |
+| mistral | `CODEXUI_MISTRAL_API_KEY` or `MISTRAL_API_KEY` | `CODEXUI_MISTRAL_MODEL` |
+
+---
+
+## GPU Passthrough
+
+GPU passthrough is a per-project opt-in feature (disabled by default).
+
+### Enable in project.yml
+
+```yaml
+run:
+  gpus: all   # or true
+```
+
+### Requirements
+
+- NVIDIA drivers installed on host
+- `nvidia-container-toolkit` with Podman integration
+- A CUDA/NVIDIA-capable base image (e.g., NVIDIA HPC SDK or CUDA)
+
+Set the base image in `project.yml`:
+```yaml
+docker:
+  base_image: nvcr.io/nvidia/nvhpc:25.9-devel-cuda13.0-ubuntu24.04
+```
+
+When enabled, codexctl adds:
+- `--device nvidia.com/gpu=all`
+- `NVIDIA_VISIBLE_DEVICES=all`
+- `NVIDIA_DRIVER_CAPABILITIES=all`
+
+---
+
+## Tips
+
+- **Show resolved paths:** `codexctl config`
+- **Where envs live:** `/var/lib/codexctl/envs` (or as configured under `envs.base_dir`)
+- **Shared directories:** See [SHARED_DIRS.md](SHARED_DIRS.md)
+- **Security modes:** See [GIT_CACHE_AND_SECURITY_MODES.md](GIT_CACHE_AND_SECURITY_MODES.md)
+
+---
+
+## FAQ
+
+### How do I install with a custom prefix?
+
+See [Custom Install Paths](#custom-install-paths) above.
+
+### Where are templates and scripts stored?
+
+Loaded from Python package resources bundled with the wheel (under `codexctl/resources/`). The application never reads from `/usr/share`.
+
+### How do I enable the TUI?
+
+```bash
+pip install 'codexctl[tui]'
+```
+
+Then run: `codexctl-tui` or `codextui`
+
+### How do I package for Debian/RPM?
+
+See [PACKAGING.md](PACKAGING.md).
+
+---
+
+## See Also
+
+- [Developer Guide](DEVELOPER.md) - Internal architecture and contributor docs
+- [Shared Directories](SHARED_DIRS.md) - Volume mounts and SSH configuration
+- [Container Layers](CONTAINER_LAYERS.md) - Docker image architecture
+- [Security Modes](GIT_CACHE_AND_SECURITY_MODES.md) - Online vs gatekeeping modes


### PR DESCRIPTION
User documentation:
- README.md: Concise quick-start guide with links to detailed docs
- docs/USAGE.md: Complete user guide (installation, configuration, workflow)

Developer documentation:
- docs/DEVELOPER.md: New file for internal architecture, container readiness detection, environment variables, and development workflow

Fixes:
- SHARED_DIRS.md: Add missing _blablador-config directory documentation
- USAGE.md: Correct UI readiness detection (log markers, not port probing)
- Remove ~85% content duplication between README.md and USAGE.md