### PR TITLE
Scope 'New Project' shortcut to project pane only

### DIFF
--- a/src/luskctl/tui/app.py
+++ b/src/luskctl/tui/app.py
@@ -135,7 +135,6 @@ if _HAS_TEXTUAL:
 
         BINDINGS = [
             ("q", "quit", "Quit"),
-            ("n", "new_project_wizard", "New Project"),
         ]
 
         def __init__(self) -> None:

--- a/src/luskctl/tui/widgets.py
+++ b/src/luskctl/tui/widgets.py
@@ -101,6 +101,7 @@ class ProjectList(ListView):
     # is dispatched to the App instance.
     BINDINGS = [
         ("enter", "app.show_project_actions", "Project\u2026"),
+        ("n", "app.new_project_wizard", "New Project"),
     ]
 
     class ProjectSelected(Message):


### PR DESCRIPTION
Move the 'n' keybinding from app-level BINDINGS to ProjectList widget so it only appears in the footer when the project list has focus.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Adjusted the keyboard shortcut for creating new projects to function within the project list context.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->