### PR TITLE
fix: use traditional networking for bypass_firewall_no_protection

### DIFF
--- a/src/terok/lib/containers/task_runners.py
+++ b/src/terok/lib/containers/task_runners.py
@@ -6,6 +6,7 @@
 
 from __future__ import annotations
 
+import os
 import re
 import subprocess
 from dataclasses import dataclass
@@ -14,7 +15,10 @@ from typing import TYPE_CHECKING
 
 import yaml
 
-from ..core.config import get_shield_bypass_firewall_no_protection
+from ..core.config import (
+    get_gate_server_port,
+    get_shield_bypass_firewall_no_protection,
+)
 from ..core.images import project_cli_image, project_web_image
 from ..core.projects import load_project
 from ..security.shield import (
@@ -57,6 +61,52 @@ if TYPE_CHECKING:
 
 _LOCALHOST = "127.0.0.1"
 _SENSITIVE_KEY_RE = re.compile(r"(?i)(KEY|TOKEN|SECRET|API|PASSWORD|PRIVATE)")
+
+# --- DANGEROUS TRANSITIONAL OVERRIDE helpers (bypass_firewall_no_protection) ---
+# Standalone network setup for when the shield is completely skipped.
+# Mirrors the networking portion of terok-shield's HookMode.pre_start()
+# but is fully independent — works even if the shield package is broken.
+# Delete this block when the bypass option is removed.
+
+_SLIRP_GATEWAY = "10.0.2.2"
+
+
+def _detect_rootless_network_mode() -> str:
+    """Detect whether podman uses pasta or slirp4netns for rootless networking."""
+    try:
+        out = subprocess.run(
+            ["podman", "info", "-f", "{{.Host.RootlessNetworkCmd}}"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        cmd = out.stdout.strip()
+        return cmd if cmd in ("pasta", "slirp4netns") else "pasta"
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        return "pasta"
+
+
+def _bypass_network_args(gate_port: int) -> list[str]:
+    """Return podman network args for the bypass path (no shield, no OCI hooks).
+
+    Replicates the networking that terok-shield's HookMode normally provides
+    but without nftables rules, annotations, hooks, or cap-drops.
+    """
+    if os.geteuid() == 0:
+        return []
+    if _detect_rootless_network_mode() == "slirp4netns":
+        return [
+            "--network",
+            "slirp4netns:allow_host_loopback=true",
+            "--add-host",
+            f"host.containers.internal:{_SLIRP_GATEWAY}",
+        ]
+    return [
+        "--network",
+        f"pasta:-T,{gate_port}",
+        "--add-host",
+        f"host.containers.internal:{_LOCALHOST}",
+    ]
 
 
 def _redact_env_args(cmd: list[str]) -> list[str]:
@@ -245,19 +295,24 @@ def _run_container(
             args (e.g. ``["-p", "127.0.0.1:8080:7860"]``).
         command: Optional command + args appended after the image name.
     """
+    cmd: list[str] = ["podman", "run", "-d"]
+    cmd += _podman_userns_args()
+    if "TEROK_UNRESTRICTED" not in env:
+        cmd += ["--security-opt", "no-new-privileges"]
+
     # DANGEROUS TRANSITIONAL OVERRIDE — bypass_firewall_no_protection
-    # Print a loud banner so the user cannot miss that the firewall is off.
+    # Skip the shield entirely and use traditional podman networking so
+    # that the gate server port is forwarded via pasta.  Completely
+    # independent of terok-shield; easy to delete once no longer needed.
     if get_shield_bypass_firewall_no_protection():
         print(
             "\n!! SHIELD BYPASSED — egress firewall DISABLED "
             f"(shield.bypass_firewall_no_protection is set) !!\n{SHIELD_SECURITY_HINT}\n"
         )
+        cmd += _bypass_network_args(get_gate_server_port())
+    else:
+        cmd += _shield_pre_start_impl(cname, task_dir)
 
-    cmd: list[str] = ["podman", "run", "-d"]
-    cmd += _podman_userns_args()
-    if "TEROK_UNRESTRICTED" not in env:
-        cmd += ["--security-opt", "no-new-privileges"]
-    cmd += _shield_pre_start_impl(cname, task_dir)
     cmd += gpu_run_args(project)
     if extra_args:
         cmd += extra_args

--- a/tests/integration/test_shield_no_podman.py
+++ b/tests/integration/test_shield_no_podman.py
@@ -265,3 +265,77 @@ class TestTaskRunnerShieldIntegration:
             )
 
         assert "--security-opt" not in captured_cmd
+
+    def _run_bypass_container(self, shield_env: dict[str, Path], network_mode: str) -> list[str]:
+        """Helper: run _run_container with bypass active and given network mode."""
+        captured_cmd: list[str] = []
+
+        def capture_run(cmd: list[str], **_kwargs) -> None:
+            captured_cmd.extend(cmd)
+
+        task_dir = shield_env["task_dir"]
+        with (
+            patch("os.geteuid", return_value=1000),
+            patch("subprocess.run", side_effect=capture_run),
+            patch(
+                "terok.lib.containers.task_runners._podman_userns_args",
+                return_value=[],
+            ),
+            patch(
+                "terok.lib.containers.task_runners.gpu_run_args",
+                return_value=[],
+            ),
+            patch(
+                "terok.lib.containers.task_runners.get_shield_bypass_firewall_no_protection",
+                return_value=True,
+            ),
+            patch(
+                "terok.lib.containers.task_runners.get_gate_server_port",
+                return_value=GATE_PORT,
+            ),
+            patch(
+                "terok.lib.containers.task_runners._detect_rootless_network_mode",
+                return_value=network_mode,
+            ),
+            # Shield must NOT be called at all when bypass is active
+            patch(
+                "terok.lib.containers.task_runners._shield_pre_start_impl",
+                side_effect=AssertionError("shield must not be called"),
+            ),
+        ):
+            from terok.lib.containers.task_runners import _run_container
+            from terok.lib.core.projects import ProjectConfig
+
+            project = MagicMock(spec=ProjectConfig)
+
+            _run_container(
+                cname="bypass-test-ctr",
+                image="alpine:latest",
+                env={},
+                volumes=[],
+                project=project,
+                task_dir=task_dir,
+            )
+        return captured_cmd
+
+    def test_bypass_uses_pasta_networking(self, shield_env: dict[str, Path]) -> None:
+        """Bypass on pasta: injects --network=pasta:-T,<port> and --add-host."""
+        cmd = self._run_bypass_container(shield_env, "pasta")
+        assert f"pasta:-T,{GATE_PORT}" in cmd
+        assert "--add-host" in cmd
+        host_idx = cmd.index("--add-host")
+        assert cmd[host_idx + 1] == HOST_ALIAS_LOOPBACK
+        # No shield args
+        assert "--annotation" not in cmd
+        assert "--cap-drop" not in cmd
+
+    def test_bypass_uses_slirp4netns_networking(self, shield_env: dict[str, Path]) -> None:
+        """Bypass on slirp4netns: injects --network=slirp4netns:... and --add-host."""
+        cmd = self._run_bypass_container(shield_env, "slirp4netns")
+        assert "slirp4netns:allow_host_loopback=true" in cmd
+        assert "--add-host" in cmd
+        host_idx = cmd.index("--add-host")
+        assert cmd[host_idx + 1] == HOST_ALIAS_SLIRP
+        # No shield args
+        assert "--annotation" not in cmd
+        assert "--cap-drop" not in cmd


### PR DESCRIPTION
## Summary

- When `bypass_firewall_no_protection` is active, skip the shield entirely and inject `--network=pasta:-T,<gate_port>`  or and equivalent for `slirp4netns` so the gate server is reachable via traditional podman networking (no OCI hooks, no nftables)
- Remove TUI short-circuit that showed stale "disabled" state for pre-existing containers — now always queries actual container shield state
- The bypass codepath is fully isolated from the shield module and easy to delete once no longer needed

## Test plan

- [x] All 1128 unit tests pass
- [x] Integration test added: verifies bypass path injects pasta networking and never calls the shield
- [x] `tach check` passes (module boundaries)
- [x] `ruff check` + `ruff format` pass

Closes #424

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added bypass networking mode for container execution
  * Support for rootless networking configurations with pasta and slirp4netns
  * Integrated port forwarding for bypass connections

* **Tests**
  * Added integration tests validating bypass networking across different rootless network modes
<!-- end of auto-generated comment: release notes by coderabbit.ai -->