### PR TITLE
fix: close terminal tab when login shell exits

### DIFF
--- a/src/terok/tui/shell_launch.py
+++ b/src/terok/tui/shell_launch.py
@@ -133,7 +133,7 @@ def spawn_terminal_with_command(command: list[str], title: str | None = None) ->
             args = ["--tab"]
             if title:
                 args.extend(["--title", title])
-            args.extend(["--", "bash", "-c", shell_cmd + "; exec bash"])
+            args.extend(["--", "bash", "-c", shell_cmd])
             subprocess.Popen(
                 ["gnome-terminal"] + args,
                 start_new_session=True,
@@ -143,7 +143,7 @@ def spawn_terminal_with_command(command: list[str], title: str | None = None) ->
             args = ["--new-tab"]
             if title:
                 args.extend(["--title", title])
-            args.extend(["-e", "bash", "-c", shell_cmd + "; exec bash"])
+            args.extend(["-e", "bash", "-c", shell_cmd])
             subprocess.Popen(
                 ["konsole"] + args,
                 start_new_session=True,


### PR DESCRIPTION
## Summary

- Remove `; exec bash` suffix from spawned gnome-terminal and konsole login tabs
- Terminal tab now closes when the podman login session ends, instead of dropping the user into a host bash shell

## Test plan

- [ ] Open TUI in gnome-terminal, login to a container, then `exit` — tab should close
- [ ] Open TUI in Konsole, login to a container, then `exit` — tab should close
- [ ] Existing unit tests pass (`tests/lib/test_shell_launch.py`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed terminal window behavior—terminal tabs now properly exit after command completion instead of remaining open with an interactive bash session.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->