### PR TITLE
Inject mounted instructions into Codex startup context

### DIFF
--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -506,8 +506,10 @@ Every task container receives instructions explaining the workspace layout, avai
 1. **YAML `instructions` key** — controls the inheritance chain via config stack. Uses `_inherit` in list form to splice the bundled default at that position. Absent = bundled default.
 2. **Standalone `instructions.md` file** in the project root — always appended at the end of whatever the YAML chain resolved. Purely additive. If empty or absent, nothing is appended.
 
-- **Claude**: instructions are injected via `--append-system-prompt` (system-level context)
-- **Other providers**: instructions are prepended to the task prompt
+- **Claude**: injected via `--append-system-prompt` (system-level context)
+- **Codex**: loaded from `/home/dev/.terok/instructions.md` via `-c model_instructions_file=...`
+  in the wrapper (applies to both `terokctl run` and `terokctl task run-cli`)
+- **Other providers**: prepended to the task prompt (headless `terokctl run`)
 
 ### Scenarios
 

--- a/src/terok/lib/containers/headless_providers.py
+++ b/src/terok/lib/containers/headless_providers.py
@@ -297,10 +297,11 @@ def apply_provider_config(
         model_override: Explicit ``--model`` from CLI (takes precedence).
         max_turns_override: Explicit ``--max-turns`` from CLI.
         timeout_override: Explicit ``--timeout`` from CLI.
-        instructions: Resolved instructions text.  For non-Claude providers,
-            prepended to ``prompt_extra`` so the agent receives them as part
-            of the prompt.  Claude receives instructions via the wrapper's
-            ``--append-system-prompt`` flag instead.
+        instructions: Resolved instructions text. Delivery is provider-aware:
+            Claude receives instructions via the wrapper's
+            ``--append-system-prompt`` flag; Codex loads them via
+            ``-c model_instructions_file=...`` in the wrapper; other providers
+            get instructions prepended to ``prompt_extra``.
     """
     from ..containers.agent_config import resolve_provider_value
 
@@ -341,10 +342,12 @@ def apply_provider_config(
             f"sub-agent definitions will be ignored"
         )
 
-    # --- Instructions (non-Claude: inject into prompt) ---
-    # Claude receives instructions via --append-system-prompt in the wrapper,
-    # so we only inject into the prompt for other providers.
-    if instructions and provider.name != "claude":
+    # --- Instructions ---
+    # Claude receives instructions via --append-system-prompt in the wrapper.
+    # Codex receives instructions via -c model_instructions_file=... in the
+    # wrapper so both interactive and headless runs get startup context.
+    # Other providers get best-effort prompt prepending.
+    if instructions and provider.name not in {"claude", "codex"}:
         prompt_parts.insert(0, instructions)
 
     return ProviderConfig(
@@ -552,6 +555,17 @@ def _generate_generic_wrapper(provider: HeadlessProvider, project: Project) -> s
         lines.append("    [ -f /home/dev/.terok/session-id.txt ] && \\")
         lines.append(f"        _resume_args+=({provider.continue_flag})")
 
+    # Codex supports model_instructions_file in config; this injects the
+    # mounted /home/dev/.terok/instructions.md into startup context for both
+    # interactive CLI and headless exec runs.
+    if provider.name == "codex":
+        lines.append("    local _instr_args=()")
+        lines.append("    [ -f /home/dev/.terok/instructions.md ] && \\")
+        lines.append(
+            "        _instr_args+=(-c "
+            "'model_instructions_file=\"/home/dev/.terok/instructions.md\"')"
+        )
+
     # Git env vars and exec — with optional timeout
     lines.append('    if [ -n "$_timeout" ]; then')
     lines.append(f"        GIT_AUTHOR_NAME={author_name} \\")
@@ -564,6 +578,8 @@ def _generate_generic_wrapper(provider: HeadlessProvider, project: Project) -> s
         # Write session marker so subsequent runs pass --continue.
         # Preserve the agent's exit code across the touch.
         lines.append("        local _rc=$?; touch /home/dev/.terok/session-id.txt; return $_rc")
+    elif provider.name == "codex":
+        lines.append(f'        timeout "$_timeout" {binary} "${{_instr_args[@]}}" "$@"')
     else:
         lines.append(f'        timeout "$_timeout" {binary} "$@"')
 
@@ -576,6 +592,8 @@ def _generate_generic_wrapper(provider: HeadlessProvider, project: Project) -> s
     if provider.continue_flag:
         lines.append(f'        command {binary} "${{_resume_args[@]}}" "$@"')
         lines.append("        local _rc=$?; touch /home/dev/.terok/session-id.txt; return $_rc")
+    elif provider.name == "codex":
+        lines.append(f'        command {binary} "${{_instr_args[@]}}" "$@"')
     else:
         lines.append(f'        command {binary} "$@"')
 

--- a/tests/lib/test_headless_providers.py
+++ b/tests/lib/test_headless_providers.py
@@ -266,6 +266,8 @@ class GenerateAgentWrapperTests(unittest.TestCase):
         self.assertIn("codex()", wrapper)
         self.assertIn("GIT_AUTHOR_NAME=Codex", wrapper)
         self.assertIn("GIT_AUTHOR_EMAIL=noreply@openai.com", wrapper)
+        self.assertIn("model_instructions_file", wrapper)
+        self.assertIn("instructions.md", wrapper)
         self.assertNotIn("--add-dir", wrapper)
 
     def test_generic_wrapper_has_timeout_support(self) -> None:
@@ -480,9 +482,9 @@ class ApplyProviderConfigTests(unittest.TestCase):
         self.assertIsNone(pcfg.model)
         self.assertIsNone(pcfg.max_turns)
 
-    def test_instructions_non_claude_in_prompt_extra(self) -> None:
-        """Non-Claude providers get instructions prepended to prompt_extra."""
-        p = HEADLESS_PROVIDERS["codex"]
+    def test_instructions_other_provider_in_prompt_extra(self) -> None:
+        """Non-Claude/Codex providers get instructions prepended to prompt_extra."""
+        p = HEADLESS_PROVIDERS["copilot"]
         pcfg = apply_provider_config(p, {}, instructions="Custom instructions.")
         self.assertIn("Custom instructions.", pcfg.prompt_extra)
 
@@ -492,9 +494,15 @@ class ApplyProviderConfigTests(unittest.TestCase):
         pcfg = apply_provider_config(p, {}, instructions="Custom instructions.")
         self.assertNotIn("Custom instructions.", pcfg.prompt_extra)
 
+    def test_instructions_codex_not_in_prompt_extra(self) -> None:
+        """Codex provider does NOT get prompt injection (uses wrapper config)."""
+        p = HEADLESS_PROVIDERS["codex"]
+        pcfg = apply_provider_config(p, {}, instructions="Custom instructions.")
+        self.assertNotIn("Custom instructions.", pcfg.prompt_extra)
+
     def test_instructions_prepended_before_other_prompt_parts(self) -> None:
-        """Instructions are prepended before max-turns guidance for non-Claude."""
-        p = HEADLESS_PROVIDERS["codex"]  # no max_turns_flag
+        """Instructions are prepended before max-turns guidance for other providers."""
+        p = HEADLESS_PROVIDERS["copilot"]  # no max_turns_flag
         pcfg = apply_provider_config(p, {"max_turns": 30}, instructions="Do the thing.")
         # Instructions should come before the max-turns guidance
         idx_instr = pcfg.prompt_extra.index("Do the thing.")


### PR DESCRIPTION
## Summary
- inject `/home/dev/.terok/instructions.md` into Codex startup via `-c model_instructions_file=...` in the generated non-Claude wrapper
- apply this wrapper path to both interactive CLI (`task run-cli`) and headless autopilot (`run`) flows
- avoid duplicate delivery by skipping prompt-prepend instructions for Codex in `apply_provider_config`
- update docs and tests to reflect Codex-specific instruction delivery

## Validation
- `make check` (passes)
- `poetry run pytest -q tests/lib/test_headless_providers.py tests/lib/test_autopilot.py`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated instruction delivery documentation to clarify provider-specific behaviors
  
* **Improvements**
  * Refined instruction handling to be provider-aware, optimizing how startup context is delivered across different AI providers

<!-- end of auto-generated comment: release notes by coderabbit.ai -->