### PR TITLE
Fix autopilot: add --verbose flag to claude command when using --output-format stream-json

### DIFF
--- a/src/luskctl/lib/tasks.py
+++ b/src/luskctl/lib/tasks.py
@@ -888,7 +888,7 @@ def task_run_headless(
     headless_cmd = (
         f"init-ssh-and-repo.sh && timeout {effective_timeout} claude -p "
         '"$(cat /home/dev/.luskctl/prompt.txt)"'
-        f"{claude_flags} --output-format stream-json"
+        f"{claude_flags} --output-format stream-json --verbose"
     )
     cmd: list[str] = ["podman", "run", "-d"]
     cmd += _podman_userns_args()


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced verbose output for headless Claude invocation to provide more detailed runtime information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->