### PR TITLE
chore: clean up SPDX headers across the codebase

### DIFF
--- a/.reuse/templates/compact.jinja2
+++ b/.reuse/templates/compact.jinja2
@@ -1,0 +1,9 @@
+{% for copyright_line in copyright_lines %}
+{{ copyright_line }}
+{% endfor %}
+{% for contributor_line in contributor_lines %}
+SPDX-FileContributor: {{ contributor_line }}
+{% endfor %}
+{% for expression in spdx_expressions %}
+SPDX-License-Identifier: {{ expression }}
+{% endfor %}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -52,6 +52,7 @@ make install-dev          # Apply the updated lockfile to your local environment
 make install-dev  # Install all development dependencies
 make docs         # Serve documentation locally
 make clean        # Remove build artifacts
+make spdx NAME="Your Name" FILES="src/terok/new_file.py"  # Add SPDX header
 ```
 
 ## Coding Standards
@@ -62,6 +63,12 @@ make clean        # Remove build artifacts
 - **Type hints**: Use Python 3.12+ type hints
 - **Docstrings**: Required for all public functions, classes, and modules (enforced by `docstr-coverage` at 95% minimum in CI)
 - **Testing**: Add tests for new functionality; maintain coverage
+- **SPDX headers**: Every source file (`.py`, `.sh`, etc.) must start with a compact two-line SPDX header — no blank line between them:
+  ```python
+  # SPDX-FileCopyrightText: 2025-2026 Jiri Vyskocil
+  # SPDX-License-Identifier: Apache-2.0
+  ```
+  Use `make spdx NAME="Your Name" FILES="path/to/file.py"` to add headers (uses the compact template in `.reuse/templates/`). For files that already have a header, this adds a second copyright line — it does not replace the existing one. Files covered by `REUSE.toml` glob patterns (`.md`, `.yml`, `.toml`, `.json`, etc.) do not need inline headers. `make reuse` checks compliance but does not generate headers.
 - **Emojis**: Must be natively wide (`East_Asian_Width=W`) — no VS16 (U+FE0F) sequences. Use `draw_emoji()` from `terok.lib.util.emoji` for aligned output. See `docs/DEVELOPER.md` → "Emoji width constraints" for details
 
 ## Development Workflow

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all lint format test tach docstrings complexity deadcode reuse check install install-dev clean
+.PHONY: all lint format test tach docstrings complexity deadcode reuse check install install-dev clean spdx
 
 all: check
 
@@ -36,6 +36,13 @@ deadcode:
 reuse:
 	find . -type d -name __pycache__ -exec rm -rf {} + 2>/dev/null || true
 	poetry run reuse lint
+
+# Add SPDX header to files: make spdx FILES="src/terok/new_file.py" [NAME="Your Name"]
+spdx:
+ifndef NAME
+	$(error NAME is required. Usage: make spdx NAME="Your Name" FILES="src/terok/new_file.py")
+endif
+	poetry run reuse annotate --template compact --copyright "$(NAME)" --license Apache-2.0 $(FILES)
 
 # Run all checks (equivalent to CI)
 check: lint test tach docstrings deadcode reuse

--- a/REUSE.toml
+++ b/REUSE.toml
@@ -20,5 +20,5 @@ path = [
   "vulture_whitelist.py",
   "src/terok/resources/scripts/blablador",
 ]
-SPDX-FileCopyrightText = "2025-2026 Jiri Vyskocil <jiri@vyskocil.com>"
+SPDX-FileCopyrightText = "2025-2026 Jiri Vyskocil"
 SPDX-License-Identifier = "Apache-2.0"

--- a/docs/gen_quality_report.py
+++ b/docs/gen_quality_report.py
@@ -1,5 +1,4 @@
-# SPDX-FileCopyrightText: 2025-2026 Jiri Vyskocil <jiri@vyskocil.com>
-#
+# SPDX-FileCopyrightText: 2026 Jiri Vyskocil
 # SPDX-License-Identifier: Apache-2.0
 
 """Generate a code quality report page for MkDocs.

--- a/docs/gen_ref_pages.py
+++ b/docs/gen_ref_pages.py
@@ -1,5 +1,4 @@
-# SPDX-FileCopyrightText: 2025-2026 Jiri Vyskocil <jiri@vyskocil.com>
-#
+# SPDX-FileCopyrightText: 2025-2026 Jiri Vyskocil
 # SPDX-License-Identifier: Apache-2.0
 
 """Generate the code reference pages and navigation."""

--- a/src/terok/__init__.py
+++ b/src/terok/__init__.py
@@ -1,5 +1,4 @@
-# SPDX-FileCopyrightText: 2025-2026 Jiri Vyskocil <jiri@vyskocil.com>
-#
+# SPDX-FileCopyrightText: 2025-2026 Jiri Vyskocil
 # SPDX-License-Identifier: Apache-2.0
 
 """terok package.

--- a/src/terok/cli/__init__.py
+++ b/src/terok/cli/__init__.py
@@ -1,5 +1,4 @@
-# SPDX-FileCopyrightText: 2025-2026 Jiri Vyskocil <jiri@vyskocil.com>
-#
+# SPDX-FileCopyrightText: 2025-2026 Jiri Vyskocil
 # SPDX-License-Identifier: Apache-2.0
 
 """terok CLI package."""

--- a/src/terok/cli/__main__.py
+++ b/src/terok/cli/__main__.py
@@ -1,5 +1,4 @@
-# SPDX-FileCopyrightText: 2025-2026 Jiri Vyskocil <jiri@vyskocil.com>
-#
+# SPDX-FileCopyrightText: 2025-2026 Jiri Vyskocil
 # SPDX-License-Identifier: Apache-2.0
 
 """CLI entry point for ``python -m terok.cli``."""

--- a/src/terok/cli/commands/__init__.py
+++ b/src/terok/cli/commands/__init__.py
@@ -1,5 +1,4 @@
-# SPDX-FileCopyrightText: 2025-2026 Jiri Vyskocil <jiri@vyskocil.com>
-#
+# SPDX-FileCopyrightText: 2026 Jiri Vyskocil
 # SPDX-License-Identifier: Apache-2.0
 
 """CLI command modules.

--- a/src/terok/cli/commands/_completers.py
+++ b/src/terok/cli/commands/_completers.py
@@ -1,5 +1,4 @@
-# SPDX-FileCopyrightText: 2025-2026 Jiri Vyskocil <jiri@vyskocil.com>
-#
+# SPDX-FileCopyrightText: 2026 Jiri Vyskocil
 # SPDX-License-Identifier: Apache-2.0
 
 """Shared argcomplete completers and helpers for CLI commands."""

--- a/src/terok/cli/commands/completions.py
+++ b/src/terok/cli/commands/completions.py
@@ -1,5 +1,4 @@
-# SPDX-FileCopyrightText: 2025-2026 Jiri Vyskocil <jiri@vyskocil.com>
-#
+# SPDX-FileCopyrightText: 2026 Jiri Vyskocil
 # SPDX-License-Identifier: Apache-2.0
 
 """CLI subcommand for generating and installing shell completions."""

--- a/src/terok/cli/commands/gate_server.py
+++ b/src/terok/cli/commands/gate_server.py
@@ -1,5 +1,4 @@
-# SPDX-FileCopyrightText: 2025-2026 Jiri Vyskocil <jiri@vyskocil.com>
-#
+# SPDX-FileCopyrightText: 2026 Jiri Vyskocil
 # SPDX-License-Identifier: Apache-2.0
 
 """Gate server management commands: install, uninstall, start, stop, status.

--- a/src/terok/cli/commands/image.py
+++ b/src/terok/cli/commands/image.py
@@ -1,5 +1,4 @@
-# SPDX-FileCopyrightText: 2025-2026 Jiri Vyskocil <jiri@vyskocil.com>
-#
+# SPDX-FileCopyrightText: 2026 Jiri Vyskocil
 # SPDX-License-Identifier: Apache-2.0
 
 """Image management commands: list and cleanup."""

--- a/src/terok/cli/commands/info.py
+++ b/src/terok/cli/commands/info.py
@@ -1,5 +1,4 @@
-# SPDX-FileCopyrightText: 2025-2026 Jiri Vyskocil <jiri@vyskocil.com>
-#
+# SPDX-FileCopyrightText: 2026 Jiri Vyskocil
 # SPDX-License-Identifier: Apache-2.0
 
 """Informational CLI commands: config overview and resolved agent config."""

--- a/src/terok/cli/commands/project.py
+++ b/src/terok/cli/commands/project.py
@@ -1,5 +1,4 @@
-# SPDX-FileCopyrightText: 2025-2026 Jiri Vyskocil <jiri@vyskocil.com>
-#
+# SPDX-FileCopyrightText: 2026 Jiri Vyskocil
 # SPDX-License-Identifier: Apache-2.0
 
 """Project management commands: list, derive, wizard, presets, delete."""

--- a/src/terok/cli/commands/setup.py
+++ b/src/terok/cli/commands/setup.py
@@ -1,5 +1,4 @@
-# SPDX-FileCopyrightText: 2025-2026 Jiri Vyskocil <jiri@vyskocil.com>
-#
+# SPDX-FileCopyrightText: 2026 Jiri Vyskocil
 # SPDX-License-Identifier: Apache-2.0
 
 """Infrastructure setup commands: generate, build, ssh-init, gate-sync, auth."""

--- a/src/terok/cli/commands/sickbay.py
+++ b/src/terok/cli/commands/sickbay.py
@@ -1,5 +1,4 @@
-# SPDX-FileCopyrightText: 2025-2026 Jiri Vyskocil <jiri@vyskocil.com>
-#
+# SPDX-FileCopyrightText: 2026 Jiri Vyskocil
 # SPDX-License-Identifier: Apache-2.0
 
 """Health check command (DS9-themed diagnostic bay).

--- a/src/terok/cli/commands/task.py
+++ b/src/terok/cli/commands/task.py
@@ -1,5 +1,4 @@
-# SPDX-FileCopyrightText: 2025-2026 Jiri Vyskocil <jiri@vyskocil.com>
-#
+# SPDX-FileCopyrightText: 2026 Jiri Vyskocil
 # SPDX-License-Identifier: Apache-2.0
 
 """Task management commands: new, list, run-cli, run-web, start, etc."""

--- a/src/terok/cli/main.py
+++ b/src/terok/cli/main.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
 
-# SPDX-FileCopyrightText: 2025-2026 Jiri Vyskocil <jiri@vyskocil.com>
-#
+# SPDX-FileCopyrightText: 2025-2026 Jiri Vyskocil
 # SPDX-License-Identifier: Apache-2.0
 
 """CLI entry point and argument parser for terok.

--- a/src/terok/gate/__init__.py
+++ b/src/terok/gate/__init__.py
@@ -1,5 +1,4 @@
-# SPDX-FileCopyrightText: 2025-2026 Jiri Vyskocil <jiri@vyskocil.com>
-#
+# SPDX-FileCopyrightText: 2026 Jiri Vyskocil
 # SPDX-License-Identifier: Apache-2.0
 
 """Standalone HTTP gate server wrapping ``git http-backend`` with token auth."""

--- a/src/terok/gate/__main__.py
+++ b/src/terok/gate/__main__.py
@@ -1,5 +1,4 @@
-# SPDX-FileCopyrightText: 2025-2026 Jiri Vyskocil <jiri@vyskocil.com>
-#
+# SPDX-FileCopyrightText: 2025-2026 Jiri Vyskocil
 # SPDX-License-Identifier: Apache-2.0
 
 """Allow ``python -m terok.gate`` to start the gate server."""

--- a/src/terok/gate/resources/systemd/terok-gate.socket
+++ b/src/terok/gate/resources/systemd/terok-gate.socket
@@ -1,5 +1,4 @@
-# SPDX-FileCopyrightText: 2025-2026 Jiri Vyskocil <jiri@vyskocil.com>
-#
+# SPDX-FileCopyrightText: 2025-2026 Jiri Vyskocil
 # SPDX-License-Identifier: Apache-2.0
 
 # terok-gate-version: {{UNIT_VERSION}}

--- a/src/terok/gate/resources/systemd/terok-gate@.service
+++ b/src/terok/gate/resources/systemd/terok-gate@.service
@@ -1,5 +1,4 @@
-# SPDX-FileCopyrightText: 2025-2026 Jiri Vyskocil <jiri@vyskocil.com>
-#
+# SPDX-FileCopyrightText: 2025-2026 Jiri Vyskocil
 # SPDX-License-Identifier: Apache-2.0
 
 # terok-gate-version: {{UNIT_VERSION}}

--- a/src/terok/gate/server.py
+++ b/src/terok/gate/server.py
@@ -1,5 +1,4 @@
-# SPDX-FileCopyrightText: 2025-2026 Jiri Vyskocil <jiri@vyskocil.com>
-#
+# SPDX-FileCopyrightText: 2026 Jiri Vyskocil
 # SPDX-License-Identifier: Apache-2.0
 
 """Standalone HTTP gate server wrapping ``git http-backend`` with token auth.

--- a/src/terok/lib/__init__.py
+++ b/src/terok/lib/__init__.py
@@ -1,5 +1,4 @@
-# SPDX-FileCopyrightText: 2025-2026 Jiri Vyskocil <jiri@vyskocil.com>
-#
+# SPDX-FileCopyrightText: 2025-2026 Jiri Vyskocil
 # SPDX-License-Identifier: Apache-2.0
 
 """terok.lib — business logic layer.

--- a/src/terok/lib/containers/__init__.py
+++ b/src/terok/lib/containers/__init__.py
@@ -1,5 +1,4 @@
-# SPDX-FileCopyrightText: 2025-2026 Jiri Vyskocil <jiri@vyskocil.com>
-#
+# SPDX-FileCopyrightText: 2026 Jiri Vyskocil
 # SPDX-License-Identifier: Apache-2.0
 
 """Container orchestration: task lifecycle, runtime, Dockerfiles."""

--- a/src/terok/lib/containers/agent_config.py
+++ b/src/terok/lib/containers/agent_config.py
@@ -1,5 +1,4 @@
-# SPDX-FileCopyrightText: 2025-2026 Jiri Vyskocil <jiri@vyskocil.com>
-#
+# SPDX-FileCopyrightText: 2026 Jiri Vyskocil
 # SPDX-License-Identifier: Apache-2.0
 
 """Agent config resolution: layered merging across global, project, preset, and CLI scopes.

--- a/src/terok/lib/containers/agents.py
+++ b/src/terok/lib/containers/agents.py
@@ -1,5 +1,4 @@
-# SPDX-FileCopyrightText: 2025-2026 Jiri Vyskocil <jiri@vyskocil.com>
-#
+# SPDX-FileCopyrightText: 2026 Jiri Vyskocil
 # SPDX-License-Identifier: Apache-2.0
 
 """Agent configuration: parsing, filtering, and wrapper generation.

--- a/src/terok/lib/containers/autopilot.py
+++ b/src/terok/lib/containers/autopilot.py
@@ -1,5 +1,4 @@
-# SPDX-FileCopyrightText: 2025-2026 Jiri Vyskocil <jiri@vyskocil.com>
-#
+# SPDX-FileCopyrightText: 2026 Jiri Vyskocil
 # SPDX-License-Identifier: Apache-2.0
 
 """Autopilot container lifecycle helpers.

--- a/src/terok/lib/containers/docker.py
+++ b/src/terok/lib/containers/docker.py
@@ -1,5 +1,4 @@
-# SPDX-FileCopyrightText: 2025-2026 Jiri Vyskocil <jiri@vyskocil.com>
-#
+# SPDX-FileCopyrightText: 2025-2026 Jiri Vyskocil
 # SPDX-License-Identifier: Apache-2.0
 
 """Dockerfile generation, image building, and build-context hashing."""

--- a/src/terok/lib/containers/environment.py
+++ b/src/terok/lib/containers/environment.py
@@ -1,5 +1,4 @@
-# SPDX-FileCopyrightText: 2025-2026 Jiri Vyskocil <jiri@vyskocil.com>
-#
+# SPDX-FileCopyrightText: 2026 Jiri Vyskocil
 # SPDX-License-Identifier: Apache-2.0
 
 """Container environment and volume assembly for task containers.

--- a/src/terok/lib/containers/headless_providers.py
+++ b/src/terok/lib/containers/headless_providers.py
@@ -1,5 +1,4 @@
-# SPDX-FileCopyrightText: 2025-2026 Jiri Vyskocil <jiri@vyskocil.com>
-#
+# SPDX-FileCopyrightText: 2026 Jiri Vyskocil
 # SPDX-License-Identifier: Apache-2.0
 
 """Headless (autopilot) provider registry for multi-agent support.

--- a/src/terok/lib/containers/image_cleanup.py
+++ b/src/terok/lib/containers/image_cleanup.py
@@ -1,5 +1,4 @@
-# SPDX-FileCopyrightText: 2025-2026 Jiri Vyskocil <jiri@vyskocil.com>
-#
+# SPDX-FileCopyrightText: 2026 Jiri Vyskocil
 # SPDX-License-Identifier: Apache-2.0
 
 """Image listing and cleanup for terok-managed container images."""

--- a/src/terok/lib/containers/instructions.py
+++ b/src/terok/lib/containers/instructions.py
@@ -1,5 +1,4 @@
-# SPDX-FileCopyrightText: 2025-2026 Jiri Vyskocil <jiri@vyskocil.com>
-#
+# SPDX-FileCopyrightText: 2026 Jiri Vyskocil
 # SPDX-License-Identifier: Apache-2.0
 
 """Agent instruction resolution: layered merging with bundled defaults.

--- a/src/terok/lib/containers/log_format.py
+++ b/src/terok/lib/containers/log_format.py
@@ -1,5 +1,4 @@
-# SPDX-FileCopyrightText: 2025-2026 Jiri Vyskocil <jiri@vyskocil.com>
-#
+# SPDX-FileCopyrightText: 2026 Jiri Vyskocil
 # SPDX-License-Identifier: Apache-2.0
 
 """Agent log formatters for structured container log output.

--- a/src/terok/lib/containers/ports.py
+++ b/src/terok/lib/containers/ports.py
@@ -1,5 +1,4 @@
-# SPDX-FileCopyrightText: 2025-2026 Jiri Vyskocil <jiri@vyskocil.com>
-#
+# SPDX-FileCopyrightText: 2026 Jiri Vyskocil
 # SPDX-License-Identifier: Apache-2.0
 
 """Web port allocation for task containers.

--- a/src/terok/lib/containers/project_state.py
+++ b/src/terok/lib/containers/project_state.py
@@ -1,5 +1,4 @@
-# SPDX-FileCopyrightText: 2025-2026 Jiri Vyskocil <jiri@vyskocil.com>
-#
+# SPDX-FileCopyrightText: 2026 Jiri Vyskocil
 # SPDX-License-Identifier: Apache-2.0
 
 """Read-only project state inspection and reporting.

--- a/src/terok/lib/containers/runtime.py
+++ b/src/terok/lib/containers/runtime.py
@@ -1,5 +1,4 @@
-# SPDX-FileCopyrightText: 2025-2026 Jiri Vyskocil <jiri@vyskocil.com>
-#
+# SPDX-FileCopyrightText: 2026 Jiri Vyskocil
 # SPDX-License-Identifier: Apache-2.0
 
 """Container utility functions that can be safely imported by other modules."""

--- a/src/terok/lib/containers/task_display.py
+++ b/src/terok/lib/containers/task_display.py
@@ -1,5 +1,4 @@
-# SPDX-FileCopyrightText: 2025-2026 Jiri Vyskocil <jiri@vyskocil.com>
-#
+# SPDX-FileCopyrightText: 2026 Jiri Vyskocil
 # SPDX-License-Identifier: Apache-2.0
 
 """Task display types and status computation.

--- a/src/terok/lib/containers/task_logs.py
+++ b/src/terok/lib/containers/task_logs.py
@@ -1,5 +1,4 @@
-# SPDX-FileCopyrightText: 2025-2026 Jiri Vyskocil <jiri@vyskocil.com>
-#
+# SPDX-FileCopyrightText: 2026 Jiri Vyskocil
 # SPDX-License-Identifier: Apache-2.0
 
 """Task log viewing and streaming.

--- a/src/terok/lib/containers/task_runners.py
+++ b/src/terok/lib/containers/task_runners.py
@@ -1,5 +1,4 @@
-# SPDX-FileCopyrightText: 2025-2026 Jiri Vyskocil <jiri@vyskocil.com>
-#
+# SPDX-FileCopyrightText: 2025-2026 Jiri Vyskocil
 # SPDX-License-Identifier: Apache-2.0
 
 """Task container runners: CLI, web, headless, and restart.

--- a/src/terok/lib/containers/tasks.py
+++ b/src/terok/lib/containers/tasks.py
@@ -1,5 +1,4 @@
-# SPDX-FileCopyrightText: 2025-2026 Jiri Vyskocil <jiri@vyskocil.com>
-#
+# SPDX-FileCopyrightText: 2025-2026 Jiri Vyskocil
 # SPDX-License-Identifier: Apache-2.0
 
 """Task metadata, lifecycle, and query operations.

--- a/src/terok/lib/containers/work_status.py
+++ b/src/terok/lib/containers/work_status.py
@@ -1,5 +1,4 @@
-# SPDX-FileCopyrightText: 2025-2026 Jiri Vyskocil <jiri@vyskocil.com>
-#
+# SPDX-FileCopyrightText: 2026 Jiri Vyskocil
 # SPDX-License-Identifier: Apache-2.0
 
 """Agent work-status reporting: read/write ``work-status.yml`` from agent-config dirs.

--- a/src/terok/lib/core/__init__.py
+++ b/src/terok/lib/core/__init__.py
@@ -1,5 +1,4 @@
-# SPDX-FileCopyrightText: 2025-2026 Jiri Vyskocil <jiri@vyskocil.com>
-#
+# SPDX-FileCopyrightText: 2026 Jiri Vyskocil
 # SPDX-License-Identifier: Apache-2.0
 
 """Core foundation types, configuration, and project model."""

--- a/src/terok/lib/core/config.py
+++ b/src/terok/lib/core/config.py
@@ -1,5 +1,4 @@
-# SPDX-FileCopyrightText: 2025-2026 Jiri Vyskocil <jiri@vyskocil.com>
-#
+# SPDX-FileCopyrightText: 2025-2026 Jiri Vyskocil
 # SPDX-License-Identifier: Apache-2.0
 
 """Global configuration, directory helpers, and preset/image path resolution."""

--- a/src/terok/lib/core/images.py
+++ b/src/terok/lib/core/images.py
@@ -1,5 +1,4 @@
-# SPDX-FileCopyrightText: 2025-2026 Jiri Vyskocil <jiri@vyskocil.com>
-#
+# SPDX-FileCopyrightText: 2025-2026 Jiri Vyskocil
 # SPDX-License-Identifier: Apache-2.0
 
 """Container image tag conventions for the terok layer system (L0/L1/L2)."""

--- a/src/terok/lib/core/paths.py
+++ b/src/terok/lib/core/paths.py
@@ -1,5 +1,4 @@
-# SPDX-FileCopyrightText: 2025-2026 Jiri Vyskocil <jiri@vyskocil.com>
-#
+# SPDX-FileCopyrightText: 2025-2026 Jiri Vyskocil
 # SPDX-License-Identifier: Apache-2.0
 
 """Platform-aware path resolution for config, state, and runtime directories."""

--- a/src/terok/lib/core/project_model.py
+++ b/src/terok/lib/core/project_model.py
@@ -1,5 +1,4 @@
-# SPDX-FileCopyrightText: 2025-2026 Jiri Vyskocil <jiri@vyskocil.com>
-#
+# SPDX-FileCopyrightText: 2026 Jiri Vyskocil
 # SPDX-License-Identifier: Apache-2.0
 
 """Project and preset data models.

--- a/src/terok/lib/core/projects.py
+++ b/src/terok/lib/core/projects.py
@@ -1,5 +1,4 @@
-# SPDX-FileCopyrightText: 2025-2026 Jiri Vyskocil <jiri@vyskocil.com>
-#
+# SPDX-FileCopyrightText: 2025-2026 Jiri Vyskocil
 # SPDX-License-Identifier: Apache-2.0
 
 """Project discovery, loading, and preset management."""

--- a/src/terok/lib/core/version.py
+++ b/src/terok/lib/core/version.py
@@ -1,5 +1,4 @@
-# SPDX-FileCopyrightText: 2025-2026 Jiri Vyskocil <jiri@vyskocil.com>
-#
+# SPDX-FileCopyrightText: 2025-2026 Jiri Vyskocil
 # SPDX-License-Identifier: Apache-2.0
 
 """Version and branch information for terok.

--- a/src/terok/lib/facade.py
+++ b/src/terok/lib/facade.py
@@ -1,5 +1,4 @@
-# SPDX-FileCopyrightText: 2025-2026 Jiri Vyskocil <jiri@vyskocil.com>
-#
+# SPDX-FileCopyrightText: 2026 Jiri Vyskocil
 # SPDX-License-Identifier: Apache-2.0
 
 """Service facade for common cross-cutting operations.

--- a/src/terok/lib/security/__init__.py
+++ b/src/terok/lib/security/__init__.py
@@ -1,5 +1,4 @@
-# SPDX-FileCopyrightText: 2025-2026 Jiri Vyskocil <jiri@vyskocil.com>
-#
+# SPDX-FileCopyrightText: 2026 Jiri Vyskocil
 # SPDX-License-Identifier: Apache-2.0
 
 """Security: authentication, SSH, and git gate."""

--- a/src/terok/lib/security/auth.py
+++ b/src/terok/lib/security/auth.py
@@ -1,5 +1,4 @@
-# SPDX-FileCopyrightText: 2025-2026 Jiri Vyskocil <jiri@vyskocil.com>
-#
+# SPDX-FileCopyrightText: 2025-2026 Jiri Vyskocil
 # SPDX-License-Identifier: Apache-2.0
 
 """Authentication workflows for AI coding agents.

--- a/src/terok/lib/security/gate_server.py
+++ b/src/terok/lib/security/gate_server.py
@@ -1,5 +1,4 @@
-# SPDX-FileCopyrightText: 2025-2026 Jiri Vyskocil <jiri@vyskocil.com>
-#
+# SPDX-FileCopyrightText: 2026 Jiri Vyskocil
 # SPDX-License-Identifier: Apache-2.0
 
 """Gate server lifecycle management.

--- a/src/terok/lib/security/gate_tokens.py
+++ b/src/terok/lib/security/gate_tokens.py
@@ -1,5 +1,4 @@
-# SPDX-FileCopyrightText: 2025-2026 Jiri Vyskocil <jiri@vyskocil.com>
-#
+# SPDX-FileCopyrightText: 2026 Jiri Vyskocil
 # SPDX-License-Identifier: Apache-2.0
 
 """Token CRUD for gate server per-task authentication.

--- a/src/terok/lib/security/git_gate.py
+++ b/src/terok/lib/security/git_gate.py
@@ -1,5 +1,4 @@
-# SPDX-FileCopyrightText: 2025-2026 Jiri Vyskocil <jiri@vyskocil.com>
-#
+# SPDX-FileCopyrightText: 2025-2026 Jiri Vyskocil
 # SPDX-License-Identifier: Apache-2.0
 
 """Host-side git gate (mirror) management and upstream comparison."""

--- a/src/terok/lib/security/ssh.py
+++ b/src/terok/lib/security/ssh.py
@@ -1,5 +1,4 @@
-# SPDX-FileCopyrightText: 2025-2026 Jiri Vyskocil <jiri@vyskocil.com>
-#
+# SPDX-FileCopyrightText: 2025-2026 Jiri Vyskocil
 # SPDX-License-Identifier: Apache-2.0
 
 """Per-project SSH keypair generation and config directory setup."""

--- a/src/terok/lib/util/__init__.py
+++ b/src/terok/lib/util/__init__.py
@@ -1,5 +1,4 @@
-# SPDX-FileCopyrightText: 2025-2026 Jiri Vyskocil <jiri@vyskocil.com>
-#
+# SPDX-FileCopyrightText: 2026 Jiri Vyskocil
 # SPDX-License-Identifier: Apache-2.0
 
 """Pure internal helpers: filesystem, templates, logging."""

--- a/src/terok/lib/util/ansi.py
+++ b/src/terok/lib/util/ansi.py
@@ -1,5 +1,4 @@
-# SPDX-FileCopyrightText: 2025-2026 Jiri Vyskocil <jiri@vyskocil.com>
-#
+# SPDX-FileCopyrightText: 2026 Jiri Vyskocil
 # SPDX-License-Identifier: Apache-2.0
 
 """Pure ANSI color utilities for service-layer modules.

--- a/src/terok/lib/util/config_stack.py
+++ b/src/terok/lib/util/config_stack.py
@@ -1,5 +1,4 @@
-# SPDX-FileCopyrightText: 2025-2026 Jiri Vyskocil <jiri@vyskocil.com>
-#
+# SPDX-FileCopyrightText: 2026 Jiri Vyskocil
 # SPDX-License-Identifier: Apache-2.0
 
 """Generic layered config resolution.

--- a/src/terok/lib/util/emoji.py
+++ b/src/terok/lib/util/emoji.py
@@ -1,5 +1,4 @@
-# SPDX-FileCopyrightText: 2025-2026 Jiri Vyskocil <jiri@vyskocil.com>
-#
+# SPDX-FileCopyrightText: 2026 Jiri Vyskocil
 # SPDX-License-Identifier: Apache-2.0
 
 """Emoji display-width utilities for consistent terminal alignment.

--- a/src/terok/lib/util/fs.py
+++ b/src/terok/lib/util/fs.py
@@ -1,5 +1,4 @@
-# SPDX-FileCopyrightText: 2025-2026 Jiri Vyskocil <jiri@vyskocil.com>
-#
+# SPDX-FileCopyrightText: 2025-2026 Jiri Vyskocil
 # SPDX-License-Identifier: Apache-2.0
 
 """Filesystem helpers for directory creation and writability checks."""

--- a/src/terok/lib/util/logging_utils.py
+++ b/src/terok/lib/util/logging_utils.py
@@ -1,5 +1,4 @@
-# SPDX-FileCopyrightText: 2025-2026 Jiri Vyskocil <jiri@vyskocil.com>
-#
+# SPDX-FileCopyrightText: 2026 Jiri Vyskocil
 # SPDX-License-Identifier: Apache-2.0
 
 """Utility functions for logging."""

--- a/src/terok/lib/util/podman.py
+++ b/src/terok/lib/util/podman.py
@@ -1,5 +1,4 @@
-# SPDX-FileCopyrightText: 2025-2026 Jiri Vyskocil <jiri@vyskocil.com>
-#
+# SPDX-FileCopyrightText: 2025-2026 Jiri Vyskocil
 # SPDX-License-Identifier: Apache-2.0
 
 """Podman user-namespace and network helpers for rootless operation."""

--- a/src/terok/lib/util/template_utils.py
+++ b/src/terok/lib/util/template_utils.py
@@ -1,5 +1,4 @@
-# SPDX-FileCopyrightText: 2025-2026 Jiri Vyskocil <jiri@vyskocil.com>
-#
+# SPDX-FileCopyrightText: 2025-2026 Jiri Vyskocil
 # SPDX-License-Identifier: Apache-2.0
 
 """Minimal template rendering via ``{{VAR}}`` token replacement."""

--- a/src/terok/lib/wizards/__init__.py
+++ b/src/terok/lib/wizards/__init__.py
@@ -1,5 +1,4 @@
-# SPDX-FileCopyrightText: 2025-2026 Jiri Vyskocil <jiri@vyskocil.com>
-#
+# SPDX-FileCopyrightText: 2026 Jiri Vyskocil
 # SPDX-License-Identifier: Apache-2.0
 
 """Interactive workflows: project creation wizard."""

--- a/src/terok/lib/wizards/new_project.py
+++ b/src/terok/lib/wizards/new_project.py
@@ -1,5 +1,4 @@
-# SPDX-FileCopyrightText: 2025-2026 Jiri Vyskocil <jiri@vyskocil.com>
-#
+# SPDX-FileCopyrightText: 2026 Jiri Vyskocil
 # SPDX-License-Identifier: Apache-2.0
 
 """Interactive project wizard for creating new project configurations."""

--- a/src/terok/resources/scripts/init-ssh-and-repo.sh
+++ b/src/terok/resources/scripts/init-ssh-and-repo.sh
@@ -1,7 +1,6 @@
 #!/usr/bin/env bash
 
-# SPDX-FileCopyrightText: 2025-2026 Jiri Vyskocil <jiri@vyskocil.com>
-#
+# SPDX-FileCopyrightText: 2025-2026 Jiri Vyskocil
 # SPDX-License-Identifier: Apache-2.0
 
 set -euo pipefail

--- a/src/terok/resources/scripts/mistral-model-sync.py
+++ b/src/terok/resources/scripts/mistral-model-sync.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
 
-# SPDX-FileCopyrightText: 2025-2026 Jiri Vyskocil <jiri@vyskocil.com>
-#
+# SPDX-FileCopyrightText: 2025-2026 Jiri Vyskocil
 # SPDX-License-Identifier: Apache-2.0
 
 """

--- a/src/terok/resources/scripts/opencode-session-plugin.mjs
+++ b/src/terok/resources/scripts/opencode-session-plugin.mjs
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: 2025-2026 Jiri Vyskocil <jiri@vyskocil.com>
+// SPDX-FileCopyrightText: 2026 Jiri Vyskocil
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/src/terok/resources/scripts/setup-codex-auth.sh
+++ b/src/terok/resources/scripts/setup-codex-auth.sh
@@ -1,7 +1,6 @@
 #!/usr/bin/env bash
 
-# SPDX-FileCopyrightText: 2025-2026 Jiri Vyskocil <jiri@vyskocil.com>
-#
+# SPDX-FileCopyrightText: 2025-2026 Jiri Vyskocil
 # SPDX-License-Identifier: Apache-2.0
 
 # Setup port forwarding for codex auth (port 1455)

--- a/src/terok/resources/scripts/terok-ui-entry.sh
+++ b/src/terok/resources/scripts/terok-ui-entry.sh
@@ -1,7 +1,6 @@
 #!/usr/bin/env bash
 
-# SPDX-FileCopyrightText: 2025-2026 Jiri Vyskocil <jiri@vyskocil.com>
-#
+# SPDX-FileCopyrightText: 2025-2026 Jiri Vyskocil
 # SPDX-License-Identifier: Apache-2.0
 
 set -euo pipefail

--- a/src/terok/resources/scripts/vibe-model-sync.sh
+++ b/src/terok/resources/scripts/vibe-model-sync.sh
@@ -1,7 +1,6 @@
 #!/usr/bin/env bash
 
-# SPDX-FileCopyrightText: 2025-2026 Jiri Vyskocil <jiri@vyskocil.com>
-#
+# SPDX-FileCopyrightText: 2025-2026 Jiri Vyskocil
 # SPDX-License-Identifier: Apache-2.0
 
 # Mistral Model Sync Wrapper Script

--- a/src/terok/tui/__init__.py
+++ b/src/terok/tui/__init__.py
@@ -1,5 +1,4 @@
-# SPDX-FileCopyrightText: 2025-2026 Jiri Vyskocil <jiri@vyskocil.com>
-#
+# SPDX-FileCopyrightText: 2025-2026 Jiri Vyskocil
 # SPDX-License-Identifier: Apache-2.0
 
 """terok TUI package."""

--- a/src/terok/tui/__main__.py
+++ b/src/terok/tui/__main__.py
@@ -1,5 +1,4 @@
-# SPDX-FileCopyrightText: 2025-2026 Jiri Vyskocil <jiri@vyskocil.com>
-#
+# SPDX-FileCopyrightText: 2025-2026 Jiri Vyskocil
 # SPDX-License-Identifier: Apache-2.0
 
 """TUI entry point for ``python -m terok.tui``."""

--- a/src/terok/tui/app.py
+++ b/src/terok/tui/app.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
 
-# SPDX-FileCopyrightText: 2025-2026 Jiri Vyskocil <jiri@vyskocil.com>
-#
+# SPDX-FileCopyrightText: 2025-2026 Jiri Vyskocil
 # SPDX-License-Identifier: Apache-2.0
 
 """Terok TUI application built on Textual."""

--- a/src/terok/tui/clipboard.py
+++ b/src/terok/tui/clipboard.py
@@ -1,5 +1,4 @@
-# SPDX-FileCopyrightText: 2025-2026 Jiri Vyskocil <jiri@vyskocil.com>
-#
+# SPDX-FileCopyrightText: 2026 Jiri Vyskocil
 # SPDX-License-Identifier: Apache-2.0
 
 """System clipboard integration for the TUI."""

--- a/src/terok/tui/log_viewer.py
+++ b/src/terok/tui/log_viewer.py
@@ -1,5 +1,4 @@
-# SPDX-FileCopyrightText: 2025-2026 Jiri Vyskocil <jiri@vyskocil.com>
-#
+# SPDX-FileCopyrightText: 2026 Jiri Vyskocil
 # SPDX-License-Identifier: Apache-2.0
 
 """In-app log viewer screen for the TUI.

--- a/src/terok/tui/polling.py
+++ b/src/terok/tui/polling.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
 
-# SPDX-FileCopyrightText: 2025-2026 Jiri Vyskocil <jiri@vyskocil.com>
-#
+# SPDX-FileCopyrightText: 2026 Jiri Vyskocil
 # SPDX-License-Identifier: Apache-2.0
 
 """Polling mixin for the TerokTUI app.

--- a/src/terok/tui/project_actions.py
+++ b/src/terok/tui/project_actions.py
@@ -1,5 +1,4 @@
-# SPDX-FileCopyrightText: 2025-2026 Jiri Vyskocil <jiri@vyskocil.com>
-#
+# SPDX-FileCopyrightText: 2026 Jiri Vyskocil
 # SPDX-License-Identifier: Apache-2.0
 
 """ProjectActionsMixin — project infrastructure actions for TerokTUI.

--- a/src/terok/tui/screens.py
+++ b/src/terok/tui/screens.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
 
-# SPDX-FileCopyrightText: 2025-2026 Jiri Vyskocil <jiri@vyskocil.com>
-#
+# SPDX-FileCopyrightText: 2026 Jiri Vyskocil
 # SPDX-License-Identifier: Apache-2.0
 
 """Full-page and modal Textual screens for the terok TUI."""

--- a/src/terok/tui/shell_launch.py
+++ b/src/terok/tui/shell_launch.py
@@ -1,5 +1,4 @@
-# SPDX-FileCopyrightText: 2025-2026 Jiri Vyskocil <jiri@vyskocil.com>
-#
+# SPDX-FileCopyrightText: 2026 Jiri Vyskocil
 # SPDX-License-Identifier: Apache-2.0
 
 """Helpers for launching interactive login shells from the TUI.

--- a/src/terok/tui/task_actions.py
+++ b/src/terok/tui/task_actions.py
@@ -1,5 +1,4 @@
-# SPDX-FileCopyrightText: 2025-2026 Jiri Vyskocil <jiri@vyskocil.com>
-#
+# SPDX-FileCopyrightText: 2026 Jiri Vyskocil
 # SPDX-License-Identifier: Apache-2.0
 
 """TaskActionsMixin — task lifecycle operations for TerokTUI.

--- a/src/terok/tui/widgets/__init__.py
+++ b/src/terok/tui/widgets/__init__.py
@@ -1,5 +1,4 @@
-# SPDX-FileCopyrightText: 2025-2026 Jiri Vyskocil <jiri@vyskocil.com>
-#
+# SPDX-FileCopyrightText: 2026 Jiri Vyskocil
 # SPDX-License-Identifier: Apache-2.0
 
 """Reusable Textual widgets for the terok TUI.

--- a/src/terok/tui/widgets/project_list.py
+++ b/src/terok/tui/widgets/project_list.py
@@ -1,5 +1,4 @@
-# SPDX-FileCopyrightText: 2025-2026 Jiri Vyskocil <jiri@vyskocil.com>
-#
+# SPDX-FileCopyrightText: 2026 Jiri Vyskocil
 # SPDX-License-Identifier: Apache-2.0
 
 """Project list and action bar widgets."""

--- a/src/terok/tui/widgets/project_state.py
+++ b/src/terok/tui/widgets/project_state.py
@@ -1,5 +1,4 @@
-# SPDX-FileCopyrightText: 2025-2026 Jiri Vyskocil <jiri@vyskocil.com>
-#
+# SPDX-FileCopyrightText: 2026 Jiri Vyskocil
 # SPDX-License-Identifier: Apache-2.0
 
 """Project state rendering widget and helpers."""

--- a/src/terok/tui/widgets/status_bar.py
+++ b/src/terok/tui/widgets/status_bar.py
@@ -1,5 +1,4 @@
-# SPDX-FileCopyrightText: 2025-2026 Jiri Vyskocil <jiri@vyskocil.com>
-#
+# SPDX-FileCopyrightText: 2026 Jiri Vyskocil
 # SPDX-License-Identifier: Apache-2.0
 
 """Status bar widget for the TUI footer."""

--- a/src/terok/tui/widgets/task_detail.py
+++ b/src/terok/tui/widgets/task_detail.py
@@ -1,5 +1,4 @@
-# SPDX-FileCopyrightText: 2025-2026 Jiri Vyskocil <jiri@vyskocil.com>
-#
+# SPDX-FileCopyrightText: 2026 Jiri Vyskocil
 # SPDX-License-Identifier: Apache-2.0
 
 """Task detail rendering widget and helper."""

--- a/src/terok/tui/widgets/task_list.py
+++ b/src/terok/tui/widgets/task_list.py
@@ -1,5 +1,4 @@
-# SPDX-FileCopyrightText: 2025-2026 Jiri Vyskocil <jiri@vyskocil.com>
-#
+# SPDX-FileCopyrightText: 2026 Jiri Vyskocil
 # SPDX-License-Identifier: Apache-2.0
 
 """Task list widget and helpers."""

--- a/src/terok/ui_utils/__init__.py
+++ b/src/terok/ui_utils/__init__.py
@@ -1,5 +1,4 @@
-# SPDX-FileCopyrightText: 2025-2026 Jiri Vyskocil <jiri@vyskocil.com>
-#
+# SPDX-FileCopyrightText: 2026 Jiri Vyskocil
 # SPDX-License-Identifier: Apache-2.0
 
 """User-facing terminal interaction: terminal, clipboard, editor, shell."""

--- a/src/terok/ui_utils/editor.py
+++ b/src/terok/ui_utils/editor.py
@@ -1,5 +1,4 @@
-# SPDX-FileCopyrightText: 2025-2026 Jiri Vyskocil <jiri@vyskocil.com>
-#
+# SPDX-FileCopyrightText: 2026 Jiri Vyskocil
 # SPDX-License-Identifier: Apache-2.0
 
 """Utility to open files in the user's preferred editor."""

--- a/src/terok/ui_utils/terminal.py
+++ b/src/terok/ui_utils/terminal.py
@@ -1,5 +1,4 @@
-# SPDX-FileCopyrightText: 2025-2026 Jiri Vyskocil <jiri@vyskocil.com>
-#
+# SPDX-FileCopyrightText: 2026 Jiri Vyskocil
 # SPDX-License-Identifier: Apache-2.0
 
 """Terminal ANSI formatting helpers.

--- a/tests/cli/__init__.py
+++ b/tests/cli/__init__.py
@@ -1,3 +1,2 @@
-# SPDX-FileCopyrightText: 2025-2026 Jiri Vyskocil <jiri@vyskocil.com>
-#
+# SPDX-FileCopyrightText: 2025-2026 Jiri Vyskocil
 # SPDX-License-Identifier: Apache-2.0

--- a/tests/cli/test_cli_autopilot.py
+++ b/tests/cli/test_cli_autopilot.py
@@ -1,5 +1,4 @@
-# SPDX-FileCopyrightText: 2025-2026 Jiri Vyskocil <jiri@vyskocil.com>
-#
+# SPDX-FileCopyrightText: 2026 Jiri Vyskocil
 # SPDX-License-Identifier: Apache-2.0
 
 """Tests for autopilot CLI commands: terokctl run (replaces run-claude)."""

--- a/tests/cli/test_cli_completions.py
+++ b/tests/cli/test_cli_completions.py
@@ -1,5 +1,4 @@
-# SPDX-FileCopyrightText: 2025-2026 Jiri Vyskocil <jiri@vyskocil.com>
-#
+# SPDX-FileCopyrightText: 2026 Jiri Vyskocil
 # SPDX-License-Identifier: Apache-2.0
 
 """Tests for the completions CLI subcommand."""

--- a/tests/cli/test_cli_config.py
+++ b/tests/cli/test_cli_config.py
@@ -1,5 +1,4 @@
-# SPDX-FileCopyrightText: 2025-2026 Jiri Vyskocil <jiri@vyskocil.com>
-#
+# SPDX-FileCopyrightText: 2025-2026 Jiri Vyskocil
 # SPDX-License-Identifier: Apache-2.0
 
 import importlib

--- a/tests/cli/test_cli_gate_server.py
+++ b/tests/cli/test_cli_gate_server.py
@@ -1,5 +1,4 @@
-# SPDX-FileCopyrightText: 2025-2026 Jiri Vyskocil <jiri@vyskocil.com>
-#
+# SPDX-FileCopyrightText: 2026 Jiri Vyskocil
 # SPDX-License-Identifier: Apache-2.0
 
 """Tests for gate-server CLI commands."""

--- a/tests/cli/test_cli_image.py
+++ b/tests/cli/test_cli_image.py
@@ -1,5 +1,4 @@
-# SPDX-FileCopyrightText: 2025-2026 Jiri Vyskocil <jiri@vyskocil.com>
-#
+# SPDX-FileCopyrightText: 2026 Jiri Vyskocil
 # SPDX-License-Identifier: Apache-2.0
 
 import unittest

--- a/tests/cli/test_cli_module.py
+++ b/tests/cli/test_cli_module.py
@@ -1,5 +1,4 @@
-# SPDX-FileCopyrightText: 2025-2026 Jiri Vyskocil <jiri@vyskocil.com>
-#
+# SPDX-FileCopyrightText: 2025-2026 Jiri Vyskocil
 # SPDX-License-Identifier: Apache-2.0
 
 import importlib

--- a/tests/cli/test_cli_sickbay.py
+++ b/tests/cli/test_cli_sickbay.py
@@ -1,5 +1,4 @@
-# SPDX-FileCopyrightText: 2025-2026 Jiri Vyskocil <jiri@vyskocil.com>
-#
+# SPDX-FileCopyrightText: 2026 Jiri Vyskocil
 # SPDX-License-Identifier: Apache-2.0
 
 """Tests for sickbay CLI command."""

--- a/tests/cli/test_cli_wizard.py
+++ b/tests/cli/test_cli_wizard.py
@@ -1,5 +1,4 @@
-# SPDX-FileCopyrightText: 2025-2026 Jiri Vyskocil <jiri@vyskocil.com>
-#
+# SPDX-FileCopyrightText: 2026 Jiri Vyskocil
 # SPDX-License-Identifier: Apache-2.0
 
 import unittest

--- a/tests/cli/test_cli_workflows.py
+++ b/tests/cli/test_cli_workflows.py
@@ -1,5 +1,4 @@
-# SPDX-FileCopyrightText: 2025-2026 Jiri Vyskocil <jiri@vyskocil.com>
-#
+# SPDX-FileCopyrightText: 2026 Jiri Vyskocil
 # SPDX-License-Identifier: Apache-2.0
 
 import unittest

--- a/tests/gate/__init__.py
+++ b/tests/gate/__init__.py
@@ -1,3 +1,2 @@
-# SPDX-FileCopyrightText: 2025-2026 Jiri Vyskocil <jiri@vyskocil.com>
-#
+# SPDX-FileCopyrightText: 2025-2026 Jiri Vyskocil
 # SPDX-License-Identifier: Apache-2.0

--- a/tests/gate/test_server.py
+++ b/tests/gate/test_server.py
@@ -1,5 +1,4 @@
-# SPDX-FileCopyrightText: 2025-2026 Jiri Vyskocil <jiri@vyskocil.com>
-#
+# SPDX-FileCopyrightText: 2026 Jiri Vyskocil
 # SPDX-License-Identifier: Apache-2.0
 
 """Tests for the standalone gate HTTP server."""

--- a/tests/lib/__init__.py
+++ b/tests/lib/__init__.py
@@ -1,3 +1,2 @@
-# SPDX-FileCopyrightText: 2025-2026 Jiri Vyskocil <jiri@vyskocil.com>
-#
+# SPDX-FileCopyrightText: 2025-2026 Jiri Vyskocil
 # SPDX-License-Identifier: Apache-2.0

--- a/tests/lib/test_agent_config.py
+++ b/tests/lib/test_agent_config.py
@@ -1,5 +1,4 @@
-# SPDX-FileCopyrightText: 2025-2026 Jiri Vyskocil <jiri@vyskocil.com>
-#
+# SPDX-FileCopyrightText: 2026 Jiri Vyskocil
 # SPDX-License-Identifier: Apache-2.0
 
 """Tests for layered agent config resolution and presets."""

--- a/tests/lib/test_autopilot.py
+++ b/tests/lib/test_autopilot.py
@@ -1,5 +1,4 @@
-# SPDX-FileCopyrightText: 2025-2026 Jiri Vyskocil <jiri@vyskocil.com>
-#
+# SPDX-FileCopyrightText: 2026 Jiri Vyskocil
 # SPDX-License-Identifier: Apache-2.0
 
 """Tests for autopilot (Level 1+2) features: terokctl run and agent config."""

--- a/tests/lib/test_cdi_hint.py
+++ b/tests/lib/test_cdi_hint.py
@@ -1,5 +1,4 @@
-# SPDX-FileCopyrightText: 2025-2026 Jiri Vyskocil <jiri@vyskocil.com>
-#
+# SPDX-FileCopyrightText: 2026 Jiri Vyskocil
 # SPDX-License-Identifier: Apache-2.0
 
 """Tests for NVIDIA CDI error detection and user hint."""

--- a/tests/lib/test_config.py
+++ b/tests/lib/test_config.py
@@ -1,5 +1,4 @@
-# SPDX-FileCopyrightText: 2025-2026 Jiri Vyskocil <jiri@vyskocil.com>
-#
+# SPDX-FileCopyrightText: 2025-2026 Jiri Vyskocil
 # SPDX-License-Identifier: Apache-2.0
 
 import os

--- a/tests/lib/test_config_stack.py
+++ b/tests/lib/test_config_stack.py
@@ -1,5 +1,4 @@
-# SPDX-FileCopyrightText: 2025-2026 Jiri Vyskocil <jiri@vyskocil.com>
-#
+# SPDX-FileCopyrightText: 2026 Jiri Vyskocil
 # SPDX-License-Identifier: Apache-2.0
 
 """Tests for the generic config stack engine."""

--- a/tests/lib/test_container_lifecycle.py
+++ b/tests/lib/test_container_lifecycle.py
@@ -1,5 +1,4 @@
-# SPDX-FileCopyrightText: 2025-2026 Jiri Vyskocil <jiri@vyskocil.com>
-#
+# SPDX-FileCopyrightText: 2026 Jiri Vyskocil
 # SPDX-License-Identifier: Apache-2.0
 
 import subprocess

--- a/tests/lib/test_docker.py
+++ b/tests/lib/test_docker.py
@@ -1,5 +1,4 @@
-# SPDX-FileCopyrightText: 2025-2026 Jiri Vyskocil <jiri@vyskocil.com>
-#
+# SPDX-FileCopyrightText: 2025-2026 Jiri Vyskocil
 # SPDX-License-Identifier: Apache-2.0
 
 import unittest

--- a/tests/lib/test_editor.py
+++ b/tests/lib/test_editor.py
@@ -1,5 +1,4 @@
-# SPDX-FileCopyrightText: 2025-2026 Jiri Vyskocil <jiri@vyskocil.com>
-#
+# SPDX-FileCopyrightText: 2026 Jiri Vyskocil
 # SPDX-License-Identifier: Apache-2.0
 
 import subprocess

--- a/tests/lib/test_effective_status.py
+++ b/tests/lib/test_effective_status.py
@@ -1,5 +1,4 @@
-# SPDX-FileCopyrightText: 2025-2026 Jiri Vyskocil <jiri@vyskocil.com>
-#
+# SPDX-FileCopyrightText: 2026 Jiri Vyskocil
 # SPDX-License-Identifier: Apache-2.0
 
 """Tests for effective_status(), mode_emoji(), and batch container state queries."""

--- a/tests/lib/test_emoji.py
+++ b/tests/lib/test_emoji.py
@@ -1,5 +1,4 @@
-# SPDX-FileCopyrightText: 2025-2026 Jiri Vyskocil <jiri@vyskocil.com>
-#
+# SPDX-FileCopyrightText: 2026 Jiri Vyskocil
 # SPDX-License-Identifier: Apache-2.0
 
 """Tests for the emoji display-width utility."""

--- a/tests/lib/test_environment_gate_server.py
+++ b/tests/lib/test_environment_gate_server.py
@@ -1,5 +1,4 @@
-# SPDX-FileCopyrightText: 2025-2026 Jiri Vyskocil <jiri@vyskocil.com>
-#
+# SPDX-FileCopyrightText: 2026 Jiri Vyskocil
 # SPDX-License-Identifier: Apache-2.0
 
 """Tests for environment.py gate server integration."""

--- a/tests/lib/test_gate_server.py
+++ b/tests/lib/test_gate_server.py
@@ -1,5 +1,4 @@
-# SPDX-FileCopyrightText: 2025-2026 Jiri Vyskocil <jiri@vyskocil.com>
-#
+# SPDX-FileCopyrightText: 2026 Jiri Vyskocil
 # SPDX-License-Identifier: Apache-2.0
 
 """Tests for gate_server module."""

--- a/tests/lib/test_gate_tokens.py
+++ b/tests/lib/test_gate_tokens.py
@@ -1,5 +1,4 @@
-# SPDX-FileCopyrightText: 2025-2026 Jiri Vyskocil <jiri@vyskocil.com>
-#
+# SPDX-FileCopyrightText: 2026 Jiri Vyskocil
 # SPDX-License-Identifier: Apache-2.0
 
 """Tests for gate_tokens module."""

--- a/tests/lib/test_git_gate.py
+++ b/tests/lib/test_git_gate.py
@@ -1,5 +1,4 @@
-# SPDX-FileCopyrightText: 2025-2026 Jiri Vyskocil <jiri@vyskocil.com>
-#
+# SPDX-FileCopyrightText: 2025-2026 Jiri Vyskocil
 # SPDX-License-Identifier: Apache-2.0
 
 import subprocess

--- a/tests/lib/test_headless_providers.py
+++ b/tests/lib/test_headless_providers.py
@@ -1,5 +1,4 @@
-# SPDX-FileCopyrightText: 2025-2026 Jiri Vyskocil <jiri@vyskocil.com>
-#
+# SPDX-FileCopyrightText: 2026 Jiri Vyskocil
 # SPDX-License-Identifier: Apache-2.0
 
 """Tests for headless provider registry and dispatch functions."""

--- a/tests/lib/test_image_cleanup.py
+++ b/tests/lib/test_image_cleanup.py
@@ -1,5 +1,4 @@
-# SPDX-FileCopyrightText: 2025-2026 Jiri Vyskocil <jiri@vyskocil.com>
-#
+# SPDX-FileCopyrightText: 2026 Jiri Vyskocil
 # SPDX-License-Identifier: Apache-2.0
 
 import subprocess

--- a/tests/lib/test_images.py
+++ b/tests/lib/test_images.py
@@ -1,5 +1,4 @@
-# SPDX-FileCopyrightText: 2025-2026 Jiri Vyskocil <jiri@vyskocil.com>
-#
+# SPDX-FileCopyrightText: 2025-2026 Jiri Vyskocil
 # SPDX-License-Identifier: Apache-2.0
 
 import unittest

--- a/tests/lib/test_instructions.py
+++ b/tests/lib/test_instructions.py
@@ -1,5 +1,4 @@
-# SPDX-FileCopyrightText: 2025-2026 Jiri Vyskocil <jiri@vyskocil.com>
-#
+# SPDX-FileCopyrightText: 2026 Jiri Vyskocil
 # SPDX-License-Identifier: Apache-2.0
 
 """Tests for agent instruction resolution module."""

--- a/tests/lib/test_log_format.py
+++ b/tests/lib/test_log_format.py
@@ -1,5 +1,4 @@
-# SPDX-FileCopyrightText: 2025-2026 Jiri Vyskocil <jiri@vyskocil.com>
-#
+# SPDX-FileCopyrightText: 2026 Jiri Vyskocil
 # SPDX-License-Identifier: Apache-2.0
 
 """Tests for log_format module (agent log formatters)."""

--- a/tests/lib/test_login.py
+++ b/tests/lib/test_login.py
@@ -1,5 +1,4 @@
-# SPDX-FileCopyrightText: 2025-2026 Jiri Vyskocil <jiri@vyskocil.com>
-#
+# SPDX-FileCopyrightText: 2026 Jiri Vyskocil
 # SPDX-License-Identifier: Apache-2.0
 
 import types

--- a/tests/lib/test_podman_network.py
+++ b/tests/lib/test_podman_network.py
@@ -1,5 +1,4 @@
-# SPDX-FileCopyrightText: 2025-2026 Jiri Vyskocil <jiri@vyskocil.com>
-#
+# SPDX-FileCopyrightText: 2026 Jiri Vyskocil
 # SPDX-License-Identifier: Apache-2.0
 
 """Tests for Podman rootless network detection and args."""

--- a/tests/lib/test_project_archive.py
+++ b/tests/lib/test_project_archive.py
@@ -1,5 +1,4 @@
-# SPDX-FileCopyrightText: 2025-2026 Jiri Vyskocil <jiri@vyskocil.com>
-#
+# SPDX-FileCopyrightText: 2026 Jiri Vyskocil
 # SPDX-License-Identifier: Apache-2.0
 
 import tarfile

--- a/tests/lib/test_project_delete.py
+++ b/tests/lib/test_project_delete.py
@@ -1,5 +1,4 @@
-# SPDX-FileCopyrightText: 2025-2026 Jiri Vyskocil <jiri@vyskocil.com>
-#
+# SPDX-FileCopyrightText: 2026 Jiri Vyskocil
 # SPDX-License-Identifier: Apache-2.0
 
 import os

--- a/tests/lib/test_projects.py
+++ b/tests/lib/test_projects.py
@@ -1,5 +1,4 @@
-# SPDX-FileCopyrightText: 2025-2026 Jiri Vyskocil <jiri@vyskocil.com>
-#
+# SPDX-FileCopyrightText: 2025-2026 Jiri Vyskocil
 # SPDX-License-Identifier: Apache-2.0
 
 import os

--- a/tests/lib/test_shell_launch.py
+++ b/tests/lib/test_shell_launch.py
@@ -1,5 +1,4 @@
-# SPDX-FileCopyrightText: 2025-2026 Jiri Vyskocil <jiri@vyskocil.com>
-#
+# SPDX-FileCopyrightText: 2026 Jiri Vyskocil
 # SPDX-License-Identifier: Apache-2.0
 
 import subprocess

--- a/tests/lib/test_ssh.py
+++ b/tests/lib/test_ssh.py
@@ -1,5 +1,4 @@
-# SPDX-FileCopyrightText: 2025-2026 Jiri Vyskocil <jiri@vyskocil.com>
-#
+# SPDX-FileCopyrightText: 2025-2026 Jiri Vyskocil
 # SPDX-License-Identifier: Apache-2.0
 
 import os

--- a/tests/lib/test_task_names.py
+++ b/tests/lib/test_task_names.py
@@ -1,5 +1,4 @@
-# SPDX-FileCopyrightText: 2025-2026 Jiri Vyskocil <jiri@vyskocil.com>
-#
+# SPDX-FileCopyrightText: 2026 Jiri Vyskocil
 # SPDX-License-Identifier: Apache-2.0
 
 """Tests for task name functionality: sanitize, generate, rename, and YAML persistence."""

--- a/tests/lib/test_tasks.py
+++ b/tests/lib/test_tasks.py
@@ -1,5 +1,4 @@
-# SPDX-FileCopyrightText: 2025-2026 Jiri Vyskocil <jiri@vyskocil.com>
-#
+# SPDX-FileCopyrightText: 2025-2026 Jiri Vyskocil
 # SPDX-License-Identifier: Apache-2.0
 
 import os

--- a/tests/lib/test_wizard.py
+++ b/tests/lib/test_wizard.py
@@ -1,5 +1,4 @@
-# SPDX-FileCopyrightText: 2025-2026 Jiri Vyskocil <jiri@vyskocil.com>
-#
+# SPDX-FileCopyrightText: 2026 Jiri Vyskocil
 # SPDX-License-Identifier: Apache-2.0
 
 import tempfile

--- a/tests/lib/test_wizard_templates.py
+++ b/tests/lib/test_wizard_templates.py
@@ -1,5 +1,4 @@
-# SPDX-FileCopyrightText: 2025-2026 Jiri Vyskocil <jiri@vyskocil.com>
-#
+# SPDX-FileCopyrightText: 2026 Jiri Vyskocil
 # SPDX-License-Identifier: Apache-2.0
 
 import unittest

--- a/tests/lib/test_work_status.py
+++ b/tests/lib/test_work_status.py
@@ -1,5 +1,4 @@
-# SPDX-FileCopyrightText: 2025-2026 Jiri Vyskocil <jiri@vyskocil.com>
-#
+# SPDX-FileCopyrightText: 2026 Jiri Vyskocil
 # SPDX-License-Identifier: Apache-2.0
 
 """Tests for agent work-status reading."""

--- a/tests/scripts/__init__.py
+++ b/tests/scripts/__init__.py
@@ -1,5 +1,4 @@
-# SPDX-FileCopyrightText: 2025-2026 Jiri Vyskocil <jiri@vyskocil.com>
-#
+# SPDX-FileCopyrightText: 2025-2026 Jiri Vyskocil
 # SPDX-License-Identifier: Apache-2.0
 
 # Tests for shell scripts in terok resources

--- a/tests/scripts/test_blablador.py
+++ b/tests/scripts/test_blablador.py
@@ -1,5 +1,4 @@
-# SPDX-FileCopyrightText: 2025-2026 Jiri Vyskocil <jiri@vyskocil.com>
-#
+# SPDX-FileCopyrightText: 2025-2026 Jiri Vyskocil
 # SPDX-License-Identifier: Apache-2.0
 
 """Tests for the Blablador wrapper script and Dockerfile integration.

--- a/tests/scripts/test_init_branch_selection.py
+++ b/tests/scripts/test_init_branch_selection.py
@@ -1,5 +1,4 @@
-# SPDX-FileCopyrightText: 2025-2026 Jiri Vyskocil <jiri@vyskocil.com>
-#
+# SPDX-FileCopyrightText: 2025-2026 Jiri Vyskocil
 # SPDX-License-Identifier: Apache-2.0
 
 """Tests for init-ssh-and-repo.sh branch selection behavior.

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,5 +1,4 @@
-# SPDX-FileCopyrightText: 2025-2026 Jiri Vyskocil <jiri@vyskocil.com>
-#
+# SPDX-FileCopyrightText: 2025-2026 Jiri Vyskocil
 # SPDX-License-Identifier: Apache-2.0
 
 import json

--- a/tests/tui/__init__.py
+++ b/tests/tui/__init__.py
@@ -1,3 +1,2 @@
-# SPDX-FileCopyrightText: 2025-2026 Jiri Vyskocil <jiri@vyskocil.com>
-#
+# SPDX-FileCopyrightText: 2025-2026 Jiri Vyskocil
 # SPDX-License-Identifier: Apache-2.0

--- a/tests/tui/conftest.py
+++ b/tests/tui/conftest.py
@@ -1,5 +1,4 @@
-# SPDX-FileCopyrightText: 2025-2026 Jiri Vyskocil <jiri@vyskocil.com>
-#
+# SPDX-FileCopyrightText: 2026 Jiri Vyskocil
 # SPDX-License-Identifier: Apache-2.0
 
 """Add tests/tui/ to sys.path so tui_test_helpers is importable."""

--- a/tests/tui/test_detail_screens.py
+++ b/tests/tui/test_detail_screens.py
@@ -1,5 +1,4 @@
-# SPDX-FileCopyrightText: 2025-2026 Jiri Vyskocil <jiri@vyskocil.com>
-#
+# SPDX-FileCopyrightText: 2026 Jiri Vyskocil
 # SPDX-License-Identifier: Apache-2.0
 
 """Tests for TUI detail screens (Phase 2) and rendering helpers."""

--- a/tests/tui/test_log_viewer.py
+++ b/tests/tui/test_log_viewer.py
@@ -1,5 +1,4 @@
-# SPDX-FileCopyrightText: 2025-2026 Jiri Vyskocil <jiri@vyskocil.com>
-#
+# SPDX-FileCopyrightText: 2026 Jiri Vyskocil
 # SPDX-License-Identifier: Apache-2.0
 
 """Tests for the TUI log viewer screen and formatters."""

--- a/tests/tui/test_polling.py
+++ b/tests/tui/test_polling.py
@@ -1,5 +1,4 @@
-# SPDX-FileCopyrightText: 2025-2026 Jiri Vyskocil <jiri@vyskocil.com>
-#
+# SPDX-FileCopyrightText: 2025-2026 Jiri Vyskocil
 # SPDX-License-Identifier: Apache-2.0
 
 """Tests for TUI upstream polling logic."""

--- a/tests/tui/test_project_state_staleness.py
+++ b/tests/tui/test_project_state_staleness.py
@@ -1,5 +1,4 @@
-# SPDX-FileCopyrightText: 2025-2026 Jiri Vyskocil <jiri@vyskocil.com>
-#
+# SPDX-FileCopyrightText: 2026 Jiri Vyskocil
 # SPDX-License-Identifier: Apache-2.0
 
 from unittest import TestCase, main, mock

--- a/tests/tui/test_tui_module.py
+++ b/tests/tui/test_tui_module.py
@@ -1,5 +1,4 @@
-# SPDX-FileCopyrightText: 2025-2026 Jiri Vyskocil <jiri@vyskocil.com>
-#
+# SPDX-FileCopyrightText: 2025-2026 Jiri Vyskocil
 # SPDX-License-Identifier: Apache-2.0
 
 import sys

--- a/tests/tui/test_version_branch_detection.py
+++ b/tests/tui/test_version_branch_detection.py
@@ -1,5 +1,4 @@
-# SPDX-FileCopyrightText: 2025-2026 Jiri Vyskocil <jiri@vyskocil.com>
-#
+# SPDX-FileCopyrightText: 2025-2026 Jiri Vyskocil
 # SPDX-License-Identifier: Apache-2.0
 
 """Tests for version and branch detection functionality."""

--- a/tests/tui/tui_test_helpers.py
+++ b/tests/tui/tui_test_helpers.py
@@ -1,5 +1,4 @@
-# SPDX-FileCopyrightText: 2025-2026 Jiri Vyskocil <jiri@vyskocil.com>
-#
+# SPDX-FileCopyrightText: 2026 Jiri Vyskocil
 # SPDX-License-Identifier: Apache-2.0
 
 """Shared test helpers for TUI tests that need Textual stubs."""


### PR DESCRIPTION
## Summary

- Compact SPDX headers from 3 lines to 2 (remove blank `#` line between copyright and license)
- Drop email from copyright lines to reduce clutter as more contributors join
- Fix year on files created after Jan 31 2026: `2026` instead of `2025-2026`
- Add `.reuse/templates/compact.jinja2` so `reuse annotate --template compact` produces the expected format
- Add `make spdx NAME="Your Name" FILES="..."` target for easy header generation
- Document the expected SPDX format and workflow in AGENTS.md

## Test plan

- [x] `reuse lint` passes (198/198 files compliant)
- [x] Patch applies cleanly on top of upstream master

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new command to automatically apply SPDX headers to source files with author name and license information.
  * Added a compact SPDX header template for streamlined metadata formatting.

* **Documentation**
  * Updated coding standards documentation with SPDX header requirements and usage guidance.

* **Chores**
  * Updated copyright information across the codebase to reflect current year and removed redundant contact details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->