### PR TITLE
feat: add no-new-privileges to restricted mode containers

### DIFF
--- a/src/terok/lib/containers/task_runners.py
+++ b/src/terok/lib/containers/task_runners.py
@@ -255,6 +255,8 @@ def _run_container(
 
     cmd: list[str] = ["podman", "run", "-d"]
     cmd += _podman_userns_args()
+    if "TEROK_UNRESTRICTED" not in env:
+        cmd += ["--security-opt", "no-new-privileges"]
     cmd += _shield_pre_start_impl(cname, task_dir)
     cmd += gpu_run_args(project)
     if extra_args:

--- a/tests/integration/test_shield_no_podman.py
+++ b/tests/integration/test_shield_no_podman.py
@@ -223,3 +223,49 @@ class TestTaskRunnerShieldIntegration:
         assert "--annotation" in captured_cmd
         assert "--cap-drop" in captured_cmd
         assert any("terok.shield.profiles" in a for a in captured_cmd)
+
+        # Restricted mode (no TEROK_UNRESTRICTED) → no-new-privileges
+        secopt_indices = [i for i, v in enumerate(captured_cmd) if v == "--security-opt"]
+        secopt_values = [captured_cmd[i + 1] for i in secopt_indices]
+        assert "no-new-privileges" in secopt_values
+
+    def test_unrestricted_skips_no_new_privileges(self, shield_env: dict[str, Path]) -> None:
+        """Unrestricted containers must NOT set no-new-privileges (sudo needed)."""
+        captured_cmd: list[str] = []
+
+        def capture_run(cmd: list[str], **_kwargs) -> None:
+            captured_cmd.extend(cmd)
+
+        task_dir = shield_env["task_dir"]
+        with (
+            patch("os.geteuid", return_value=1000),
+            patch("subprocess.run", side_effect=capture_run),
+            patch(
+                "terok.lib.containers.task_runners._podman_userns_args",
+                return_value=[],
+            ),
+            patch(
+                "terok.lib.containers.task_runners.gpu_run_args",
+                return_value=[],
+            ),
+            # Mock shield away to isolate terok's own --security-opt logic
+            patch(
+                "terok.lib.containers.task_runners._shield_pre_start_impl",
+                return_value=[],
+            ),
+        ):
+            from terok.lib.containers.task_runners import _run_container
+            from terok.lib.core.projects import ProjectConfig
+
+            project = MagicMock(spec=ProjectConfig)
+
+            _run_container(
+                cname="integ-test-ctr",
+                image="alpine:latest",
+                env={"TEROK_UNRESTRICTED": "1"},
+                volumes=[],
+                project=project,
+                task_dir=task_dir,
+            )
+
+        assert "--security-opt" not in captured_cmd


### PR DESCRIPTION
## Summary
- Restricted containers (no `TEROK_UNRESTRICTED`) now get `--security-opt no-new-privileges`, blocking setuid privilege escalation
- Unrestricted containers are unaffected — `sudo` keeps working for `apt install` etc.
- Complements terok-shield#104 which removed this flag from shield (not a firewall concern)

Closes #419

## Test plan
- [x] Existing shield integration test extended to assert `no-new-privileges` in restricted mode
- [x] New test verifies unrestricted mode does NOT set the flag
- [x] Full test suite passes (1138 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Container execution now includes --security-opt no-new-privileges by default to restrict privilege escalation.
  * Set TEROK_UNRESTRICTED environment variable to disable this security restriction when needed.

* **Tests**
  * Added tests verifying container security behavior in both restricted and unrestricted modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->