### PR TITLE
Auto-build missing L0/L1 images and pause for SSH key registration

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,6 +11,7 @@
 - **Container Runtime**: Podman
 - **Testing**: pytest with coverage
 - **Linting/Formatting**: ruff
+- **Module Boundaries**: tach (enforced in CI via `tach.toml`)
 - **Documentation**: MkDocs with Material theme
 - **TUI Framework**: Textual
 
@@ -32,7 +33,8 @@ make format    # Auto-fix lint issues if lint fails
 **Before pushing:**
 ```bash
 make test      # Run full test suite with coverage
-make check     # Run both lint and test (equivalent to CI)
+make tach      # Check module boundary rules (tach.toml)
+make check     # Run lint + test + tach (equivalent to CI)
 ```
 
 **When `pyproject.toml` changes** (added/removed/changed dependencies):
@@ -65,8 +67,9 @@ make clean        # Remove build artifacts
 2. Run `make lint` frequently during development
 3. Add/update tests in `tests/` directory
 4. Run `make test` to verify changes
-5. Update documentation in `docs/` if needed
-6. Run `make check` before pushing
+5. If you added or changed cross-module imports, run `make tach` to verify module boundary rules
+6. Update documentation in `docs/` if needed
+7. Run `make check` before pushing
 
 ## Key Guidelines
 
@@ -76,10 +79,19 @@ make clean        # Remove build artifacts
 - **Existing Tests**: Never remove or modify unrelated tests
 - **Dependencies**: Use Poetry for dependency management; avoid adding unnecessary dependencies
 
+## Module Boundaries (tach)
+
+The project uses [tach](https://github.com/gauge-sh/tach) to enforce module boundary rules defined in `tach.toml`. Each module declares its allowed dependencies and public interface. When adding new cross-module imports:
+
+- If importing from an existing dependency, ensure the symbol is in that module's `[[interfaces]]` `expose` list
+- If adding a new dependency between modules, add it to the `depends_on` list and update `[[interfaces]]` as needed
+- Run `make tach` (or `tach check`) to verify; CI will reject boundary violations
+
 ## Important Files
 
 - `docs/DEVELOPER.md`: Detailed architecture and implementation guide
 - `docs/USAGE.md`: Complete user documentation
 - `Makefile`: Build and test automation
 - `pyproject.toml`: Project configuration and dependencies
+- `tach.toml`: Module boundary rules (enforced in CI)
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: lint format test check install install-dev clean
+.PHONY: lint format test tach check install install-dev clean
 
 # Run linter and format checker (fast, run before commits)
 lint:
@@ -14,8 +14,12 @@ format:
 test:
 	poetry run pytest --cov=luskctl --cov-report=term-missing
 
+# Check module boundary rules (tach.toml)
+tach:
+	tach check
+
 # Run all checks (equivalent to CI)
-check: lint test
+check: lint test tach
 
 # Install runtime dependencies only
 install:

--- a/docs/DEVELOPER.md
+++ b/docs/DEVELOPER.md
@@ -156,10 +156,16 @@ Tests are written using `unittest` and run with `pytest`.
 make test      # Run full test suite with coverage
 ```
 
-To run both (equivalent to CI):
+**Check module boundaries** if you changed cross-module imports:
 
 ```bash
-make check     # Runs lint + test
+make tach      # Verify tach.toml boundary rules
+```
+
+To run all checks (equivalent to CI):
+
+```bash
+make check     # Runs lint + test + tach
 ```
 
 ### Available Make Targets
@@ -169,7 +175,8 @@ make check     # Runs lint + test
 | `make lint` | Check linting and formatting | Before every commit |
 | `make format` | Auto-fix lint issues and format | When lint fails |
 | `make test` | Run tests with coverage | Before pushing |
-| `make check` | Run lint + test | Before opening a PR |
+| `make tach` | Check module boundary rules | After changing imports |
+| `make check` | Run lint + test + tach | Before opening a PR |
 | `make docs` | Serve documentation locally | When editing docs |
 | `make install-dev` | Install all dependencies | Initial setup |
 | `make clean` | Remove build artifacts | When needed |

--- a/src/luskctl/cli/main.py
+++ b/src/luskctl/cli/main.py
@@ -42,6 +42,7 @@ from ..lib.facade import (
     codex_auth,
     generate_dockerfiles,
     init_project_ssh,
+    maybe_pause_for_ssh_key_registration,
     mistral_auth,
     sync_project_gate,
 )
@@ -119,6 +120,7 @@ def _cmd_project_init(project_id: str) -> None:
     """Full project setup: ssh-init, generate, build, gate-sync."""
     print("==> Initializing SSH...")
     init_project_ssh(project_id)
+    maybe_pause_for_ssh_key_registration(project_id)
 
     print("==> Generating Dockerfiles...")
     generate_dockerfiles(project_id)

--- a/src/luskctl/lib/facade.py
+++ b/src/luskctl/lib/facade.py
@@ -11,6 +11,7 @@ helpers for multi-step workflows like project initialization.
 from .containers.docker import build_images, generate_dockerfiles
 from .containers.environment import WEB_BACKENDS
 from .containers.project_state import get_project_state, is_task_image_old
+from .core.projects import load_project
 from .security.auth import blablador_auth, claude_auth, codex_auth, mistral_auth
 from .security.git_gate import (
     GateStalenessInfo,
@@ -22,6 +23,23 @@ from .security.git_gate import (
 )
 from .security.ssh import init_project_ssh
 
+
+def maybe_pause_for_ssh_key_registration(project_id: str) -> None:
+    """If the project's upstream uses SSH, pause so the user can register the deploy key.
+
+    Call this right after ``init_project_ssh()`` — the public key will already
+    have been printed to the terminal.  For HTTPS upstreams this is a no-op.
+    """
+    project = load_project(project_id)
+    upstream = project.upstream_url or ""
+    if upstream.startswith("git@") or upstream.startswith("ssh://"):
+        print("\n" + "=" * 60)
+        print("ACTION REQUIRED: Add the public key shown above as a")
+        print("deploy key (or to your SSH keys) on the git remote.")
+        print("=" * 60)
+        input("Press Enter once the key is registered... ")
+
+
 __all__ = [
     # Docker / image management
     "generate_dockerfiles",
@@ -31,6 +49,8 @@ __all__ = [
     # Security setup
     "init_project_ssh",
     "sync_project_gate",
+    # Workflow helpers
+    "maybe_pause_for_ssh_key_registration",
     # Auth providers
     "codex_auth",
     "claude_auth",

--- a/src/luskctl/tui/actions.py
+++ b/src/luskctl/tui/actions.py
@@ -37,6 +37,7 @@ from ..lib.facade import (
     codex_auth,
     generate_dockerfiles,
     init_project_ssh,
+    maybe_pause_for_ssh_key_registration,
     mistral_auth,
     sync_project_gate,
 )
@@ -218,6 +219,8 @@ class ActionsMixin:
                 print(f"=== Full Setup for {pid} ===\n")
                 print("Step 1/4: Initializing SSH...")
                 init_project_ssh(pid)
+                maybe_pause_for_ssh_key_registration(pid)
+
                 print("\nStep 2/4: Generating Dockerfiles...")
                 generate_dockerfiles(pid)
                 print("\nStep 3/4: Building images...")

--- a/tach.toml
+++ b/tach.toml
@@ -72,6 +72,7 @@ depends_on = [
     "luskctl.lib.containers.docker",
     "luskctl.lib.containers.environment",
     "luskctl.lib.containers.project_state",
+    "luskctl.lib.core.projects",
     "luskctl.lib.security.auth",
     "luskctl.lib.security.git_gate",
     "luskctl.lib.security.ssh",
@@ -485,6 +486,7 @@ expose = [
     "find_projects_sharing_gate",
     "get_project_state",
     "is_task_image_old",
+    "maybe_pause_for_ssh_key_registration",
 ]
 from = ["luskctl.lib.facade"]
 

--- a/tests/lib/test_docker.py
+++ b/tests/lib/test_docker.py
@@ -116,7 +116,10 @@ git:
                 result.returncode = 0
                 return result
 
-            with unittest.mock.patch("subprocess.run", side_effect=mock_run):
+            with (
+                unittest.mock.patch("subprocess.run", side_effect=mock_run),
+                unittest.mock.patch("luskctl.lib.containers.docker._check_podman_available"),
+            ):
                 # Test default (L2 only)
                 build_commands.clear()
                 build_images(project_id)


### PR DESCRIPTION
build_images() now checks if L0/L1 images exist locally before building L2. If missing, they are built automatically, so first-time builds and cross-project setups work without requiring --agents. Subsequent builds with the same base image skip L0/L1 (fast path).

project-init (CLI and TUI) now pauses after SSH key generation when the upstream URL uses SSH, giving the user a chance to register the deploy key at the remote before gate-sync attempts to clone.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Project initialization now detects SSH upstream repositories and prompts users to register SSH keys (pauses until confirmed).
  * Local build tooling now checks container tooling availability and auto-detects missing base images to skip or include base-layer rebuilds.

* **Tests**
  * Added and updated tests covering SSH vs HTTPS project init behavior and container build checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->