### PR TITLE
Remove backward compatibility code

### DIFF
--- a/src/luskctl/lib/containers/runtime.py
+++ b/src/luskctl/lib/containers/runtime.py
@@ -134,7 +134,7 @@ def gpu_run_args(project: "Project") -> list[str]:
     try:
         proj_cfg = yaml.safe_load((project.root / "project.yml").read_text()) or {}
         run_cfg = proj_cfg.get("run", {}) or {}
-        gpus = run_cfg.get("gpus", run_cfg.get("gpu"))
+        gpus = run_cfg.get("gpus")
         if isinstance(gpus, str):
             enabled = gpus.lower() == "all"
         elif isinstance(gpus, bool):

--- a/src/luskctl/lib/containers/tasks.py
+++ b/src/luskctl/lib/containers/tasks.py
@@ -487,8 +487,7 @@ def task_list(
 ) -> None:
     """List tasks for a project, optionally filtered by status, mode, or agent preset.
 
-    Status is computed live from podman container state + task metadata
-    (never from the legacy ``status`` YAML field).
+    Status is computed live from podman container state + task metadata.
     """
     tasks = get_tasks(project_id)
 

--- a/src/luskctl/tui/actions.py
+++ b/src/luskctl/tui/actions.py
@@ -98,10 +98,7 @@ class ActionsMixin:
     def _prompt_ui_backend(self) -> str:
         """Prompt the user to select a web UI backend and return the choice."""
         backends = list(WEB_BACKENDS)
-        # Check DEFAULT_AGENT first, fall back to LUSKUI_BACKEND
         default = os.environ.get("DEFAULT_AGENT", "").strip().lower()
-        if not default:
-            default = os.environ.get("LUSKUI_BACKEND", "").strip().lower()
         if not default:
             default = backends[0] if backends else "codex"
 

--- a/src/luskctl/tui/app.py
+++ b/src/luskctl/tui/app.py
@@ -40,7 +40,7 @@ if _HAS_TEXTUAL:
 
     from ..lib.containers.tasks import get_tasks
     from ..lib.core.config import get_tui_default_tmux
-    from ..lib.core.projects import Project as CodexProject, list_projects, load_project
+    from ..lib.core.projects import Project, list_projects, load_project
 
     # Import version info function (shared with CLI --version)
     from ..lib.core.version import get_version_info as _get_version_info
@@ -181,7 +181,7 @@ if _HAS_TEXTUAL:
 
             self.current_project_id: str | None = None
             self.current_task: TaskMeta | None = None
-            self._projects_by_id: dict[str, CodexProject] = {}
+            self._projects_by_id: dict[str, Project] = {}
             self._last_task_count: int | None = None
             # Upstream polling state
             self._staleness_info: GateStalenessInfo | None = None
@@ -481,7 +481,7 @@ if _HAS_TEXTUAL:
 
         def _load_project_state(
             self, project_id: str
-        ) -> tuple[str, CodexProject | None, dict | None, GateStalenessInfo | None, str | None]:
+        ) -> tuple[str, Project | None, dict | None, GateStalenessInfo | None, str | None]:
             """Load project infrastructure state in a background thread."""
             try:
                 project = load_project(project_id)

--- a/src/luskctl/tui/clipboard.py
+++ b/src/luskctl/tui/clipboard.py
@@ -173,8 +173,3 @@ def copy_to_clipboard_detailed(text: str) -> ClipboardCopyResult:
     return ClipboardCopyResult(
         ok=False, error=errors[-1] if errors else "Clipboard copy failed.", hint=hint or None
     )
-
-
-def copy_to_clipboard(text: str) -> bool:
-    """Backward-compatible clipboard copy helper returning only success."""
-    return copy_to_clipboard_detailed(text).ok

--- a/src/luskctl/tui/screens.py
+++ b/src/luskctl/tui/screens.py
@@ -39,7 +39,7 @@ except Exception:  # pragma: no cover - textual may be a stub module
     Input = None  # type: ignore[assignment,misc]
 
 from ..lib.containers.tasks import sanitize_task_name, validate_task_name
-from ..lib.core.projects import Project as CodexProject
+from ..lib.core.projects import Project
 from ..lib.facade import GateStalenessInfo
 from .widgets import TaskMeta, render_project_details, render_project_loading, render_task_details
 
@@ -108,7 +108,7 @@ class ProjectDetailsScreen(screen.Screen[str | None]):
 
     def __init__(
         self,
-        project: CodexProject,
+        project: Project,
         state: dict | None,
         task_count: int | None,
         staleness: GateStalenessInfo | None = None,

--- a/src/luskctl/tui/widgets.py
+++ b/src/luskctl/tui/widgets.py
@@ -17,7 +17,7 @@ from ..lib.containers.tasks import (
     TaskMeta,
     mode_emoji,
 )
-from ..lib.core.projects import Project as CodexProject
+from ..lib.core.projects import Project
 from ..lib.facade import GateStalenessInfo
 from ..lib.util.emoji import draw_emoji
 
@@ -83,10 +83,10 @@ class ProjectList(ListView):
     def __init__(self, **kwargs: Any) -> None:
         """Initialize the project list with empty state."""
         super().__init__(**kwargs)
-        self.projects: list[CodexProject] = []
+        self.projects: list[Project] = []
         self._generation = 0
 
-    def set_projects(self, projects: list[CodexProject]) -> None:
+    def set_projects(self, projects: list[Project]) -> None:
         """Populate the list with projects."""
         self.projects = projects
         self._generation += 1
@@ -390,7 +390,7 @@ def render_task_details(
 
 
 def render_project_loading(
-    project: CodexProject | None,
+    project: Project | None,
     task_count: int | None = None,
 ) -> Text:
     """Render project loading state as a Rich Text object."""
@@ -414,7 +414,7 @@ def render_project_loading(
 
 
 def render_project_details(
-    project: CodexProject | None,
+    project: Project | None,
     state: dict | None,
     task_count: int | None = None,
     staleness: GateStalenessInfo | None = None,
@@ -571,13 +571,13 @@ class ProjectState(Static):
         """Initialize the project state panel."""
         super().__init__(**kwargs)
 
-    def set_loading(self, project: CodexProject | None, task_count: int | None = None) -> None:
+    def set_loading(self, project: Project | None, task_count: int | None = None) -> None:
         """Show a loading placeholder while project state is being fetched."""
         self.update(render_project_loading(project, task_count))
 
     def set_state(
         self,
-        project: CodexProject | None,
+        project: Project | None,
         state: dict | None,
         task_count: int | None = None,
         staleness: GateStalenessInfo | None = None,

--- a/tests/lib/test_agent_config.py
+++ b/tests/lib/test_agent_config.py
@@ -169,21 +169,21 @@ class ResolveAgentConfigTests(unittest.TestCase):
             names = [s["name"] for s in result["subagents"] if isinstance(s, dict)]
             self.assertEqual(names, ["base-agent", "extra-agent"])
 
-    def test_legacy_compat_no_preset(self) -> None:
-        """Existing project.yml works unchanged without preset."""
+    def test_project_config_without_preset(self) -> None:
+        """Project agent config resolves correctly without a preset."""
         with tempfile.TemporaryDirectory() as td:
             base = Path(td)
             config_root = base / "config"
             write_project(
                 config_root,
-                "legacy",
-                "project:\n  id: legacy\nagent:\n  model: sonnet\n"
+                "proj2",
+                "project:\n  id: proj2\nagent:\n  model: sonnet\n"
                 "  subagents:\n    - name: sa1\n      default: true\n",
             )
 
             with unittest.mock.patch.dict(os.environ, _env(config_root, base / "s")):
                 with mock_git_config():
-                    result = resolve_agent_config("legacy")
+                    result = resolve_agent_config("proj2")
             self.assertEqual(result["model"], "sonnet")
             self.assertEqual(result["subagents"][0]["name"], "sa1")
 

--- a/tests/lib/test_tasks.py
+++ b/tests/lib/test_tasks.py
@@ -19,7 +19,6 @@ from luskctl.lib.containers.tasks import (
 )
 from luskctl.lib.core.projects import load_project
 from luskctl.tui.clipboard import (
-    copy_to_clipboard,
     copy_to_clipboard_detailed,
     get_clipboard_helper_status,
 )
@@ -906,12 +905,12 @@ class TaskTests(unittest.TestCase):
                 self.assertIsNone(result)
 
     def test_copy_to_clipboard_empty_text(self) -> None:
-        """Test copy_to_clipboard returns False for empty text."""
-        result = copy_to_clipboard("")
-        self.assertFalse(result)
+        """Test copy_to_clipboard_detailed returns failure for empty text."""
+        result = copy_to_clipboard_detailed("")
+        self.assertFalse(result.ok)
 
     def test_copy_to_clipboard_success_wl_copy(self) -> None:
-        """Test copy_to_clipboard succeeds with wl-copy."""
+        """Test copy_to_clipboard_detailed succeeds with wl-copy."""
         with unittest.mock.patch.dict(
             os.environ, {"XDG_SESSION_TYPE": "wayland", "WAYLAND_DISPLAY": "wayland-0"}
         ):
@@ -921,8 +920,8 @@ class TaskTests(unittest.TestCase):
                 with unittest.mock.patch("luskctl.tui.clipboard.subprocess.run") as run_mock:
                     run_mock.return_value = subprocess.CompletedProcess(args=[], returncode=0)
 
-                    result = copy_to_clipboard("test content")
-                    self.assertTrue(result)
+                    result = copy_to_clipboard_detailed("test content")
+                    self.assertTrue(result.ok)
 
                     run_mock.assert_called_once()
                     args, kwargs = run_mock.call_args
@@ -933,7 +932,7 @@ class TaskTests(unittest.TestCase):
                     self.assertTrue(kwargs["capture_output"])
 
     def test_copy_to_clipboard_fallback_to_xclip(self) -> None:
-        """Test copy_to_clipboard uses xclip on X11 when available."""
+        """Test copy_to_clipboard_detailed uses xclip on X11 when available."""
         # Ensure Wayland environment variables are not set to force X11 detection
         env = {"XDG_SESSION_TYPE": "x11", "DISPLAY": ":0", "WAYLAND_DISPLAY": ""}
 
@@ -944,8 +943,8 @@ class TaskTests(unittest.TestCase):
                 with unittest.mock.patch("luskctl.tui.clipboard.subprocess.run") as run_mock:
                     run_mock.return_value = subprocess.CompletedProcess(args=[], returncode=0)
 
-                    result = copy_to_clipboard("test content")
-                    self.assertTrue(result)
+                    result = copy_to_clipboard_detailed("test content")
+                    self.assertTrue(result.ok)
 
                     run_mock.assert_called_once()
                     args, _kwargs = run_mock.call_args


### PR DESCRIPTION
## Summary
- Remove `copy_to_clipboard()` backward-compat wrapper — no production callers; tests updated to use `copy_to_clipboard_detailed()` directly
- Rename `CodexProject` alias to `Project` across all TUI files (legacy naming from pre-rename era)
- Drop `gpu` → `gpus` config key fallback in `runtime.py` — only `gpus` is now accepted
- Remove `LUSKUI_BACKEND` env var fallback in `actions.py` — only `DEFAULT_AGENT` is used on host side
- Clean up legacy YAML field comment in `tasks.py` docstring
- Rename `test_legacy_compat_no_preset` → `test_project_config_without_preset`

Net result: -10 lines, cleaner code with no backward compat baggage.

## Test plan
- [x] `make lint` passes
- [x] `make test` passes (591 tests)
- [x] `make tach` passes
- [x] `make docstrings` passes (100% coverage)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated GPU configuration to read only the "gpus" key from project settings, removing fallback behavior.
  * Simplified backend selection logic to depend solely on default agent configuration.

* **Refactor**
  * Consolidated clipboard copying API to a single detailed function.
  * Standardized internal type references across TUI modules.

* **Documentation**
  * Clarified task status documentation.

* **Tests**
  * Updated test method naming and assertions for agent configuration.
  * Adapted clipboard tests to updated API.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->