### PR TITLE
Set UTF-8 locale defaults in base image

### DIFF
--- a/src/luskctl/resources/templates/l0.dev.Dockerfile.template
+++ b/src/luskctl/resources/templates/l0.dev.Dockerfile.template
@@ -5,6 +5,8 @@ FROM ${BASE_IMAGE}
 ENV DEBIAN_FRONTEND=noninteractive \
     REPO_ROOT="/workspace" \
     GIT_RESET_MODE="none" \
+    LANG="C.UTF-8" \
+    LC_ALL="C.UTF-8" \
     USER="dev"
 
 # Basic dev tooling common to all projects

--- a/tests/lib/test_docker.py
+++ b/tests/lib/test_docker.py
@@ -43,6 +43,10 @@ class DockerTests(unittest.TestCase):
                 self.assertTrue(l1_ui.is_file())
                 self.assertTrue(l2.is_file())
 
+                l0_content = l0.read_text(encoding="utf-8")
+                self.assertIn('LANG="C.UTF-8"', l0_content)
+                self.assertIn('LC_ALL="C.UTF-8"', l0_content)
+
                 content = l2.read_text(encoding="utf-8")
                 self.assertIn(f'SSH_KEY_NAME="id_ed25519_{project_id}"', content)
                 self.assertNotIn("{{DEFAULT_BRANCH}}", content)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Docker container configuration now includes LANG and LC_ALL environment variables set to C.UTF-8.

* **Tests**
  * Added test to verify Docker images include proper locale environment variable configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->