### PR TITLE
Add TUI in-app log viewer with formatted output

### DIFF
--- a/src/luskctl/tui/log_viewer.py
+++ b/src/luskctl/tui/log_viewer.py
@@ -1,0 +1,500 @@
+"""In-app log viewer screen for the TUI.
+
+Provides a full-page ``LogViewerScreen`` backed by Textual's ``RichLog``
+widget that renders formatted, color-coded container log output inline —
+replacing the previous approach of launching an external terminal.
+
+The ``_TuiLogFormatter`` mirrors the state machine in
+``luskctl.lib.containers.log_format.ClaudeStreamJsonFormatter`` but
+produces Rich ``Text`` objects instead of ANSI ``print()`` calls.
+"""
+
+from __future__ import annotations
+
+import json
+import select
+import subprocess
+import threading
+from enum import Enum, auto
+
+from rich.style import Style
+from rich.text import Text
+from textual import screen
+from textual.app import ComposeResult
+from textual.widgets import RichLog, Static
+
+from .screens import _modal_binding
+
+try:  # pragma: no cover - optional import for test stubs
+    from textual.css.query import NoMatches
+except Exception:  # pragma: no cover - textual may be a stub module
+    NoMatches = Exception  # type: ignore[assignment,misc]
+
+
+# ---------------------------------------------------------------------------
+# Style constants (match CLI color scheme)
+# ---------------------------------------------------------------------------
+
+_STYLE_SYSTEM = Style(color="blue")
+_STYLE_TOOL = Style(color="blue")
+_STYLE_TOOL_INPUT = Style(color="yellow")
+_STYLE_RESULT_OK = Style(color="green")
+_STYLE_RESULT_ERR = Style(color="red", bold=True)
+_STYLE_SUMMARY = Style(color="yellow")
+
+
+# ---------------------------------------------------------------------------
+# TUI log formatter (Rich Text output)
+# ---------------------------------------------------------------------------
+
+
+class _StreamState(Enum):
+    IDLE = auto()
+    TEXT_BLOCK = auto()
+    TOOL_USE_BLOCK = auto()
+
+
+class _TuiLogFormatter:
+    """Parse Claude stream-json NDJSON into Rich ``Text`` objects.
+
+    Same state machine as ``ClaudeStreamJsonFormatter`` in ``log_format.py``
+    but outputs ``Text`` objects for ``RichLog.write()`` instead of ANSI
+    ``print()`` calls.
+    """
+
+    def __init__(self, *, streaming: bool = True) -> None:
+        self._streaming = streaming
+        self._state = _StreamState.IDLE
+        self._tool_input_buf: list[str] = []
+        self._current_tool_name: str = ""
+        self._text_buf: list[str] = []
+        self._result: dict[str, object] | None = None
+
+    def feed_line(self, line: str) -> list[Text]:
+        """Process one log line and return zero or more ``Text`` objects."""
+        if not line.strip():
+            return []
+        stripped = line.strip()
+        try:
+            data = json.loads(stripped)
+        except (json.JSONDecodeError, ValueError):
+            # Not JSON — pass through as plain text
+            return [Text(line.rstrip("\r\n"))]
+
+        msg_type = data.get("type", "")
+
+        if msg_type == "system":
+            return self._handle_system(data)
+        if msg_type == "assistant":
+            return self._handle_assistant(data)
+        if msg_type == "user":
+            return self._handle_user(data)
+        if msg_type == "result":
+            return self._handle_result(data)
+        if self._streaming and msg_type == "content_block_start":
+            return self._handle_block_start(data)
+        if self._streaming and msg_type == "content_block_delta":
+            return self._handle_block_delta(data)
+        if self._streaming and msg_type == "content_block_stop":
+            return self._handle_block_stop(data)
+        return []
+
+    def finish(self) -> list[Text]:
+        """Flush any in-progress block and return summary if available."""
+        out: list[Text] = []
+        if self._state == _StreamState.TEXT_BLOCK and self._text_buf:
+            out.append(Text("".join(self._text_buf)))
+            self._text_buf.clear()
+        elif self._state == _StreamState.TOOL_USE_BLOCK:
+            accumulated = "".join(self._tool_input_buf)
+            if accumulated:
+                out.append(Text(f"  {accumulated}", style=_STYLE_TOOL_INPUT))
+            self._tool_input_buf.clear()
+        self._state = _StreamState.IDLE
+
+        if self._result:
+            out.extend(self._format_result_summary())
+        return out
+
+    # -- message handlers --
+
+    def _handle_system(self, data: dict) -> list[Text]:
+        subtype = data.get("subtype", "")
+        if subtype == "init":
+            session_id = data.get("session_id", "")
+            tools = data.get("tools", [])
+            model = data.get("model", "")
+            parts = [f"Session: {session_id}"] if session_id else []
+            if model:
+                parts.append(f"model={model}")
+            if tools:
+                parts.append(f"{len(tools)} tools available")
+            if parts:
+                return [Text(f"[system] {', '.join(parts)}", style=_STYLE_SYSTEM)]
+        return []
+
+    def _handle_assistant(self, data: dict) -> list[Text]:
+        out: list[Text] = []
+        message = data.get("message", {})
+        content = message.get("content", [])
+        for block in content:
+            block_type = block.get("type", "")
+            if block_type == "text":
+                text = block.get("text", "")
+                if text.strip():
+                    out.append(Text(text))
+            elif block_type == "tool_use":
+                name = block.get("name", "unknown")
+                tool_input = block.get("input", {})
+                out.append(Text(f"[tool] {name}", style=_STYLE_TOOL))
+                out.extend(self._format_tool_input(tool_input))
+        return out
+
+    def _handle_user(self, data: dict) -> list[Text]:
+        out: list[Text] = []
+        message = data.get("message", {})
+        content = message.get("content", [])
+        for block in content:
+            block_type = block.get("type", "")
+            if block_type == "tool_result":
+                tool_id = block.get("tool_use_id", "")
+                result_content = block.get("content", "")
+                is_error = block.get("is_error", False)
+                label = "[tool_error]" if is_error else "[tool_result]"
+                style = _STYLE_RESULT_ERR if is_error else _STYLE_RESULT_OK
+                if isinstance(result_content, str):
+                    text = result_content
+                elif isinstance(result_content, list):
+                    text = " ".join(
+                        b.get("text", "") for b in result_content if b.get("type") == "text"
+                    )
+                else:
+                    text = str(result_content)
+                # Truncate long results for readability
+                if len(text) > 500:
+                    text = text[:497] + "..."
+                if tool_id:
+                    out.append(Text(f"{label} ({tool_id[:8]}...)", style=style))
+                else:
+                    out.append(Text(label, style=style))
+                if text.strip():
+                    out.append(Text(f"  {text}"))
+        return out
+
+    def _handle_result(self, data: dict) -> list[Text]:
+        self._result = data
+        return []
+
+    # -- streaming event handlers --
+
+    def _handle_block_start(self, data: dict) -> list[Text]:
+        content_block = data.get("content_block", {})
+        block_type = content_block.get("type", "")
+        if block_type == "text":
+            self._state = _StreamState.TEXT_BLOCK
+            self._text_buf.clear()
+        elif block_type == "tool_use":
+            self._state = _StreamState.TOOL_USE_BLOCK
+            self._current_tool_name = content_block.get("name", "unknown")
+            self._tool_input_buf.clear()
+            return [Text(f"[tool] {self._current_tool_name}", style=_STYLE_TOOL)]
+        return []
+
+    def _handle_block_delta(self, data: dict) -> list[Text]:
+        delta = data.get("delta", {})
+        delta_type = delta.get("type", "")
+        if self._state == _StreamState.TEXT_BLOCK and delta_type == "text_delta":
+            text = delta.get("text", "")
+            if text:
+                self._text_buf.append(text)
+        elif self._state == _StreamState.TOOL_USE_BLOCK and delta_type == "input_json_delta":
+            partial = delta.get("partial_json", "")
+            if partial:
+                self._tool_input_buf.append(partial)
+        return []
+
+    def _handle_block_stop(self, _data: dict) -> list[Text]:
+        out: list[Text] = []
+        if self._state == _StreamState.TEXT_BLOCK:
+            text = "".join(self._text_buf)
+            if text:
+                out.append(Text(text))
+            self._text_buf.clear()
+        elif self._state == _StreamState.TOOL_USE_BLOCK:
+            accumulated = "".join(self._tool_input_buf)
+            if accumulated:
+                try:
+                    parsed = json.loads(accumulated)
+                    out.extend(self._format_tool_input(parsed))
+                except (json.JSONDecodeError, ValueError):
+                    out.append(Text(f"  {accumulated}", style=_STYLE_TOOL_INPUT))
+            self._tool_input_buf.clear()
+        self._state = _StreamState.IDLE
+        return out
+
+    # -- helpers --
+
+    def _format_tool_input(self, tool_input: dict[str, object] | str) -> list[Text]:
+        out: list[Text] = []
+        if isinstance(tool_input, dict):
+            for k, v in tool_input.items():
+                val_str = str(v)
+                if len(val_str) > 200:
+                    val_str = val_str[:197] + "..."
+                out.append(Text(f"  {k}: {val_str}", style=_STYLE_TOOL_INPUT))
+        elif tool_input:
+            out.append(Text(f"  {tool_input}", style=_STYLE_TOOL_INPUT))
+        return out
+
+    def _format_result_summary(self) -> list[Text]:
+        data = self._result
+        if not data:
+            return []
+        cost_usd = data.get("cost_usd")
+        duration_ms = data.get("duration_ms")
+        is_error = data.get("is_error", False)
+        num_turns = data.get("num_turns")
+        usage = data.get("usage", {})
+
+        parts: list[str] = []
+        if is_error:
+            parts.append("FAILED")
+        if num_turns is not None:
+            parts.append(f"turns={num_turns}")
+        if cost_usd is not None:
+            parts.append(f"cost=${cost_usd:.4f}")
+        if duration_ms is not None:
+            secs = duration_ms / 1000
+            parts.append(f"duration={secs:.1f}s")
+        if usage:
+            inp = usage.get("input_tokens", 0)
+            out_tok = usage.get("output_tokens", 0)
+            if inp or out_tok:
+                parts.append(f"tokens={inp}in/{out_tok}out")
+
+        if parts:
+            summary = ", ".join(parts)
+            return [Text(f"[result] {summary}", style=_STYLE_SUMMARY)]
+        return []
+
+
+# ---------------------------------------------------------------------------
+# Plain text formatter (non-autopilot modes)
+# ---------------------------------------------------------------------------
+
+
+class _PlainTextTuiFormatter:
+    """Pass-through formatter that wraps each non-empty line in a ``Text``."""
+
+    def feed_line(self, line: str) -> list[Text]:
+        if not line.strip():
+            return []
+        return [Text(line.rstrip("\r\n"))]
+
+    def finish(self) -> list[Text]:
+        return []
+
+
+# ---------------------------------------------------------------------------
+# LogViewerScreen
+# ---------------------------------------------------------------------------
+
+
+class LogViewerScreen(screen.Screen[None]):
+    """Full-page log viewer with formatted, color-coded output."""
+
+    BINDINGS = [
+        _modal_binding("escape", "dismiss_screen", "Back"),
+        _modal_binding("q", "dismiss_screen", "Back"),
+        _modal_binding("f", "toggle_follow", "Follow"),
+        _modal_binding("c", "clear_log", "Clear"),
+    ]
+
+    CSS = """
+    LogViewerScreen {
+        layout: vertical;
+        background: $background;
+    }
+
+    #log-header {
+        height: 1;
+        background: $primary;
+        color: $text;
+        padding: 0 1;
+    }
+
+    #log-view {
+        height: 1fr;
+    }
+
+    #log-footer {
+        height: 1;
+        background: $primary;
+        color: $text;
+        padding: 0 1;
+    }
+    """
+
+    def __init__(
+        self,
+        project_id: str,
+        task_id: str,
+        mode: str,
+        container_name: str,
+        *,
+        follow: bool = True,
+    ) -> None:
+        super().__init__()
+        self.project_id = project_id
+        self.task_id = task_id
+        self.mode = mode
+        self.container_name = container_name
+        self.follow = follow
+        self._stop_event = threading.Event()
+        self._process: subprocess.Popen | None = None
+
+    def compose(self) -> ComposeResult:
+        scroll_label = "AUTO-SCROLL" if self.follow else "SCROLL PAUSED"
+        yield Static(
+            f" Task {self.task_id} ({self.mode}) | {self.container_name} \\[{scroll_label}]",
+            id="log-header",
+        )
+        yield RichLog(auto_scroll=self.follow, id="log-view")
+        yield Static(" \\[Esc/q] Back  \\[f] Toggle scroll  \\[c] Clear", id="log-footer")
+
+    def on_mount(self) -> None:
+        self.run_worker(self._stream_logs, thread=True, group="log-stream")
+
+    def _stream_logs(self) -> None:
+        """Worker thread: stream podman logs through the formatter."""
+        formatter: _TuiLogFormatter | _PlainTextTuiFormatter
+        if self.mode == "run":
+            formatter = _TuiLogFormatter(streaming=self.follow)
+        else:
+            formatter = _PlainTextTuiFormatter()
+
+        cmd = ["podman", "logs"]
+        if self.follow:
+            cmd.append("-f")
+        cmd.append(self.container_name)
+
+        try:
+            self._process = subprocess.Popen(
+                cmd,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
+                text=True,
+            )
+        except FileNotFoundError:
+            self._post_text(Text("Error: podman not found", style=_STYLE_RESULT_ERR))
+            return
+        except OSError as e:
+            self._post_text(Text(f"Error launching podman: {e}", style=_STYLE_RESULT_ERR))
+            return
+
+        try:
+            stdout = self._process.stdout
+            if stdout is None:
+                return
+            fd = stdout.fileno()
+
+            while not self._stop_event.is_set():
+                ready, _, _ = select.select([fd], [], [], 0.2)
+                if not ready:
+                    # Check if process has exited
+                    if self._process.poll() is not None:
+                        break
+                    continue
+                line = stdout.readline()
+                if not line:
+                    break
+                texts = formatter.feed_line(line)
+                for t in texts:
+                    self._post_text(t)
+
+            # Drain remaining output after process exits
+            for line in stdout:
+                if self._stop_event.is_set():
+                    break
+                texts = formatter.feed_line(line)
+                for t in texts:
+                    self._post_text(t)
+
+            # Finish (summary, etc.)
+            for t in formatter.finish():
+                self._post_text(t)
+        finally:
+            if self._process and self._process.poll() is None:
+                self._process.terminate()
+                try:
+                    self._process.wait(timeout=2)
+                except subprocess.TimeoutExpired:
+                    self._process.kill()
+
+        # Post status after stream ends
+        exit_code = self._process.returncode if self._process else None
+        status_msg = f"--- Log stream ended (exit code: {exit_code}) ---"
+        self._post_text(Text(status_msg, style=_STYLE_SYSTEM))
+        self._update_footer_static()
+
+    def _post_text(self, text: Text) -> None:
+        """Thread-safe write to the RichLog widget."""
+        self.app.call_from_thread(self._write_to_log, text)
+
+    def _write_to_log(self, text: Text) -> None:
+        try:
+            log_widget = self.query_one("#log-view", RichLog)
+            log_widget.write(text)
+        except NoMatches:
+            pass  # Screen may have been dismissed
+
+    def _update_footer_static(self) -> None:
+        """Update footer to reflect STATIC mode after stream ends."""
+
+        def _update() -> None:
+            try:
+                footer = self.query_one("#log-footer", Static)
+                footer.update(" \\[Esc/q] Back  \\[f] Toggle scroll  \\[c] Clear  \\[STREAM ENDED]")
+                log_widget = self.query_one("#log-view", RichLog)
+                log_widget.auto_scroll = False
+            except NoMatches:
+                pass
+
+        self.app.call_from_thread(_update)
+
+    # -- cleanup --
+
+    def _cleanup_process(self) -> None:
+        """Signal the worker to stop and terminate the subprocess if running."""
+        self._stop_event.set()
+        if self._process and self._process.poll() is None:
+            self._process.terminate()
+
+    # -- actions --
+
+    def action_dismiss_screen(self) -> None:
+        self._cleanup_process()
+        self.dismiss(None)
+
+    def action_toggle_follow(self) -> None:
+        self.follow = not self.follow
+        try:
+            log_widget = self.query_one("#log-view", RichLog)
+            log_widget.auto_scroll = self.follow
+            header = self.query_one("#log-header", Static)
+            scroll_label = "AUTO-SCROLL" if self.follow else "SCROLL PAUSED"
+            header.update(
+                f" Task {self.task_id} ({self.mode}) | {self.container_name} \\[{scroll_label}]"
+            )
+        except NoMatches:
+            pass
+
+    def action_clear_log(self) -> None:
+        try:
+            log_widget = self.query_one("#log-view", RichLog)
+            log_widget.clear()
+        except NoMatches:
+            pass
+
+    def on_unmount(self) -> None:
+        self._cleanup_process()

--- a/src/luskctl/tui/screens.py
+++ b/src/luskctl/tui/screens.py
@@ -495,8 +495,8 @@ class TaskDetailsScreen(screen.Screen[str | None]):
         ]
         if self._has_tasks:
             options.append(Option("\\[l]ogin to container", id="login"))
-            if self._task_meta and self._task_meta.mode == "run":
-                options.append(Option("\\[f]ollow logs", id="follow_logs"))
+            if self._task_meta and self._task_meta.mode:
+                options.append(Option("view \\[f]ormatted logs", id="follow_logs"))
             options.append(None)
             options.append(Option("run \\[c]li agent", id="cli"))
             options.append(Option("run \\[w]eb UI", id="web"))
@@ -565,9 +565,9 @@ class TaskDetailsScreen(screen.Screen[str | None]):
             event.stop()
             return
 
-        # 'f' (follow logs) — only available for autopilot tasks
+        # 'f' (view formatted logs) — available for all modes with containers
         if key == "f":
-            if self._has_tasks and self._task_meta and self._task_meta.mode == "run":
+            if self._has_tasks and self._task_meta and self._task_meta.mode:
                 self.dismiss("follow_logs")
                 event.stop()
 

--- a/tests/tui/test_detail_screens.py
+++ b/tests/tui/test_detail_screens.py
@@ -364,7 +364,7 @@ class TaskScreenKeyBindingTests(TestCase):
         screen.on_key(event)
         screen.dismiss.assert_called_once_with("follow_logs")
 
-    def test_lowercase_f_ignored_for_non_autopilot_task(self) -> None:
+    def test_lowercase_f_works_for_non_autopilot_task(self) -> None:
         screens, widgets = import_screens()
         task = widgets.TaskMeta(
             task_id="t1", status="running", mode="cli", workspace="/w", web_port=None
@@ -373,7 +373,7 @@ class TaskScreenKeyBindingTests(TestCase):
         screen.dismiss = mock.Mock()
         event = make_key_event("f")
         screen.on_key(event)
-        screen.dismiss.assert_not_called()
+        screen.dismiss.assert_called_once_with("follow_logs")
 
     def test_lowercase_f_blocked_without_tasks(self) -> None:
         screens, _ = import_screens()

--- a/tests/tui/test_log_viewer.py
+++ b/tests/tui/test_log_viewer.py
@@ -1,0 +1,388 @@
+"""Tests for the TUI log viewer screen and formatters."""
+
+import json
+from unittest import TestCase, main
+
+from tui_test_helpers import import_log_viewer
+
+
+class TuiLogFormatterTests(TestCase):
+    """Tests for _TuiLogFormatter (Rich Text output, no Textual stubs needed)."""
+
+    def _make_formatter(self, **kwargs):
+        mod = import_log_viewer()
+        return mod._TuiLogFormatter(**kwargs)
+
+    def test_system_init_blue_text(self) -> None:
+        fmt = self._make_formatter()
+        line = json.dumps({"type": "system", "subtype": "init", "session_id": "abc123"})
+        result = fmt.feed_line(line)
+        self.assertEqual(len(result), 1)
+        self.assertIn("abc123", str(result[0]))
+        self.assertEqual(result[0].style.color.name, "blue")
+
+    def test_system_init_with_model_and_tools(self) -> None:
+        fmt = self._make_formatter()
+        line = json.dumps(
+            {
+                "type": "system",
+                "subtype": "init",
+                "session_id": "s1",
+                "model": "claude-4",
+                "tools": ["a", "b"],
+            }
+        )
+        result = fmt.feed_line(line)
+        self.assertEqual(len(result), 1)
+        text = str(result[0])
+        self.assertIn("model=claude-4", text)
+        self.assertIn("2 tools available", text)
+
+    def test_assistant_text_block_streaming(self) -> None:
+        fmt = self._make_formatter(streaming=True)
+        # Start text block
+        start = json.dumps(
+            {
+                "type": "content_block_start",
+                "content_block": {"type": "text"},
+            }
+        )
+        result = fmt.feed_line(start)
+        self.assertEqual(result, [])
+
+        # Delta with text
+        delta = json.dumps(
+            {
+                "type": "content_block_delta",
+                "delta": {"type": "text_delta", "text": "Hello world"},
+            }
+        )
+        result = fmt.feed_line(delta)
+        self.assertEqual(result, [])
+
+        # Stop
+        stop = json.dumps({"type": "content_block_stop"})
+        result = fmt.feed_line(stop)
+        self.assertEqual(len(result), 1)
+        self.assertEqual(str(result[0]), "Hello world")
+
+    def test_tool_use_block_streaming(self) -> None:
+        fmt = self._make_formatter(streaming=True)
+        # Start tool_use block
+        start = json.dumps(
+            {
+                "type": "content_block_start",
+                "content_block": {"type": "tool_use", "name": "Read"},
+            }
+        )
+        result = fmt.feed_line(start)
+        self.assertEqual(len(result), 1)
+        self.assertIn("[tool] Read", str(result[0]))
+        self.assertEqual(result[0].style.color.name, "blue")
+
+        # Input delta
+        delta = json.dumps(
+            {
+                "type": "content_block_delta",
+                "delta": {"type": "input_json_delta", "partial_json": '{"file": "foo.py"}'},
+            }
+        )
+        result = fmt.feed_line(delta)
+        self.assertEqual(result, [])
+
+        # Stop — should produce yellow tool input
+        stop = json.dumps({"type": "content_block_stop"})
+        result = fmt.feed_line(stop)
+        self.assertEqual(len(result), 1)
+        self.assertIn("file", str(result[0]))
+        self.assertEqual(result[0].style.color.name, "yellow")
+
+    def test_coalesced_assistant_non_streaming(self) -> None:
+        fmt = self._make_formatter(streaming=False)
+        line = json.dumps(
+            {
+                "type": "assistant",
+                "message": {
+                    "content": [
+                        {"type": "text", "text": "I will help you."},
+                        {"type": "tool_use", "name": "Bash", "input": {"cmd": "ls"}},
+                    ],
+                },
+            }
+        )
+        result = fmt.feed_line(line)
+        self.assertEqual(len(result), 3)  # text + tool label + tool input
+        self.assertEqual(str(result[0]), "I will help you.")
+        self.assertIn("[tool] Bash", str(result[1]))
+        self.assertIn("cmd", str(result[2]))
+
+    def test_user_tool_result_green(self) -> None:
+        fmt = self._make_formatter()
+        line = json.dumps(
+            {
+                "type": "user",
+                "message": {
+                    "content": [
+                        {
+                            "type": "tool_result",
+                            "tool_use_id": "toolu_abc12345",
+                            "content": "Success!",
+                            "is_error": False,
+                        }
+                    ],
+                },
+            }
+        )
+        result = fmt.feed_line(line)
+        self.assertTrue(len(result) >= 1)
+        self.assertIn("[tool_result]", str(result[0]))
+        self.assertEqual(result[0].style.color.name, "green")
+
+    def test_user_tool_error_red(self) -> None:
+        fmt = self._make_formatter()
+        line = json.dumps(
+            {
+                "type": "user",
+                "message": {
+                    "content": [
+                        {
+                            "type": "tool_result",
+                            "tool_use_id": "toolu_err12345",
+                            "content": "File not found",
+                            "is_error": True,
+                        }
+                    ],
+                },
+            }
+        )
+        result = fmt.feed_line(line)
+        self.assertTrue(len(result) >= 1)
+        self.assertIn("[tool_error]", str(result[0]))
+        self.assertEqual(result[0].style.color.name, "red")
+
+    def test_result_summary_on_finish(self) -> None:
+        fmt = self._make_formatter()
+        line = json.dumps(
+            {
+                "type": "result",
+                "cost_usd": 0.0123,
+                "duration_ms": 5000,
+                "num_turns": 3,
+                "is_error": False,
+                "usage": {"input_tokens": 100, "output_tokens": 50},
+            }
+        )
+        result = fmt.feed_line(line)
+        self.assertEqual(result, [])
+
+        finish_result = fmt.finish()
+        self.assertEqual(len(finish_result), 1)
+        text = str(finish_result[0])
+        self.assertIn("[result]", text)
+        self.assertIn("turns=3", text)
+        self.assertIn("cost=$0.0123", text)
+        self.assertIn("duration=5.0s", text)
+        self.assertIn("tokens=100in/50out", text)
+        self.assertEqual(finish_result[0].style.color.name, "yellow")
+
+    def test_malformed_json_passthrough(self) -> None:
+        fmt = self._make_formatter()
+        result = fmt.feed_line("this is not JSON at all")
+        self.assertEqual(len(result), 1)
+        self.assertEqual(str(result[0]), "this is not JSON at all")
+        # No style (default) — Rich uses empty string for unstyled Text
+        self.assertIn(result[0].style, ("", None))
+
+    def test_empty_line_skipped(self) -> None:
+        fmt = self._make_formatter()
+        self.assertEqual(fmt.feed_line(""), [])
+        self.assertEqual(fmt.feed_line("   "), [])
+        self.assertEqual(fmt.feed_line("\n"), [])
+
+    def test_long_result_truncated(self) -> None:
+        fmt = self._make_formatter()
+        long_text = "x" * 600
+        line = json.dumps(
+            {
+                "type": "user",
+                "message": {
+                    "content": [
+                        {
+                            "type": "tool_result",
+                            "content": long_text,
+                        }
+                    ],
+                },
+            }
+        )
+        result = fmt.feed_line(line)
+        # Find the content text (second element after label)
+        content_texts = [str(t) for t in result]
+        joined = " ".join(content_texts)
+        self.assertIn("...", joined)
+        # Should be truncated to 500 chars
+        for t in result:
+            text = str(t)
+            if text.startswith("  x"):
+                # Content line: "  " + truncated text
+                self.assertLessEqual(len(text), 502)  # "  " + 497 + "..."
+
+    def test_streaming_events_ignored_when_non_streaming(self) -> None:
+        fmt = self._make_formatter(streaming=False)
+        start = json.dumps(
+            {
+                "type": "content_block_start",
+                "content_block": {"type": "text"},
+            }
+        )
+        result = fmt.feed_line(start)
+        self.assertEqual(result, [])
+
+    def test_finish_flushes_text_block(self) -> None:
+        fmt = self._make_formatter(streaming=True)
+        # Start a text block
+        fmt.feed_line(
+            json.dumps(
+                {
+                    "type": "content_block_start",
+                    "content_block": {"type": "text"},
+                }
+            )
+        )
+        # Delta without stop
+        fmt.feed_line(
+            json.dumps(
+                {
+                    "type": "content_block_delta",
+                    "delta": {"type": "text_delta", "text": "partial"},
+                }
+            )
+        )
+        # Finish should flush
+        result = fmt.finish()
+        self.assertEqual(len(result), 1)
+        self.assertEqual(str(result[0]), "partial")
+
+    def test_tool_result_with_list_content(self) -> None:
+        fmt = self._make_formatter()
+        line = json.dumps(
+            {
+                "type": "user",
+                "message": {
+                    "content": [
+                        {
+                            "type": "tool_result",
+                            "content": [
+                                {"type": "text", "text": "part1"},
+                                {"type": "text", "text": "part2"},
+                            ],
+                        }
+                    ],
+                },
+            }
+        )
+        result = fmt.feed_line(line)
+        joined = " ".join(str(t) for t in result)
+        self.assertIn("part1 part2", joined)
+
+    def test_tool_input_truncates_long_values(self) -> None:
+        fmt = self._make_formatter(streaming=False)
+        long_val = "v" * 250
+        line = json.dumps(
+            {
+                "type": "assistant",
+                "message": {
+                    "content": [
+                        {"type": "tool_use", "name": "Write", "input": {"content": long_val}},
+                    ],
+                },
+            }
+        )
+        result = fmt.feed_line(line)
+        input_texts = [str(t) for t in result if "content:" in str(t)]
+        self.assertTrue(len(input_texts) > 0)
+        self.assertIn("...", input_texts[0])
+
+
+class PlainTextTuiFormatterTests(TestCase):
+    """Tests for _PlainTextTuiFormatter."""
+
+    def _make_formatter(self):
+        mod = import_log_viewer()
+        return mod._PlainTextTuiFormatter()
+
+    def test_plain_text_passthrough(self) -> None:
+        fmt = self._make_formatter()
+        result = fmt.feed_line("hello world")
+        self.assertEqual(len(result), 1)
+        self.assertEqual(str(result[0]), "hello world")
+
+    def test_plain_text_empty_line(self) -> None:
+        fmt = self._make_formatter()
+        self.assertEqual(fmt.feed_line(""), [])
+        self.assertEqual(fmt.feed_line("  "), [])
+
+    def test_plain_text_strips_trailing_newline(self) -> None:
+        fmt = self._make_formatter()
+        result = fmt.feed_line("hello\n")
+        self.assertEqual(str(result[0]), "hello")
+
+    def test_plain_text_finish_returns_empty(self) -> None:
+        fmt = self._make_formatter()
+        self.assertEqual(fmt.finish(), [])
+
+
+class LogViewerScreenConstructionTests(TestCase):
+    """Tests for LogViewerScreen construction (with Textual stubs)."""
+
+    def test_construction_follow_mode(self) -> None:
+        mod = import_log_viewer()
+        screen = mod.LogViewerScreen(
+            project_id="proj1",
+            task_id="42",
+            mode="run",
+            container_name="proj1-run-42",
+            follow=True,
+        )
+        self.assertEqual(screen.project_id, "proj1")
+        self.assertEqual(screen.task_id, "42")
+        self.assertEqual(screen.mode, "run")
+        self.assertEqual(screen.container_name, "proj1-run-42")
+        self.assertTrue(screen.follow)
+
+    def test_construction_static_mode(self) -> None:
+        mod = import_log_viewer()
+        screen = mod.LogViewerScreen(
+            project_id="proj1",
+            task_id="7",
+            mode="cli",
+            container_name="proj1-cli-7",
+            follow=False,
+        )
+        self.assertFalse(screen.follow)
+        self.assertEqual(screen.mode, "cli")
+
+    def test_construction_default_follow(self) -> None:
+        mod = import_log_viewer()
+        screen = mod.LogViewerScreen(
+            project_id="p",
+            task_id="1",
+            mode="run",
+            container_name="p-run-1",
+        )
+        self.assertTrue(screen.follow)
+
+    def test_stop_event_initialized(self) -> None:
+        mod = import_log_viewer()
+        screen = mod.LogViewerScreen(
+            project_id="p",
+            task_id="1",
+            mode="run",
+            container_name="p-run-1",
+        )
+        self.assertFalse(screen._stop_event.is_set())
+        self.assertIsNone(screen._process)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- Add `LogViewerScreen` with `RichLog` widget for inline, formatted, color-coded container log viewing
- Replace external terminal launch (`_launch_terminal_session`) with `push_screen(LogViewerScreen(...))` for the log viewing action
- Expand log viewing from autopilot-only (`mode == "run"`) to all task modes with containers
- Auto-detect follow vs static mode based on container state (running → follow, exited → static)

### New files
- `src/luskctl/tui/log_viewer.py` — `_TuiLogFormatter` (Rich `Text` output, same state machine as CLI's `ClaudeStreamJsonFormatter`), `_PlainTextTuiFormatter`, and `LogViewerScreen` with keybindings (Esc/q=back, f=toggle follow, c=clear)
- `tests/tui/test_log_viewer.py` — 20 tests covering formatter state machine, plain text formatter, and screen construction

### Modified files
- `src/luskctl/tui/actions.py` — Rewrote `_action_follow_logs` to use `LogViewerScreen` with auto-detected follow mode
- `src/luskctl/tui/screens.py` — Expanded mode checks from `== "run"` to truthy `mode` for the log option and 'f' key
- `tests/tui/tui_test_helpers.py` — Added `RichLog` stub and `import_log_viewer()` helper
- `tests/tui/test_detail_screens.py` — Updated 'f' key test to expect `follow_logs` for non-autopilot tasks

### Design note
The `_TuiLogFormatter` intentionally duplicates the parsing logic from `ClaudeStreamJsonFormatter` rather than sharing a base class. The two have incompatible output contracts (`print()` vs `list[Text]` return values) and different streaming behavior (CLI prints deltas immediately; TUI buffers until block_stop). Keeping them separate is cleaner than an abstraction layer that hides these differences.

## Test plan
- [x] `make lint` passes
- [x] `make test` passes (483 tests, 47 subtests)
- [x] No new module boundary crossings (no tach.toml changes needed)
- [ ] Manual: `luskctl-tui` → select task → press 'f' → see formatted logs inline
- [ ] Manual: verify Esc/q dismisses, 'f' toggles follow, 'c' clears log

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * In-app formatted log viewer with colorized output, system header, follow toggle, clear, and dismiss controls; plain-text fallback when needed.
  * "View formatted logs" option now available for tasks with any non-empty mode.

* **Bug Fixes**
  * Viewing only enabled when the container exists (notifies otherwise); follow defaults to running containers and uses the correct container name; no external terminal launched.

* **Tests**
  * Extensive unit tests for formatters, streaming semantics, truncation, errors, screen construction, and key behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->