### PR TITLE
ci: skip workflow jobs on forks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,12 +2,13 @@ name: CI
 
 on:
   push:
-    branches: [master, main]
+    branches: [master]
   pull_request:
-    branches: [master, main]
+    branches: [master]
 
 jobs:
   reuse:
+    if: github.repository == 'terok-ops/terok'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -15,6 +16,7 @@ jobs:
         uses: fsfe/reuse-action@v6
 
   lint:
+    if: github.repository == 'terok-ops/terok'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -30,6 +32,7 @@ jobs:
           args: format --check
 
   boundary-check:
+    if: github.repository == 'terok-ops/terok'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -46,6 +49,7 @@ jobs:
         run: tach check
 
   docstring-coverage:
+    if: github.repository == 'terok-ops/terok'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -62,6 +66,7 @@ jobs:
         run: docstr-coverage src/terok/ --fail-under=95
 
   dead-code:
+    if: github.repository == 'terok-ops/terok'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -78,6 +83,7 @@ jobs:
         run: vulture src/terok/ vulture_whitelist.py --min-confidence 80
 
   test:
+    if: github.repository == 'terok-ops/terok'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -2,9 +2,9 @@ name: Documentation
 
 on:
   push:
-    branches: [master, main]
+    branches: [master]
   pull_request:
-    branches: [master, main]
+    branches: [master]
   workflow_dispatch:
 
 # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
@@ -20,6 +20,7 @@ concurrency:
 
 jobs:
   build:
+    if: github.repository == 'terok-ops/terok'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -55,18 +56,18 @@ jobs:
         run: poetry run mkdocs build --strict
 
       - name: Setup Pages
-        if: github.event_name == 'push' && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main')
+        if: github.event_name == 'push' && (github.ref == 'refs/heads/master')
         uses: actions/configure-pages@v5
 
       - name: Upload artifact
-        if: github.event_name == 'push' && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main')
+        if: github.event_name == 'push' && (github.ref == 'refs/heads/master')
         uses: actions/upload-pages-artifact@v4
         with:
           path: site
 
   deploy:
     # Only deploy on push to master/main, not on PRs
-    if: github.event_name == 'push' && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main')
+    if: github.event_name == 'push' && (github.ref == 'refs/heads/master')
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,7 @@ permissions:
 
 jobs:
   build:
+    if: github.repository == 'terok-ops/terok'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
## Summary

- Add `if: github.repository == 'terok-ops/terok'` to all jobs in ci.yml, docs.yml, and release.yml so fork master syncs (via wei/pull) don't run redundant CI
- Replace `[master, main]` with `[master]` in branch triggers (repo only uses `master`)
- Remove redundant `refs/heads/main` checks in docs deploy conditions

## Test plan

- [ ] CI runs normally on upstream PRs and pushes
- [ ] Fork master sync via pull app no longer triggers CI jobs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflows with enhanced repository validation and refined branch configurations for improved build pipeline security and consistency across automated processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->