### PR TITLE
fix: correct ast-grep binary name in agent instructions

### DIFF
--- a/src/terok/resources/instructions/default.md
+++ b/src/terok/resources/instructions/default.md
@@ -16,7 +16,7 @@ You are running inside an isolated Podman container managed by terok.
 
 ## Pre-installed tools
 
-git, gh (GitHub CLI), glab (GitLab CLI), rg (ripgrep), fd-find, jq, yq, ast-grep (`sg` — structural code search/rewrite using AST patterns; `sg run -p 'PATTERN' -l LANG` to search).
+git, gh (GitHub CLI), glab (GitLab CLI), rg (ripgrep), fd-find, jq, yq, ast-grep (structural code search/rewrite using AST patterns; `ast-grep run -p 'PATTERN' -l LANG` to search).
 
 Python 3 and Node.js are available. Use `sudo apt install` or `pip`/`npm` for anything else.
 


### PR DESCRIPTION
## Summary

- Fix `sg` reference in default agent instructions to `ast-grep` — the actual binary name from the pip package
- `/usr/bin/sg` is the coreutils "switch group" command, not ast-grep, so agents calling `sg run -p ...` would get unexpected behavior

## Test plan

- [x] Verified `ast-grep` is the correct binary name (`pip install ast-grep-cli` installs `ast-grep`)
- [x] Verified `/usr/bin/sg` is coreutils, not ast-grep
- [x] Confirmed `ast-grep run -p 'PATTERN' -l LANG` syntax works

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated pre-installed tooling documentation to clarify ast-grep command syntax in usage examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->