### PR TITLE
Add Dependabot configuration for automated dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,6 @@
 version: 2
 updates:
-  # Python dependencies (Poetry)
+  # Python dependencies (pip ecosystem covers Poetry/pyproject.toml)
   - package-ecosystem: "pip"
     directory: "/"
     schedule:


### PR DESCRIPTION
Weekly Monday checks for Python (pip/Poetry) dependencies with grouped PRs (production vs dev) and GitHub Actions version pins.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Configured automated dependency updates to run weekly on Mondays.
  * Enabled updates for Python package dependencies and GitHub Actions.
  * Split Python updates into production and development groups for separate handling.
  * Standardized commit message prefixes for dependency and CI update commits.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->