### PR TITLE
feat: hint user when NVIDIA CDI configuration is missing

### DIFF
--- a/src/terok/lib/containers/task_runners.py
+++ b/src/terok/lib/containers/task_runners.py
@@ -85,15 +85,14 @@ _CDI_HINT = (
     "See: https://podman-desktop.io/docs/podman/gpu"
 )
 
-_CDI_ERROR_PATTERNS = ("cdi.k8s.io", "nvidia.com/gpu", "cdi")
+_CDI_ERROR_PATTERNS = ("cdi.k8s.io", "nvidia.com/gpu", "CDI")
 
 
 def _enrich_run_error(prefix: str, exc: subprocess.CalledProcessError) -> str:
     """Return an enriched error message, adding a CDI hint when applicable."""
     stderr = (exc.stderr or b"").decode(errors="replace")
     msg = f"{prefix}: {exc}" if not stderr else f"{prefix}:\n{stderr.strip()}"
-    stderr_folded = stderr.casefold()
-    if any(pat in stderr_folded for pat in _CDI_ERROR_PATTERNS):
+    if any(pat in stderr for pat in _CDI_ERROR_PATTERNS):
         msg += f"\n\n{_CDI_HINT}"
     return msg
 

--- a/tests/lib/test_cdi_hint.py
+++ b/tests/lib/test_cdi_hint.py
@@ -32,8 +32,8 @@ class CdiHintTests(unittest.TestCase):
         msg = _enrich_run_error("Run failed", exc)
         self.assertIn(_CDI_HINT, msg)
 
-    def test_cdi_hint_on_generic_cdi_error(self) -> None:
-        """CDI hint is shown when stderr mentions CDI."""
+    def test_cdi_hint_on_uppercase_cdi_error(self) -> None:
+        """CDI hint is shown when stderr mentions uppercase CDI."""
         exc = self._make_error("Error: CDI device injection failed")
         msg = _enrich_run_error("Run failed", exc)
         self.assertIn(_CDI_HINT, msg)
@@ -44,6 +44,12 @@ class CdiHintTests(unittest.TestCase):
         msg = _enrich_run_error("Run failed", exc)
         self.assertNotIn(_CDI_HINT, msg)
         self.assertIn("image not found", msg)
+
+    def test_no_cdi_hint_on_lowercase_cdi_substring(self) -> None:
+        """CDI hint is NOT shown when stderr only contains 'cdi' as a lowercase substring."""
+        exc = self._make_error("Error: encoding failed")
+        msg = _enrich_run_error("Run failed", exc)
+        self.assertNotIn(_CDI_HINT, msg)
 
     def test_empty_stderr_no_hint(self) -> None:
         """No CDI hint when stderr is empty."""
@@ -59,12 +65,15 @@ class CdiHintTests(unittest.TestCase):
         msg = _enrich_run_error("Run failed", exc)
         self.assertNotIn(_CDI_HINT, msg)
 
-    def test_cdi_hint_case_insensitive(self) -> None:
-        """CDI hint is shown regardless of stderr case."""
-        for text in ("Error: cdi device failed", "Error: Cdi device failed", "Error: CDI failed"):
+    def test_cdi_hint_only_on_explicit_patterns(self) -> None:
+        """CDI hint is shown only for explicit patterns, not arbitrary case variants."""
+        for text in ("Error: cdi device failed", "Error: Cdi device failed"):
             exc = self._make_error(text)
             msg = _enrich_run_error("Run failed", exc)
-            self.assertIn(_CDI_HINT, msg, f"CDI hint missing for stderr: {text!r}")
+            self.assertNotIn(_CDI_HINT, msg, f"CDI hint should not match: {text!r}")
+        exc = self._make_error("Error: CDI device failed")
+        msg = _enrich_run_error("Run failed", exc)
+        self.assertIn(_CDI_HINT, msg)
 
     def test_prefix_in_message(self) -> None:
         """The prefix is always included in the error message."""


### PR DESCRIPTION
## Summary

Closes #141.

- When a GPU-enabled project fails to start due to missing or broken NVIDIA CDI configuration, Podman's stderr is now captured and checked for CDI-related error patterns (`nvidia.com/gpu`, `cdi.k8s.io`, `CDI`)
- When detected, a helpful hint is appended to the error message pointing the user to https://podman-desktop.io/docs/podman/gpu
- Applies to both `_run_container()` (new task launch) and `_podman_start()` (existing container restart)
- Non-CDI errors now also show Podman's stderr for better diagnostics

## Test plan

- [x] Added `tests/lib/test_cdi_hint.py` with 7 test cases covering CDI pattern detection, unrelated errors, empty/None stderr, and prefix handling
- [x] All tests pass
- [x] Linter and formatter pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced runtime error diagnostics to detect CDI/GPU-related failures; error messages now include contextual hints and guidance when container device-interface issues are detected.

* **Tests**
  * Added unit tests validating CDI/GPU hint behavior across NVIDIA, Kubernetes CDI, generic CDI, and non-CDI scenarios; tests ensure hints appear only for explicit patterns and preserve original message prefixes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->