### PR TITLE
Add configurable container shutdown timeout

### DIFF
--- a/src/luskctl/cli/main.py
+++ b/src/luskctl/cli/main.py
@@ -589,6 +589,12 @@ def main() -> None:
         _a.completer = _complete_task_ids  # type: ignore[attr-defined]
     except AttributeError:
         pass
+    t_stop.add_argument(
+        "--timeout",
+        type=int,
+        default=None,
+        help="Seconds before SIGKILL (overrides project run.shutdown_timeout, default 10)",
+    )
 
     t_restart = tsub.add_parser("restart", help="Restart a stopped task or re-run if gone")
     _a = t_restart.add_argument("project_id")
@@ -753,7 +759,7 @@ def main() -> None:
         elif args.task_cmd == "delete":
             task_delete(args.project_id, args.task_id)
         elif args.task_cmd == "stop":
-            task_stop(args.project_id, args.task_id)
+            task_stop(args.project_id, args.task_id, timeout=getattr(args, "timeout", None))
         elif args.task_cmd == "restart":
             backend = getattr(args, "backend", None)
             task_restart(args.project_id, args.task_id, backend=backend)

--- a/src/luskctl/lib/containers/task_runners.py
+++ b/src/luskctl/lib/containers/task_runners.py
@@ -574,7 +574,7 @@ def task_restart(project_id: str, task_id: str, backend: str | None = None) -> N
         # Container is running - stop it first, then start it again
         try:
             subprocess.run(
-                ["podman", "stop", cname],
+                ["podman", "stop", "--time", str(project.shutdown_timeout), cname],
                 check=True,
                 stdout=subprocess.DEVNULL,
                 stderr=subprocess.DEVNULL,

--- a/src/luskctl/lib/core/projects.py
+++ b/src/luskctl/lib/core/projects.py
@@ -90,6 +90,9 @@ class Project:
     default_agent: str | None = None
     # Agent configuration dict (from project.yml agent: section)
     agent_config: dict = field(default_factory=dict)
+    # Seconds to wait before SIGKILL when stopping a container (podman stop --time).
+    # Default 10 matches podman's built-in default.
+    shutdown_timeout: int = 10
 
     @property
     def presets_dir(self) -> Path:
@@ -369,6 +372,10 @@ def load_project(project_id: str) -> Project:
     if not default_agent:
         default_agent = get_global_default_agent()
 
+    # Run section (GPU, shutdown timeout, etc.)
+    run_cfg = cfg.get("run", {}) or {}
+    shutdown_timeout = int(run_cfg.get("shutdown_timeout", 10))
+
     # Agent config section (model, subagents, mcp_servers, etc.)
     agent_cfg = cfg.get("agent", {}) or {}
     # Resolve subagent file: paths relative to project root
@@ -402,5 +409,6 @@ def load_project(project_id: str) -> Project:
         auto_sync_branches=auto_sync_branches,
         default_agent=default_agent,
         agent_config=agent_cfg,
+        shutdown_timeout=shutdown_timeout,
     )
     return p


### PR DESCRIPTION
## Summary
- Adds `run.shutdown_timeout` to project.yml config (default 10s, matching podman's built-in default)
- Passes `--time <N>` to all `podman stop` calls in `task_stop()` and `task_restart()`
- Adds `--timeout` CLI flag to `luskctl task stop` to override the project setting
- TUI inherits the project setting automatically through the shared library functions

Closes #218

## Changes
- `src/luskctl/lib/core/projects.py`: New `shutdown_timeout` field on `Project` dataclass, parsed from `run.shutdown_timeout` in project.yml
- `src/luskctl/lib/containers/tasks.py`: `task_stop()` accepts optional `timeout` kwarg, falls back to project config
- `src/luskctl/lib/containers/task_runners.py`: `task_restart()` uses project's `shutdown_timeout` when stopping before restart
- `src/luskctl/cli/main.py`: `--timeout` flag on `task stop` subcommand
- `tests/lib/test_container_lifecycle.py`: Tests for default timeout, config-driven timeout, and CLI override

## Example usage
```yaml
# project.yml
run:
  shutdown_timeout: 30   # 30 seconds before SIGKILL
```
```bash
luskctl task stop myproject 1              # uses project config (or default 10s)
luskctl task stop myproject 1 --timeout 60 # override to 60s
```

## Test plan
- [x] `make lint` passes
- [x] `make test` passes (428 tests, including 3 new tests)
- [x] `tach check` passes (no module boundary violations)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `--timeout` option to the stop command for per-task timeout override capability
  * Added `shutdown_timeout` project configuration to control container shutdown grace period (default: 10 seconds)

* **Tests**
  * Added tests to verify timeout functionality across default, config-based, and overridden scenarios

<!-- end of auto-generated comment: release notes by coderabbit.ai -->