### PR TITLE
fix: ast-grep install conflict with coreutils sg

### DIFF
--- a/src/terok/resources/templates/l1.agent-cli.Dockerfile.template
+++ b/src/terok/resources/templates/l1.agent-cli.Dockerfile.template
@@ -32,7 +32,8 @@ RUN set -eux; \
     chmod +x /usr/local/bin/yq
 
 # ast-grep (structural code search/rewrite using AST patterns)
-RUN npm install -g @ast-grep/cli
+# Installed via pip to avoid /usr/bin/sg name conflict with coreutils sg(1).
+RUN pip install --break-system-packages ast-grep-cli
 
 # Install mistral-vibe and mistralai SDK using pipx as root, ensuring PATH is set up
 RUN set -eux; \


### PR DESCRIPTION
## Summary

- Fix image build failure: `npm install -g @ast-grep/cli` tries to create `/usr/bin/sg` which conflicts with coreutils `sg(1)`, causing `EEXIST` error
- Switch to `pip install ast-grep-cli` which installs as `ast-grep` without conflicts
- Update agent instructions to reference `ast-grep` binary name instead of `sg`

## Test plan

- [x] Verified `pip install ast-grep-cli` installs cleanly without conflicts
- [x] Verified `ast-grep run -p 'PATTERN' -l LANG` works correctly
- [ ] Rebuild L1 image to confirm build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the dependency installation process for development tools to improve build efficiency and system compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->