### PR TITLE
Add luskctl login command with TUI integration and tmux support

### DIFF
--- a/docs/LOGIN_DESIGN.md
+++ b/docs/LOGIN_DESIGN.md
@@ -10,22 +10,27 @@ the container name must be remembered or copied, and sessions are lost on discon
 ## Requirements
 
 ### R1: One-command login
+
 A single command (`luskctl login <project> <task>`) should open an interactive shell.
 No container name needed — luskctl resolves it from project/task metadata.
 
 ### R2: Persistent sessions
+
 Sessions should survive disconnects. Reconnecting should reattach to the same session
 with all state (running processes, environment, working directory) preserved.
 
 ### R3: TUI integration
+
 The TUI should allow login without leaving the interface. When possible, the login
 session should open in a separate window/tab so the TUI remains usable.
 
 ### R4: Work across environments
+
 Users run luskctl in diverse environments. Login should work well in all of them:
 terminal (bare), terminal (under tmux), desktop (GNOME, KDE), and browser (web-served TUI).
 
 ### R5: Minimize cognitive load for nested tmux
+
 Host-level tmux (for managing TUI windows) and container-level tmux (for session
 persistence) use different prefix keys and visual indicators to avoid confusion.
 

--- a/docs/LOGIN_DESIGN.md
+++ b/docs/LOGIN_DESIGN.md
@@ -1,0 +1,102 @@
+# Login Feature — Design
+
+## Problem
+
+luskctl manages containerized AI coding agent tasks. Users need to open interactive
+shells inside running containers — to debug, inspect, or interact with the agent
+directly. Currently this requires manually typing `podman exec -it <name> bash`,
+the container name must be remembered or copied, and sessions are lost on disconnect.
+
+## Requirements
+
+### R1: One-command login
+A single command (`luskctl login <project> <task>`) should open an interactive shell.
+No container name needed — luskctl resolves it from project/task metadata.
+
+### R2: Persistent sessions
+Sessions should survive disconnects. Reconnecting should reattach to the same session
+with all state (running processes, environment, working directory) preserved.
+
+### R3: TUI integration
+The TUI should allow login without leaving the interface. When possible, the login
+session should open in a separate window/tab so the TUI remains usable.
+
+### R4: Work across environments
+Users run luskctl in diverse environments. Login should work well in all of them:
+terminal (bare), terminal (under tmux), desktop (GNOME, KDE), and browser (web-served TUI).
+
+### R5: Minimize cognitive load for nested tmux
+Host-level tmux (for managing TUI windows) and container-level tmux (for session
+persistence) use different prefix keys and visual indicators to avoid confusion.
+
+## Architecture
+
+### Container layer: tmux for session persistence (R2)
+
+Every container ships tmux with a custom config (`/etc/tmux.conf`). The login command
+is always the same regardless of how the user reaches the container:
+
+    podman exec -it <container> tmux new-session -A -s main
+
+`-A` means "attach if session exists, create if not." This is idempotent — first login
+creates, subsequent logins reattach.
+
+### Host layer: environment-aware terminal delivery (R3, R4)
+
+The login command is the same; what varies is how the user gets a terminal to run it.
+A dispatch chain selects the best available method:
+
+    ┌──────────────────────────────────────────────────┐
+    │ 1. Inside tmux?  → tmux new-window              │
+    │ 2. Desktop DE?   → gnome-terminal / konsole      │
+    │ 3. Web mode?     → ttyd + open new browser tab   │
+    │ 4. Fallback      → suspend TUI, run directly     │
+    └──────────────────────────────────────────────────┘
+
+Methods 1-3 keep the TUI visible. Method 4 (suspend) blocks the TUI but works everywhere.
+
+### tmux UX: visual disambiguation (R5)
+
+Two independent tmux servers coexist: one on the host, one in the container. They are
+in different PID namespaces and do not interact. The only overlap is the prefix key,
+which is resolved by using different defaults:
+
+| Level | Prefix | Status bar | Color |
+|---|---|---|---|
+| Host | ^b (default) | `HOST tmux (^b)` | Blue |
+| Container | ^a (custom) | `CONTAINER tmux (^a)` | Green |
+
+The container status bar cross-references the host prefix (`host: ^b`) so the user
+always knows how to switch context. Color provides instant visual identification.
+
+### CLI: top-level command (R1)
+
+`luskctl login <project> <task>` replaces the current process with
+`podman exec -it <container> tmux new-session -A -s main` via `os.execvp()`.
+Validation (task exists, has been run, container is running) happens before exec.
+
+### TUI: `l` keybind with dispatch (R3)
+
+The TUI calls `get_login_command()` to get the validated command, then `launch_login()`
+to dispatch via the chain above. The return value indicates which method was used,
+and the TUI shows a notification or falls back to suspend accordingly.
+
+### Web mode: ttyd for browser-tab terminals (R4)
+
+When the TUI is served via `textual serve`, `suspend()` is silently ignored (no real
+terminal to suspend). Instead, ttyd (a lightweight HTTP terminal server using xterm.js)
+is started on the host, and `App.open_url()` opens a new browser tab pointing to it.
+The user gets a real terminal in the new tab while the TUI remains in the original tab.
+
+### `--tmux` opt-in wrapper (R3, R5)
+
+`luskctl-tui --tmux` wraps the TUI in a managed tmux session with the host config
+(blue status bar, usage hints). Login sessions become additional tmux windows.
+This is opt-in — without the flag, the TUI runs directly in the terminal as before.
+
+## Future Directions
+
+- Embedded terminal widget in the TUI (pyte-based, requires significant effort)
+- Support for additional terminal emulators beyond gnome-terminal and konsole
+- Auto-wrap in tmux by default (pending user feedback on the opt-in flag)
+- Toad/ACP integration as alternative agent frontend

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -137,6 +137,8 @@ git:
 
 - Podman installed and working
 - OpenSSH client tools (ssh, ssh-keygen) for private Git over SSH
+- tmux (optional, for `luskctl-tui --tmux` and persistent container sessions)
+- ttyd (optional, for web-mode terminal access)
 
 ### Step 1: Create Project Directory
 
@@ -241,6 +243,48 @@ luskctl task run-cli myproj 1
 # Or run in UI mode (web interface)
 luskctl task run-ui myproj 1 --backend codex
 ```
+
+### Step 8: Log into a Running Container
+
+```bash
+# Open a shell in a running task container (persistent tmux session)
+luskctl login myproj 1
+```
+
+This opens a tmux session inside the container. The session persists across
+disconnects — re-running `luskctl login` reattaches to the same session.
+
+#### From the TUI
+
+Press `l` on any running task to open a login session. The TUI picks the best
+method automatically:
+
+| Environment | What happens |
+|---|---|
+| Inside tmux | Opens new tmux window (TUI stays visible) |
+| Desktop (GNOME/KDE) | Opens new terminal window |
+| Web (textual serve) | Opens new browser tab (via ttyd) |
+| Plain terminal | Suspends TUI, opens shell, resumes on exit |
+
+#### Running the TUI under tmux (recommended)
+
+```bash
+luskctl-tui --tmux
+```
+
+This wraps the TUI in a managed tmux session with a blue status bar showing
+keyboard shortcuts. Login sessions open as additional tmux windows — press
+`^b n`/`^b p` to switch between TUI and container shells.
+
+#### tmux Quick Reference
+
+| Context | Prefix | Status bar color | Common keys |
+|---|---|---|---|
+| Host tmux | `^b` | Blue | `^b n/p` switch windows, `^b d` detach |
+| Container tmux | `^a` | Green | `^a n/p` switch windows, `^a c` new window |
+
+The container's tmux prefix (`^a`) is different from the host's (`^b`) to avoid
+conflicts. The container status bar shows `host: ^b` as a reminder.
 
 ### UI Mode Configuration
 

--- a/src/luskctl/cli/main.py
+++ b/src/luskctl/cli/main.py
@@ -38,6 +38,7 @@ from ..lib.tasks import (
     WEB_BACKENDS,
     task_delete,
     task_list,
+    task_login,
     task_new,
     task_restart,
     task_run_cli,
@@ -232,6 +233,7 @@ def main() -> None:
             "  1. Setup:  luskctl project-init <project_id>\n"
             "  2. Work:   luskctl task start <project_id>         (new CLI task)\n"
             "             luskctl task start <project_id> --web   (new web task)\n"
+            "  3. Login:  luskctl login <project_id> <task_id>\n"
             "\n"
             "Step-by-step (order of operations):\n"
             "  Online (HTTPS): generate → build → gate-sync (optional) → task new → task run-*\n"
@@ -373,6 +375,19 @@ def main() -> None:
     _a = p_auth_blablador.add_argument("project_id")
     try:
         _a.completer = _complete_project_ids  # type: ignore[attr-defined]
+    except Exception:
+        pass
+
+    # login (top-level shortcut)
+    p_login = sub.add_parser("login", help="Open interactive shell in a running task container")
+    _a = p_login.add_argument("project_id")
+    try:
+        _a.completer = _complete_project_ids  # type: ignore[attr-defined]
+    except Exception:
+        pass
+    _a = p_login.add_argument("task_id")
+    try:
+        _a.completer = _complete_task_ids  # type: ignore[attr-defined]
     except Exception:
         pass
 
@@ -552,6 +567,8 @@ def main() -> None:
             for p in projs:
                 upstream = p.upstream_url or "-"
                 print(f"- {p.id} [{p.security_class}] upstream={upstream} config_root={p.root}")
+    elif args.cmd == "login":
+        task_login(args.project_id, args.task_id)
     elif args.cmd == "task":
         if args.task_cmd == "new":
             task_new(args.project_id)

--- a/src/luskctl/lib/shell_launch.py
+++ b/src/luskctl/lib/shell_launch.py
@@ -1,0 +1,145 @@
+"""Helpers for launching interactive login shells from the TUI.
+
+Provides tmux detection, desktop terminal detection, web-mode ttyd spawning,
+and an orchestrator that picks the best available method.
+"""
+
+import os
+import shlex
+import shutil
+import socket
+import subprocess
+
+
+def is_inside_tmux() -> bool:
+    """Return True if the current process is running inside a tmux session."""
+    return bool(os.environ.get("TMUX"))
+
+
+def tmux_new_window(command: list[str], title: str | None = None) -> bool:
+    """Open a new tmux window running the given command.
+
+    Returns True if the tmux command succeeded, False otherwise.
+    The caller must verify that we are inside tmux before calling this.
+    """
+    shell_cmd = " ".join(shlex.quote(c) for c in command)
+    tmux_cmd: list[str] = ["tmux", "new-window"]
+    if title:
+        tmux_cmd += ["-n", title]
+    tmux_cmd.append(shell_cmd)
+    try:
+        subprocess.run(tmux_cmd, check=True)
+        return True
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        return False
+
+
+def detect_terminal_emulator() -> str | None:
+    """Detect an available graphical terminal emulator.
+
+    Returns the name of the first available terminal emulator found,
+    or None if no supported terminal is available.  Currently supports
+    gnome-terminal (GNOME) and konsole (KDE).
+    """
+    candidates = ["gnome-terminal", "konsole"]
+    for name in candidates:
+        if shutil.which(name):
+            return name
+    return None
+
+
+def spawn_terminal_with_command(command: list[str]) -> bool:
+    """Spawn a new terminal window running the given command.
+
+    Returns True if the terminal was spawned, False if no terminal
+    emulator was found or if the spawn failed.
+    """
+    terminal = detect_terminal_emulator()
+    if not terminal:
+        return False
+
+    shell_cmd = " ".join(shlex.quote(c) for c in command)
+
+    try:
+        if terminal == "gnome-terminal":
+            subprocess.Popen(
+                ["gnome-terminal", "--", "bash", "-c", shell_cmd + "; exec bash"],
+                start_new_session=True,
+            )
+        elif terminal == "konsole":
+            subprocess.Popen(
+                ["konsole", "-e", "bash", "-c", shell_cmd + "; exec bash"],
+                start_new_session=True,
+            )
+        else:
+            return False
+        return True
+    except (FileNotFoundError, OSError):
+        return False
+
+
+def is_web_mode() -> bool:
+    """Detect if the app is running under textual-serve (web mode).
+
+    When served via ``textual serve``, the TERM_PROGRAM environment
+    variable is typically absent and the textual driver changes.  We
+    check for the presence of an env var set by textual-serve.
+    """
+    # textual-serve sets TEXTUAL_DRIVER when running in web mode
+    driver = os.environ.get("TEXTUAL_DRIVER", "")
+    return "web" in driver.lower()
+
+
+def _find_free_port() -> int:
+    """Find a free TCP port on localhost."""
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(("127.0.0.1", 0))
+        return s.getsockname()[1]
+
+
+def spawn_ttyd(command: list[str], port: int = 0) -> int | None:
+    """Start ttyd serving the given command on a local port.
+
+    Returns the port number on success, or None if ttyd is not installed.
+    If port is 0, a free port is selected automatically.
+    """
+    if not shutil.which("ttyd"):
+        return None
+
+    if port == 0:
+        port = _find_free_port()
+
+    ttyd_cmd = ["ttyd", "-W", "-o", "-p", str(port)] + command
+    try:
+        subprocess.Popen(ttyd_cmd, start_new_session=True)
+        return port
+    except (FileNotFoundError, OSError):
+        return None
+
+
+def launch_login(
+    command: list[str],
+    title: str | None = None,
+) -> tuple[str, int | None]:
+    """Launch a login session using the best available method.
+
+    Returns a tuple of (method, port):
+    - ("tmux", None): opened in a new tmux window
+    - ("terminal", None): opened in a new desktop terminal window
+    - ("web", port): started ttyd on the given port (caller should open_url)
+    - ("none", None): no external method available; caller should suspend
+    """
+    if is_inside_tmux():
+        if tmux_new_window(command, title=title):
+            return ("tmux", None)
+
+    if not is_web_mode():
+        if spawn_terminal_with_command(command):
+            return ("terminal", None)
+
+    if is_web_mode():
+        port = spawn_ttyd(command)
+        if port is not None:
+            return ("web", port)
+
+    return ("none", None)

--- a/src/luskctl/lib/shell_launch.py
+++ b/src/luskctl/lib/shell_launch.py
@@ -100,8 +100,10 @@ def _find_free_port() -> int:
 def spawn_ttyd(command: list[str], port: int = 0) -> int | None:
     """Start ttyd serving the given command on a local port.
 
-    Returns the port number on success, or None if ttyd is not installed.
-    If port is 0, a free port is selected automatically.
+    Binds to the loopback interface only (``-i lo``) so the terminal is not
+    exposed beyond localhost.  Returns the port number on success, or None
+    if ttyd is not installed.  If port is 0, a free port is selected
+    automatically.
     """
     if not shutil.which("ttyd"):
         return None
@@ -109,7 +111,7 @@ def spawn_ttyd(command: list[str], port: int = 0) -> int | None:
     if port == 0:
         port = _find_free_port()
 
-    ttyd_cmd = ["ttyd", "-W", "-o", "-p", str(port)] + command
+    ttyd_cmd = ["ttyd", "-W", "-o", "-i", "lo", "-p", str(port)] + command
     try:
         subprocess.Popen(ttyd_cmd, start_new_session=True)
         return port

--- a/src/luskctl/lib/tasks.py
+++ b/src/luskctl/lib/tasks.py
@@ -535,10 +535,17 @@ def get_login_command(project_id: str, task_id: str) -> list[str]:
 def task_login(project_id: str, task_id: str) -> None:
     """Open an interactive shell in a running task container.
 
-    Replaces the current process with podman exec + tmux.
+    Validates the task, then replaces the current process with
+    ``podman exec -it <container> tmux new-session -A -s main``.
+    Raises SystemExit if podman is not found on PATH.
     """
     cmd = get_login_command(project_id, task_id)
-    os.execvp(cmd[0], cmd)
+    try:
+        os.execvp(cmd[0], cmd)
+    except FileNotFoundError:
+        raise SystemExit(
+            f"'{cmd[0]}' not found on PATH. Please install podman or add it to your PATH."
+        )
 
 
 def task_run_cli(project_id: str, task_id: str) -> None:

--- a/src/luskctl/lib/tasks.py
+++ b/src/luskctl/lib/tasks.py
@@ -476,6 +476,70 @@ def task_delete(project_id: str, task_id: str) -> None:
     _log_debug("task_delete: finished")
 
 
+def _validate_login(project_id: str, task_id: str) -> tuple[str, str]:
+    """Validate that a task exists and its container is running.
+
+    Returns (container_name, mode) on success.
+    Raises SystemExit with actionable messages on failure.
+    """
+    project = load_project(project_id)
+    meta_dir = _tasks_meta_dir(project.id)
+    meta_path = meta_dir / f"{task_id}.yml"
+    if not meta_path.is_file():
+        raise SystemExit(f"Unknown task {task_id}")
+    meta = yaml.safe_load(meta_path.read_text()) or {}
+
+    mode = meta.get("mode")
+    if not mode:
+        raise SystemExit(
+            f"Task {task_id} has never been run (no mode set). "
+            f"Run 'luskctl task run-cli {project_id} {task_id}' first."
+        )
+
+    container_name = f"{project.id}-{mode}-{task_id}"
+    state = _get_container_state(container_name)
+    if state is None:
+        raise SystemExit(
+            f"Container {container_name} does not exist. "
+            f"Run 'luskctl task restart {project_id} {task_id}' first."
+        )
+    if state != "running":
+        raise SystemExit(
+            f"Container {container_name} is not running (state: {state}). "
+            f"Run 'luskctl task restart {project_id} {task_id}' first."
+        )
+    return container_name, mode
+
+
+def get_login_command(project_id: str, task_id: str) -> list[str]:
+    """Return the podman exec command to log into a task container.
+
+    Validates the task and container state, then returns the command list
+    for use by TUI/tmux/terminal-spawn paths.
+    """
+    container_name, _mode = _validate_login(project_id, task_id)
+    return [
+        "podman",
+        "exec",
+        "-it",
+        container_name,
+        "tmux",
+        "new-session",
+        "-A",
+        "-s",
+        "main",
+    ]
+
+
+def task_login(project_id: str, task_id: str) -> None:
+    """Open an interactive shell in a running task container.
+
+    Replaces the current process with podman exec + tmux.
+    """
+    cmd = get_login_command(project_id, task_id)
+    os.execvp(cmd[0], cmd)
+
+
 def task_run_cli(project_id: str, task_id: str) -> None:
     project = load_project(project_id)
     meta_dir = _tasks_meta_dir(project.id)
@@ -493,7 +557,10 @@ def task_run_cli(project_id: str, task_id: str) -> None:
         color_enabled = _supports_color()
         if container_state == "running":
             print(f"Container {_green(container_name, color_enabled)} is already running.")
-            print(f"Login with: podman exec -it {container_name} bash")
+            login_cmd = f"luskctl login {project.id} {task_id}"
+            raw_cmd = f"podman exec -it {container_name} bash"
+            print(f"Login with: {_blue(login_cmd, color_enabled)}")
+            print(f"  (or:      {_blue(raw_cmd, color_enabled)})")
             return
         else:
             # Container exists but is stopped/exited - start it
@@ -515,7 +582,10 @@ def task_run_cli(project_id: str, task_id: str) -> None:
             meta["mode"] = "cli"
             meta_path.write_text(yaml.safe_dump(meta))
             print("Container started.")
-            print(f"Login with: podman exec -it {container_name} bash")
+            login_cmd = f"luskctl login {project.id} {task_id}"
+            raw_cmd = f"podman exec -it {container_name} bash"
+            print(f"Login with: {_blue(login_cmd, color_enabled)}")
+            print(f"  (or:      {_blue(raw_cmd, color_enabled)})")
             return
 
     env, volumes = _build_task_env_and_volumes(project, task_id)
@@ -567,13 +637,15 @@ def task_run_cli(project_id: str, task_id: str) -> None:
 
     color_enabled = _supports_color()
     container_name = f"{project.id}-cli-{task_id}"
-    login_command = f"podman exec -it {container_name} bash"
+    login_cmd = f"luskctl login {project.id} {task_id}"
+    raw_cmd = f"podman exec -it {container_name} bash"
     stop_command = f"podman stop {container_name}"
 
     print(
         "\nCLI container is running in the background."
-        f"\n- Name: {_green(container_name, color_enabled)}"
-        f"\n- To enter: {_blue(login_command, color_enabled)}"
+        f"\n- Name:     {_green(container_name, color_enabled)}"
+        f"\n- To enter: {_blue(login_cmd, color_enabled)}"
+        f"\n  (or:      {_blue(raw_cmd, color_enabled)})"
         f"\n- To stop:  {_red(stop_command, color_enabled)}\n"
     )
 
@@ -826,7 +898,10 @@ def task_restart(project_id: str, task_id: str, backend: str | None = None) -> N
         color_enabled = _supports_color()
         print(f"Restarted task {task_id}: {_green(container_name, color_enabled)}")
         if mode == "cli":
-            print(f"Login with: podman exec -it {container_name} bash")
+            login_cmd = f"luskctl login {project_id} {task_id}"
+            raw_cmd = f"podman exec -it {container_name} bash"
+            print(f"Login with: {_blue(login_cmd, color_enabled)}")
+            print(f"  (or:      {_blue(raw_cmd, color_enabled)})")
         elif mode == "web":
             port = meta.get("web_port")
             if port:

--- a/src/luskctl/lib/tasks.py
+++ b/src/luskctl/lib/tasks.py
@@ -493,7 +493,8 @@ def _validate_login(project_id: str, task_id: str) -> tuple[str, str]:
     if not mode:
         raise SystemExit(
             f"Task {task_id} has never been run (no mode set). "
-            f"Run 'luskctl task run-cli {project_id} {task_id}' first."
+            f"Start it first via 'luskctl task run-cli {project_id} {task_id}' "
+            f"or 'luskctl task run-web {project_id} {task_id}'."
         )
 
     container_name = f"{project.id}-{mode}-{task_id}"

--- a/src/luskctl/resources/templates/l0.dev.Dockerfile.template
+++ b/src/luskctl/resources/templates/l0.dev.Dockerfile.template
@@ -10,7 +10,7 @@ ENV DEBIAN_FRONTEND=noninteractive \
 # Basic dev tooling common to all projects
 RUN apt-get update && apt-get install -y --no-install-recommends \
       ca-certificates curl gnupg git openssh-client sudo \
-      ripgrep vim \
+      ripgrep vim tmux \
     && rm -rf /var/lib/apt/lists/*
 
 RUN set -eux; \
@@ -38,6 +38,9 @@ WORKDIR /workspace
 
 COPY scripts/init-ssh-and-repo.sh /usr/local/bin/init-ssh-and-repo.sh
 RUN chmod +x /usr/local/bin/init-ssh-and-repo.sh
+
+# tmux config for persistent login sessions (prefix ^a, green status bar)
+COPY tmux/container-tmux.conf /etc/tmux.conf
 
 ENV HOME=/home/dev
 USER dev

--- a/src/luskctl/resources/tmux/container-tmux.conf
+++ b/src/luskctl/resources/tmux/container-tmux.conf
@@ -1,0 +1,19 @@
+# luskctl container tmux — prefix is ^a
+# Installed at /etc/tmux.conf inside task containers.
+# Green status bar distinguishes container from host tmux.
+
+set -g prefix C-a
+unbind C-b
+bind C-a send-prefix
+
+set -g status on
+set -g status-interval 5
+set -g status-style 'bg=colour22 fg=colour255'
+set -g status-left ' CONTAINER tmux (^a) | '
+set -g status-left-length 30
+set -g status-right ' host: ^b  ^a c:new  ^a n/p:switch '
+set -g status-right-length 45
+set -g mouse on
+set -g history-limit 10000
+set -g default-terminal "screen-256color"
+set -g base-index 1

--- a/src/luskctl/resources/tmux/host-tmux.conf
+++ b/src/luskctl/resources/tmux/host-tmux.conf
@@ -1,0 +1,19 @@
+# luskctl host tmux — prefix is ^b (default)
+# Launched by: luskctl-tui --tmux
+# Blue status bar distinguishes host from container tmux.
+
+set -g status on
+set -g status-interval 5
+set -g status-style 'bg=colour24 fg=colour255'
+set -g status-left ' HOST tmux (^b) | '
+set -g status-left-length 25
+set -g status-right ' ^b n/p:windows  ^b d:detach '
+set -g status-right-length 40
+set -g mouse on
+set -g history-limit 10000
+set -g default-terminal "screen-256color"
+set -g base-index 1
+set -g renumber-windows on
+
+# First window is always the TUI
+set -g automatic-rename off

--- a/src/luskctl/tui/app.py
+++ b/src/luskctl/tui/app.py
@@ -905,7 +905,8 @@ if _HAS_TEXTUAL:
                 self.notify(str(e))
                 return
 
-            container_name = cmd[3]  # ["podman","exec","-it",NAME,...]
+            mode = self.current_task.mode or "cli"
+            container_name = f"{pid}-{mode}-{tid}"
             title = f"login:{container_name}"
 
             method, port = launch_login(cmd, title=title)
@@ -1177,6 +1178,12 @@ if _HAS_TEXTUAL:
             )
 
     def main() -> None:
+        """CLI entry-point for launching the luskctl TUI.
+
+        Supports ``--tmux`` to wrap the TUI in a managed host tmux session
+        (blue status bar, login windows as extra tmux windows).  Without the
+        flag the TUI runs directly in the current terminal.
+        """
         import argparse
 
         parser = argparse.ArgumentParser(prog="luskctl-tui")

--- a/src/luskctl/tui/app.py
+++ b/src/luskctl/tui/app.py
@@ -1136,12 +1136,25 @@ if _HAS_TEXTUAL:
         """Launch the TUI inside a managed tmux session.
 
         If already inside tmux, just run the TUI directly.
-        Otherwise, exec into tmux with the luskctl host config.
+        Otherwise, verify that tmux is installed and exec into it with the
+        luskctl host config (blue status bar, usage hints).  Exits with an
+        actionable error message if tmux is not found on ``$PATH``.
         """
         if os.environ.get("TMUX"):
             # Already inside tmux — no double-wrap
             LuskTUI().run()
             return
+
+        import shutil
+
+        if not shutil.which("tmux"):
+            print(
+                "Error: tmux is not installed.\n"
+                "Install it (e.g. 'apt install tmux' or 'brew install tmux') "
+                "and try again,\nor run 'luskctl-tui' without --tmux.",
+                file=sys.stderr,
+            )
+            sys.exit(1)
 
         from importlib import resources as _res
 

--- a/src/luskctl/tui/app.py
+++ b/src/luskctl/tui/app.py
@@ -47,9 +47,11 @@ if _HAS_TEXTUAL:
     )
     from ..lib.projects import Project as CodexProject
     from ..lib.projects import get_project_state, list_projects, load_project
+    from ..lib.shell_launch import launch_login
     from ..lib.ssh import init_project_ssh
     from ..lib.tasks import (
         WEB_BACKENDS,
+        get_login_command,
         get_tasks,
         get_workspace_git_diff,
         task_delete,
@@ -759,6 +761,8 @@ if _HAS_TEXTUAL:
                 await self.action_copy_diff_head()
             elif action == "diff_prev":
                 await self.action_copy_diff_prev()
+            elif action == "login":
+                await self._action_login()
 
         async def _action_build_agents(self) -> None:
             """Build L0+L1+L2 with fresh agent installs."""
@@ -885,6 +889,43 @@ if _HAS_TEXTUAL:
                     print(f"Error: {e}")
                 input("\n[Press Enter to return to LuskTUI] ")
             await self.refresh_tasks()
+
+        async def _action_login(self) -> None:
+            """Log into the selected task's running container."""
+            if not self.current_project_id or not self.current_task:
+                self.notify("No task selected.")
+                return
+            pid = self.current_project_id
+            tid = self.current_task.task_id
+            try:
+                cmd = get_login_command(pid, tid)
+            except SystemExit as e:
+                self.notify(str(e))
+                return
+
+            container_name = cmd[3]  # ["podman","exec","-it",NAME,...]
+            title = f"login:{container_name}"
+
+            method, port = launch_login(cmd, title=title)
+
+            if method == "tmux":
+                self.notify(f"Opened in tmux window: {container_name}")
+            elif method == "terminal":
+                self.notify(f"Opened in new terminal: {container_name}")
+            elif method == "web" and port is not None:
+                self.open_url(f"http://localhost:{port}")
+                self.notify(f"Opened terminal in browser tab: {container_name}")
+            else:
+                # Fallback: suspend TUI
+                with self.suspend():
+                    try:
+                        import subprocess as _sp
+
+                        _sp.run(cmd)
+                    except Exception as e:
+                        print(f"Error: {e}")
+                    input("\n[Press Enter to return to LuskTUI] ")
+                await self.refresh_tasks()
 
         async def _action_sync_gate(self) -> None:
             """Sync gate (init if doesn't exist, sync if exists)."""
@@ -1087,7 +1128,53 @@ if _HAS_TEXTUAL:
             """Delete the selected task from the main screen."""
             await self.action_delete_task()
 
+        async def action_login_from_main(self) -> None:
+            """Login to the selected task from the main screen."""
+            await self._action_login()
+
+    def _launch_in_tmux() -> None:
+        """Launch the TUI inside a managed tmux session.
+
+        If already inside tmux, just run the TUI directly.
+        Otherwise, exec into tmux with the luskctl host config.
+        """
+        if os.environ.get("TMUX"):
+            # Already inside tmux — no double-wrap
+            LuskTUI().run()
+            return
+
+        from importlib import resources as _res
+
+        tmux_conf = _res.files("luskctl") / "resources" / "tmux" / "host-tmux.conf"
+        # Materialise the resource to a real file path for tmux -f
+        with _res.as_file(tmux_conf) as conf_path:
+            os.execvp(
+                "tmux",
+                [
+                    "tmux",
+                    "-f",
+                    str(conf_path),
+                    "new-session",
+                    "-s",
+                    "luskctl",
+                    "luskctl-tui",
+                ],
+            )
+
     def main() -> None:
+        import argparse
+
+        parser = argparse.ArgumentParser(prog="luskctl-tui")
+        parser.add_argument(
+            "--tmux",
+            action="store_true",
+            help="Launch TUI inside a managed tmux session",
+        )
+        args = parser.parse_args()
+
+        if args.tmux:
+            _launch_in_tmux()
+            return
         LuskTUI().run()
 
 else:

--- a/src/luskctl/tui/app.py
+++ b/src/luskctl/tui/app.py
@@ -1162,7 +1162,10 @@ if _HAS_TEXTUAL:
         from importlib import resources as _res
 
         tmux_conf = _res.files("luskctl") / "resources" / "tmux" / "host-tmux.conf"
-        # Materialise the resource to a real file path for tmux -f
+        # Materialise the resource to a real file path for tmux -f.
+        # Note: os.execvp replaces this process so the context manager's
+        # __exit__ never runs.  This is fine — tmux reads the config file
+        # at startup, and OS process cleanup handles any temp resources.
         with _res.as_file(tmux_conf) as conf_path:
             os.execvp(
                 "tmux",

--- a/src/luskctl/tui/screens.py
+++ b/src/luskctl/tui/screens.py
@@ -315,6 +315,7 @@ class TaskDetailsScreen(screen.Screen[str | None]):
             options.append(Option("run [c]li agent", id="cli"))
             options.append(Option("run [w]eb UI", id="web"))
             options.append(Option("[r]estart container", id="restart"))
+            options.append(Option("[l]ogin to container", id="login"))
             options.append(None)
             options.append(Option("Copy diff vs [H]EAD", id="diff_head"))
             options.append(Option("Copy diff vs [P]REV", id="diff_prev"))
@@ -362,7 +363,7 @@ class TaskDetailsScreen(screen.Screen[str | None]):
             return
 
         # Lowercase keys — all require tasks to exist
-        lower_map = {"d": "delete", "c": "cli", "w": "web", "r": "restart"}
+        lower_map = {"d": "delete", "c": "cli", "w": "web", "r": "restart", "l": "login"}
         if key in lower_map:
             if not self._has_tasks:
                 return
@@ -397,6 +398,10 @@ class TaskDetailsScreen(screen.Screen[str | None]):
     def action_restart(self) -> None:
         if self._has_tasks:
             self.dismiss("restart")
+
+    def action_login(self) -> None:
+        if self._has_tasks:
+            self.dismiss("login")
 
     def action_diff_head(self) -> None:
         if self._has_tasks:

--- a/src/luskctl/tui/screens.py
+++ b/src/luskctl/tui/screens.py
@@ -305,7 +305,7 @@ class TaskDetailsScreen(screen.Screen[str | None]):
         options: list[Option | None] = [
             Option("Start CLI task  \\[N]  (new task + run CLI)", id="task_start_cli"),
             Option("Start \\[W]eb task  (new task + run Web)", id="task_start_web"),
-            Option("[l]ogin to container", id="login")),
+            Option("[l]ogin to container", id="login"),
         ]
         if self._has_tasks:
             options.append(None)

--- a/src/luskctl/tui/screens.py
+++ b/src/luskctl/tui/screens.py
@@ -305,9 +305,9 @@ class TaskDetailsScreen(screen.Screen[str | None]):
         options: list[Option | None] = [
             Option("Start CLI task  \\[N]  (new task + run CLI)", id="task_start_cli"),
             Option("Start \\[W]eb task  (new task + run Web)", id="task_start_web"),
-            Option("\\[l]ogin to container", id="login"),
         ]
         if self._has_tasks:
+            options.append(Option("\\[l]ogin to container", id="login"))
             options.append(None)
             options.append(Option("run \\[c]li agent", id="cli"))
             options.append(Option("run \\[w]eb UI", id="web"))

--- a/src/luskctl/tui/screens.py
+++ b/src/luskctl/tui/screens.py
@@ -305,13 +305,13 @@ class TaskDetailsScreen(screen.Screen[str | None]):
         options: list[Option | None] = [
             Option("Start CLI task  \\[N]  (new task + run CLI)", id="task_start_cli"),
             Option("Start \\[W]eb task  (new task + run Web)", id="task_start_web"),
-            Option("[l]ogin to container", id="login"),
+            Option("\\[l]ogin to container", id="login"),
         ]
         if self._has_tasks:
             options.append(None)
-            options.append(Option("run [c]li agent", id="cli"))
-            options.append(Option("run [w]eb UI", id="web"))
-            options.append(Option("[r]estart container", id="restart"))
+            options.append(Option("run \\[c]li agent", id="cli"))
+            options.append(Option("run \\[w]eb UI", id="web"))
+            options.append(Option("\\[r]estart container", id="restart"))
             options.append(None)
             options.append(Option("Copy diff vs \\[H]EAD", id="diff_head"))
             options.append(Option("Copy diff vs \\[P]REV", id="diff_prev"))
@@ -398,6 +398,11 @@ class TaskDetailsScreen(screen.Screen[str | None]):
             self.dismiss("restart")
 
     def action_login(self) -> None:
+        """Dismiss the screen with a ``'login'`` result to trigger container login.
+
+        Only fires when the current project has tasks (``self._has_tasks``).
+        The parent ``LuskTUI`` handles the actual login dispatch.
+        """
         if self._has_tasks:
             self.dismiss("login")
 

--- a/src/luskctl/tui/widgets.py
+++ b/src/luskctl/tui/widgets.py
@@ -248,6 +248,7 @@ class TaskList(ListView):
         ("P", "app.copy_diff_prev", "Diff PREV"),
         ("c", "app.action_run_cli_from_main", "CLI"),
         ("w", "app.action_run_web_from_main", "Web"),
+        ("l", "app.action_login_from_main", "Login"),
         ("d", "app.action_delete_task_from_main", "Delete"),
     ]
 

--- a/src/luskctl/tui/widgets.py
+++ b/src/luskctl/tui/widgets.py
@@ -246,10 +246,10 @@ class TaskList(ListView):
         ("enter", "app.show_task_actions", "Task\u2026"),
         ("H", "app.copy_diff_head", "Diff HEAD"),
         ("P", "app.copy_diff_prev", "Diff PREV"),
-        ("c", "app.action_run_cli_from_main", "CLI"),
-        ("w", "app.action_run_web_from_main", "Web"),
-        ("l", "app.action_login_from_main", "Login"),
-        ("d", "app.action_delete_task_from_main", "Delete"),
+        ("c", "app.run_cli_from_main", "CLI"),
+        ("w", "app.run_web_from_main", "Web"),
+        ("l", "app.login_from_main", "Login"),
+        ("d", "app.delete_task_from_main", "Delete"),
     ]
 
     class TaskSelected(Message):

--- a/tests/cli/test_cli_workflows.py
+++ b/tests/cli/test_cli_workflows.py
@@ -108,3 +108,12 @@ class TaskStartTests(unittest.TestCase):
             main()
 
         mock_init.assert_called_once_with("myproj")
+
+    @unittest.mock.patch("luskctl.cli.main.task_login")
+    def test_login_dispatch(self, mock_login) -> None:
+        from luskctl.cli.main import main
+
+        with unittest.mock.patch("sys.argv", ["luskctl", "login", "proj1", "1"]):
+            main()
+
+        mock_login.assert_called_once_with("proj1", "1")

--- a/tests/lib/test_shell_launch.py
+++ b/tests/lib/test_shell_launch.py
@@ -54,7 +54,7 @@ class DetectTerminalTests(unittest.TestCase):
     """Tests for detect_terminal_emulator."""
 
     def test_gnome_terminal(self) -> None:
-        def which_side_effect(name: str):
+        def which_side_effect(name: str) -> str | None:
             return "/usr/bin/gnome-terminal" if name == "gnome-terminal" else None
 
         with unittest.mock.patch(
@@ -63,7 +63,7 @@ class DetectTerminalTests(unittest.TestCase):
             self.assertEqual(detect_terminal_emulator(), "gnome-terminal")
 
     def test_konsole_only(self) -> None:
-        def which_side_effect(name: str):
+        def which_side_effect(name: str) -> str | None:
             return "/usr/bin/konsole" if name == "konsole" else None
 
         with unittest.mock.patch(
@@ -80,7 +80,7 @@ class SpawnTerminalTests(unittest.TestCase):
     """Tests for spawn_terminal_with_command."""
 
     def test_gnome_terminal(self) -> None:
-        def which_side_effect(name: str):
+        def which_side_effect(name: str) -> str | None:
             return "/usr/bin/gnome-terminal" if name == "gnome-terminal" else None
 
         with (
@@ -97,7 +97,7 @@ class SpawnTerminalTests(unittest.TestCase):
             self.assertIn("--", call_args)
 
     def test_konsole(self) -> None:
-        def which_side_effect(name: str):
+        def which_side_effect(name: str) -> str | None:
             return "/usr/bin/konsole" if name == "konsole" else None
 
         with (

--- a/tests/lib/test_shell_launch.py
+++ b/tests/lib/test_shell_launch.py
@@ -1,0 +1,163 @@
+import subprocess
+import unittest
+import unittest.mock
+
+from luskctl.lib.shell_launch import (
+    detect_terminal_emulator,
+    is_inside_tmux,
+    launch_login,
+    spawn_terminal_with_command,
+    tmux_new_window,
+)
+
+
+class TmuxDetectionTests(unittest.TestCase):
+    """Tests for tmux environment detection."""
+
+    def test_is_inside_tmux_true(self) -> None:
+        with unittest.mock.patch.dict("os.environ", {"TMUX": "/tmp/tmux-1000/default,12345,0"}):
+            self.assertTrue(is_inside_tmux())
+
+    def test_is_inside_tmux_false(self) -> None:
+        with unittest.mock.patch.dict("os.environ", {}, clear=True):
+            self.assertFalse(is_inside_tmux())
+
+
+class TmuxNewWindowTests(unittest.TestCase):
+    """Tests for tmux_new_window."""
+
+    def test_success(self) -> None:
+        with unittest.mock.patch("luskctl.lib.shell_launch.subprocess.run") as mock_run:
+            mock_run.return_value = subprocess.CompletedProcess(args=[], returncode=0)
+            result = tmux_new_window(["podman", "exec", "-it", "c1", "bash"], title="login:c1")
+            self.assertTrue(result)
+            mock_run.assert_called_once()
+            call_args = mock_run.call_args[0][0]
+            self.assertEqual(call_args[:2], ["tmux", "new-window"])
+            self.assertIn("-n", call_args)
+            self.assertIn("login:c1", call_args)
+
+    def test_failure(self) -> None:
+        with unittest.mock.patch("luskctl.lib.shell_launch.subprocess.run") as mock_run:
+            mock_run.side_effect = subprocess.CalledProcessError(1, "tmux")
+            result = tmux_new_window(["podman", "exec", "-it", "c1", "bash"])
+            self.assertFalse(result)
+
+    def test_tmux_not_found(self) -> None:
+        with unittest.mock.patch("luskctl.lib.shell_launch.subprocess.run") as mock_run:
+            mock_run.side_effect = FileNotFoundError("tmux")
+            result = tmux_new_window(["echo", "hello"])
+            self.assertFalse(result)
+
+
+class DetectTerminalTests(unittest.TestCase):
+    """Tests for detect_terminal_emulator."""
+
+    def test_gnome_terminal(self) -> None:
+        def which_side_effect(name: str):
+            return "/usr/bin/gnome-terminal" if name == "gnome-terminal" else None
+
+        with unittest.mock.patch(
+            "luskctl.lib.shell_launch.shutil.which", side_effect=which_side_effect
+        ):
+            self.assertEqual(detect_terminal_emulator(), "gnome-terminal")
+
+    def test_konsole_only(self) -> None:
+        def which_side_effect(name: str):
+            return "/usr/bin/konsole" if name == "konsole" else None
+
+        with unittest.mock.patch(
+            "luskctl.lib.shell_launch.shutil.which", side_effect=which_side_effect
+        ):
+            self.assertEqual(detect_terminal_emulator(), "konsole")
+
+    def test_none_available(self) -> None:
+        with unittest.mock.patch("luskctl.lib.shell_launch.shutil.which", return_value=None):
+            self.assertIsNone(detect_terminal_emulator())
+
+
+class SpawnTerminalTests(unittest.TestCase):
+    """Tests for spawn_terminal_with_command."""
+
+    def test_gnome_terminal(self) -> None:
+        def which_side_effect(name: str):
+            return "/usr/bin/gnome-terminal" if name == "gnome-terminal" else None
+
+        with (
+            unittest.mock.patch(
+                "luskctl.lib.shell_launch.shutil.which", side_effect=which_side_effect
+            ),
+            unittest.mock.patch("luskctl.lib.shell_launch.subprocess.Popen") as mock_popen,
+        ):
+            result = spawn_terminal_with_command(["podman", "exec", "-it", "c1", "bash"])
+            self.assertTrue(result)
+            mock_popen.assert_called_once()
+            call_args = mock_popen.call_args[0][0]
+            self.assertEqual(call_args[0], "gnome-terminal")
+            self.assertIn("--", call_args)
+
+    def test_konsole(self) -> None:
+        def which_side_effect(name: str):
+            return "/usr/bin/konsole" if name == "konsole" else None
+
+        with (
+            unittest.mock.patch(
+                "luskctl.lib.shell_launch.shutil.which", side_effect=which_side_effect
+            ),
+            unittest.mock.patch("luskctl.lib.shell_launch.subprocess.Popen") as mock_popen,
+        ):
+            result = spawn_terminal_with_command(["podman", "exec", "-it", "c1", "bash"])
+            self.assertTrue(result)
+            mock_popen.assert_called_once()
+            call_args = mock_popen.call_args[0][0]
+            self.assertEqual(call_args[0], "konsole")
+            self.assertIn("-e", call_args)
+
+    def test_no_terminal(self) -> None:
+        with unittest.mock.patch("luskctl.lib.shell_launch.shutil.which", return_value=None):
+            result = spawn_terminal_with_command(["echo", "hello"])
+            self.assertFalse(result)
+
+
+class LaunchLoginTests(unittest.TestCase):
+    """Tests for the launch_login orchestrator."""
+
+    def test_prefers_tmux(self) -> None:
+        """When inside tmux and terminal is available, tmux is preferred."""
+        with (
+            unittest.mock.patch("luskctl.lib.shell_launch.is_inside_tmux", return_value=True),
+            unittest.mock.patch("luskctl.lib.shell_launch.tmux_new_window", return_value=True),
+            unittest.mock.patch(
+                "luskctl.lib.shell_launch.detect_terminal_emulator",
+                return_value="gnome-terminal",
+            ),
+        ):
+            method, port = launch_login(["podman", "exec", "-it", "c1", "bash"])
+            self.assertEqual(method, "tmux")
+            self.assertIsNone(port)
+
+    def test_falls_back_to_terminal(self) -> None:
+        """When not inside tmux but terminal is available, use terminal."""
+        with (
+            unittest.mock.patch("luskctl.lib.shell_launch.is_inside_tmux", return_value=False),
+            unittest.mock.patch("luskctl.lib.shell_launch.is_web_mode", return_value=False),
+            unittest.mock.patch(
+                "luskctl.lib.shell_launch.spawn_terminal_with_command", return_value=True
+            ),
+        ):
+            method, port = launch_login(["podman", "exec", "-it", "c1", "bash"])
+            self.assertEqual(method, "terminal")
+            self.assertIsNone(port)
+
+    def test_returns_none_when_nothing_available(self) -> None:
+        """When no method is available, return ('none', None)."""
+        with (
+            unittest.mock.patch("luskctl.lib.shell_launch.is_inside_tmux", return_value=False),
+            unittest.mock.patch("luskctl.lib.shell_launch.is_web_mode", return_value=False),
+            unittest.mock.patch(
+                "luskctl.lib.shell_launch.spawn_terminal_with_command", return_value=False
+            ),
+        ):
+            method, port = launch_login(["podman", "exec", "-it", "c1", "bash"])
+            self.assertEqual(method, "none")
+            self.assertIsNone(port)

--- a/tests/lib/test_shell_launch.py
+++ b/tests/lib/test_shell_launch.py
@@ -161,3 +161,31 @@ class LaunchLoginTests(unittest.TestCase):
             method, port = launch_login(["podman", "exec", "-it", "c1", "bash"])
             self.assertEqual(method, "none")
             self.assertIsNone(port)
+
+    def test_web_mode_with_ttyd(self) -> None:
+        """In web mode with ttyd available, launch_login returns ('web', port)."""
+        with (
+            unittest.mock.patch("luskctl.lib.shell_launch.is_inside_tmux", return_value=False),
+            unittest.mock.patch("luskctl.lib.shell_launch.is_web_mode", return_value=True),
+            unittest.mock.patch(
+                "luskctl.lib.shell_launch.spawn_terminal_with_command", return_value=False
+            ),
+            unittest.mock.patch("luskctl.lib.shell_launch.spawn_ttyd", return_value=12345),
+        ):
+            method, port = launch_login(["podman", "exec", "-it", "c1", "bash"])
+            self.assertEqual(method, "web")
+            self.assertEqual(port, 12345)
+
+    def test_web_mode_ttyd_unavailable_falls_back(self) -> None:
+        """In web mode without ttyd, launch_login falls back to ('none', None)."""
+        with (
+            unittest.mock.patch("luskctl.lib.shell_launch.is_inside_tmux", return_value=False),
+            unittest.mock.patch("luskctl.lib.shell_launch.is_web_mode", return_value=True),
+            unittest.mock.patch(
+                "luskctl.lib.shell_launch.spawn_terminal_with_command", return_value=False
+            ),
+            unittest.mock.patch("luskctl.lib.shell_launch.spawn_ttyd", return_value=None),
+        ):
+            method, port = launch_login(["podman", "exec", "-it", "c1", "bash"])
+            self.assertEqual(method, "none")
+            self.assertIsNone(port)

--- a/tests/lib/test_tasks.py
+++ b/tests/lib/test_tasks.py
@@ -19,8 +19,10 @@ from luskctl.lib.projects import load_project
 from luskctl.lib.tasks import (
     _apply_web_env_overrides,
     _build_task_env_and_volumes,
+    get_login_command,
     get_workspace_git_diff,
     task_delete,
+    task_login,
     task_new,
     task_restart,
     task_run_cli,
@@ -1489,3 +1491,212 @@ class ContainerLifecycleTests(unittest.TestCase):
                     state = get_task_container_state(project_id, "1", "cli")
                     self.assertEqual(state, "running")
                     mock_state.assert_called_once_with(f"{project_id}-cli-1")
+
+
+class LoginTests(unittest.TestCase):
+    """Tests for task_login, get_login_command, and _validate_login."""
+
+    def _setup_project_with_task(
+        self, base: Path, project_id: str, *, mode: str | None = None
+    ) -> Path:
+        """Create a project and task, optionally setting the mode in metadata."""
+        config_root = base / "config"
+        state_dir = base / "state"
+        config_root.mkdir(parents=True, exist_ok=True)
+
+        write_project(
+            config_root,
+            project_id,
+            f"project:\n  id: {project_id}\n",
+        )
+
+        with unittest.mock.patch.dict(
+            os.environ,
+            {
+                "LUSKCTL_CONFIG_DIR": str(config_root),
+                "LUSKCTL_STATE_DIR": str(state_dir),
+            },
+        ):
+            task_new(project_id)
+
+        if mode:
+            meta_dir = state_dir / "projects" / project_id / "tasks"
+            meta_path = meta_dir / "1.yml"
+            meta = yaml.safe_load(meta_path.read_text())
+            meta["mode"] = mode
+            meta_path.write_text(yaml.safe_dump(meta))
+
+        return state_dir
+
+    def test_task_login_unknown_task(self) -> None:
+        """task_login raises SystemExit for non-existent task."""
+        with tempfile.TemporaryDirectory() as td:
+            base = Path(td)
+            config_root = base / "config"
+            state_dir = base / "state"
+            config_root.mkdir(parents=True, exist_ok=True)
+
+            project_id = "proj_login_unknown"
+            write_project(
+                config_root,
+                project_id,
+                f"project:\n  id: {project_id}\n",
+            )
+
+            with unittest.mock.patch.dict(
+                os.environ,
+                {
+                    "LUSKCTL_CONFIG_DIR": str(config_root),
+                    "LUSKCTL_STATE_DIR": str(state_dir),
+                },
+            ):
+                with self.assertRaises(SystemExit) as ctx:
+                    task_login(project_id, "999")
+                self.assertIn("Unknown task", str(ctx.exception))
+
+    def test_task_login_no_mode(self) -> None:
+        """task_login raises SystemExit when task has never been run (no mode)."""
+        with tempfile.TemporaryDirectory() as td:
+            base = Path(td)
+            state_dir = self._setup_project_with_task(base, "proj_login_nomode")
+
+            with unittest.mock.patch.dict(
+                os.environ,
+                {
+                    "LUSKCTL_CONFIG_DIR": str(base / "config"),
+                    "LUSKCTL_STATE_DIR": str(state_dir),
+                },
+            ):
+                with self.assertRaises(SystemExit) as ctx:
+                    task_login("proj_login_nomode", "1")
+                self.assertIn("never been run", str(ctx.exception))
+
+    def test_task_login_container_not_found(self) -> None:
+        """task_login raises SystemExit when container does not exist."""
+        with tempfile.TemporaryDirectory() as td:
+            base = Path(td)
+            state_dir = self._setup_project_with_task(base, "proj_login_nf", mode="cli")
+
+            with unittest.mock.patch.dict(
+                os.environ,
+                {
+                    "LUSKCTL_CONFIG_DIR": str(base / "config"),
+                    "LUSKCTL_STATE_DIR": str(state_dir),
+                },
+            ):
+                with unittest.mock.patch(
+                    "luskctl.lib.tasks._get_container_state", return_value=None
+                ):
+                    with self.assertRaises(SystemExit) as ctx:
+                        task_login("proj_login_nf", "1")
+                    self.assertIn("does not exist", str(ctx.exception))
+
+    def test_task_login_container_not_running(self) -> None:
+        """task_login raises SystemExit when container is not running."""
+        with tempfile.TemporaryDirectory() as td:
+            base = Path(td)
+            state_dir = self._setup_project_with_task(base, "proj_login_nr", mode="cli")
+
+            with unittest.mock.patch.dict(
+                os.environ,
+                {
+                    "LUSKCTL_CONFIG_DIR": str(base / "config"),
+                    "LUSKCTL_STATE_DIR": str(state_dir),
+                },
+            ):
+                with unittest.mock.patch(
+                    "luskctl.lib.tasks._get_container_state", return_value="exited"
+                ):
+                    with self.assertRaises(SystemExit) as ctx:
+                        task_login("proj_login_nr", "1")
+                    self.assertIn("not running", str(ctx.exception))
+
+    def test_task_login_success(self) -> None:
+        """task_login calls os.execvp with correct podman+tmux command."""
+        with tempfile.TemporaryDirectory() as td:
+            base = Path(td)
+            state_dir = self._setup_project_with_task(base, "proj_login_ok", mode="cli")
+
+            with unittest.mock.patch.dict(
+                os.environ,
+                {
+                    "LUSKCTL_CONFIG_DIR": str(base / "config"),
+                    "LUSKCTL_STATE_DIR": str(state_dir),
+                },
+            ):
+                with (
+                    unittest.mock.patch(
+                        "luskctl.lib.tasks._get_container_state",
+                        return_value="running",
+                    ),
+                    unittest.mock.patch("luskctl.lib.tasks.os.execvp") as mock_exec,
+                ):
+                    task_login("proj_login_ok", "1")
+
+                    mock_exec.assert_called_once_with(
+                        "podman",
+                        [
+                            "podman",
+                            "exec",
+                            "-it",
+                            "proj_login_ok-cli-1",
+                            "tmux",
+                            "new-session",
+                            "-A",
+                            "-s",
+                            "main",
+                        ],
+                    )
+
+    def test_get_login_command_returns_list(self) -> None:
+        """get_login_command returns correct command list for CLI-mode task."""
+        with tempfile.TemporaryDirectory() as td:
+            base = Path(td)
+            state_dir = self._setup_project_with_task(base, "proj_logincmd", mode="cli")
+
+            with unittest.mock.patch.dict(
+                os.environ,
+                {
+                    "LUSKCTL_CONFIG_DIR": str(base / "config"),
+                    "LUSKCTL_STATE_DIR": str(state_dir),
+                },
+            ):
+                with unittest.mock.patch(
+                    "luskctl.lib.tasks._get_container_state",
+                    return_value="running",
+                ):
+                    cmd = get_login_command("proj_logincmd", "1")
+                    self.assertEqual(
+                        cmd,
+                        [
+                            "podman",
+                            "exec",
+                            "-it",
+                            "proj_logincmd-cli-1",
+                            "tmux",
+                            "new-session",
+                            "-A",
+                            "-s",
+                            "main",
+                        ],
+                    )
+
+    def test_get_login_command_web_mode(self) -> None:
+        """get_login_command uses web mode container name when mode is web."""
+        with tempfile.TemporaryDirectory() as td:
+            base = Path(td)
+            state_dir = self._setup_project_with_task(base, "proj_loginweb", mode="web")
+
+            with unittest.mock.patch.dict(
+                os.environ,
+                {
+                    "LUSKCTL_CONFIG_DIR": str(base / "config"),
+                    "LUSKCTL_STATE_DIR": str(state_dir),
+                },
+            ):
+                with unittest.mock.patch(
+                    "luskctl.lib.tasks._get_container_state",
+                    return_value="running",
+                ):
+                    cmd = get_login_command("proj_loginweb", "1")
+                    self.assertEqual(cmd[3], "proj_loginweb-web-1")


### PR DESCRIPTION
Adds first-class container login: `luskctl login <project> <task>` CLI command, TUI `l` keybind with smart dispatch (tmux > desktop terminal > web tab > suspend), tmux baked into container images for persistent sessions, and `luskctl-tui --tmux` for opt-in host tmux wrapping with guided status bars (blue host ^b, green container ^a).

New files: shell_launch.py (dispatch logic), LOGIN_DESIGN.md (architecture), tmux configs (host/container). 22 new tests covering login validation, shell launch, and CLI dispatch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New login workflow: luskctl login <project> <task> and TUI "Login" (key 'l') with automatic backend selection (host tmux, container tmux, desktop terminal, or web/ttyd); CLI --tmux mode to launch TUI inside host tmux; packaged tmux configs and container support for persistent sessions and distinct host/container prefixes.

* **Documentation**
  * New design doc and expanded usage guide with Step 8, prerequisites, tmux tips, and UX flows.

* **Tests**
  * Added unit tests for CLI dispatch, shell-launch backends, and login validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
