### PR TITLE
fix: remove misleading native Claude config from `terokctl config`

### DIFF
--- a/src/terok/cli/commands/info.py
+++ b/src/terok/cli/commands/info.py
@@ -214,21 +214,6 @@ def _print_config() -> None:
                     f"(exists: {_yes_no(path.is_file(), color_enabled)})"
                 )
 
-    # Native Claude configuration locations
-    home = Path.home()
-    claude_agents_dir = home / ".claude" / "agents"
-    claude_settings = home / ".claude" / "settings.json"
-    print("Native Claude configuration (edit with your OS tools):")
-    print(
-        f"- Global agents dir: {_gray(str(claude_agents_dir), color_enabled)} "
-        f"(exists: {_yes_no(claude_agents_dir.is_dir(), color_enabled)})"
-    )
-    print(
-        f"- Global settings: {_gray(str(claude_settings), color_enabled)} "
-        f"(exists: {_yes_no(claude_settings.is_file(), color_enabled)})"
-    )
-    print("  (MCPs go in settings.json under mcpServers)")
-
     # ENVIRONMENT
     print("Environment overrides (if set):")
     for var in (


### PR DESCRIPTION
## Summary

- Remove the "Native Claude configuration" section from `terokctl config` output
- It showed host-side `~/.claude/agents` and `~/.claude/settings.json` paths, which are irrelevant since in-container Claude dirs are mounted from dedicated host folders to avoid cross-pollution between host and container files
- The paths were display-only (not used elsewhere in the codebase) and were confusing rather than helpful

## Test plan

- [x] Verified the removed paths are not referenced anywhere else in `src/`
- [x] Existing config output test passes
- [x] `make lint` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Simplified the info command's configuration overview by removing details about global Claude agent directories and settings from the displayed output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->