### PR TITLE
Fix docs: CLI tool is terokctl, not terok

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![License: Apache-2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 [![REUSE compliant](https://api.reuse.software/badge/github.com/terok-ops/terok)](https://api.reuse.software/info/github.com/terok-ops/terok)
 
-A tool for managing containerized AI coding agent projects using Podman. Provides both a CLI (`terok`) and a Textual TUI (`terok`).
+A tool for managing containerized AI coding agent projects using Podman. Provides both a CLI (`terokctl`) and a Textual TUI (`terok`).
 
 > **Future plans and design documents** are in [`docs/brainstorming/`](docs/brainstorming/).
 

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -1,6 +1,6 @@
 # terok User Guide
 
-A prefix-/XDG-aware tool to manage containerized AI agent projects using Podman. Provides a CLI (`terok`) and a Textual TUI (`terok`).
+A prefix-/XDG-aware tool to manage containerized AI agent projects using Podman. Provides a CLI (`terokctl`) and a Textual TUI (`terok`).
 
 ## Table of Contents
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,6 @@
 # terok
 
-A tool for managing containerized AI coding agent projects using Podman. Provides both a CLI (`terok`) and a Textual TUI (`terok`).
+A tool for managing containerized AI coding agent projects using Podman. Provides both a CLI (`terokctl`) and a Textual TUI (`terok`).
 
 ## Features
 


### PR DESCRIPTION
## Summary

- Three doc files (README.md, docs/USAGE.md, docs/index.md) incorrectly listed both the CLI and TUI as `terok`
- Fixed to correctly state: CLI is `terokctl`, TUI is `terok`

## Test plan

- [x] Verified no other instances of this mislabeling remain

🤖 Generated with [Claude Code](https://claude.com/claude-code)