### PR TITLE
chore: rename GitHub org from terok-ops to terok-ai

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   reuse:
-    if: github.repository == 'terok-ops/terok'
+    if: github.repository == 'terok-ai/terok'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -16,7 +16,7 @@ jobs:
         uses: fsfe/reuse-action@v6
 
   lint:
-    if: github.repository == 'terok-ops/terok'
+    if: github.repository == 'terok-ai/terok'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -32,7 +32,7 @@ jobs:
           args: format --check
 
   boundary-check:
-    if: github.repository == 'terok-ops/terok'
+    if: github.repository == 'terok-ai/terok'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -49,7 +49,7 @@ jobs:
         run: tach check
 
   docstring-coverage:
-    if: github.repository == 'terok-ops/terok'
+    if: github.repository == 'terok-ai/terok'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -66,7 +66,7 @@ jobs:
         run: docstr-coverage src/terok/ --fail-under=95
 
   dead-code:
-    if: github.repository == 'terok-ops/terok'
+    if: github.repository == 'terok-ai/terok'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -83,7 +83,7 @@ jobs:
         run: vulture src/terok/ vulture_whitelist.py --min-confidence 80
 
   test:
-    if: github.repository == 'terok-ops/terok'
+    if: github.repository == 'terok-ai/terok'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -14,7 +14,7 @@ concurrency:
 
 jobs:
   build:
-    if: github.repository == 'terok-ops/terok'
+    if: github.repository == 'terok-ai/terok'
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   build:
-    if: github.repository == 'terok-ops/terok'
+    if: github.repository == 'terok-ai/terok'
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -110,11 +110,11 @@ The project uses [tach](https://github.com/gauge-sh/tach) to enforce module boun
 
 ## SonarCloud
 
-The project is analyzed by [SonarCloud](https://sonarcloud.io/summary/new_code?id=terok-ops_terok) on every push to master. Unlike CodeRabbit (which posts actionable PR comments), SonarCloud findings often require triage — many are low-priority style issues or false positives rather than real bugs. Treat them as input for decisions, not as a checklist.
+The project is analyzed by [SonarCloud](https://sonarcloud.io/summary/new_code?id=terok-ai_terok) on every push to master. Unlike CodeRabbit (which posts actionable PR comments), SonarCloud findings often require triage — many are low-priority style issues or false positives rather than real bugs. Treat them as input for decisions, not as a checklist.
 
 **Fetching new issues for a PR** (replace `PR_NUMBER`):
 ```bash
-curl -s 'https://sonarcloud.io/api/issues/search?projects=terok-ops_terok&pullRequest=PR_NUMBER&issueStatuses=OPEN&ps=100' \
+curl -s 'https://sonarcloud.io/api/issues/search?projects=terok-ai_terok&pullRequest=PR_NUMBER&issueStatuses=OPEN&ps=100' \
   | python3 -c "
 import json,sys
 d=json.load(sys.stdin)
@@ -128,7 +128,7 @@ for i in d.get('issues',[]):
 
 **Fetching recent issues on the main branch** (replace date as needed):
 ```bash
-curl -s 'https://sonarcloud.io/api/issues/search?projects=terok-ops_terok&issueStatuses=OPEN&createdAfter=2026-03-01&ps=100&s=CREATION_DATE&asc=false' \
+curl -s 'https://sonarcloud.io/api/issues/search?projects=terok-ai_terok&issueStatuses=OPEN&createdAfter=2026-03-01&ps=100&s=CREATION_DATE&asc=false' \
   | python3 -c "import json,sys; [print(f'[{i[\"severity\"]}] {i[\"rule\"]}: {i.get(\"message\",\"\")}\n  {i[\"component\"].split(\":\",1)[-1]}:{i.get(\"textRange\",{}).get(\"startLine\",\"?\")}') for i in json.load(sys.stdin).get('issues',[])]"
 ```
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # terok
 
 [![License: Apache-2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
-[![REUSE compliant](https://api.reuse.software/badge/github.com/terok-ops/terok)](https://api.reuse.software/info/github.com/terok-ops/terok)
-[![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=terok-ops_terok&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=terok-ops_terok)
+[![REUSE compliant](https://api.reuse.software/badge/github.com/terok-ai/terok)](https://api.reuse.software/info/github.com/terok-ai/terok)
+[![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=terok-ai_terok&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=terok-ai_terok)
 
 A tool for managing containerized AI coding agent projects using Podman. Provides both a CLI (`terokctl`) and a Textual TUI (`terok`).
 
@@ -31,7 +31,7 @@ A tool for managing containerized AI coding agent projects using Podman. Provide
 
 ```bash
 # Clone and install
-git clone git@github.com:terok-ops/terok.git
+git clone git@github.com:terok-ai/terok.git
 cd terok
 pip install .
 
@@ -149,7 +149,7 @@ git:
 
 ```bash
 # Setup
-git clone git@github.com:terok-ops/terok.git && cd terok
+git clone git@github.com:terok-ai/terok.git && cd terok
 make install-dev
 
 # Before committing

--- a/docs/DEVELOPER.md
+++ b/docs/DEVELOPER.md
@@ -132,7 +132,7 @@ See [GIT_CACHE_AND_SECURITY_MODES.md](GIT_CACHE_AND_SECURITY_MODES.md) for detai
 
 ```bash
 # Clone the repository
-git clone git@github.com:terok-ops/terok.git
+git clone git@github.com:terok-ai/terok.git
 cd terok
 
 # Install all development dependencies

--- a/docs/index.md
+++ b/docs/index.md
@@ -23,7 +23,7 @@ A tool for managing containerized AI coding agent projects using Podman. Provide
 
 ```bash
 # Clone and install
-git clone git@github.com:terok-ops/terok.git
+git clone git@github.com:terok-ai/terok.git
 cd terok
 pip install .
 
@@ -64,4 +64,4 @@ terokctl task run-cli myproj 1
 
 ## License
 
-See [LICENSE](https://github.com/terok-ops/terok/blob/master/LICENSE) file.
+See [LICENSE](https://github.com/terok-ai/terok/blob/master/LICENSE) file.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,8 +1,8 @@
 site_name: terok
 site_description: A tool for managing containerized AI coding agent projects using Podman
-site_url: https://terok-ops.github.io/terok
-repo_url: https://github.com/terok-ops/terok
-repo_name: terok-ops/terok
+site_url: https://terok-ai.github.io/terok
+repo_url: https://github.com/terok-ai/terok
+repo_name: terok-ai/terok
 
 theme:
   name: material
@@ -95,7 +95,7 @@ nav:
 extra:
   social:
     - icon: fontawesome/brands/github
-      link: https://github.com/terok-ops/terok
+      link: https://github.com/terok-ai/terok
 
 extra_css:
   - https://fonts.googleapis.com/css2?family=Ubuntu:wght@400;500;700&family=Ubuntu+Mono:wght@400;700&display=swap

--- a/src/terok/resources/templates/l1.agent-ui.Dockerfile.template
+++ b/src/terok/resources/templates/l1.agent-ui.Dockerfile.template
@@ -8,7 +8,7 @@ ENV HOST="0.0.0.0" \
     PORT="7860" \
     TEROK_UI_DIR="/opt/terok-web-ui" \
     TEROK_UI_DIST_TAG="${TEROK_UI_DIST_TAG}" \
-    TEROK_UI_DIST_URL="https://github.com/terok-ops/terok-web-ui/releases/download/${TEROK_UI_DIST_TAG}/terok-web-ui-dist.tar.gz"
+    TEROK_UI_DIST_URL="https://github.com/terok-ai/terok-web-ui/releases/download/${TEROK_UI_DIST_TAG}/terok-web-ui-dist.tar.gz"
 
 # === Root operations ===
 USER root


### PR DESCRIPTION
## Summary
- Renamed all references from `terok-ops` to `terok-ai` across the repository
- Updated CI workflows (`ci.yml`, `docs.yml`, `release.yml`) repository checks
- Updated documentation (`README.md`, `AGENTS.md`, `docs/index.md`, `docs/DEVELOPER.md`)
- Updated `mkdocs.yml` site URL, repo URL, and social links
- Updated Dockerfile template for `terok-web-ui` release URL (`terok-ops/terok-web-ui` → `terok-ai/terok-web-ui`)

## Test plan
- [ ] Verify CI workflows run on the new org (repository condition checks `terok-ai/terok`)
- [ ] Verify documentation links resolve correctly
- [ ] Verify `terok-web-ui` release URL works for container builds

🤖 Generated with [Claude Code](https://claude.com/claude-code)