### PR TITLE
Move stray state/log files under state_root() for XDG compliance

### DIFF
--- a/src/luskctl/lib/util/logging_utils.py
+++ b/src/luskctl/lib/util/logging_utils.py
@@ -9,14 +9,17 @@ def _log_debug(message: str) -> None:
     between different frontends (e.g. CLI vs TUI) when calling the shared
     helpers in this module.
 
-    Writes timestamped lines to ~/.luskctl.log. Fully exception-safe: any IO
-    error is silently ignored so this function never raises or affects callers.
+    Writes timestamped lines to ``state_root()/luskctl.log``. Fully
+    exception-safe: any IO error is silently ignored so this function never
+    raises or affects callers.
     """
     try:
-        import os
         import time
 
-        log_path = os.path.join(os.path.expanduser("~"), ".luskctl.log")
+        from ..core.paths import state_root
+
+        log_path = state_root() / "luskctl.log"
+        log_path.parent.mkdir(parents=True, exist_ok=True)
         timestamp = time.strftime("%Y-%m-%d %H:%M:%S", time.localtime())
         with open(log_path, "a", encoding="utf-8") as f:
             f.write(f"[{timestamp}] {message}\n")

--- a/src/luskctl/tui/app.py
+++ b/src/luskctl/tui/app.py
@@ -39,7 +39,7 @@ if _HAS_TEXTUAL:
     from textual.worker import Worker, WorkerState
 
     from ..lib.containers.tasks import get_tasks
-    from ..lib.core.config import get_tui_default_tmux
+    from ..lib.core.config import get_tui_default_tmux, state_root
     from ..lib.core.projects import Project, list_projects, load_project
 
     # Import version info function (shared with CLI --version)
@@ -268,15 +268,13 @@ if _HAS_TEXTUAL:
                 pass
 
         def _log_layout_debug(self) -> None:
-            """Write a one-shot snapshot of key widget sizes to /tmp.
+            """Write a one-shot snapshot of key widget sizes to the state dir.
 
             This is for debugging why the right-hand task list/details may
             not be visible even though the widgets exist.
             """
             try:
-                from pathlib import Path as _Path
-
-                log_path = _Path("/tmp/luskctl-tui.log")
+                log_path = state_root() / "luskctl-tui.log"
                 log_path.parent.mkdir(parents=True, exist_ok=True)
 
                 left_pane = self.query_one("#left-pane")
@@ -313,9 +311,8 @@ if _HAS_TEXTUAL:
 
             try:
                 from datetime import datetime as _dt
-                from pathlib import Path as _Path
 
-                log_path = _Path("/tmp/luskctl-tui.log")
+                log_path = state_root() / "luskctl-tui.log"
                 log_path.parent.mkdir(parents=True, exist_ok=True)
                 ts = _dt.now().isoformat(timespec="seconds")
                 with log_path.open("a", encoding="utf-8") as _f:
@@ -328,9 +325,8 @@ if _HAS_TEXTUAL:
             """Load last selected project and tasks from persistent storage."""
             try:
                 import json
-                from pathlib import Path as _Path
 
-                state_path = _Path("~/.luskctl-tui-state.json").expanduser()
+                state_path = state_root() / "luskctl-tui-state.json"
                 if state_path.exists():
                     with state_path.open("r", encoding="utf-8") as f:
                         state = json.load(f)
@@ -345,9 +341,9 @@ if _HAS_TEXTUAL:
             """Save current selection state to persistent storage."""
             try:
                 import json
-                from pathlib import Path as _Path
 
-                state_path = _Path("~/.luskctl-tui-state.json").expanduser()
+                state_path = state_root() / "luskctl-tui-state.json"
+                state_path.parent.mkdir(parents=True, exist_ok=True)
                 state = {
                     "last_project": self.current_project_id,
                     "last_tasks": self._last_selected_tasks,

--- a/tach.toml
+++ b/tach.toml
@@ -319,7 +319,7 @@ utility = true
 [[modules]]
 path = "luskctl.lib.util.logging_utils"
 layer = "core"
-depends_on = []
+depends_on = ["luskctl.lib.core.paths"]
 utility = true
 
 # Emoji display-width utilities


### PR DESCRIPTION
## Summary

- Move TUI selection state from `~/.luskctl-tui-state.json` to `state_root()/luskctl-tui-state.json`
- Move TUI debug log from `/tmp/luskctl-tui.log` to `state_root()/luskctl-tui.log`
- Move library debug log from `~/.luskctl.log` to `state_root()/luskctl.log`

All runtime state now lives under `~/.local/share/luskctl` (or `LUSKCTL_STATE_DIR`), keeping `~` clean and respecting the XDG layout: config in `~/.config/luskctl`, state in `~/.local/share/luskctl`.

## Test plan

- [x] `make lint` passes
- [x] `tach check` passes (added `luskctl.lib.core.paths` dep to `logging_utils`)
- [x] All 593 tests pass
- [ ] Verify TUI remembers last-selected project across restarts
- [ ] Verify debug logs appear in `~/.local/share/luskctl/` instead of `~` or `/tmp`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated application log and state files to the project state directory for improved organization and consistency across the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->