### PR TITLE
docs: document Shift+click clipboard workaround

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,10 @@ terokctl task list <project>   # List tasks
 terokctl task delete <project> <task_id>  # Delete a task
 ```
 
+## Tips
+
+- **Clipboard:** If mouse selection doesn't copy to your clipboard, hold **Shift** while selecting, then **Shift+Ctrl+C** to copy. See [Tips](docs/USAGE.md#tips) for details.
+
 ## Configuration
 
 ### Global Config

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -760,6 +760,13 @@ When enabled, terok adds:
 - **Where envs live:** `~/.local/share/terok/envs` (or `/var/lib/terok/envs` if root, or as configured under `envs.base_dir`)
 - **Shared directories:** See [SHARED_DIRS.md](SHARED_DIRS.md)
 - **Security modes:** See [GIT_CACHE_AND_SECURITY_MODES.md](GIT_CACHE_AND_SECURITY_MODES.md)
+- **Copying text from the terminal:** Normal mouse text selection may not
+  reach your system clipboard when running inside the TUI or in-container
+  agents. This is due to the somewhat unpredictable interaction of nested
+  Textual TUIs and tmux sessions intercepting mouse events. Hold **Shift**
+  while selecting text with the mouse, then use your terminal's copy shortcut
+  (usually **Shift+Ctrl+C**) to copy to the system clipboard. This applies to
+  most terminals and all in-container agents (OpenCode, Claude Code, etc.).
 
 ---
 


### PR DESCRIPTION
## Summary

- Adds a "Tips" section to README.md documenting the Shift+click workaround for copying text from inside containers or the TUI
- Closes #127

## Test plan

- [ ] Verify README renders correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a new Tips entry explaining how to copy text from terminals (TUI and in-container agents) including Shift-based selection and terminal copy shortcuts.
  * The guidance is now included earlier in the main docs and also added to the usage guide for easier discovery.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->