### PR TITLE
feat: add project delete action (CLI + TUI)

### DIFF
--- a/src/terok/cli/commands/project.py
+++ b/src/terok/cli/commands/project.py
@@ -2,13 +2,14 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-"""Project management commands: list, derive, wizard, presets."""
+"""Project management commands: list, derive, delete, wizard, presets."""
 
 from __future__ import annotations
 
 import argparse
 
 from ...lib.core.projects import derive_project, list_presets, list_projects
+from ...lib.facade import project_delete
 from ...lib.wizards.new_project import run_wizard
 from ._completers import complete_project_ids as _complete_project_ids, set_completer
 from .setup import cmd_project_init
@@ -35,6 +36,17 @@ def register(subparsers: argparse._SubParsersAction[argparse.ArgumentParser]) ->
         _complete_project_ids,
     )
     p_derive.add_argument("new_id", help="New project ID")
+
+    # project-delete
+    p_delete = subparsers.add_parser(
+        "project-delete",
+        help="Delete a project and all its associated data (non-recoverable)",
+    )
+    set_completer(
+        p_delete.add_argument("project_id", help="Project ID to delete"),
+        _complete_project_ids,
+    )
+    p_delete.add_argument("--force", action="store_true", help="Skip confirmation prompt")
 
     # presets
     p_presets = subparsers.add_parser("presets", help="Manage agent config presets")
@@ -64,6 +76,19 @@ def dispatch(args: argparse.Namespace) -> bool:
         print(f"  1. Edit {target / 'project.yml'} (customize agent: section)")
         print(f"  2. Initialize: terokctl project-init {args.new_id}")
         print("  Tip: global presets are shared across projects (see terokctl config)")
+        return True
+    if args.cmd == "project-delete":
+        pid = args.project_id
+        if not args.force:
+            print(f"WARNING: This will permanently delete project '{pid}' and all its data.")
+            print("This includes task workspaces, containers, build artifacts, and config files.")
+            print("This action cannot be undone.")
+            answer = input(f"\nType the project ID '{pid}' to confirm deletion: ")
+            if answer.strip() != pid:
+                print("Aborted.")
+                return True
+        project_delete(pid)
+        print(f"Project '{pid}' has been deleted.")
         return True
     if args.cmd == "project-wizard":
         run_wizard(init_fn=cmd_project_init)

--- a/src/terok/lib/facade.py
+++ b/src/terok/lib/facade.py
@@ -12,6 +12,9 @@ The facade re-exports key service functions and provides composite
 helpers for multi-step workflows like project initialization.
 """
 
+import logging
+import shutil
+
 from .containers.docker import build_images, generate_dockerfiles
 from .containers.environment import WEB_BACKENDS
 from .containers.project_state import get_project_state, is_task_image_old
@@ -32,7 +35,9 @@ from .containers.tasks import (  # noqa: F401 — re-exported public API
     task_rename,
     task_status,
     task_stop,
+    tasks_meta_dir,
 )
+from .core.config import build_root, get_envs_base_dir, state_root
 from .core.projects import load_project
 from .security.auth import AUTH_PROVIDERS, AuthProvider, authenticate
 from .security.git_gate import (
@@ -44,6 +49,68 @@ from .security.git_gate import (
     sync_project_gate,
 )
 from .security.ssh import init_project_ssh
+
+_logger = logging.getLogger(__name__)
+
+
+def project_delete(project_id: str) -> None:
+    """Delete a project's configuration, state, and all associated artifacts.
+
+    Removes (in order):
+
+    1. All task containers (stopped best-effort) and their workspaces/metadata
+    2. Git gate mirror (only if no other projects share it)
+    3. SSH key directory
+    4. Build artifacts (generated Dockerfiles)
+    5. Project config directory (``project.yml``, instructions, presets)
+
+    Raises :class:`SystemExit` if the project is not found.
+    """
+    project = load_project(project_id)
+
+    # Delete every task (stops containers, removes workspace + metadata)
+    meta_dir = tasks_meta_dir(project.id)
+    if meta_dir.is_dir():
+        for meta_file in meta_dir.glob("*.yml"):
+            try:
+                task_delete(project_id, meta_file.stem)
+            except Exception:
+                pass
+
+    # Remove leftover task workspaces dir (task_delete handles individual dirs,
+    # but the parent may remain)
+    if project.tasks_root.is_dir():
+        shutil.rmtree(project.tasks_root, ignore_errors=True)
+
+    # Remove project state directory
+    project_state_dir = state_root() / "projects" / project.id
+    if project_state_dir.is_dir():
+        shutil.rmtree(project_state_dir, ignore_errors=True)
+
+    # Remove gate only if no other projects share it
+    if project.gate_path.is_dir():
+        sharing = find_projects_sharing_gate(project.gate_path, exclude_project=project.id)
+        if not sharing:
+            shutil.rmtree(project.gate_path, ignore_errors=True)
+        else:
+            shared_ids = ", ".join(pid for pid, _ in sharing)
+            _logger.info("Keeping gate %s (shared by: %s)", project.gate_path, shared_ids)
+
+    # Remove SSH directory
+    ssh_dir = project.ssh_host_dir or (get_envs_base_dir() / f"_ssh-config-{project.id}")
+    if ssh_dir.is_dir():
+        shutil.rmtree(ssh_dir, ignore_errors=True)
+
+    # Remove build artifacts
+    project_build_dir = build_root() / project.id
+    if project_build_dir.is_dir():
+        shutil.rmtree(project_build_dir, ignore_errors=True)
+
+    # Remove project config directory (last — load_project needed it above)
+    if project.root.is_dir():
+        shutil.rmtree(project.root, ignore_errors=True)
+
+    _logger.info("Deleted project '%s'", project_id)
 
 
 def maybe_pause_for_ssh_key_registration(project_id: str) -> None:
@@ -88,6 +155,8 @@ __all__ = [
     # Security setup
     "init_project_ssh",
     "sync_project_gate",
+    # Project lifecycle
+    "project_delete",
     # Workflow helpers
     "maybe_pause_for_ssh_key_registration",
     # Auth

--- a/src/terok/tui/app.py
+++ b/src/terok/tui/app.py
@@ -84,6 +84,7 @@ if _HAS_TEXTUAL:
         "edit_instructions": "_action_edit_instructions",
         "toggle_inherit": "_action_toggle_instructions_inherit",
         "show_resolved": "_action_show_resolved_instructions",
+        "delete_project": "_action_delete_project",
     }
 
     TASK_ACTION_HANDLERS: dict[str, str] = {

--- a/src/terok/tui/project_actions.py
+++ b/src/terok/tui/project_actions.py
@@ -24,6 +24,7 @@ from ..lib.facade import (
     generate_dockerfiles,
     init_project_ssh,
     maybe_pause_for_ssh_key_registration,
+    project_delete,
     sync_project_gate,
 )
 from .shell_launch import launch_login
@@ -430,6 +431,46 @@ class ProjectActionsMixin:
             print(f"\n=== End ({len(text)} chars) ===")
 
         await self._run_suspended(work, refresh=None)
+
+    # ---------- Project deletion ----------
+
+    async def _action_delete_project(self) -> None:
+        """Delete the current project after confirmation."""
+        if not self.current_project_id:
+            self.notify("No project selected.")
+            return
+
+        from .screens import ConfirmDeleteScreen
+
+        pid = self.current_project_id
+        await self.push_screen(
+            ConfirmDeleteScreen(pid),
+            self._on_delete_project_confirmed,
+        )
+
+    async def _on_delete_project_confirmed(self, confirmed: bool) -> None:
+        """Handle the result from the delete confirmation screen."""
+        if not confirmed or not self.current_project_id:
+            return
+
+        pid = self.current_project_id
+
+        def work() -> None:
+            """Delete the project and all associated data."""
+            project_delete(pid)
+
+        with self.suspend():
+            try:
+                work()
+                print(f"Project '{pid}' has been deleted.")
+            except SystemExit as e:
+                print(f"Error: {e}")
+            except Exception as e:
+                print(f"Error: {e}")
+            input("\n[Press Enter to return to TerokTUI] ")
+
+        await self.refresh_projects()
+        self.notify(f"Project '{pid}' deleted.")
 
     # --- Project wizard ---
 

--- a/src/terok/tui/screens.py
+++ b/src/terok/tui/screens.py
@@ -102,6 +102,7 @@ class ProjectDetailsScreen(screen.Screen[str | None]):
         _modal_binding("I", "edit_instructions", "Edit instructions"),
         _modal_binding("t", "toggle_inherit", "Toggle inherit"),
         _modal_binding("v", "show_resolved", "Show resolved instructions"),
+        _modal_binding("X", "delete_project", "Delete project"),
     ]
 
     CSS = (
@@ -153,6 +154,8 @@ class ProjectDetailsScreen(screen.Screen[str | None]):
             Option("edit \\[I]nstructions", id="edit_instructions"),
             Option("\\[t]oggle instructions inherit", id="toggle_inherit"),
             Option("\\[v]iew resolved instructions", id="show_resolved"),
+            None,
+            Option("delete project  \\[X]", id="delete_project"),
             id="actions-list",
         )
 
@@ -234,6 +237,107 @@ class ProjectDetailsScreen(screen.Screen[str | None]):
     def action_show_resolved(self) -> None:
         """Show fully resolved instructions."""
         self.dismiss("show_resolved")
+
+    def action_delete_project(self) -> None:
+        """Trigger project deletion (with confirmation)."""
+        self.dismiss("delete_project")
+
+
+# ---------------------------------------------------------------------------
+# Confirm Delete Screen
+# ---------------------------------------------------------------------------
+
+
+class ConfirmDeleteScreen(screen.ModalScreen[bool]):
+    """Modal that requires the user to type a project ID to confirm deletion."""
+
+    BINDINGS = [
+        _modal_binding("escape", "cancel", "Cancel"),
+    ]
+
+    CSS = """
+    ConfirmDeleteScreen {
+        align: center middle;
+    }
+
+    #confirm-dialog {
+        width: 60;
+        height: auto;
+        max-height: 80%;
+        border: heavy $error;
+        border-title-align: right;
+        border-subtitle-align: left;
+        background: $surface;
+        padding: 1;
+    }
+
+    #confirm-warning {
+        color: $error;
+        margin-bottom: 1;
+    }
+
+    #confirm-input {
+        margin-bottom: 1;
+    }
+
+    #confirm-buttons {
+        height: auto;
+        align-horizontal: right;
+    }
+
+    #confirm-buttons Button {
+        margin-left: 1;
+    }
+    """
+
+    def __init__(self, project_id: str) -> None:
+        """Create the confirmation screen for the given project."""
+        super().__init__()
+        self._project_id = project_id
+
+    def compose(self) -> ComposeResult:
+        """Build the confirmation dialog with warning, input, and buttons."""
+        with Vertical(id="confirm-dialog") as dialog:
+            yield Static(
+                f"This will permanently delete project '{self._project_id}' "
+                "and all its data.\nThis action cannot be undone.",
+                id="confirm-warning",
+            )
+            yield Static(f"Type '{self._project_id}' to confirm:")
+            yield Input(placeholder=self._project_id, id="confirm-input")
+            with Horizontal(id="confirm-buttons"):
+                yield Button("Cancel", id="btn-cancel", variant="default")
+                yield Button("Delete", id="btn-delete", variant="error")
+        dialog.border_title = "Delete Project"
+        dialog.border_subtitle = "Esc to cancel"
+
+    def on_mount(self) -> None:
+        """Focus the input for immediate typing."""
+        inp = self.query_one("#confirm-input", Input)
+        inp.focus()
+
+    def on_button_pressed(self, event: Button.Pressed) -> None:
+        """Handle Delete or Cancel button clicks."""
+        if event.button.id == "btn-delete":
+            self._submit()
+        elif event.button.id == "btn-cancel":
+            self.dismiss(False)
+
+    def on_input_submitted(self, event: "Input.Submitted") -> None:  # type: ignore[name-defined]
+        """Accept on Enter key press."""
+        self._submit()
+
+    def _submit(self) -> None:
+        """Confirm deletion if the input matches the project ID."""
+        inp = self.query_one("#confirm-input", Input)
+        if inp.value.strip() == self._project_id:
+            self.dismiss(True)
+        else:
+            self.notify("Project ID does not match.", severity="error")
+
+    def action_cancel(self) -> None:
+        """Cancel deletion."""
+        self.dismiss(False)
 
 
 # ---------------------------------------------------------------------------

--- a/tach.toml
+++ b/tach.toml
@@ -77,6 +77,7 @@ depends_on = [
     "terok.lib.containers.task_logs",
     "terok.lib.containers.task_runners",
     "terok.lib.containers.tasks",
+    "terok.lib.core.config",
     "terok.lib.core.projects",
     "terok.lib.security.auth",
     "terok.lib.security.git_gate",
@@ -627,6 +628,7 @@ expose = [
     "find_projects_sharing_gate",
     "get_project_state",
     "is_task_image_old",
+    "project_delete",
     "maybe_pause_for_ssh_key_registration",
 ]
 from = ["terok.lib.facade"]

--- a/tests/lib/test_projects.py
+++ b/tests/lib/test_projects.py
@@ -9,8 +9,10 @@ import unittest.mock
 from pathlib import Path
 
 from terok.lib.containers.project_state import get_project_state
+from terok.lib.containers.tasks import task_new
 from terok.lib.core.config import build_root, state_root
 from terok.lib.core.projects import list_projects, load_project
+from terok.lib.facade import project_delete
 from test_utils import project_env, write_project
 
 
@@ -143,3 +145,89 @@ git:
                     "gate_last_commit": None,
                 },
             )
+
+    def test_project_delete_removes_config_and_state(self) -> None:
+        """project_delete removes project config dir and task state."""
+        project_id = "del-proj"
+        yaml_text = f"project:\n  id: {project_id}\n"
+        with project_env(yaml_text, project_id=project_id) as ctx:
+            # Create a task so there's state to clean up
+            with unittest.mock.patch("terok.lib.containers.tasks.subprocess.run") as run_mock:
+                run_mock.return_value.returncode = 0
+                task_id = task_new(project_id)
+
+            meta_path = ctx.state_dir / "projects" / project_id / "tasks" / f"{task_id}.yml"
+            self.assertTrue(meta_path.is_file())
+
+            proj = load_project(project_id)
+            workspace = proj.tasks_root / str(task_id)
+            self.assertTrue(workspace.is_dir())
+            config_dir = proj.root
+            self.assertTrue(config_dir.is_dir())
+
+            with unittest.mock.patch("terok.lib.containers.tasks.subprocess.run") as run_mock:
+                run_mock.return_value.returncode = 0
+                project_delete(project_id)
+
+            # Config, workspace, and metadata should all be gone
+            self.assertFalse(config_dir.exists())
+            self.assertFalse(workspace.exists())
+            self.assertFalse(meta_path.exists())
+
+    def test_project_delete_preserves_shared_gate(self) -> None:
+        """project_delete keeps the gate if another project shares it."""
+        with tempfile.TemporaryDirectory() as td:
+            base = Path(td)
+            config_dir = base / "config"
+            state_dir = base / "state"
+
+            # Two projects sharing the same gate path
+            gate_path = state_dir / "gate" / "shared.git"
+            gate_path.mkdir(parents=True, exist_ok=True)
+            (gate_path / "HEAD").write_text("ref: refs/heads/main\n")
+
+            for pid in ("proj-a", "proj-b"):
+                write_project(
+                    config_dir,
+                    pid,
+                    f"project:\n  id: {pid}\ngate:\n  path: {gate_path}\n",
+                )
+
+            with unittest.mock.patch.dict(
+                os.environ,
+                {
+                    "TEROK_CONFIG_DIR": str(config_dir),
+                    "TEROK_STATE_DIR": str(state_dir),
+                },
+            ):
+                with unittest.mock.patch("terok.lib.containers.tasks.subprocess.run"):
+                    project_delete("proj-a")
+
+                # Gate should still exist because proj-b uses it
+                self.assertTrue(gate_path.is_dir())
+                # proj-a config should be gone
+                self.assertFalse((config_dir / "proj-a").exists())
+                # proj-b should still be loadable
+                proj_b = load_project("proj-b")
+                self.assertEqual(proj_b.id, "proj-b")
+
+    def test_project_delete_removes_unshared_gate(self) -> None:
+        """project_delete removes the gate when no other project uses it."""
+        project_id = "solo-gate"
+        yaml_text = f"project:\n  id: {project_id}\n"
+        with project_env(yaml_text, project_id=project_id) as ctx:
+            # Create a gate directory
+            gate_dir = ctx.state_dir / "gate" / f"{project_id}.git"
+            gate_dir.mkdir(parents=True, exist_ok=True)
+            (gate_dir / "HEAD").write_text("ref: refs/heads/main\n")
+
+            with unittest.mock.patch("terok.lib.containers.tasks.subprocess.run"):
+                project_delete(project_id)
+
+            self.assertFalse(gate_dir.exists())
+
+    def test_project_delete_nonexistent_raises(self) -> None:
+        """project_delete raises SystemExit for a nonexistent project."""
+        with project_env("project:\n  id: exists\n", project_id="exists"):
+            with self.assertRaises(SystemExit):
+                project_delete("no-such-project")


### PR DESCRIPTION
## Summary

- Adds `terokctl project-delete <id>` CLI command with `--force` flag to skip confirmation
- Adds "delete project [X]" action in TUI project details screen with a type-to-confirm modal dialog
- Core `project_delete()` function in the facade cleanly removes all project artifacts: task containers/workspaces, git gate (preserved if shared), SSH keys, build artifacts, and config
- 4 new tests covering deletion with tasks, shared gate preservation, unshared gate removal, and error handling

Closes #284

## Test plan
- [x] All 744 existing tests pass
- [x] 4 new tests for project deletion pass
- [x] ruff lint + format checks pass
- [x] tach module boundary checks pass
- [x] docstr-coverage at 100%

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added project deletion capability via CLI with optional `--force` flag for automatic confirmation.
  * New deletion confirmation dialog requiring project ID verification for added safety.

* **Tests**
  * Added comprehensive test coverage for project deletion scenarios, including shared resources and error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->