### PR TITLE
Fix UTF-8 locale generation in container images

### DIFF
--- a/src/luskctl/resources/templates/l0.dev.Dockerfile.template
+++ b/src/luskctl/resources/templates/l0.dev.Dockerfile.template
@@ -5,15 +5,22 @@ FROM ${BASE_IMAGE}
 ENV DEBIAN_FRONTEND=noninteractive \
     REPO_ROOT="/workspace" \
     GIT_RESET_MODE="none" \
-    LANG="C.UTF-8" \
-    LC_ALL="C.UTF-8" \
+    LANG="en_US.UTF-8" \
+    LC_ALL="en_US.UTF-8" \
+    LANGUAGE="en_US:en" \
     USER="dev"
 
 # Basic dev tooling common to all projects
 RUN apt-get update && apt-get install -y --no-install-recommends \
-      ca-certificates curl gnupg git openssh-client sudo \
+      ca-certificates curl gnupg git locales openssh-client sudo \
       ripgrep vim tmux \
     && rm -rf /var/lib/apt/lists/*
+
+# Ensure en_US.UTF-8 exists so bash and agent-spawned shells can always set LC_ALL safely.
+RUN set -eux; \
+    sed -i 's/^# *en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen; \
+    grep -q '^en_US.UTF-8 UTF-8' /etc/locale.gen || echo 'en_US.UTF-8 UTF-8' >> /etc/locale.gen; \
+    locale-gen en_US.UTF-8
 
 RUN set -eux; \
     uid_owner="$(getent passwd 1000 | cut -d: -f1 || true)"; \

--- a/tests/lib/test_docker.py
+++ b/tests/lib/test_docker.py
@@ -44,8 +44,11 @@ class DockerTests(unittest.TestCase):
                 self.assertTrue(l2.is_file())
 
                 l0_content = l0.read_text(encoding="utf-8")
-                self.assertIn('LANG="C.UTF-8"', l0_content)
-                self.assertIn('LC_ALL="C.UTF-8"', l0_content)
+                self.assertIn('LANG="en_US.UTF-8"', l0_content)
+                self.assertIn('LC_ALL="en_US.UTF-8"', l0_content)
+                self.assertIn('LANGUAGE="en_US:en"', l0_content)
+                self.assertIn("locales", l0_content)
+                self.assertIn("locale-gen en_US.UTF-8", l0_content)
 
                 content = l2.read_text(encoding="utf-8")
                 self.assertIn(f'SSH_KEY_NAME="id_ed25519_{project_id}"', content)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Docker container locale configuration to use en_US.UTF-8 with proper locale generation and environment variable setup.

* **Tests**
  * Updated test validation to verify correct English (US) locale configuration in Docker containers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->