### PR TITLE
fix: set both author and committer in human/agent authorship modes

### DIFF
--- a/docs/SHARED_DIRS.md
+++ b/docs/SHARED_DIRS.md
@@ -104,8 +104,8 @@ terokctl ssh-init <project_id> [--key-type ed25519|rsa] [--key-name NAME] [--for
 - The mapping is configurable via `git.authorship` in `project.yml` or global `config.yml`.
   - `agent-human` (default): author = agent, committer = human
   - `human-agent`: author = human, committer = agent
-  - `human`: author = human, committer left to git defaults
-  - `agent`: author = agent, committer left to git defaults
+  - `human`: author = human, committer = human
+  - `agent`: author = agent, committer = agent
 - **For CLI mode**: Git identity is set by terok's shell wrappers for each agent:
   - `codex` -> Author: `Codex <noreply@openai.com>`, Committer: human credentials
   - `claude` -> Author: `Claude <noreply@anthropic.com>`, Committer: human credentials

--- a/src/terok/resources/scripts/terok-git-identity.sh
+++ b/src/terok/resources/scripts/terok-git-identity.sh
@@ -41,10 +41,14 @@ _terok_apply_git_identity() {
     agent)
       export GIT_AUTHOR_NAME="${agent_name}"
       export GIT_AUTHOR_EMAIL="${agent_email}"
+      export GIT_COMMITTER_NAME="${agent_name}"
+      export GIT_COMMITTER_EMAIL="${agent_email}"
       ;;
     human)
       export GIT_AUTHOR_NAME="${human_name}"
       export GIT_AUTHOR_EMAIL="${human_email}"
+      export GIT_COMMITTER_NAME="${human_name}"
+      export GIT_COMMITTER_EMAIL="${human_email}"
       ;;
     *)
       export GIT_AUTHOR_NAME="${agent_name}"

--- a/tests/lib/test_git_authorship.py
+++ b/tests/lib/test_git_authorship.py
@@ -60,19 +60,19 @@ PY
         self.assertEqual(env["GIT_COMMITTER_NAME"], "Codex")
         self.assertEqual(env["GIT_COMMITTER_EMAIL"], "noreply@openai.com")
 
-    def test_human_mode_unsets_committer(self) -> None:
+    def test_human_mode_sets_both_to_human(self) -> None:
         env = self._apply_mode("human")
         self.assertEqual(env["GIT_AUTHOR_NAME"], "Alice Example")
         self.assertEqual(env["GIT_AUTHOR_EMAIL"], "alice@example.com")
-        self.assertIsNone(env["GIT_COMMITTER_NAME"])
-        self.assertIsNone(env["GIT_COMMITTER_EMAIL"])
+        self.assertEqual(env["GIT_COMMITTER_NAME"], "Alice Example")
+        self.assertEqual(env["GIT_COMMITTER_EMAIL"], "alice@example.com")
 
-    def test_agent_mode_unsets_committer(self) -> None:
+    def test_agent_mode_sets_both_to_agent(self) -> None:
         env = self._apply_mode("agent")
         self.assertEqual(env["GIT_AUTHOR_NAME"], "Codex")
         self.assertEqual(env["GIT_AUTHOR_EMAIL"], "noreply@openai.com")
-        self.assertIsNone(env["GIT_COMMITTER_NAME"])
-        self.assertIsNone(env["GIT_COMMITTER_EMAIL"])
+        self.assertEqual(env["GIT_COMMITTER_NAME"], "Codex")
+        self.assertEqual(env["GIT_COMMITTER_EMAIL"], "noreply@openai.com")
 
     def test_invalid_mode_falls_back_to_agent_human(self) -> None:
         env = self._apply_mode("invalid-mode")


### PR DESCRIPTION
## Summary
- The `human` and `agent` git authorship modes in `terok-git-identity.sh` only set `GIT_AUTHOR_*` but left `GIT_COMMITTER_*` unset after explicitly unsetting all four vars
- Since containers have no `git config user.name`/`user.email`, git fell back to container defaults (e.g. `dev@container-id`) for the committer — breaking the auto-fill from host git credentials
- Now both modes set all four git identity env vars to the same identity

## Test plan
- [x] All 1106 existing tests pass
- [x] Updated `test_human_mode_sets_both_to_human` and `test_agent_mode_sets_both_to_agent` assertions
- [ ] Manual: configure `git.authorship: human` without `human_name` in project.yml, verify commits use host git credentials for both author and committer

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Git commit attribution to explicitly set committer identity to match author in both human and agent modes, ensuring consistent authorship information across all configurations.

* **Documentation**
  * Updated Git identity mapping documentation to reflect committer configuration changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->