### PR TITLE
Fix quality report generation failures and improve readability

### DIFF
--- a/docs/gen_quality_report.py
+++ b/docs/gen_quality_report.py
@@ -52,9 +52,7 @@ def _section_complexity() -> str:
     # Run complexipy to populate the cache (use CLI entry point, not -m).
     # Note: --quiet is omitted because it causes a spurious non-zero exit code
     # in complexipy >=5.x.  capture_output=True suppresses stdout anyway.
-    run_result = _run(
-        str(_VENV_BIN / "complexipy"), str(SRC), "--ignore-complexity"
-    )
+    run_result = _run(str(_VENV_BIN / "complexipy"), str(SRC), "--ignore-complexity")
     if run_result.returncode != 0:
         output = (run_result.stdout + run_result.stderr).strip()
         return f"!!! warning\n    complexipy failed; skipping complexity report.\n\n```\n{output}\n```\n"


### PR DESCRIPTION
## Summary
- **complexipy & docstr-coverage failures**: Both tools lack `__main__.py`, so `python -m` invocation fails in CI. Switched to CLI entry points resolved via `sys.executable` parent directory
- **complexipy `--quiet` bug**: Dropped the flag which causes a spurious non-zero exit code in complexipy >=5.x (stdout is already captured by subprocess)
- **Dependency graph unreadable**: Coarsened the Mermaid diagram from ~70 fine-grained module edges to ~23 high-level edges (depth 3), with aggregated edge counts as labels
- **Dependency report too long**: Wrapped `tach report` output in a collapsible `<details>` block

## Test plan
- [x] `mkdocs build` succeeds locally
- [x] Complexity section now renders stats and table (was failing with empty error)
- [x] Docstring coverage section renders summary lines (was failing with empty error)
- [x] Mermaid graph has ~23 readable edges instead of ~70 tiny ones
- [x] Dependency report is collapsed by default
- [ ] Verify rendered report on GitHub Pages after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Simplified, coarsened dependency diagrams that deduplicate edges and surface counts for clearer top-down views.
  * Dependency reports wrapped in expandable sections to reduce clutter while preserving isolated nodes.

* **Improvements**
  * More reliable command execution with timeouts and permissive failure handling to avoid spurious errors.
  * CLI-based tooling invocation for more consistent analysis and updated output formatting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->