### PR TITLE
fix: cleanup leftover codexctl references and add bash completion docs

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,6 +1,6 @@
 include pyproject.toml
 recursive-include src *.py
-recursive-include src/codexctl/resources *
+recursive-include src/luskctl/resources *
 recursive-include completions *
 recursive-include docs *.md
 recursive-include examples *

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ format:
 
 # Run tests with coverage
 test:
-	poetry run pytest --cov=codexctl --cov-report=term-missing
+	poetry run pytest --cov=luskctl --cov-report=term-missing
 
 # Run all checks (equivalent to CI)
 check: lint test

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # luskctl
 
-A tool for managing containerized AI coding agent projects using Podman. Provides both a CLI (`luskctl`) and a Textual TUI (`lusktui`).
+A tool for managing containerized AI coding agent projects using Podman. Provides both a CLI (`luskctl`) and a Textual TUI (`luskctl-tui`).
 
 > **Future plans and design documents** are in [`docs/brainstorming/`](docs/brainstorming/).
 
@@ -35,7 +35,27 @@ pip install .
 
 # With TUI support
 pip install '.[tui]'
+
+# Test bash completions (should work automatically)
+eval "$(register-python-argcomplete luskctl)"  # Only needed if global handler not working
 ```
+
+### Bash Completions
+
+Bash completions work automatically through the **global python-argcomplete system**:
+
+1. **Automatic Detection**: When installed via pip, luskctl is registered as a console script that uses argcomplete
+2. **Global Handler**: The system's `/etc/bash_completion.d/global-python-argcomplete` automatically detects and completes Python console scripts
+3. **No Manual Setup Needed**: Completions work immediately after installation on systems with bash-completion
+
+**Troubleshooting:**
+
+If completions don't work:
+- Ensure bash-completion is installed: `sudo apt-get install bash-completion`
+- Source it in your current shell: `source /usr/share/bash-completion/bash_completion`
+- For immediate testing: `eval "$(register-python-argcomplete luskctl)"`
+
+**How it works:** The `argcomplete.autocomplete(parser)` call in luskctl's main.py enables completions when the global argcomplete handler detects the command.
 
 ### Basic Workflow
 

--- a/completions/luskctl
+++ b/completions/luskctl
@@ -1,8 +1,8 @@
-# Bash completion for codexctl via argcomplete
-# This file is installed to share/bash-completion/completions/codexctl
+# Bash completion for luskctl via argcomplete
+# This file is installed to share/bash-completion/completions/luskctl
 # so that bash (with bash-completion) auto-loads completions for the command.
 
-# If argcomplete is available, register completion for codexctl.
+# If argcomplete is available, register completion for luskctl.
 if command -v register-python-argcomplete >/dev/null 2>&1; then
-    eval "$(register-python-argcomplete codexctl)"
+    eval "$(register-python-argcomplete luskctl)"
 fi

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -1,6 +1,6 @@
 # luskctl User Guide
 
-A prefix-/XDG-aware tool to manage containerized AI agent projects using Podman. Provides a CLI (`luskctl`) and a Textual TUI (`codextui`).
+A prefix-/XDG-aware tool to manage containerized AI agent projects using Podman. Provides a CLI (`luskctl`) and a Textual TUI (`luskctl-tui`).
 
 ## Table of Contents
 
@@ -31,7 +31,7 @@ pip install -e .
 pip install '.[tui]'
 ```
 
-After install, you should have console scripts: `luskctl`, `luskctl-tui`, `codextui`
+After install, you should have console scripts: `luskctl`, `luskctl-tui`
 
 ### Bash Completion
 
@@ -294,7 +294,7 @@ Loaded from Python package resources bundled with the wheel (under `luskctl/reso
 pip install 'luskctl[tui]'
 ```
 
-Then run: `luskctl-tui` or `codextui`
+Then run: `luskctl-tui`
 
 ### How do I package for Debian/RPM?
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,6 @@
 # luskctl
 
-A tool for managing containerized AI coding agent projects using Podman. Provides both a CLI (`luskctl`) and a Textual TUI (`codextui`).
+A tool for managing containerized AI coding agent projects using Podman. Provides both a CLI (`luskctl`) and a Textual TUI (`luskctl-tui`).
 
 ## Features
 

--- a/src/luskctl/__init__.py
+++ b/src/luskctl/__init__.py
@@ -2,7 +2,7 @@
 
 Modules:
 - luskctl.cli: CLI entry point package (luskctl)
-- luskctl.tui: Text UI entry point package (luskctl-tui / codextui)
+- luskctl.tui: Text UI entry point package (luskctl-tui)
 - luskctl.tui.widgets: TUI widgets
 - luskctl.lib: Core library package (auth, config, docker, git_gate, projects, ssh, tasks)
 - luskctl.lib.paths: Base path helpers

--- a/src/luskctl/tui/app.py
+++ b/src/luskctl/tui/app.py
@@ -65,7 +65,7 @@ if _HAS_TEXTUAL:
         TaskMeta,
     )
 
-    class CodexTUI(App):
+    class LuskTUI(App):
         """Minimal TUI frontend for luskctl core modules."""
 
         CSS_PATH = None
@@ -674,7 +674,7 @@ if _HAS_TEXTUAL:
                     generate_dockerfiles(self.current_project_id)
                 except SystemExit as e:
                     print(f"Error: {e}")
-                input("\n[Press Enter to return to CodexTUI] ")
+                input("\n[Press Enter to return to LuskTUI] ")
             self.notify(f"Generated Dockerfiles for {self.current_project_id}")
             self._refresh_project_state()
 
@@ -687,7 +687,7 @@ if _HAS_TEXTUAL:
                     build_images(self.current_project_id)
                 except SystemExit as e:
                     print(f"Error: {e}")
-                input("\n[Press Enter to return to CodexTUI] ")
+                input("\n[Press Enter to return to LuskTUI] ")
             self.notify(f"Built images for {self.current_project_id}")
             self._refresh_project_state()
 
@@ -702,7 +702,7 @@ if _HAS_TEXTUAL:
                     init_project_ssh(self.current_project_id)
                 except SystemExit as e:
                     print(f"Error: {e}")
-                input("\n[Press Enter to return to CodexTUI] ")
+                input("\n[Press Enter to return to LuskTUI] ")
 
             self.notify(f"Initialized SSH dir for {self.current_project_id}")
             self._refresh_project_state()
@@ -722,7 +722,7 @@ if _HAS_TEXTUAL:
                     )
                 except SystemExit as e:
                     print(f"Error: {e}")
-                input("\n[Press Enter to return to CodexTUI] ")
+                input("\n[Press Enter to return to LuskTUI] ")
 
             self.notify(f"Git gate initialized for {self.current_project_id}")
             self._refresh_project_state()
@@ -736,7 +736,7 @@ if _HAS_TEXTUAL:
                     task_new(self.current_project_id)
                 except SystemExit as e:
                     print(f"Error: {e}")
-                input("\n[Press Enter to return to CodexTUI] ")
+                input("\n[Press Enter to return to LuskTUI] ")
             await self.refresh_tasks()
             self.notify("Task created.")
 
@@ -751,7 +751,7 @@ if _HAS_TEXTUAL:
                     task_run_cli(self.current_project_id, tid)
                 except SystemExit as e:
                     print(f"Error: {e}")
-                input("\n[Press Enter to return to CodexTUI] ")
+                input("\n[Press Enter to return to LuskTUI] ")
             await self.refresh_tasks()
 
         async def action_run_ui(self) -> None:
@@ -768,7 +768,7 @@ if _HAS_TEXTUAL:
                     task_run_ui(self.current_project_id, tid, backend=backend)
                 except SystemExit as e:
                     print(f"Error: {e}")
-                input("\n[Press Enter to return to CodexTUI] ")
+                input("\n[Press Enter to return to LuskTUI] ")
             await self.refresh_tasks()
 
         async def action_delete_task(self) -> None:
@@ -852,7 +852,7 @@ if _HAS_TEXTUAL:
             await self._copy_diff_to_clipboard("PREV", "PREV")
 
     def main() -> None:
-        CodexTUI().run()
+        LuskTUI().run()
 
 else:
 


### PR DESCRIPTION
- Replace all remaining codexctl/codextui/CodexTUI references with luskctl/luskctl-tui/LuskTUI
- Update MANIFEST.in, completions, Makefile, docs, and source code
- Fix typo in README: lusktui -> luskctl-tui
- Add bash completion instructions to README with persistent setup guide
- Ensure consistent branding throughout the codebase