### PR TITLE
Fix autopilot timeout failure caused by command builtin

### DIFF
--- a/src/luskctl/lib/containers/agents.py
+++ b/src/luskctl/lib/containers/agents.py
@@ -189,7 +189,7 @@ def _generate_claude_wrapper(
     lines.append("        GIT_AUTHOR_EMAIL=noreply@anthropic.com \\")
     lines.append(f"        GIT_COMMITTER_NAME=${{HUMAN_GIT_NAME:-{human_name}}} \\")
     lines.append(f"        GIT_COMMITTER_EMAIL=${{HUMAN_GIT_EMAIL:-{human_email}}} \\")
-    lines.append('        timeout "$_timeout" command claude "${_args[@]}" "$@"')
+    lines.append('        timeout "$_timeout" claude "${_args[@]}" "$@"')
     lines.append("    else")
     lines.append("        GIT_AUTHOR_NAME=Claude \\")
     lines.append("        GIT_AUTHOR_EMAIL=noreply@anthropic.com \\")

--- a/tests/lib/test_autopilot.py
+++ b/tests/lib/test_autopilot.py
@@ -295,7 +295,7 @@ class GenerateClaudeWrapperTests(unittest.TestCase):
         self.assertIn("--luskctl-timeout", wrapper)
         self.assertIn("_timeout", wrapper)
         # Wrapper should use timeout command when _timeout is set
-        self.assertIn('timeout "$_timeout" command claude', wrapper)
+        self.assertIn('timeout "$_timeout" claude', wrapper)
         # Wrapper should still have the non-timeout path
         self.assertIn('command claude "${_args[@]}" "$@"', wrapper)
         # Both paths should have git env vars


### PR DESCRIPTION
## Summary

- Autopilot/headless mode fails immediately after init with `timeout: failed to run command 'command': No such file or directory`
- The `timeout` coreutils binary uses `execvp()` to launch its target — it doesn't go through bash, so the `command` builtin (which has no on-disk binary) can't be found
- Dropping `command` from the timeout path lets `timeout` find the `claude` binary via PATH, equivalent to what `command claude` does on the interactive path

## Test plan

- [x] `make lint` passes
- [x] `make test` passes (541 tests, including updated `test_wrapper_timeout_support`)
- [x] Manual: run an autopilot task and confirm it gets past init into claude execution

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved timeout command execution behavior for Claude interactions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->