### PR TITLE
feat: replace gate volume mount with git daemon server

### DIFF
--- a/src/terok/cli/commands/gate_server.py
+++ b/src/terok/cli/commands/gate_server.py
@@ -1,0 +1,110 @@
+# SPDX-FileCopyrightText: 2025-2026 Jiri Vyskocil <jiri@vyskocil.com>
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Gate server management commands: install, uninstall, start, stop, status."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+
+from ...lib.facade import (
+    GateServerStatus,
+    get_server_status,
+    install_systemd_units,
+    is_daemon_running,
+    is_systemd_available,
+    start_daemon,
+    stop_daemon,
+    uninstall_systemd_units,
+)
+
+
+def register(subparsers: argparse._SubParsersAction[argparse.ArgumentParser]) -> None:
+    """Register the ``gate-server`` subcommand group."""
+    p = subparsers.add_parser("gate-server", help="Manage the git gate server")
+    sub = p.add_subparsers(dest="gate_server_cmd", required=True)
+
+    sub.add_parser("install", help="Install and start systemd socket activation")
+    sub.add_parser("uninstall", help="Stop and remove systemd units")
+
+    p_start = sub.add_parser("start", help="Start git daemon (non-systemd fallback)")
+    p_start.add_argument("--port", type=int, default=None, help="Override port")
+
+    sub.add_parser("stop", help="Stop the managed git daemon")
+    sub.add_parser("status", help="Show gate server status")
+
+
+def dispatch(args: argparse.Namespace) -> bool:
+    """Handle gate-server commands.  Returns True if handled."""
+    if args.cmd != "gate-server":
+        return False
+
+    cmd = args.gate_server_cmd
+    if cmd == "install":
+        _cmd_install()
+    elif cmd == "uninstall":
+        _cmd_uninstall()
+    elif cmd == "start":
+        _cmd_start(port=getattr(args, "port", None))
+    elif cmd == "stop":
+        _cmd_stop()
+    elif cmd == "status":
+        _cmd_status()
+    else:
+        return False
+    return True
+
+
+def _cmd_install() -> None:
+    """Install systemd socket activation units."""
+    if not is_systemd_available():
+        print(
+            "Error: systemd user services are not available on this host.\n"
+            "Use 'terokctl gate-server start' to run the gate server without systemd."
+        )
+        sys.exit(1)
+    install_systemd_units()
+    print("Systemd gate socket installed and started.")
+
+
+def _cmd_uninstall() -> None:
+    """Uninstall systemd units."""
+    if not is_systemd_available():
+        print("Error: systemd user services are not available on this host.\nNothing to uninstall.")
+        sys.exit(1)
+    uninstall_systemd_units()
+    print("Systemd gate units removed.")
+
+
+def _cmd_start(port: int | None) -> None:
+    """Start the managed git daemon."""
+    status = get_server_status()
+    if status.running:
+        print(f"Gate server is already running ({status.mode}).")
+        sys.exit(1)
+    start_daemon(port=port)
+    print("Gate daemon started.")
+
+
+def _cmd_stop() -> None:
+    """Stop the managed git daemon."""
+    if not is_daemon_running():
+        print("Gate daemon is not running.")
+        return
+    stop_daemon()
+    print("Gate daemon stopped.")
+
+
+def _cmd_status() -> None:
+    """Show gate server status."""
+    status: GateServerStatus = get_server_status()
+    state = "running" if status.running else "stopped"
+    print(f"Mode:   {status.mode}")
+    print(f"Status: {state}")
+    print(f"Port:   {status.port}")
+    if not status.running and status.mode == "none" and is_systemd_available():
+        print(
+            "\nHint: systemd is available — run 'terokctl gate-server install' to set up socket activation."
+        )

--- a/src/terok/cli/commands/sickbay.py
+++ b/src/terok/cli/commands/sickbay.py
@@ -1,0 +1,76 @@
+# SPDX-FileCopyrightText: 2025-2026 Jiri Vyskocil <jiri@vyskocil.com>
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Health check command (DS9-themed diagnostic bay).
+
+Runs a series of checks and reports their status.  Exit codes:
+- 0: all checks passed
+- 1: warnings present
+- 2: errors present
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+
+from ...lib.facade import get_server_status, is_systemd_available
+
+
+def register(subparsers: argparse._SubParsersAction[argparse.ArgumentParser]) -> None:
+    """Register the ``sickbay`` subcommand."""
+    subparsers.add_parser("sickbay", help="Run health checks")
+
+
+def dispatch(args: argparse.Namespace) -> bool:
+    """Handle the sickbay command.  Returns True if handled."""
+    if args.cmd != "sickbay":
+        return False
+    _cmd_sickbay()
+    return True
+
+
+def _check_gate_server() -> tuple[str, str, str]:
+    """Check gate server status.
+
+    Returns (status, label, detail) where status is 'ok', 'warn', or 'error'.
+    """
+    status = get_server_status()
+    label = "Gate server"
+    if status.running:
+        return ("ok", label, f"{status.mode}, port {status.port}")
+    if status.mode == "systemd":
+        return ("error", label, "socket installed but not active")
+    if is_systemd_available():
+        return ("warn", label, "not running — run 'terokctl gate-server install'")
+    return ("warn", label, "not running — run 'terokctl gate-server start'")
+
+
+_CHECKS = [
+    _check_gate_server,
+]
+
+_STATUS_MARKERS = {
+    "ok": "ok",
+    "warn": "WARN",
+    "error": "ERROR",
+}
+
+
+def _cmd_sickbay() -> None:
+    """Run all health checks and report results."""
+    worst = "ok"
+    for check in _CHECKS:
+        status, label, detail = check()
+        marker = _STATUS_MARKERS.get(status, status)
+        print(f"  {label} .... {marker} ({detail})")
+        if status == "error":
+            worst = "error"
+        elif status == "warn" and worst != "error":
+            worst = "warn"
+
+    if worst == "error":
+        sys.exit(2)
+    elif worst == "warn":
+        sys.exit(1)

--- a/src/terok/cli/main.py
+++ b/src/terok/cli/main.py
@@ -15,7 +15,7 @@ import argparse
 
 from ..lib.core.config import set_experimental
 from ..lib.core.version import format_version_string, get_version_info
-from .commands import completions, image, info, project, setup, task
+from .commands import completions, gate_server, image, info, project, setup, sickbay, task
 
 # Optional: bash completion via argcomplete
 try:
@@ -29,6 +29,8 @@ _DISPATCHERS = [
     project.dispatch,
     setup.dispatch,
     image.dispatch,
+    gate_server.dispatch,
+    sickbay.dispatch,
     info.dispatch,
     completions.dispatch,
 ]
@@ -85,6 +87,8 @@ def main() -> None:
     project.register(sub)
     setup.register(sub)
     image.register(sub)
+    gate_server.register(sub)
+    sickbay.register(sub)
     info.register(sub)
     completions.register(sub)
 

--- a/src/terok/lib/containers/environment.py
+++ b/src/terok/lib/containers/environment.py
@@ -17,6 +17,7 @@ from pathlib import Path
 
 from ..core.config import get_envs_base_dir
 from ..core.projects import Project
+from ..security.gate_server import ensure_server_reachable, get_gate_base_path, get_gate_server_port
 from ..util.fs import ensure_dir_writable
 
 # ---------- Constants ----------
@@ -140,6 +141,25 @@ def _shared_volume_mounts(host_dirs: dict[str, Path]) -> list[str]:
     return [f"{host_dirs[m.key]}:{m.container_path}:z" for m in SHARED_MOUNTS]
 
 
+def _gate_url(gate_repo: Path, gate_base: Path, port: int, project_id: str) -> str:
+    """Build the ``git://`` URL for a gate repo served by ``git daemon``.
+
+    Derives the path relative to the gate base directory so that custom
+    ``gate.path`` settings produce correct URLs.  Raises ``SystemExit`` if
+    the gate repo is outside the configured gate base path.
+    """
+    try:
+        rel = gate_repo.relative_to(gate_base).as_posix()
+    except ValueError as exc:
+        raise SystemExit(
+            f"Gate repo for project '{project_id}' is outside gate base.\n"
+            f"Repo: {gate_repo}\n"
+            f"Gate base: {gate_base}\n"
+            "Adjust gate.path or gate server base path so the repo is servable."
+        ) from exc
+    return f"git://host.containers.internal:{port}/{rel}"
+
+
 def _security_mode_env_and_volumes(
     project: Project, ssh_host_dir: Path
 ) -> tuple[dict[str, str], list[str]]:
@@ -148,8 +168,6 @@ def _security_mode_env_and_volumes(
     volumes: list[str] = []
 
     gate_repo = project.gate_path
-    gate_parent = gate_repo.parent
-    gate_mount_inside = "/git-gate/gate.git"
 
     if project.security_class == "gatekeeping":
         if not gate_repo.exists():
@@ -158,9 +176,11 @@ def _security_mode_env_and_volumes(
                 f"Expected at: {gate_repo}\n"
                 f"Run 'terokctl gate-sync {project.id}' to create/update the local mirror."
             )
-        gate_parent.mkdir(parents=True, exist_ok=True)
-        volumes.append(f"{gate_repo}:{gate_mount_inside}:z")
-        env["CODE_REPO"] = f"file://{gate_mount_inside}"
+        ensure_server_reachable()
+        port = get_gate_server_port()
+        gate_base = get_gate_base_path()
+        gate_url = _gate_url(gate_repo, gate_base, port, project.id)
+        env["CODE_REPO"] = gate_url
         if project.default_branch:
             env["GIT_BRANCH"] = project.default_branch
         if project.expose_external_remote and project.upstream_url:
@@ -170,9 +190,15 @@ def _security_mode_env_and_volumes(
             volumes.append(f"{ssh_host_dir}:/home/dev/.ssh:z")
     else:
         if gate_repo.exists():
-            gate_parent.mkdir(parents=True, exist_ok=True)
-            volumes.append(f"{gate_repo}:{gate_mount_inside}:z,ro")
-            env["CLONE_FROM"] = f"file://{gate_mount_inside}"
+            try:
+                ensure_server_reachable()
+            except SystemExit:
+                pass  # gate server down; skip CLONE_FROM, fall back to upstream
+            else:
+                port = get_gate_server_port()
+                gate_base = get_gate_base_path()
+                gate_url = _gate_url(gate_repo, gate_base, port, project.id)
+                env["CLONE_FROM"] = gate_url
         if project.upstream_url:
             env["CODE_REPO"] = project.upstream_url
             if project.default_branch:

--- a/src/terok/lib/containers/task_runners.py
+++ b/src/terok/lib/containers/task_runners.py
@@ -18,6 +18,7 @@ from typing import TYPE_CHECKING
 
 import yaml
 
+from ..core.config import get_gate_server_port
 from ..core.images import project_cli_image, project_web_image
 from ..core.projects import load_project
 from ..util.ansi import (
@@ -27,7 +28,7 @@ from ..util.ansi import (
     supports_color as _supports_color,
     yellow as _yellow,
 )
-from ..util.podman import _podman_userns_args
+from ..util.podman import _podman_network_args, _podman_userns_args
 from .agent_config import resolve_agent_config
 from .agents import AgentConfigSpec, prepare_agent_config_dir
 from .environment import (
@@ -207,6 +208,7 @@ def _run_container(
     """
     cmd: list[str] = ["podman", "run", "-d"]
     cmd += _podman_userns_args()
+    cmd += _podman_network_args(gate_port=get_gate_server_port())
     cmd += gpu_run_args(project)
     if extra_args:
         cmd += extra_args

--- a/src/terok/lib/core/config.py
+++ b/src/terok/lib/core/config.py
@@ -279,6 +279,16 @@ def get_task_name_categories() -> list[str] | None:
     return None
 
 
+def get_gate_server_port() -> int:
+    """Return the gate server port from global config (default 9418)."""
+    return int(get_global_section("gate_server").get("port", 9418))
+
+
+def get_gate_server_suppress_warning() -> bool:
+    """Return whether to suppress the systemd suggestion warning."""
+    return bool(get_global_section("gate_server").get("suppress_systemd_warning", False))
+
+
 def get_global_agent_config() -> dict[str, Any]:
     """Return the ``agent:`` section from the global config, or ``{}``."""
     return get_global_section("agent")

--- a/src/terok/lib/facade.py
+++ b/src/terok/lib/facade.py
@@ -50,6 +50,18 @@ from .containers.tasks import (  # noqa: F401 — re-exported public API
 from .core.config import build_root, deleted_projects_dir, get_envs_base_dir, state_root
 from .core.projects import load_project
 from .security.auth import AUTH_PROVIDERS, AuthProvider, authenticate
+from .security.gate_server import (  # noqa: F401 — re-exported public API
+    GateServerStatus,
+    get_gate_base_path,
+    get_gate_server_port,
+    get_server_status,
+    install_systemd_units,
+    is_daemon_running,
+    is_systemd_available,
+    start_daemon,
+    stop_daemon,
+    uninstall_systemd_units,
+)
 from .security.git_gate import (
     GateStalenessInfo,
     compare_gate_vs_upstream,
@@ -267,6 +279,17 @@ __all__ = [
     "AUTH_PROVIDERS",
     "AuthProvider",
     "authenticate",
+    # Gate server
+    "GateServerStatus",
+    "get_server_status",
+    "get_gate_base_path",
+    "get_gate_server_port",
+    "install_systemd_units",
+    "uninstall_systemd_units",
+    "start_daemon",
+    "stop_daemon",
+    "is_daemon_running",
+    "is_systemd_available",
     # Git gate
     "compare_gate_vs_upstream",
     "sync_gate_branches",

--- a/src/terok/lib/security/gate_server.py
+++ b/src/terok/lib/security/gate_server.py
@@ -1,0 +1,354 @@
+# SPDX-FileCopyrightText: 2025-2026 Jiri Vyskocil <jiri@vyskocil.com>
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Gate server lifecycle management.
+
+Replaces the host-writable volume mount of gate repos with a ``git daemon``
+bound to ``127.0.0.1``.  Containers reach the gate via ``git://`` URLs
+through ``host.containers.internal`` — standard git protocol, no bind-mount
+escape vector.
+
+Networking across Podman versions:
+
+- **pasta** (Podman 5+) sets ``host.containers.internal`` to a link-local
+  address (``169.254.1.2``) that does *not* reach the host's loopback.
+  The task runner injects ``--network pasta:-T,<port>`` (namespace-to-host
+  TCP forwarding) and ``--add-host host.containers.internal:127.0.0.1``
+  so the ``git://`` URL is forwarded to the host's loopback.
+- **slirp4netns** (Podman 4.x) routes the container gateway ``10.0.2.2`` to
+  ``127.0.0.1`` when ``allow_host_loopback=true`` is set.  The task runner
+  injects ``--network slirp4netns:allow_host_loopback=true`` and
+  ``--add-host host.containers.internal:10.0.2.2`` automatically (see
+  ``_podman_network_args`` in ``terok.lib.util.podman``).
+
+Phase 2 adds HTTP with per-task token authentication.
+
+**Deployment modes (ordered by preference):**
+
+1. **Systemd socket activation** — zero-idle-cost, crash resilience, and no
+   PID management.  Recommended for any Linux host with ``systemctl --user``.
+
+2. **Managed ``git daemon`` process** — best-effort fallback.  Works correctly
+   but has a simpler lifecycle (manual start/stop, PID file).
+
+**No auto-start.**  Task creation checks reachability and fails with an
+actionable error rather than silently starting a daemon.
+"""
+
+from __future__ import annotations
+
+import os
+import signal
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+
+from ..core.config import get_global_section, state_root
+from ..core.paths import runtime_root
+
+# ---------- Constants ----------
+
+_DEFAULT_PORT = 9418
+_UNIT_VERSION = 1
+"""Bump when the systemd unit templates change.  ``ensure_server_reachable``
+checks the installed version and refuses to start tasks if it is stale."""
+
+
+# ---------- Config helpers ----------
+
+
+def _get_port() -> int:
+    """Return the configured gate server port (default 9418)."""
+    return int(get_global_section("gate_server").get("port", _DEFAULT_PORT))
+
+
+def _get_gate_base_path() -> Path:
+    """Return the base path for ``git daemon`` (where gate repos live)."""
+    return state_root() / "gate"
+
+
+def _pid_file() -> Path:
+    """Return the path to the PID file for the managed daemon."""
+    return runtime_root() / "gate-server.pid"
+
+
+def _systemd_unit_dir() -> Path:
+    """Return the systemd user unit directory."""
+    xdg = os.environ.get("XDG_CONFIG_HOME")
+    return (Path(xdg) if xdg else Path.home() / ".config") / "systemd" / "user"
+
+
+# ---------- Systemd helpers ----------
+
+
+def is_systemd_available() -> bool:
+    """Check whether ``systemctl --user`` is usable.
+
+    Uses ``is-system-running`` which returns well-defined exit codes:
+    0 = running, 1 = degraded/starting/stopping — both mean systemd is
+    present.  Any other code (or missing binary) means unavailable.
+    """
+    try:
+        result = subprocess.run(
+            ["systemctl", "--user", "is-system-running"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+        # "running" (0), "degraded" (1), "starting" (1), "stopping" (1)
+        # all indicate a usable user session.
+        return result.returncode in (0, 1)
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        return False
+
+
+def is_socket_installed() -> bool:
+    """Check whether the ``terok-gate.socket`` unit file exists."""
+    unit_dir = _systemd_unit_dir()
+    return (unit_dir / "terok-gate.socket").is_file()
+
+
+def is_socket_active() -> bool:
+    """Check whether the ``terok-gate.socket`` unit is active (listening)."""
+    try:
+        result = subprocess.run(
+            ["systemctl", "--user", "is-active", "terok-gate.socket"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+        return result.stdout.strip() == "active"
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        return False
+
+
+def _installed_unit_version() -> int | None:
+    """Return the version stamp from the installed socket unit, or ``None``."""
+    unit_file = _systemd_unit_dir() / "terok-gate.socket"
+    if not unit_file.is_file():
+        return None
+    try:
+        for line in unit_file.read_text(encoding="utf-8").splitlines():
+            if line.startswith("# terok-gate-version:"):
+                return int(line.split(":", 1)[1].strip())
+    except (ValueError, OSError):
+        pass
+    return None
+
+
+def install_systemd_units() -> None:
+    """Render and install systemd socket+service units, then enable+start the socket."""
+    from ..util.template_utils import render_template
+
+    unit_dir = _systemd_unit_dir()
+    unit_dir.mkdir(parents=True, exist_ok=True)
+
+    resource_dir = Path(__file__).resolve().parent.parent.parent / "resources" / "systemd"
+    variables = {
+        "PORT": str(_get_port()),
+        "GATE_BASE_PATH": str(_get_gate_base_path()),
+        "UNIT_VERSION": str(_UNIT_VERSION),
+    }
+
+    for template_name in ("terok-gate.socket", "terok-gate@.service"):
+        template_path = resource_dir / template_name
+        if not template_path.is_file():
+            raise SystemExit(f"Missing systemd template: {template_path}")
+        content = render_template(template_path, variables)
+        (unit_dir / template_name).write_text(content, encoding="utf-8")
+
+    subprocess.run(["systemctl", "--user", "daemon-reload"], check=True, timeout=10)
+    subprocess.run(
+        ["systemctl", "--user", "enable", "--now", "terok-gate.socket"],
+        check=True,
+        timeout=10,
+    )
+
+
+def uninstall_systemd_units() -> None:
+    """Disable+stop the socket and remove unit files."""
+    unit_dir = _systemd_unit_dir()
+
+    subprocess.run(
+        ["systemctl", "--user", "disable", "--now", "terok-gate.socket"],
+        check=False,
+        timeout=10,
+    )
+    subprocess.run(["systemctl", "--user", "daemon-reload"], check=False, timeout=10)
+
+    for name in ("terok-gate.socket", "terok-gate@.service"):
+        unit_file = unit_dir / name
+        if unit_file.is_file():
+            unit_file.unlink()
+
+    subprocess.run(["systemctl", "--user", "daemon-reload"], check=False, timeout=10)
+
+
+# ---------- Daemon fallback ----------
+
+
+def start_daemon(port: int | None = None) -> None:
+    """Start a ``git daemon`` process (non-systemd fallback).
+
+    Writes a PID file to ``runtime_root() / "gate-server.pid"``.
+    """
+    effective_port = port or _get_port()
+    gate_base = _get_gate_base_path()
+    gate_base.mkdir(parents=True, exist_ok=True)
+    pidfile = _pid_file()
+    pidfile.parent.mkdir(parents=True, exist_ok=True)
+
+    subprocess.run(
+        [
+            "git",
+            "daemon",
+            "--listen=127.0.0.1",
+            f"--port={effective_port}",
+            f"--base-path={gate_base}",
+            "--export-all",
+            "--enable=receive-pack",
+            "--detach",
+            f"--pid-file={pidfile}",
+        ],
+        check=True,
+        timeout=10,
+    )
+
+
+def _is_managed_git_daemon(pid: int) -> bool:
+    """Return whether *pid* belongs to the managed git daemon.
+
+    Reads ``/proc/<pid>/cmdline`` and verifies that the process is a
+    ``git daemon`` launched with *our* PID file, guarding against both
+    PID reuse and unrelated ``git daemon`` processes.
+    """
+    cmdline_path = Path(f"/proc/{pid}/cmdline")
+    if not cmdline_path.is_file():
+        return False
+    try:
+        raw = cmdline_path.read_bytes()
+    except OSError:
+        return False
+    args = raw.rstrip(b"\x00").split(b"\x00")
+    if len(args) < 2:
+        return False
+    args_str = [a.decode("utf-8", errors="ignore") for a in args]
+    # argv[0] must be git (possibly a full path like /usr/bin/git)
+    if not args_str[0].endswith("git"):
+        return False
+    if args_str[1] != "daemon":
+        return False
+    # Verify our PID file is among the arguments
+    expected_pid_flag = f"--pid-file={_pid_file()}"
+    return expected_pid_flag in args_str
+
+
+def stop_daemon() -> None:
+    """Stop the managed daemon by reading the PID file and sending SIGTERM."""
+    pidfile = _pid_file()
+    if not pidfile.is_file():
+        return
+    try:
+        pid = int(pidfile.read_text().strip())
+        if _is_managed_git_daemon(pid):
+            os.kill(pid, signal.SIGTERM)
+    except (ValueError, ProcessLookupError, PermissionError):
+        pass
+    finally:
+        if pidfile.is_file():
+            pidfile.unlink()
+
+
+def is_daemon_running() -> bool:
+    """Check whether the managed daemon process is alive via its PID file."""
+    pidfile = _pid_file()
+    if not pidfile.is_file():
+        return False
+    try:
+        pid = int(pidfile.read_text().strip())
+        if not _is_managed_git_daemon(pid):
+            return False
+        os.kill(pid, 0)  # signal 0 = existence check
+        return True
+    except (ValueError, ProcessLookupError, PermissionError):
+        return False
+
+
+# ---------- Status ----------
+
+
+@dataclass(frozen=True)
+class GateServerStatus:
+    """Current state of the gate server."""
+
+    mode: str
+    """``"systemd"``, ``"daemon"``, or ``"none"``."""
+
+    running: bool
+    """Whether the server is currently reachable."""
+
+    port: int
+    """Configured port."""
+
+
+def get_server_status() -> GateServerStatus:
+    """Return the current gate server status."""
+    port = _get_port()
+
+    if is_socket_installed():
+        if is_socket_active():
+            return GateServerStatus(mode="systemd", running=True, port=port)
+        # Socket installed but inactive — check if the daemon fallback is running
+        if is_daemon_running():
+            return GateServerStatus(mode="daemon", running=True, port=port)
+        return GateServerStatus(mode="systemd", running=False, port=port)
+
+    if is_daemon_running():
+        return GateServerStatus(mode="daemon", running=True, port=port)
+
+    return GateServerStatus(mode="none", running=False, port=port)
+
+
+def get_gate_base_path() -> Path:
+    """Return the gate base path (public API)."""
+    return _get_gate_base_path()
+
+
+def get_gate_server_port() -> int:
+    """Return the configured gate server port."""
+    return _get_port()
+
+
+def ensure_server_reachable() -> None:
+    """Verify the gate server is running; raise ``SystemExit`` if not.
+
+    Called before task creation to fail early with an actionable message.
+    """
+    status = get_server_status()
+    if status.running:
+        if status.mode == "systemd":
+            installed = _installed_unit_version()
+            if installed is None or installed < _UNIT_VERSION:
+                installed_label = "unversioned" if installed is None else f"v{installed}"
+                raise SystemExit(
+                    "Gate server systemd units are outdated "
+                    f"(installed {installed_label}, expected v{_UNIT_VERSION}).\n"
+                    "Run 'terokctl gate-server install' to update."
+                )
+        return
+
+    msg = (
+        "Gate server is not running.\n"
+        "\n"
+        "The gate server serves git repos to task containers over the network,\n"
+        "replacing the previous volume-mount approach.\n"
+        "\n"
+    )
+    if is_systemd_available():
+        msg += (
+            "Recommended: install and start the systemd socket:\n  terokctl gate-server install\n"
+        )
+    else:
+        msg += "Start the gate daemon:\n  terokctl gate-server start\n"
+    raise SystemExit(msg)

--- a/src/terok/lib/util/podman.py
+++ b/src/terok/lib/util/podman.py
@@ -2,9 +2,12 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-"""Podman user-namespace helpers for rootless operation."""
+"""Podman user-namespace and network helpers for rootless operation."""
 
+import functools
+import json
 import os
+import subprocess
 
 
 def _podman_userns_args() -> list[str]:
@@ -12,3 +15,77 @@ def _podman_userns_args() -> list[str]:
     if os.geteuid() == 0:
         return []
     return ["--userns=keep-id:uid=1000,gid=1000"]
+
+
+@functools.lru_cache(maxsize=1)
+def _detect_rootless_network_mode() -> str:
+    """Return ``"slirp4netns"``, ``"pasta"``, or ``"unknown"`` from ``podman info``.
+
+    Reads ``host.rootlessNetworkCmd`` (present on some Podman 4.x and all 5.x).
+    When the field is absent, falls back to the Podman major version:
+    Podman 5+ defaults to pasta, 4.x defaults to slirp4netns (regardless
+    of whether the pasta binary is installed).  On error returns
+    ``"unknown"``.
+    """
+    try:
+        raw = subprocess.check_output(
+            ["podman", "info", "-f", "json"],
+            stderr=subprocess.DEVNULL,
+            timeout=10,
+        )
+        info = json.loads(raw)
+        host = info.get("host", {})
+
+        # Primary: rootlessNetworkCmd is the authoritative answer
+        cmd = host.get("rootlessNetworkCmd", "")
+        if cmd in ("pasta", "slirp4netns"):
+            return cmd
+
+        # Fallback: Podman 5+ defaults to pasta, 4.x to slirp4netns.
+        version_str = info.get("version", {}).get("Version", "")
+        major = int(version_str.split(".")[0]) if version_str else 0
+        return "pasta" if major >= 5 else "slirp4netns"
+    except (
+        FileNotFoundError,
+        subprocess.CalledProcessError,
+        subprocess.TimeoutExpired,
+        TypeError,
+        ValueError,
+    ):
+        return "unknown"
+
+
+def _podman_network_args(gate_port: int = 9418) -> list[str]:
+    """Return network flags so rootless containers can reach host loopback.
+
+    On **slirp4netns** (Podman 4.x), the container's default gateway
+    ``10.0.2.2`` is routed to the host's ``127.0.0.1`` when
+    ``allow_host_loopback=true`` is set.  We override
+    ``host.containers.internal`` to ``10.0.2.2`` so ``git://`` URLs work.
+
+    On **pasta** (Podman 5+), Podman sets ``host.containers.internal`` to a
+    link-local address (``169.254.1.2``) which does **not** reach the host's
+    loopback.  We use pasta's ``-T`` (``--tcp-ns``) option to forward
+    *gate_port* from the container namespace to the host, and override
+    ``host.containers.internal`` to ``127.0.0.1`` so the ``git://`` URL
+    targets a forwarded port.
+    """
+    if os.geteuid() == 0:
+        return []
+
+    mode = _detect_rootless_network_mode()
+    if mode == "slirp4netns":
+        return [
+            "--network",
+            "slirp4netns:allow_host_loopback=true",
+            "--add-host",
+            "host.containers.internal:10.0.2.2",
+        ]
+    if mode == "pasta":
+        return [
+            "--network",
+            f"pasta:-T,{gate_port}",
+            "--add-host",
+            "host.containers.internal:127.0.0.1",
+        ]
+    return []

--- a/src/terok/resources/systemd/terok-gate.socket
+++ b/src/terok/resources/systemd/terok-gate.socket
@@ -1,0 +1,15 @@
+# SPDX-FileCopyrightText: 2025-2026 Jiri Vyskocil <jiri@vyskocil.com>
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# terok-gate-version: {{UNIT_VERSION}}
+
+[Unit]
+Description=terok git gate socket
+
+[Socket]
+ListenStream=127.0.0.1:{{PORT}}
+Accept=yes
+
+[Install]
+WantedBy=sockets.target

--- a/src/terok/resources/systemd/terok-gate@.service
+++ b/src/terok/resources/systemd/terok-gate@.service
@@ -1,0 +1,13 @@
+# SPDX-FileCopyrightText: 2025-2026 Jiri Vyskocil <jiri@vyskocil.com>
+#
+# SPDX-License-Identifier: Apache-2.0
+
+# terok-gate-version: {{UNIT_VERSION}}
+
+[Unit]
+Description=terok git gate connection handler
+
+[Service]
+Type=simple
+StandardInput=socket
+ExecStart=/usr/bin/env git daemon --inetd --export-all --enable=receive-pack --base-path={{GATE_BASE_PATH}}

--- a/tach.toml
+++ b/tach.toml
@@ -82,6 +82,7 @@ depends_on = [
     "terok.lib.core.config",
     "terok.lib.core.projects",
     "terok.lib.security.auth",
+    "terok.lib.security.gate_server",
     "terok.lib.security.git_gate",
     "terok.lib.security.ssh",
     "terok.lib.util.fs",
@@ -180,6 +181,7 @@ depends_on = [
     "terok.lib.containers.ports",
     "terok.lib.containers.runtime",
     "terok.lib.containers.tasks",
+    "terok.lib.core.config",
     "terok.lib.core.images",
     "terok.lib.core.projects",
     "terok.lib.util.ansi",
@@ -196,7 +198,7 @@ depends_on = ["terok.lib.core.projects", "terok.lib.util.logging_utils"]
 [[modules]]
 path = "terok.lib.containers.environment"
 layer = "services"
-depends_on = ["terok.lib.core.config", "terok.lib.core.projects", "terok.lib.util.fs"]
+depends_on = ["terok.lib.core.config", "terok.lib.core.projects", "terok.lib.security.gate_server", "terok.lib.util.fs"]
 
 # Task port allocation
 [[modules]]
@@ -253,6 +255,12 @@ depends_on = [
     "terok.lib.util.fs",
     "terok.lib.util.template_utils",
 ]
+
+# Gate server lifecycle management
+[[modules]]
+path = "terok.lib.security.gate_server"
+layer = "services"
+depends_on = ["terok.lib.core.config", "terok.lib.core.paths", "terok.lib.util.template_utils"]
 
 # Git gate sync & validation
 [[modules]]
@@ -529,6 +537,22 @@ expose = ["list_images", "find_orphaned_images", "cleanup_images", "ImageInfo", 
 from = ["terok.lib.containers.image_cleanup"]
 
 [[interfaces]]
+expose = [
+    "GateServerStatus",
+    "get_server_status",
+    "get_gate_base_path",
+    "get_gate_server_port",
+    "install_systemd_units",
+    "uninstall_systemd_units",
+    "start_daemon",
+    "stop_daemon",
+    "is_daemon_running",
+    "is_systemd_available",
+    "ensure_server_reachable",
+]
+from = ["terok.lib.security.gate_server"]
+
+[[interfaces]]
 expose = ["init_project_ssh"]
 from = ["terok.lib.security.ssh"]
 
@@ -570,6 +594,8 @@ expose = [
     "load_global_config",
     "get_global_section",
     "get_global_agent_config",
+    "get_gate_server_port",
+    "get_gate_server_suppress_warning",
     "get_task_name_categories",
     "get_prefix",
     "is_experimental",
@@ -658,6 +684,16 @@ expose = [
     "AUTH_PROVIDERS",
     "AuthProvider",
     "authenticate",
+    "GateServerStatus",
+    "get_server_status",
+    "get_gate_base_path",
+    "get_gate_server_port",
+    "install_systemd_units",
+    "uninstall_systemd_units",
+    "start_daemon",
+    "stop_daemon",
+    "is_daemon_running",
+    "is_systemd_available",
     "compare_gate_vs_upstream",
     "sync_gate_branches",
     "get_gate_last_commit",

--- a/tests/cli/test_cli_gate_server.py
+++ b/tests/cli/test_cli_gate_server.py
@@ -1,0 +1,141 @@
+# SPDX-FileCopyrightText: 2025-2026 Jiri Vyskocil <jiri@vyskocil.com>
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for gate-server CLI commands."""
+
+import unittest
+import unittest.mock
+from io import StringIO
+
+from terok.cli.commands.gate_server import (
+    _cmd_install,
+    _cmd_start,
+    _cmd_status,
+    _cmd_stop,
+    _cmd_uninstall,
+)
+from terok.lib.security.gate_server import GateServerStatus
+
+
+class TestCmdInstall(unittest.TestCase):
+    """Tests for gate-server install."""
+
+    @unittest.mock.patch("terok.cli.commands.gate_server.install_systemd_units")
+    @unittest.mock.patch("terok.cli.commands.gate_server.is_systemd_available", return_value=True)
+    def test_install(
+        self, _mock_avail: unittest.mock.Mock, mock_install: unittest.mock.Mock
+    ) -> None:
+        with unittest.mock.patch("sys.stdout", new_callable=StringIO) as out:
+            _cmd_install()
+        mock_install.assert_called_once()
+        self.assertIn("installed", out.getvalue())
+
+    @unittest.mock.patch("terok.cli.commands.gate_server.is_systemd_available", return_value=False)
+    def test_install_no_systemd(self, _mock: unittest.mock.Mock) -> None:
+        """Install exits with error when systemd is unavailable."""
+        with self.assertRaises(SystemExit):
+            _cmd_install()
+
+
+class TestCmdUninstall(unittest.TestCase):
+    """Tests for gate-server uninstall."""
+
+    @unittest.mock.patch("terok.cli.commands.gate_server.uninstall_systemd_units")
+    @unittest.mock.patch("terok.cli.commands.gate_server.is_systemd_available", return_value=True)
+    def test_uninstall(
+        self, _mock_avail: unittest.mock.Mock, mock_uninstall: unittest.mock.Mock
+    ) -> None:
+        with unittest.mock.patch("sys.stdout", new_callable=StringIO) as out:
+            _cmd_uninstall()
+        mock_uninstall.assert_called_once()
+        self.assertIn("removed", out.getvalue())
+
+    @unittest.mock.patch("terok.cli.commands.gate_server.is_systemd_available", return_value=False)
+    def test_uninstall_no_systemd(self, _mock: unittest.mock.Mock) -> None:
+        """Uninstall exits with error when systemd is unavailable."""
+        with self.assertRaises(SystemExit):
+            _cmd_uninstall()
+
+
+class TestCmdStart(unittest.TestCase):
+    """Tests for gate-server start."""
+
+    @unittest.mock.patch("terok.cli.commands.gate_server.start_daemon")
+    @unittest.mock.patch(
+        "terok.cli.commands.gate_server.get_server_status",
+        return_value=GateServerStatus(mode="none", running=False, port=9418),
+    )
+    def test_start(self, _mock_status: unittest.mock.Mock, mock_start: unittest.mock.Mock) -> None:
+        with unittest.mock.patch("sys.stdout", new_callable=StringIO) as out:
+            _cmd_start(port=9999)
+        mock_start.assert_called_once_with(port=9999)
+        self.assertIn("started", out.getvalue())
+
+    @unittest.mock.patch(
+        "terok.cli.commands.gate_server.get_server_status",
+        return_value=GateServerStatus(mode="systemd", running=True, port=9418),
+    )
+    def test_start_already_running(self, _mock: unittest.mock.Mock) -> None:
+        with self.assertRaises(SystemExit):
+            _cmd_start(port=None)
+
+
+class TestCmdStop(unittest.TestCase):
+    """Tests for gate-server stop."""
+
+    @unittest.mock.patch("terok.cli.commands.gate_server.stop_daemon")
+    @unittest.mock.patch("terok.cli.commands.gate_server.is_daemon_running", return_value=True)
+    def test_stop(self, _mock_running: unittest.mock.Mock, mock_stop: unittest.mock.Mock) -> None:
+        with unittest.mock.patch("sys.stdout", new_callable=StringIO) as out:
+            _cmd_stop()
+        mock_stop.assert_called_once()
+        self.assertIn("stopped", out.getvalue())
+
+    @unittest.mock.patch("terok.cli.commands.gate_server.is_daemon_running", return_value=False)
+    def test_stop_not_running(self, _mock: unittest.mock.Mock) -> None:
+        with unittest.mock.patch("sys.stdout", new_callable=StringIO) as out:
+            _cmd_stop()
+        self.assertIn("not running", out.getvalue())
+
+
+class TestCmdStatus(unittest.TestCase):
+    """Tests for gate-server status."""
+
+    @unittest.mock.patch(
+        "terok.cli.commands.gate_server.get_server_status",
+        return_value=GateServerStatus(mode="daemon", running=True, port=9418),
+    )
+    def test_status_running(self, _mock: unittest.mock.Mock) -> None:
+        with unittest.mock.patch("sys.stdout", new_callable=StringIO) as out:
+            _cmd_status()
+        output = out.getvalue()
+        self.assertIn("daemon", output)
+        self.assertIn("running", output)
+        self.assertIn("9418", output)
+
+    @unittest.mock.patch("terok.cli.commands.gate_server.is_systemd_available", return_value=True)
+    @unittest.mock.patch(
+        "terok.cli.commands.gate_server.get_server_status",
+        return_value=GateServerStatus(mode="none", running=False, port=9418),
+    )
+    def test_status_stopped_with_systemd(self, *_mocks: unittest.mock.Mock) -> None:
+        with unittest.mock.patch("sys.stdout", new_callable=StringIO) as out:
+            _cmd_status()
+        output = out.getvalue()
+        self.assertIn("none", output)
+        self.assertIn("stopped", output)
+        self.assertIn("gate-server install", output)
+
+    @unittest.mock.patch("terok.cli.commands.gate_server.is_systemd_available", return_value=False)
+    @unittest.mock.patch(
+        "terok.cli.commands.gate_server.get_server_status",
+        return_value=GateServerStatus(mode="none", running=False, port=9418),
+    )
+    def test_status_stopped_no_systemd(self, *_mocks: unittest.mock.Mock) -> None:
+        with unittest.mock.patch("sys.stdout", new_callable=StringIO) as out:
+            _cmd_status()
+        output = out.getvalue()
+        self.assertIn("none", output)
+        self.assertIn("stopped", output)
+        self.assertNotIn("gate-server install", output)

--- a/tests/cli/test_cli_sickbay.py
+++ b/tests/cli/test_cli_sickbay.py
@@ -1,0 +1,69 @@
+# SPDX-FileCopyrightText: 2025-2026 Jiri Vyskocil <jiri@vyskocil.com>
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for sickbay CLI command."""
+
+import unittest
+import unittest.mock
+from io import StringIO
+
+from terok.cli.commands.sickbay import _cmd_sickbay
+from terok.lib.security.gate_server import GateServerStatus
+
+
+class TestSickbay(unittest.TestCase):
+    """Tests for the sickbay health check command."""
+
+    @unittest.mock.patch(
+        "terok.cli.commands.sickbay.get_server_status",
+        return_value=GateServerStatus(mode="systemd", running=True, port=9418),
+    )
+    def test_all_ok(self, _mock: unittest.mock.Mock) -> None:
+        with unittest.mock.patch("sys.stdout", new_callable=StringIO) as out:
+            _cmd_sickbay()
+        output = out.getvalue()
+        self.assertIn("Gate server", output)
+        self.assertIn("ok", output)
+        self.assertIn("systemd", output)
+
+    @unittest.mock.patch("terok.cli.commands.sickbay.is_systemd_available", return_value=True)
+    @unittest.mock.patch(
+        "terok.cli.commands.sickbay.get_server_status",
+        return_value=GateServerStatus(mode="none", running=False, port=9418),
+    )
+    def test_warn_not_running_systemd(self, *_mocks: unittest.mock.Mock) -> None:
+        with self.assertRaises(SystemExit) as ctx:
+            with unittest.mock.patch("sys.stdout", new_callable=StringIO) as out:
+                _cmd_sickbay()
+        self.assertEqual(ctx.exception.code, 1)
+        output = out.getvalue()
+        self.assertIn("WARN", output)
+        self.assertIn("gate-server install", output)
+
+    @unittest.mock.patch("terok.cli.commands.sickbay.is_systemd_available", return_value=False)
+    @unittest.mock.patch(
+        "terok.cli.commands.sickbay.get_server_status",
+        return_value=GateServerStatus(mode="none", running=False, port=9418),
+    )
+    def test_warn_not_running_no_systemd(self, *_mocks: unittest.mock.Mock) -> None:
+        with self.assertRaises(SystemExit) as ctx:
+            with unittest.mock.patch("sys.stdout", new_callable=StringIO) as out:
+                _cmd_sickbay()
+        self.assertEqual(ctx.exception.code, 1)
+        output = out.getvalue()
+        self.assertIn("WARN", output)
+        self.assertIn("gate-server start", output)
+
+    @unittest.mock.patch(
+        "terok.cli.commands.sickbay.get_server_status",
+        return_value=GateServerStatus(mode="systemd", running=False, port=9418),
+    )
+    def test_error_socket_inactive(self, _mock: unittest.mock.Mock) -> None:
+        with self.assertRaises(SystemExit) as ctx:
+            with unittest.mock.patch("sys.stdout", new_callable=StringIO) as out:
+                _cmd_sickbay()
+        self.assertEqual(ctx.exception.code, 2)
+        output = out.getvalue()
+        self.assertIn("ERROR", output)
+        self.assertIn("not active", output)

--- a/tests/lib/test_environment_gate_server.py
+++ b/tests/lib/test_environment_gate_server.py
@@ -1,0 +1,146 @@
+# SPDX-FileCopyrightText: 2025-2026 Jiri Vyskocil <jiri@vyskocil.com>
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for environment.py gate server integration."""
+
+import unittest
+import unittest.mock
+from pathlib import Path
+
+from terok.lib.containers.environment import _security_mode_env_and_volumes
+from terok.lib.core.projects import load_project
+from test_utils import mock_git_config, project_env
+
+_GATEKEEPING_YAML = """\
+project:
+  id: gk-proj
+  security_class: gatekeeping
+git:
+  upstream_url: https://example.com/repo.git
+  default_branch: main
+"""
+
+_ONLINE_YAML = """\
+project:
+  id: online-proj
+  security_class: online
+git:
+  upstream_url: https://example.com/repo.git
+  default_branch: main
+"""
+
+
+class TestGatekeepingMode(unittest.TestCase):
+    """Gatekeeping mode produces git:// URLs, no volume mounts for gate."""
+
+    @unittest.mock.patch(
+        "terok.lib.security.gate_server.get_server_status",
+        return_value=unittest.mock.Mock(running=True),
+    )
+    @unittest.mock.patch(
+        "terok.lib.security.gate_server._get_port",
+        return_value=9418,
+    )
+    def test_gatekeeping_uses_git_url(self, *_mocks: unittest.mock.Mock) -> None:
+        with (
+            mock_git_config(),
+            project_env(_GATEKEEPING_YAML, project_id="gk-proj", with_gate=True) as ctx,
+        ):
+            project = load_project("gk-proj")
+            env, volumes = _security_mode_env_and_volumes(project, Path(ctx.base / "ssh"))
+
+        self.assertEqual(
+            env["CODE_REPO"],
+            "git://host.containers.internal:9418/gk-proj.git",
+        )
+        # No gate volume mount
+        gate_mounts = [v for v in volumes if "git-gate" in v or "gate" in v.split(":")[0]]
+        self.assertEqual(gate_mounts, [])
+        self.assertEqual(env["GIT_BRANCH"], "main")
+
+    def test_gatekeeping_missing_gate_raises(self) -> None:
+        with (
+            mock_git_config(),
+            project_env(_GATEKEEPING_YAML, project_id="gk-proj", with_gate=False),
+        ):
+            project = load_project("gk-proj")
+            with self.assertRaises(SystemExit) as ctx:
+                _security_mode_env_and_volumes(project, Path("/tmp/ssh"))
+            self.assertIn("gate-sync", str(ctx.exception))
+
+    @unittest.mock.patch(
+        "terok.lib.security.gate_server.get_server_status",
+        return_value=unittest.mock.Mock(running=False),
+    )
+    @unittest.mock.patch("terok.lib.security.gate_server.is_systemd_available", return_value=False)
+    @unittest.mock.patch(
+        "terok.lib.security.gate_server._get_port",
+        return_value=9418,
+    )
+    def test_gatekeeping_server_not_running_raises(self, *_mocks: unittest.mock.Mock) -> None:
+        with (
+            mock_git_config(),
+            project_env(_GATEKEEPING_YAML, project_id="gk-proj", with_gate=True),
+        ):
+            project = load_project("gk-proj")
+            with self.assertRaises(SystemExit) as ctx:
+                _security_mode_env_and_volumes(project, Path("/tmp/ssh"))
+            self.assertIn("Gate server", str(ctx.exception))
+
+
+class TestOnlineMode(unittest.TestCase):
+    """Online mode produces git:// CLONE_FROM when gate exists."""
+
+    @unittest.mock.patch(
+        "terok.lib.security.gate_server.get_server_status",
+        return_value=unittest.mock.Mock(running=True),
+    )
+    @unittest.mock.patch(
+        "terok.lib.security.gate_server._get_port",
+        return_value=9418,
+    )
+    def test_online_with_gate_uses_git_url(self, *_mocks: unittest.mock.Mock) -> None:
+        with (
+            mock_git_config(),
+            project_env(_ONLINE_YAML, project_id="online-proj", with_gate=True) as ctx,
+        ):
+            project = load_project("online-proj")
+            env, volumes = _security_mode_env_and_volumes(project, Path(ctx.base / "ssh"))
+
+        self.assertEqual(
+            env["CLONE_FROM"],
+            "git://host.containers.internal:9418/online-proj.git",
+        )
+        self.assertEqual(env["CODE_REPO"], "https://example.com/repo.git")
+        # No gate volume mount
+        gate_mounts = [v for v in volumes if "git-gate" in v or "gate" in v.split(":")[0]]
+        self.assertEqual(gate_mounts, [])
+
+    @unittest.mock.patch(
+        "terok.lib.security.gate_server.get_server_status",
+        return_value=unittest.mock.Mock(running=False),
+    )
+    @unittest.mock.patch("terok.lib.security.gate_server.is_systemd_available", return_value=False)
+    def test_online_gate_server_down_skips_clone_from(self, *_mocks: unittest.mock.Mock) -> None:
+        """Online mode with gate repo but server down falls back gracefully."""
+        with (
+            mock_git_config(),
+            project_env(_ONLINE_YAML, project_id="online-proj", with_gate=True) as ctx,
+        ):
+            project = load_project("online-proj")
+            env, _volumes = _security_mode_env_and_volumes(project, Path(ctx.base / "ssh"))
+
+        self.assertNotIn("CLONE_FROM", env)
+        self.assertEqual(env["CODE_REPO"], "https://example.com/repo.git")
+
+    def test_online_without_gate_no_clone_from(self) -> None:
+        with (
+            mock_git_config(),
+            project_env(_ONLINE_YAML, project_id="online-proj", with_gate=False) as ctx,
+        ):
+            project = load_project("online-proj")
+            env, volumes = _security_mode_env_and_volumes(project, Path(ctx.base / "ssh"))
+
+        self.assertNotIn("CLONE_FROM", env)
+        self.assertEqual(env["CODE_REPO"], "https://example.com/repo.git")

--- a/tests/lib/test_gate_server.py
+++ b/tests/lib/test_gate_server.py
@@ -1,0 +1,478 @@
+# SPDX-FileCopyrightText: 2025-2026 Jiri Vyskocil <jiri@vyskocil.com>
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for gate_server module."""
+
+import contextlib
+import os
+import subprocess
+import tempfile
+import unittest
+import unittest.mock
+from pathlib import Path
+
+from terok.lib.security.gate_server import (
+    _UNIT_VERSION,
+    GateServerStatus,
+    _installed_unit_version,
+    _is_managed_git_daemon,
+    ensure_server_reachable,
+    get_server_status,
+    install_systemd_units,
+    is_daemon_running,
+    is_socket_active,
+    is_socket_installed,
+    is_systemd_available,
+    start_daemon,
+    stop_daemon,
+    uninstall_systemd_units,
+)
+
+
+class TestSystemdDetection(unittest.TestCase):
+    """Tests for systemd availability detection."""
+
+    @unittest.mock.patch("subprocess.run")
+    def test_systemd_available(self, mock_run: unittest.mock.Mock) -> None:
+        mock_run.return_value = unittest.mock.Mock(returncode=0)
+        self.assertTrue(is_systemd_available())
+
+    @unittest.mock.patch("subprocess.run")
+    def test_systemd_available_exit_1(self, mock_run: unittest.mock.Mock) -> None:
+        mock_run.return_value = unittest.mock.Mock(returncode=1)
+        self.assertTrue(is_systemd_available())
+
+    @unittest.mock.patch("subprocess.run", side_effect=FileNotFoundError)
+    def test_systemd_not_available(self, _mock: unittest.mock.Mock) -> None:
+        self.assertFalse(is_systemd_available())
+
+    @unittest.mock.patch("subprocess.run")
+    def test_systemd_unavailable_exit_2(self, mock_run: unittest.mock.Mock) -> None:
+        mock_run.return_value = unittest.mock.Mock(returncode=2)
+        self.assertFalse(is_systemd_available())
+
+
+class TestSocketInstalled(unittest.TestCase):
+    """Tests for socket unit file detection."""
+
+    def test_socket_not_installed(self) -> None:
+        with unittest.mock.patch(
+            "terok.lib.security.gate_server._systemd_unit_dir",
+            return_value=Path("/nonexistent"),
+        ):
+            self.assertFalse(is_socket_installed())
+
+    def test_socket_installed(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            unit_dir = Path(td)
+            (unit_dir / "terok-gate.socket").write_text("[Socket]\n")
+            with unittest.mock.patch(
+                "terok.lib.security.gate_server._systemd_unit_dir",
+                return_value=unit_dir,
+            ):
+                self.assertTrue(is_socket_installed())
+
+
+class TestSocketActive(unittest.TestCase):
+    """Tests for socket active check."""
+
+    @unittest.mock.patch("subprocess.run")
+    def test_active(self, mock_run: unittest.mock.Mock) -> None:
+        mock_run.return_value = unittest.mock.Mock(stdout="active\n", returncode=0)
+        self.assertTrue(is_socket_active())
+
+    @unittest.mock.patch("subprocess.run")
+    def test_inactive(self, mock_run: unittest.mock.Mock) -> None:
+        mock_run.return_value = unittest.mock.Mock(stdout="inactive\n", returncode=3)
+        self.assertFalse(is_socket_active())
+
+    @unittest.mock.patch("subprocess.run", side_effect=FileNotFoundError)
+    def test_no_systemctl(self, _mock: unittest.mock.Mock) -> None:
+        self.assertFalse(is_socket_active())
+
+
+class TestInstallUninstall(unittest.TestCase):
+    """Tests for systemd unit install/uninstall."""
+
+    @unittest.mock.patch("subprocess.run")
+    def test_install_writes_files(self, mock_run: unittest.mock.Mock) -> None:
+        mock_run.return_value = unittest.mock.Mock(returncode=0)
+        with tempfile.TemporaryDirectory() as td:
+            unit_dir = Path(td) / "systemd" / "user"
+            with (
+                unittest.mock.patch(
+                    "terok.lib.security.gate_server._systemd_unit_dir",
+                    return_value=unit_dir,
+                ),
+                unittest.mock.patch("terok.lib.security.gate_server._get_port", return_value=9418),
+                unittest.mock.patch(
+                    "terok.lib.security.gate_server._get_gate_base_path",
+                    return_value=Path("/tmp/gate"),
+                ),
+            ):
+                install_systemd_units()
+
+            self.assertTrue((unit_dir / "terok-gate.socket").is_file())
+            self.assertTrue((unit_dir / "terok-gate@.service").is_file())
+            # Verify socket file contains port
+            socket_content = (unit_dir / "terok-gate.socket").read_text()
+            self.assertIn("127.0.0.1:9418", socket_content)
+            # Verify service file contains base path
+            service_content = (unit_dir / "terok-gate@.service").read_text()
+            self.assertIn("/tmp/gate", service_content)
+            # Verify version stamp is rendered in both files
+            self.assertIn("# terok-gate-version: 1", socket_content)
+            self.assertIn("# terok-gate-version: 1", service_content)
+
+    @unittest.mock.patch("subprocess.run")
+    def test_uninstall_removes_files(self, mock_run: unittest.mock.Mock) -> None:
+        mock_run.return_value = unittest.mock.Mock(returncode=0)
+        with tempfile.TemporaryDirectory() as td:
+            unit_dir = Path(td)
+            (unit_dir / "terok-gate.socket").write_text("[Socket]\n")
+            (unit_dir / "terok-gate@.service").write_text("[Service]\n")
+
+            with unittest.mock.patch(
+                "terok.lib.security.gate_server._systemd_unit_dir",
+                return_value=unit_dir,
+            ):
+                uninstall_systemd_units()
+
+            self.assertFalse((unit_dir / "terok-gate.socket").exists())
+            self.assertFalse((unit_dir / "terok-gate@.service").exists())
+
+
+class TestDaemon(unittest.TestCase):
+    """Tests for daemon start/stop."""
+
+    @unittest.mock.patch("subprocess.run")
+    def test_start_daemon(self, mock_run: unittest.mock.Mock) -> None:
+        mock_run.return_value = unittest.mock.Mock(returncode=0)
+        with tempfile.TemporaryDirectory() as td:
+            with (
+                unittest.mock.patch(
+                    "terok.lib.security.gate_server._get_gate_base_path",
+                    return_value=Path(td) / "gate",
+                ),
+                unittest.mock.patch(
+                    "terok.lib.security.gate_server._pid_file",
+                    return_value=Path(td) / "gate-server.pid",
+                ),
+            ):
+                start_daemon(port=9999)
+
+            mock_run.assert_called_once()
+            cmd = mock_run.call_args[0][0]
+            self.assertIn("--port=9999", cmd)
+            self.assertIn("--listen=127.0.0.1", cmd)
+
+    @unittest.mock.patch("subprocess.run", side_effect=subprocess.CalledProcessError(1, "git"))
+    def test_start_daemon_failure(self, _mock: unittest.mock.Mock) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            with (
+                unittest.mock.patch(
+                    "terok.lib.security.gate_server._get_gate_base_path",
+                    return_value=Path(td) / "gate",
+                ),
+                unittest.mock.patch(
+                    "terok.lib.security.gate_server._pid_file",
+                    return_value=Path(td) / "gate-server.pid",
+                ),
+            ):
+                with self.assertRaises(subprocess.CalledProcessError):
+                    start_daemon(port=9999)
+
+    def test_stop_daemon_no_pidfile(self) -> None:
+        with unittest.mock.patch(
+            "terok.lib.security.gate_server._pid_file",
+            return_value=Path("/nonexistent/pid"),
+        ):
+            stop_daemon()  # Should not raise
+
+    @unittest.mock.patch("terok.lib.security.gate_server._is_managed_git_daemon", return_value=True)
+    def test_stop_daemon_with_pidfile(self, _mock_check: unittest.mock.Mock) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            pidfile = Path(td) / "gate-server.pid"
+            pidfile.write_text("99999\n")
+            with (
+                unittest.mock.patch(
+                    "terok.lib.security.gate_server._pid_file",
+                    return_value=pidfile,
+                ),
+                unittest.mock.patch("os.kill") as mock_kill,
+            ):
+                stop_daemon()
+                mock_kill.assert_called_once_with(99999, unittest.mock.ANY)
+            self.assertFalse(pidfile.exists())
+
+    @unittest.mock.patch(
+        "terok.lib.security.gate_server._is_managed_git_daemon", return_value=False
+    )
+    def test_stop_daemon_stale_pid_not_killed(self, _mock_check: unittest.mock.Mock) -> None:
+        """Stop removes PID file even if the process is not our daemon."""
+        with tempfile.TemporaryDirectory() as td:
+            pidfile = Path(td) / "gate-server.pid"
+            pidfile.write_text("99999\n")
+            with (
+                unittest.mock.patch(
+                    "terok.lib.security.gate_server._pid_file",
+                    return_value=pidfile,
+                ),
+                unittest.mock.patch("os.kill") as mock_kill,
+            ):
+                stop_daemon()
+                mock_kill.assert_not_called()
+            self.assertFalse(pidfile.exists())
+
+
+class TestIsDaemonRunning(unittest.TestCase):
+    """Tests for is_daemon_running."""
+
+    def test_no_pidfile(self) -> None:
+        with unittest.mock.patch(
+            "terok.lib.security.gate_server._pid_file",
+            return_value=Path("/nonexistent/pid"),
+        ):
+            self.assertFalse(is_daemon_running())
+
+    @unittest.mock.patch("terok.lib.security.gate_server._is_managed_git_daemon", return_value=True)
+    def test_stale_pid(self, _mock_check: unittest.mock.Mock) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            pidfile = Path(td) / "gate-server.pid"
+            pidfile.write_text("99999\n")
+            with (
+                unittest.mock.patch(
+                    "terok.lib.security.gate_server._pid_file",
+                    return_value=pidfile,
+                ),
+                unittest.mock.patch("os.kill", side_effect=ProcessLookupError),
+            ):
+                self.assertFalse(is_daemon_running())
+
+    @unittest.mock.patch("terok.lib.security.gate_server._is_managed_git_daemon", return_value=True)
+    def test_valid_pid(self, _mock_check: unittest.mock.Mock) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            pidfile = Path(td) / "gate-server.pid"
+            pidfile.write_text(f"{os.getpid()}\n")
+            with unittest.mock.patch(
+                "terok.lib.security.gate_server._pid_file",
+                return_value=pidfile,
+            ):
+                self.assertTrue(is_daemon_running())
+
+    def test_not_our_daemon(self) -> None:
+        """PID exists but is not a git daemon — should return False."""
+        with tempfile.TemporaryDirectory() as td:
+            pidfile = Path(td) / "gate-server.pid"
+            pidfile.write_text(f"{os.getpid()}\n")
+            with (
+                unittest.mock.patch(
+                    "terok.lib.security.gate_server._pid_file",
+                    return_value=pidfile,
+                ),
+                unittest.mock.patch(
+                    "terok.lib.security.gate_server._is_managed_git_daemon",
+                    return_value=False,
+                ),
+            ):
+                self.assertFalse(is_daemon_running())
+
+
+class TestIsManagedGitDaemon(unittest.TestCase):
+    """Tests for _is_managed_git_daemon."""
+
+    def test_no_proc_entry(self) -> None:
+        self.assertFalse(_is_managed_git_daemon(999999999))
+
+    def test_current_process_is_not_git_daemon(self) -> None:
+        # The current process is python, not git daemon
+        self.assertFalse(_is_managed_git_daemon(os.getpid()))
+
+    def _check_cmdline(self, cmdline: bytes, pid_file: Path | None = None) -> bool:
+        """Write *cmdline* to a temp file and call ``_is_managed_git_daemon``."""
+        with tempfile.TemporaryDirectory() as td:
+            fake_cmdline = Path(td) / "cmdline"
+            fake_cmdline.write_bytes(cmdline)
+            patches = [
+                unittest.mock.patch(
+                    "terok.lib.security.gate_server.Path",
+                    return_value=fake_cmdline,
+                ),
+            ]
+            if pid_file is not None:
+                patches.append(
+                    unittest.mock.patch(
+                        "terok.lib.security.gate_server._pid_file",
+                        return_value=pid_file,
+                    )
+                )
+            with contextlib.ExitStack() as stack:
+                for p in patches:
+                    stack.enter_context(p)
+                return _is_managed_git_daemon(12345)
+
+    def test_matches_managed_daemon(self) -> None:
+        """Cmdline with git daemon and our PID file returns True."""
+        pid_file = Path("/run/user/1000/terok/gate-server.pid")
+        cmdline = b"git\x00daemon\x00--listen=127.0.0.1\x00--pid-file=" + str(pid_file).encode()
+        self.assertTrue(self._check_cmdline(cmdline, pid_file))
+
+    def test_rejects_different_pid_file(self) -> None:
+        """Git daemon with a different --pid-file is not ours."""
+        cmdline = b"git\x00daemon\x00--listen=127.0.0.1\x00--pid-file=/other/pid"
+        self.assertFalse(self._check_cmdline(cmdline, Path("/run/user/1000/terok/gate-server.pid")))
+
+    def test_rejects_non_git_process(self) -> None:
+        """Process that is not git at all returns False."""
+        cmdline = b"python3\x00-m\x00pytest"
+        self.assertFalse(self._check_cmdline(cmdline, Path("/run/user/1000/terok/gate-server.pid")))
+
+    def test_matches_full_path_git(self) -> None:
+        """Cmdline with full path like /usr/bin/git is recognized."""
+        pid_file = Path("/run/user/1000/terok/gate-server.pid")
+        cmdline = b"/usr/bin/git\x00daemon\x00--pid-file=" + str(pid_file).encode()
+        self.assertTrue(self._check_cmdline(cmdline, pid_file))
+
+
+class TestGetServerStatus(unittest.TestCase):
+    """Tests for get_server_status."""
+
+    @unittest.mock.patch("terok.lib.security.gate_server.is_daemon_running", return_value=False)
+    @unittest.mock.patch("terok.lib.security.gate_server.is_socket_installed", return_value=False)
+    @unittest.mock.patch("terok.lib.security.gate_server._get_port", return_value=9418)
+    def test_none(self, *_mocks: unittest.mock.Mock) -> None:
+        status = get_server_status()
+        self.assertEqual(status, GateServerStatus(mode="none", running=False, port=9418))
+
+    @unittest.mock.patch("terok.lib.security.gate_server.is_socket_active", return_value=True)
+    @unittest.mock.patch("terok.lib.security.gate_server.is_socket_installed", return_value=True)
+    @unittest.mock.patch("terok.lib.security.gate_server._get_port", return_value=9418)
+    def test_systemd_active(self, *_mocks: unittest.mock.Mock) -> None:
+        status = get_server_status()
+        self.assertEqual(status, GateServerStatus(mode="systemd", running=True, port=9418))
+
+    @unittest.mock.patch("terok.lib.security.gate_server.is_daemon_running", return_value=False)
+    @unittest.mock.patch("terok.lib.security.gate_server.is_socket_active", return_value=False)
+    @unittest.mock.patch("terok.lib.security.gate_server.is_socket_installed", return_value=True)
+    @unittest.mock.patch("terok.lib.security.gate_server._get_port", return_value=9418)
+    def test_systemd_inactive(self, *_mocks: unittest.mock.Mock) -> None:
+        status = get_server_status()
+        self.assertEqual(status, GateServerStatus(mode="systemd", running=False, port=9418))
+
+    @unittest.mock.patch("terok.lib.security.gate_server.is_daemon_running", return_value=True)
+    @unittest.mock.patch("terok.lib.security.gate_server.is_socket_active", return_value=False)
+    @unittest.mock.patch("terok.lib.security.gate_server.is_socket_installed", return_value=True)
+    @unittest.mock.patch("terok.lib.security.gate_server._get_port", return_value=9418)
+    def test_daemon_fallback_when_socket_inactive(self, *_mocks: unittest.mock.Mock) -> None:
+        """Daemon fallback is detected even when systemd units are installed."""
+        status = get_server_status()
+        self.assertEqual(status, GateServerStatus(mode="daemon", running=True, port=9418))
+
+    @unittest.mock.patch("terok.lib.security.gate_server.is_daemon_running", return_value=True)
+    @unittest.mock.patch("terok.lib.security.gate_server.is_socket_installed", return_value=False)
+    @unittest.mock.patch("terok.lib.security.gate_server._get_port", return_value=9418)
+    def test_daemon_running(self, *_mocks: unittest.mock.Mock) -> None:
+        status = get_server_status()
+        self.assertEqual(status, GateServerStatus(mode="daemon", running=True, port=9418))
+
+
+class TestEnsureServerReachable(unittest.TestCase):
+    """Tests for ensure_server_reachable."""
+
+    @unittest.mock.patch(
+        "terok.lib.security.gate_server.get_server_status",
+        return_value=GateServerStatus(mode="daemon", running=True, port=9418),
+    )
+    def test_passes_when_running(self, _mock: unittest.mock.Mock) -> None:
+        ensure_server_reachable()  # Should not raise
+
+    @unittest.mock.patch("terok.lib.security.gate_server.is_systemd_available", return_value=True)
+    @unittest.mock.patch(
+        "terok.lib.security.gate_server.get_server_status",
+        return_value=GateServerStatus(mode="none", running=False, port=9418),
+    )
+    def test_raises_when_not_running_systemd(self, *_mocks: unittest.mock.Mock) -> None:
+        with self.assertRaises(SystemExit) as ctx:
+            ensure_server_reachable()
+        self.assertIn("gate-server install", str(ctx.exception))
+
+    @unittest.mock.patch("terok.lib.security.gate_server.is_systemd_available", return_value=False)
+    @unittest.mock.patch(
+        "terok.lib.security.gate_server.get_server_status",
+        return_value=GateServerStatus(mode="none", running=False, port=9418),
+    )
+    def test_raises_when_not_running_no_systemd(self, *_mocks: unittest.mock.Mock) -> None:
+        with self.assertRaises(SystemExit) as ctx:
+            ensure_server_reachable()
+        self.assertIn("gate-server start", str(ctx.exception))
+
+    @unittest.mock.patch(
+        "terok.lib.security.gate_server._installed_unit_version",
+        return_value=0,
+    )
+    @unittest.mock.patch(
+        "terok.lib.security.gate_server.get_server_status",
+        return_value=GateServerStatus(mode="systemd", running=True, port=9418),
+    )
+    def test_raises_when_units_outdated(self, *_mocks: unittest.mock.Mock) -> None:
+        with self.assertRaises(SystemExit) as ctx:
+            ensure_server_reachable()
+        self.assertIn("outdated", str(ctx.exception))
+        self.assertIn("gate-server install", str(ctx.exception))
+
+    @unittest.mock.patch(
+        "terok.lib.security.gate_server._installed_unit_version",
+        return_value=None,
+    )
+    @unittest.mock.patch(
+        "terok.lib.security.gate_server.get_server_status",
+        return_value=GateServerStatus(mode="systemd", running=True, port=9418),
+    )
+    def test_raises_when_units_unversioned(self, *_mocks: unittest.mock.Mock) -> None:
+        with self.assertRaises(SystemExit) as ctx:
+            ensure_server_reachable()
+        self.assertIn("unversioned", str(ctx.exception))
+
+    @unittest.mock.patch(
+        "terok.lib.security.gate_server._installed_unit_version",
+        return_value=_UNIT_VERSION,
+    )
+    @unittest.mock.patch(
+        "terok.lib.security.gate_server.get_server_status",
+        return_value=GateServerStatus(mode="systemd", running=True, port=9418),
+    )
+    def test_passes_when_units_current(self, *_mocks: unittest.mock.Mock) -> None:
+        ensure_server_reachable()  # Should not raise
+
+
+class TestInstalledUnitVersion(unittest.TestCase):
+    """Tests for _installed_unit_version."""
+
+    def test_no_file(self) -> None:
+        with unittest.mock.patch(
+            "terok.lib.security.gate_server._systemd_unit_dir",
+            return_value=Path("/nonexistent"),
+        ):
+            self.assertIsNone(_installed_unit_version())
+
+    def test_reads_version(self) -> None:
+        with tempfile.TemporaryDirectory() as td:
+            unit_dir = Path(td)
+            (unit_dir / "terok-gate.socket").write_text("# terok-gate-version: 42\n[Socket]\n")
+            with unittest.mock.patch(
+                "terok.lib.security.gate_server._systemd_unit_dir",
+                return_value=unit_dir,
+            ):
+                self.assertEqual(_installed_unit_version(), 42)
+
+    def test_missing_stamp(self) -> None:
+        """Unit file without version stamp returns None."""
+        with tempfile.TemporaryDirectory() as td:
+            unit_dir = Path(td)
+            (unit_dir / "terok-gate.socket").write_text("[Socket]\nListenStream=127.0.0.1:9418\n")
+            with unittest.mock.patch(
+                "terok.lib.security.gate_server._systemd_unit_dir",
+                return_value=unit_dir,
+            ):
+                self.assertIsNone(_installed_unit_version())

--- a/tests/lib/test_podman_network.py
+++ b/tests/lib/test_podman_network.py
@@ -1,0 +1,115 @@
+# SPDX-FileCopyrightText: 2025-2026 Jiri Vyskocil <jiri@vyskocil.com>
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for Podman rootless network detection and args."""
+
+import json
+import subprocess
+import unittest
+import unittest.mock
+
+from terok.lib.util.podman import _detect_rootless_network_mode, _podman_network_args
+
+
+class TestDetectRootlessNetworkMode(unittest.TestCase):
+    """Tests for _detect_rootless_network_mode."""
+
+    def setUp(self) -> None:
+        _detect_rootless_network_mode.cache_clear()
+
+    def tearDown(self) -> None:
+        _detect_rootless_network_mode.cache_clear()
+
+    @unittest.mock.patch("subprocess.check_output")
+    def test_detects_pasta(self, mock_output: unittest.mock.Mock) -> None:
+        """rootlessNetworkCmd: 'pasta' returns 'pasta'."""
+        mock_output.return_value = json.dumps({"host": {"rootlessNetworkCmd": "pasta"}}).encode()
+        self.assertEqual(_detect_rootless_network_mode(), "pasta")
+
+    @unittest.mock.patch("subprocess.check_output")
+    def test_detects_slirp4netns(self, mock_output: unittest.mock.Mock) -> None:
+        """rootlessNetworkCmd: 'slirp4netns' returns 'slirp4netns'."""
+        mock_output.return_value = json.dumps(
+            {"host": {"rootlessNetworkCmd": "slirp4netns"}}
+        ).encode()
+        self.assertEqual(_detect_rootless_network_mode(), "slirp4netns")
+
+    @unittest.mock.patch("subprocess.check_output")
+    def test_fallback_podman5(self, mock_output: unittest.mock.Mock) -> None:
+        """No rootlessNetworkCmd on Podman 5+ returns 'pasta'."""
+        mock_output.return_value = json.dumps(
+            {"host": {}, "version": {"Version": "5.2.1"}}
+        ).encode()
+        self.assertEqual(_detect_rootless_network_mode(), "pasta")
+
+    @unittest.mock.patch("subprocess.check_output")
+    def test_fallback_podman4(self, mock_output: unittest.mock.Mock) -> None:
+        """No rootlessNetworkCmd on Podman 4.x returns 'slirp4netns'."""
+        mock_output.return_value = json.dumps(
+            {"host": {}, "version": {"Version": "4.9.3"}}
+        ).encode()
+        self.assertEqual(_detect_rootless_network_mode(), "slirp4netns")
+
+    @unittest.mock.patch("subprocess.check_output", side_effect=FileNotFoundError)
+    def test_podman_not_found(self, _mock: unittest.mock.Mock) -> None:
+        """FileNotFoundError (no podman) returns 'unknown'."""
+        self.assertEqual(_detect_rootless_network_mode(), "unknown")
+
+    @unittest.mock.patch(
+        "subprocess.check_output",
+        side_effect=subprocess.CalledProcessError(1, "podman"),
+    )
+    def test_podman_error(self, _mock: unittest.mock.Mock) -> None:
+        """CalledProcessError returns 'unknown'."""
+        self.assertEqual(_detect_rootless_network_mode(), "unknown")
+
+
+class TestPodmanNetworkArgs(unittest.TestCase):
+    """Tests for _podman_network_args."""
+
+    @unittest.mock.patch(
+        "terok.lib.util.podman._detect_rootless_network_mode",
+        return_value="slirp4netns",
+    )
+    @unittest.mock.patch("os.geteuid", return_value=1000)
+    def test_slirp4netns_returns_flags(
+        self, _euid: unittest.mock.Mock, _mode: unittest.mock.Mock
+    ) -> None:
+        """slirp4netns mode returns network flags with allow_host_loopback."""
+        args = _podman_network_args()
+        self.assertEqual(len(args), 4)
+        self.assertIn("slirp4netns:allow_host_loopback=true", args[1])
+        self.assertIn("--add-host", args)
+        self.assertIn("host.containers.internal:10.0.2.2", args)
+
+    @unittest.mock.patch(
+        "terok.lib.util.podman._detect_rootless_network_mode",
+        return_value="pasta",
+    )
+    @unittest.mock.patch("os.geteuid", return_value=1000)
+    def test_pasta_returns_network_and_add_host(
+        self, _euid: unittest.mock.Mock, _mode: unittest.mock.Mock
+    ) -> None:
+        """pasta mode returns --network pasta:-T,<port> and --add-host to loopback."""
+        args = _podman_network_args(gate_port=9418)
+        self.assertEqual(len(args), 4)
+        self.assertIn("--network", args)
+        self.assertIn("pasta:-T,9418", args)
+        self.assertIn("--add-host", args)
+        self.assertIn("host.containers.internal:127.0.0.1", args)
+
+    @unittest.mock.patch(
+        "terok.lib.util.podman._detect_rootless_network_mode",
+        return_value="pasta",
+    )
+    @unittest.mock.patch("os.geteuid", return_value=1000)
+    def test_pasta_custom_port(self, _euid: unittest.mock.Mock, _mode: unittest.mock.Mock) -> None:
+        """pasta mode uses the provided gate_port in -T option."""
+        args = _podman_network_args(gate_port=9999)
+        self.assertIn("pasta:-T,9999", args)
+
+    @unittest.mock.patch("os.geteuid", return_value=0)
+    def test_root_returns_empty(self, _euid: unittest.mock.Mock) -> None:
+        """Root user returns empty list regardless of network mode."""
+        self.assertEqual(_podman_network_args(), [])

--- a/tests/lib/test_tasks.py
+++ b/tests/lib/test_tasks.py
@@ -347,26 +347,35 @@ class TaskTests(unittest.TestCase):
                     task_list(project_id, status="running")
             self.assertIn("No tasks found", buf.getvalue())
 
-    def test_build_task_env_gatekeeping(self) -> None:
+    @unittest.mock.patch("terok.lib.containers.environment.ensure_server_reachable")
+    @unittest.mock.patch("terok.lib.containers.environment.get_gate_server_port", return_value=9418)
+    def test_build_task_env_gatekeeping(self, *_mocks) -> None:
         project_id = "proj9"
         with project_env(
             f"project:\n  id: {project_id}\n  security_class: gatekeeping\ngit:\n  default_branch: main\n",
             project_id=project_id,
             with_config_file=True,
             with_gate=True,
-        ) as ctx:
+        ):
             env, volumes = build_task_env_and_volumes(
                 project=load_project(project_id),
                 task_id="7",
             )
 
-            self.assertEqual(env["CODE_REPO"], "file:///git-gate/gate.git")
-            _assert_volume_mount(volumes, f"{ctx.gate_dir}:/git-gate/gate.git", ":z")
+            self.assertEqual(
+                env["CODE_REPO"],
+                f"git://host.containers.internal:9418/{project_id}.git",
+            )
+            # No gate volume mount (served via git daemon)
+            gate_mounts = [v for v in volumes if "gate" in v.split(":")[0]]
+            self.assertEqual(gate_mounts, [])
             # Verify SSH is NOT mounted by default in gatekeeping mode
             ssh_mounts = [v for v in volumes if "/home/dev/.ssh" in v]
             self.assertEqual(ssh_mounts, [])
 
-    def test_build_task_env_gatekeeping_with_ssh(self) -> None:
+    @unittest.mock.patch("terok.lib.containers.environment.ensure_server_reachable")
+    @unittest.mock.patch("terok.lib.containers.environment.get_gate_server_port", return_value=9418)
+    def test_build_task_env_gatekeeping_with_ssh(self, *_mocks) -> None:
         """Gatekeeping mode with mount_in_gatekeeping enabled should mount SSH."""
         project_id = "proj_gatekeeping_ssh"
         with project_env(
@@ -389,13 +398,17 @@ class TaskTests(unittest.TestCase):
                 task_id="9",
             )
 
-            # Verify gatekeeping behavior: CODE_REPO is file-based gate
-            self.assertEqual(env["CODE_REPO"], "file:///git-gate/gate.git")
-            _assert_volume_mount(volumes, f"{ctx.gate_dir}:/git-gate/gate.git", ":z")
+            # Verify gatekeeping behavior: CODE_REPO is git:// URL
+            self.assertEqual(
+                env["CODE_REPO"],
+                f"git://host.containers.internal:9418/{project_id}.git",
+            )
             # Verify SSH IS mounted when mount_in_gatekeeping is true
             _assert_volume_mount(volumes, f"{ssh_dir}:/home/dev/.ssh", ":z")
 
-    def test_build_task_env_online(self) -> None:
+    @unittest.mock.patch("terok.lib.containers.environment.ensure_server_reachable")
+    @unittest.mock.patch("terok.lib.containers.environment.get_gate_server_port", return_value=9418)
+    def test_build_task_env_online(self, *_mocks) -> None:
         project_id = "proj10"
         with project_env(
             "placeholder",
@@ -415,7 +428,10 @@ class TaskTests(unittest.TestCase):
             env, volumes = build_task_env_and_volumes(load_project(project_id), task_id="8")
             self.assertEqual(env["CODE_REPO"], "https://example.com/repo.git")
             self.assertEqual(env["GIT_BRANCH"], "main")
-            _assert_volume_mount(volumes, f"{ctx.gate_dir}:/git-gate/gate.git", ":z")
+            self.assertEqual(
+                env["CLONE_FROM"],
+                f"git://host.containers.internal:9418/{project_id}.git",
+            )
             _assert_volume_mount(volumes, f"{ssh_dir}:/home/dev/.ssh", ":z")
 
     def test_apply_ui_env_overrides_passthrough(self) -> None:
@@ -1055,7 +1071,9 @@ class TaskTests(unittest.TestCase):
                 self.assertIsNotNone(status.hint)
                 self.assertIn("xclip", status.hint)
 
-    def test_build_task_env_gatekeeping_expose_external_remote_enabled(self) -> None:
+    @unittest.mock.patch("terok.lib.containers.environment.ensure_server_reachable")
+    @unittest.mock.patch("terok.lib.containers.environment.get_gate_server_port", return_value=9418)
+    def test_build_task_env_gatekeeping_expose_external_remote_enabled(self, *_mocks) -> None:
         """Test expose_external_remote=true with upstream_url sets EXTERNAL_REMOTE_URL."""
         project_id = "proj_external_remote_enabled"
         upstream_url = "https://github.com/example/repo.git"
@@ -1064,7 +1082,7 @@ class TaskTests(unittest.TestCase):
             project_id=project_id,
             with_config_file=True,
             with_gate=True,
-        ) as ctx:
+        ):
             env, volumes = build_task_env_and_volumes(
                 project=load_project(project_id),
                 task_id="10",
@@ -1073,10 +1091,14 @@ class TaskTests(unittest.TestCase):
             # Verify EXTERNAL_REMOTE_URL is set when expose_external_remote is enabled
             self.assertEqual(env["EXTERNAL_REMOTE_URL"], upstream_url)
             # Verify gatekeeping mode settings are still correct
-            self.assertEqual(env["CODE_REPO"], "file:///git-gate/gate.git")
-            _assert_volume_mount(volumes, f"{ctx.gate_dir}:/git-gate/gate.git", ":z")
+            self.assertEqual(
+                env["CODE_REPO"],
+                f"git://host.containers.internal:9418/{project_id}.git",
+            )
 
-    def test_build_task_env_gatekeeping_expose_external_remote_disabled(self) -> None:
+    @unittest.mock.patch("terok.lib.containers.environment.ensure_server_reachable")
+    @unittest.mock.patch("terok.lib.containers.environment.get_gate_server_port", return_value=9418)
+    def test_build_task_env_gatekeeping_expose_external_remote_disabled(self, *_mocks) -> None:
         """Test expose_external_remote=false does not set EXTERNAL_REMOTE_URL."""
         project_id = "proj_external_remote_disabled"
         upstream_url = "https://github.com/example/repo.git"
@@ -1085,7 +1107,7 @@ class TaskTests(unittest.TestCase):
             project_id=project_id,
             with_config_file=True,
             with_gate=True,
-        ) as ctx:
+        ):
             env, volumes = build_task_env_and_volumes(
                 project=load_project(project_id),
                 task_id="11",
@@ -1094,10 +1116,14 @@ class TaskTests(unittest.TestCase):
             # Verify EXTERNAL_REMOTE_URL is NOT set when expose_external_remote is false
             self.assertNotIn("EXTERNAL_REMOTE_URL", env)
             # Verify gatekeeping mode settings are still correct
-            self.assertEqual(env["CODE_REPO"], "file:///git-gate/gate.git")
-            _assert_volume_mount(volumes, f"{ctx.gate_dir}:/git-gate/gate.git", ":z")
+            self.assertEqual(
+                env["CODE_REPO"],
+                f"git://host.containers.internal:9418/{project_id}.git",
+            )
 
-    def test_build_task_env_gatekeeping_expose_external_remote_no_upstream(self) -> None:
+    @unittest.mock.patch("terok.lib.containers.environment.ensure_server_reachable")
+    @unittest.mock.patch("terok.lib.containers.environment.get_gate_server_port", return_value=9418)
+    def test_build_task_env_gatekeeping_expose_external_remote_no_upstream(self, *_mocks) -> None:
         """Test expose_external_remote=true without upstream_url does not set EXTERNAL_REMOTE_URL."""
         project_id = "proj_external_remote_no_upstream"
         with project_env(
@@ -1105,7 +1131,7 @@ class TaskTests(unittest.TestCase):
             project_id=project_id,
             with_config_file=True,
             with_gate=True,
-        ) as ctx:
+        ):
             env, volumes = build_task_env_and_volumes(
                 project=load_project(project_id),
                 task_id="12",
@@ -1114,8 +1140,10 @@ class TaskTests(unittest.TestCase):
             # Verify EXTERNAL_REMOTE_URL is NOT set when upstream_url is missing
             self.assertNotIn("EXTERNAL_REMOTE_URL", env)
             # Verify gatekeeping mode settings are still correct
-            self.assertEqual(env["CODE_REPO"], "file:///git-gate/gate.git")
-            _assert_volume_mount(volumes, f"{ctx.gate_dir}:/git-gate/gate.git", ":z")
+            self.assertEqual(
+                env["CODE_REPO"],
+                f"git://host.containers.internal:9418/{project_id}.git",
+            )
 
 
 class TaskLogsTests(unittest.TestCase):


### PR DESCRIPTION
## Summary

Replaces the host-writable volume mount used to share gate repos with task containers. Instead, a `git daemon` on the host serves repos over the git protocol, and containers clone via `git://host.containers.internal:9418/...`.

**What's included:**

- **Gate server module** (`terok.lib.security.gate_server`) — full lifecycle management for the git daemon, with two deployment modes:
  1. **Systemd socket activation** (preferred) — zero-idle-cost, crash resilience, `terokctl gate-server install/uninstall`
  2. **Managed daemon** (fallback) — `terokctl gate-server start/stop` for non-systemd hosts
- **CLI commands** — `terokctl gate-server {install,uninstall,start,stop,status}`
- **Health check** — `terokctl sickbay` reports gate server status alongside other diagnostics
- **Pre-flight check** — task creation fails early with an actionable message if the gate server is not running
- **Environment integration** — gatekeeping and online modes build `git://` clone URLs instead of volume mounts
- **Loopback-only binding** — daemon listens on `127.0.0.1`
- **Podman 4.x (slirp4netns) support** — auto-detects the rootless network mode via `podman info` and injects `--network slirp4netns:allow_host_loopback=true` + `--add-host host.containers.internal:10.0.2.2` so containers can reach host loopback
- **Module boundaries** — new `gate_server` and `podman` entries in `tach.toml`

## Test plan

- [x] 955 tests pass (`make check`: lint, test, tach, docstrings, REUSE)
- [ ] On Podman 5+ (pasta): `terokctl gate-server install` → `terokctl task run-cli` clones via git protocol
- [ ] On Podman 4.x (slirp4netns): same flow works via `allow_host_loopback`
- [ ] `ss -tlnp | grep 9418` confirms daemon only on `127.0.0.1`
- [ ] `terokctl sickbay` reports gate server status correctly

Closes #331

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Gate-server CLI: install, uninstall, start, stop, and status commands.
  * Sickbay health-check command reporting component statuses and exit codes.

* **Improvements**
  * Systemd socket-activation support with packaged unit files; fallback managed daemon.
  * Podman rootless network detection and improved container network args.
  * Git access now prefers network git:// URLs instead of local file mounts.
  * Configurable gate-server port and suppressible systemd warnings.

* **Tests**
  * Extensive unit tests for gate-server, sickbay, environment, podman, and related flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->