### PR TITLE
Add gh and glab CLI tools to luskctl containers

### DIFF
--- a/src/luskctl/cli/main.py
+++ b/src/luskctl/cli/main.py
@@ -41,6 +41,8 @@ from ..lib.facade import (
     claude_auth,
     codex_auth,
     generate_dockerfiles,
+    gh_auth,
+    glab_auth,
     init_project_ssh,
     maybe_pause_for_ssh_key_registration,
     mistral_auth,
@@ -480,6 +482,28 @@ def main() -> None:
     except Exception:
         pass
 
+    # auth-gh
+    p_auth_gh = sub.add_parser(
+        "auth-gh",
+        help="Authenticate GitHub CLI (gh) inside an L2 CLI container",
+    )
+    _a = p_auth_gh.add_argument("project_id")
+    try:
+        _a.completer = _complete_project_ids  # type: ignore[attr-defined]
+    except Exception:
+        pass
+
+    # auth-glab
+    p_auth_glab = sub.add_parser(
+        "auth-glab",
+        help="Authenticate GitLab CLI (glab) inside an L2 CLI container",
+    )
+    _a = p_auth_glab.add_argument("project_id")
+    try:
+        _a.completer = _complete_project_ids  # type: ignore[attr-defined]
+    except Exception:
+        pass
+
     # login (top-level shortcut)
     p_login = sub.add_parser("login", help="Open interactive shell in a running task container")
     _a = p_login.add_argument("project_id")
@@ -723,6 +747,10 @@ def main() -> None:
         claude_auth(args.project_id)
     elif args.cmd == "auth-blablador":
         blablador_auth(args.project_id)
+    elif args.cmd == "auth-gh":
+        gh_auth(args.project_id)
+    elif args.cmd == "auth-glab":
+        glab_auth(args.project_id)
     elif args.cmd == "config":
         _print_config()
     elif args.cmd == "config-show":

--- a/src/luskctl/lib/containers/environment.py
+++ b/src/luskctl/lib/containers/environment.py
@@ -93,6 +93,8 @@ def _shared_config_dirs(envs_base: Path) -> dict[str, Path]:
         "opencode_config": envs_base / "_opencode-config",
         "opencode_data": envs_base / "_opencode-data",
         "opencode_state": envs_base / "_opencode-state",
+        "gh": envs_base / "_gh-config",
+        "glab": envs_base / "_glab-config",
     }
     labels = {
         "codex": "Codex config",
@@ -102,6 +104,8 @@ def _shared_config_dirs(envs_base: Path) -> dict[str, Path]:
         "opencode_config": "OpenCode config",
         "opencode_data": "OpenCode data",
         "opencode_state": "OpenCode state",
+        "gh": "GitHub CLI config",
+        "glab": "GitLab CLI config",
     }
     for key, path in dirs.items():
         ensure_dir_writable(path, labels[key])
@@ -118,6 +122,8 @@ def _shared_volume_mounts(config_dirs: dict[str, Path]) -> list[str]:
         f"{config_dirs['opencode_config']}:/home/dev/.config/opencode:z",
         f"{config_dirs['opencode_data']}:/home/dev/.local/share/opencode:z",
         f"{config_dirs['opencode_state']}:/home/dev/.local/state:z",
+        f"{config_dirs['gh']}:/home/dev/.config/gh:z",
+        f"{config_dirs['glab']}:/home/dev/.config/glab-cli:z",
     ]
 
 

--- a/src/luskctl/lib/facade.py
+++ b/src/luskctl/lib/facade.py
@@ -12,7 +12,7 @@ from .containers.docker import build_images, generate_dockerfiles
 from .containers.environment import WEB_BACKENDS
 from .containers.project_state import get_project_state, is_task_image_old
 from .core.projects import load_project
-from .security.auth import blablador_auth, claude_auth, codex_auth, mistral_auth
+from .security.auth import blablador_auth, claude_auth, codex_auth, gh_auth, glab_auth, mistral_auth
 from .security.git_gate import (
     GateStalenessInfo,
     compare_gate_vs_upstream,
@@ -56,6 +56,8 @@ __all__ = [
     "claude_auth",
     "mistral_auth",
     "blablador_auth",
+    "gh_auth",
+    "glab_auth",
     # Git gate
     "compare_gate_vs_upstream",
     "sync_gate_branches",

--- a/src/luskctl/lib/security/auth.py
+++ b/src/luskctl/lib/security/auth.py
@@ -1,9 +1,10 @@
 """Authentication workflows for AI coding agents.
 
-Each public function (codex_auth, claude_auth, mistral_auth, blablador_auth)
-sets up credentials for a specific agent inside a temporary L2 CLI container.
-The shared helper ``_run_auth_container`` handles the common lifecycle:
-check podman, load project, ensure host dir, cleanup old container, run.
+Each public function (codex_auth, claude_auth, mistral_auth, blablador_auth,
+gh_auth, glab_auth) sets up credentials for a specific agent inside a
+temporary L2 CLI container.  The shared helper ``_run_auth_container``
+handles the common lifecycle: check podman, load project, ensure host dir,
+cleanup old container, run.
 """
 
 import shutil
@@ -263,6 +264,65 @@ def blablador_auth(project_id: str) -> None:
             "",
             "You will be prompted to enter your Blablador API key.",
             "Get your API key at: https://codebase.helmholtz.cloud/-/user_settings/personal_access_tokens",
+            "",
+        ],
+    )
+
+
+# ---------- GitHub CLI authentication ----------
+
+
+def gh_auth(project_id: str) -> None:
+    """Run ``gh auth login`` inside the L2 CLI container.
+
+    This command:
+    - Spins up a temporary L2 CLI container for the project
+    - Mounts the shared GitHub CLI config directory (~/.config/gh)
+    - Runs ``gh auth login`` interactively (device flow or paste a token)
+    - The authentication persists in the shared config folder
+    """
+    _run_auth_container(
+        project_id=project_id,
+        container_suffix="auth-gh",
+        host_dir_name="_gh-config",
+        host_dir_label="GitHub CLI config",
+        container_mount="/home/dev/.config/gh",
+        command=["gh", "auth", "login"],
+        banner_lines=[
+            f"Authenticating GitHub CLI for project: {project_id}",
+            "",
+            "You will be guided through GitHub authentication.",
+            "Recommended: choose 'Login with a web browser' or paste a token.",
+            "",
+        ],
+    )
+
+
+# ---------- GitLab CLI authentication ----------
+
+
+def glab_auth(project_id: str) -> None:
+    """Run ``glab auth login`` inside the L2 CLI container.
+
+    This command:
+    - Spins up a temporary L2 CLI container for the project
+    - Mounts the shared GitLab CLI config directory (~/.config/glab-cli)
+    - Runs ``glab auth login`` interactively
+    - The authentication persists in the shared config folder
+    """
+    _run_auth_container(
+        project_id=project_id,
+        container_suffix="auth-glab",
+        host_dir_name="_glab-config",
+        host_dir_label="GitLab CLI config",
+        container_mount="/home/dev/.config/glab-cli",
+        command=["glab", "auth", "login"],
+        banner_lines=[
+            f"Authenticating GitLab CLI for project: {project_id}",
+            "",
+            "You will be guided through GitLab authentication.",
+            "You will need a GitLab personal access token.",
+            "Create one at: https://gitlab.com/-/user_settings/personal_access_tokens",
             "",
         ],
     )

--- a/src/luskctl/resources/templates/l1.agent-cli.Dockerfile.template
+++ b/src/luskctl/resources/templates/l1.agent-cli.Dockerfile.template
@@ -24,6 +24,29 @@ RUN set -eux; \
     pipx install mistral-vibe; \
     pipx inject mistral-vibe mistralai
 
+# Install GitHub CLI (gh) from official APT repository
+RUN set -eux; \
+    wget -nv -O /tmp/githubcli-archive-keyring.gpg https://cli.github.com/packages/githubcli-archive-keyring.gpg; \
+    install -o root -g root -m 644 /tmp/githubcli-archive-keyring.gpg /etc/apt/keyrings/githubcli-archive-keyring.gpg; \
+    echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" > /etc/apt/sources.list.d/github-cli.list; \
+    apt-get update; \
+    apt-get install -y --no-install-recommends gh; \
+    rm -rf /var/lib/apt/lists/* /tmp/githubcli-archive-keyring.gpg
+
+# Install GitLab CLI (glab) from official GitLab releases
+RUN set -eux; \
+    GLAB_VERSION=$(curl -sSL "https://gitlab.com/api/v4/projects/gitlab-org%2Fcli/releases/permalink/latest" \
+      | grep -o '"tag_name":"v[^"]*"' | head -1 | sed 's/"tag_name":"v//;s/"//'); \
+    ARCH=$(dpkg --print-architecture); \
+    DEB_NAME="glab_${GLAB_VERSION}_linux_${ARCH}.deb"; \
+    curl -sSL -o /tmp/glab.deb \
+      "https://gitlab.com/gitlab-org/cli/-/releases/v${GLAB_VERSION}/downloads/${DEB_NAME}"; \
+    curl -sSL -o /tmp/checksums.txt \
+      "https://gitlab.com/gitlab-org/cli/-/releases/v${GLAB_VERSION}/downloads/checksums.txt"; \
+    grep "  ${DEB_NAME}$" /tmp/checksums.txt | sed "s|${DEB_NAME}|/tmp/glab.deb|" | sha256sum -c -; \
+    dpkg -i /tmp/glab.deb; \
+    rm -f /tmp/glab.deb /tmp/checksums.txt
+
 # Copy setup script for codex auth (port forwarding for OAuth callbacks)
 COPY scripts/setup-codex-auth.sh /usr/local/bin/setup-codex-auth.sh
 RUN chmod +x /usr/local/bin/setup-codex-auth.sh
@@ -44,6 +67,8 @@ RUN set -eux; \
       'alias copilot="GIT_AUTHOR_NAME=\"GitHub Copilot\" GIT_AUTHOR_EMAIL=copilot@github.com GIT_COMMITTER_NAME=\"\${HUMAN_GIT_NAME:-Nobody}\" GIT_COMMITTER_EMAIL=\"\${HUMAN_GIT_EMAIL:-nobody@localhost}\" copilot"' \
       'alias vibe="GIT_AUTHOR_NAME=\"Mistral Vibe\" GIT_AUTHOR_EMAIL=vibe@mistral.ai GIT_COMMITTER_NAME=\"\${HUMAN_GIT_NAME:-Nobody}\" GIT_COMMITTER_EMAIL=\"\${HUMAN_GIT_EMAIL:-nobody@localhost}\" vibe --agent auto-approve"' \
       'alias blablador="GIT_AUTHOR_NAME=Blablador GIT_AUTHOR_EMAIL=blablador@helmholtz.de GIT_COMMITTER_NAME="\${HUMAN_GIT_NAME:-Nobody}" GIT_COMMITTER_EMAIL="\${HUMAN_GIT_EMAIL:-nobody@localhost}" blablador"' \
+      'alias gh="GIT_AUTHOR_NAME=\"GitHub CLI\" GIT_AUTHOR_EMAIL=gh@github.com GIT_COMMITTER_NAME=\"\${HUMAN_GIT_NAME:-Nobody}\" GIT_COMMITTER_EMAIL=\"\${HUMAN_GIT_EMAIL:-nobody@localhost}\" gh"' \
+      'alias glab="GIT_AUTHOR_NAME=\"GitLab CLI\" GIT_AUTHOR_EMAIL=glab@gitlab.com GIT_COMMITTER_NAME=\"\${HUMAN_GIT_NAME:-Nobody}\" GIT_COMMITTER_EMAIL=\"\${HUMAN_GIT_EMAIL:-nobody@localhost}\" glab"' \
       '' \
       '# Print available agents on interactive login' \
       'if [ -t 1 ] && [ -z "$_LUSKCTL_AGENTS_SHOWN" ]; then' \
@@ -54,6 +79,8 @@ RUN set -eux; \
       '  printf "  \\033[36mcopilot\\033[0m   - GitHub Copilot CLI\\n"' \
       '  printf "  \\033[36mvibe\\033[0m      - Mistral Vibe CLI (auto-approve enabled)\\n"' \
       '  printf "  \\033[36mblablador\\033[0m - OpenCode with Helmholtz Blablador (full permissions)\\n"' \
+      '  printf "  \\033[36mgh\\033[0m        - GitHub CLI (issues, PRs, releases)\\n"' \
+      '  printf "  \\033[36mglab\\033[0m      - GitLab CLI (issues, MRs, pipelines)\\n"' \
       '  printf "\\n"' \
       'fi' \
       '' \

--- a/src/luskctl/tui/actions.py
+++ b/src/luskctl/tui/actions.py
@@ -37,6 +37,8 @@ from ..lib.facade import (
     claude_auth,
     codex_auth,
     generate_dockerfiles,
+    gh_auth,
+    glab_auth,
     init_project_ssh,
     maybe_pause_for_ssh_key_registration,
     mistral_auth,
@@ -291,6 +293,8 @@ class ActionsMixin:
             "claude": claude_auth,
             "mistral": mistral_auth,
             "blablador": blablador_auth,
+            "gh": gh_auth,
+            "glab": glab_auth,
         }
         func = auth_funcs.get(agent)
         if not func:

--- a/src/luskctl/tui/app.py
+++ b/src/luskctl/tui/app.py
@@ -703,6 +703,10 @@ if _HAS_TEXTUAL:
                 await self._action_auth("mistral")
             elif action == "auth_blablador":
                 await self._action_auth("blablador")
+            elif action == "auth_gh":
+                await self._action_auth("gh")
+            elif action == "auth_glab":
+                await self._action_auth("glab")
 
         async def _handle_task_action(self, action: str) -> None:
             """Handle task actions."""

--- a/src/luskctl/tui/screens.py
+++ b/src/luskctl/tui/screens.py
@@ -204,6 +204,8 @@ class AuthActionsScreen(screen.ModalScreen[str | None]):
         _modal_binding("2", "auth_claude", "Claude"),
         _modal_binding("3", "auth_mistral", "Mistral"),
         _modal_binding("4", "auth_blablador", "Blablador"),
+        _modal_binding("5", "auth_gh", "GitHub CLI"),
+        _modal_binding("6", "auth_glab", "GitLab CLI"),
     ]
 
     CSS = """
@@ -234,6 +236,8 @@ class AuthActionsScreen(screen.ModalScreen[str | None]):
                 Option("\\[2] Claude", id="auth_claude"),
                 Option("\\[3] Mistral", id="auth_mistral"),
                 Option("\\[4] Blablador", id="auth_blablador"),
+                Option("\\[5] GitHub CLI", id="auth_gh"),
+                Option("\\[6] GitLab CLI", id="auth_glab"),
                 id="auth-actions-list",
             )
         dialog.border_title = "Authenticate Agents"
@@ -263,6 +267,12 @@ class AuthActionsScreen(screen.ModalScreen[str | None]):
 
     def action_auth_blablador(self) -> None:
         self.dismiss("auth_blablador")
+
+    def action_auth_gh(self) -> None:
+        self.dismiss("auth_gh")
+
+    def action_auth_glab(self) -> None:
+        self.dismiss("auth_glab")
 
 
 # ---------------------------------------------------------------------------

--- a/tach.toml
+++ b/tach.toml
@@ -374,6 +374,8 @@ expose = [
     "claude_auth",
     "mistral_auth",
     "blablador_auth",
+    "gh_auth",
+    "glab_auth",
 ]
 from = ["luskctl.lib.security.auth"]
 
@@ -479,6 +481,8 @@ expose = [
     "claude_auth",
     "mistral_auth",
     "blablador_auth",
+    "gh_auth",
+    "glab_auth",
     "compare_gate_vs_upstream",
     "sync_gate_branches",
     "get_gate_last_commit",

--- a/tests/tui/test_detail_screens.py
+++ b/tests/tui/test_detail_screens.py
@@ -432,6 +432,24 @@ class ActionDispatchTests(TestCase):
 
         instance._action_auth.assert_called_once_with("blablador")
 
+    def test_project_action_dispatch_auth_gh(self) -> None:
+        app_mod, AppClass = import_app()
+        instance = mock.Mock(spec=AppClass)
+
+        coro = AppClass._handle_project_action(instance, "auth_gh")
+        asyncio.run(coro)
+
+        instance._action_auth.assert_called_once_with("gh")
+
+    def test_project_action_dispatch_auth_glab(self) -> None:
+        app_mod, AppClass = import_app()
+        instance = mock.Mock(spec=AppClass)
+
+        coro = AppClass._handle_project_action(instance, "auth_glab")
+        asyncio.run(coro)
+
+        instance._action_auth.assert_called_once_with("glab")
+
     def test_task_action_dispatch_task_start_cli(self) -> None:
         app_mod, AppClass = import_app()
         instance = mock.Mock(spec=AppClass)


### PR DESCRIPTION
Install GitHub CLI (gh) and GitLab CLI (glab) in the L1 agent-cli container image, with shared config mounts, auth flows, CLI commands (auth-gh, auth-glab), and TUI auth modal integration so agents can interact with GitHub/GitLab APIs (PRs, issues, pipelines) from inside task containers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * GitHub CLI and GitLab CLI authentication added via new CLI subcommands and corresponding UI actions/screens.
  * Both CLIs integrated into the agent environment with installation, shell aliases, and visible entries in interactive lists.
  * Config directories for both tools are persisted/mapped so authentication state is retained.

* **Tests**
  * Added tests covering dispatch of the new authentication actions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->