### PR TITLE
Fix task restart to actually restart running containers

### DIFF
--- a/src/luskctl/tui/actions.py
+++ b/src/luskctl/tui/actions.py
@@ -517,7 +517,7 @@ class ActionsMixin:
             await self.refresh_tasks()
 
     async def _action_restart_task(self) -> None:
-        """Restart a stopped task container."""
+        """Restart a task container (stops it first if running)."""
         if not self.current_project_id or not self.current_task:
             self.notify("No task selected.")
             return


### PR DESCRIPTION
Previously `task_restart` on a running container was a no-op that only printed "already running". Now it stops the container first and then starts it again, making it a true restart for both running and stopped containers.