### PR TITLE
feat: include task name in login tab/window title

### DIFF
--- a/src/terok/tui/task_actions.py
+++ b/src/terok/tui/task_actions.py
@@ -463,7 +463,8 @@ class TaskActionsMixin:
 
         mode = self.current_task.mode or "cli"
         cname = container_name(pid, mode, tid)
-        await self._launch_terminal_session(cmd, title=f"login:{cname}", cname=cname)
+        task_name = self.current_task.name or tid
+        await self._launch_terminal_session(cmd, title=f"{pid}:{tid}:{task_name}", cname=cname)
 
     # ---------- Task management actions ----------
 


### PR DESCRIPTION
## Summary

- Changes the tab/window title format for login sessions from `login:{project}-{mode}-{taskid}` to `{project}:{taskid}:{taskname}`
- Makes it easier to identify tabs when multiple tasks are open, since task names are human-readable

## Changes

Single-line change in `src/terok/tui/task_actions.py` (`_action_login`). The title flows unchanged through `launch_login` → tmux (`-n`), GNOME Terminal (`--title`), and Konsole (`--title`).

## Test plan

- [ ] Open TUI with `--tmux`, login to a named task → verify tmux window title shows `project:taskid:taskname`
- [ ] Login to a task without a name → verify it falls back to `project:taskid:taskid`
- [ ] If running in GNOME Terminal or Konsole, verify tab title matches the new format

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced terminal session titles to display additional contextual information including process ID, task ID, and task name for improved clarity during session management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->