### PR TITLE
fix: close unclosed subshells in generic agent wrapper

### DIFF
--- a/src/terok/lib/containers/headless_providers.py
+++ b/src/terok/lib/containers/headless_providers.py
@@ -709,6 +709,8 @@ def _generate_generic_wrapper(provider: HeadlessProvider, project: ProjectConfig
     if provider.name == "vibe" and session_path:
         lines.append("        local _rc=$?; _terok_capture_vibe_session; return $_rc")
 
+    lines.append("        )")
+
     # Interactive mode (no timeout)
     lines.append("    else")
     lines.append("        (")
@@ -719,6 +721,7 @@ def _generate_generic_wrapper(provider: HeadlessProvider, project: ProjectConfig
 
     lines.append(f'        command {binary}{extra} "$@"')
 
+    lines.append("        )")
     lines.append("    fi")
     lines.append("}")
 

--- a/tests/lib/test_headless_providers.py
+++ b/tests/lib/test_headless_providers.py
@@ -650,3 +650,14 @@ class GenerateAllWrappersTests(unittest.TestCase):
         self.assertGreaterEqual(
             wrapper.count("_terok_apply_git_identity"), len(HEADLESS_PROVIDERS) * 2
         )
+
+    def test_all_wrappers_valid_bash_syntax(self) -> None:
+        """Combined wrapper output passes bash -n syntax check."""
+        import subprocess
+
+        project = _make_project()
+        wrapper = generate_all_wrappers(
+            project, has_agents=True, claude_wrapper_fn=self._claude_wrapper_fn
+        )
+        result = subprocess.run(["bash", "-n"], input=wrapper, capture_output=True, text=True)
+        self.assertEqual(result.returncode, 0, f"bash syntax error:\n{result.stderr}")


### PR DESCRIPTION
## Summary

- `_generate_generic_wrapper()` opened subshells with `(` in both the timeout and interactive branches but never closed them with `)`, causing `bash: syntax error near unexpected token 'else'` when containers sourced `zz-terok-project.sh`
- Added `bash -n` regression test that validates all generated wrappers have valid shell syntax

## Test plan

- [x] `bash -n` syntax check passes for all 6 providers' wrappers
- [x] All 1099 existing tests pass
- [ ] Manual: launch a container and verify no syntax error from `/etc/profile.d/zz-terok-project.sh`

Closes #401

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed generated shell wrapper syntax so provider integrations produce valid, executable scripts.

* **Tests**
  * Added a validation test that checks generated wrapper scripts pass a bash syntax check.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->