### PR TITLE
fix: show shield bypass status in error color

### DIFF
--- a/src/terok/tui/widgets/project_state.py
+++ b/src/terok/tui/widgets/project_state.py
@@ -143,7 +143,7 @@ def render_project_details(
             "ok": success_color,
             "setup-needed": error_color,
             "stale-hooks": warning_color,
-            "bypass": warning_color,
+            "bypass": error_color,
         }
         shield_color = _shield_colors.get(shield_env.health, error_color)
         shield_s = Text(shield_env.health, style=Style(color=shield_color))


### PR DESCRIPTION
## Summary

- Change shield "bypass" status color from warning (yellow) to error (red) in the project state widget — bypass disables the egress firewall entirely, which warrants error-level severity

## Test plan

- [x] Visual: bypass health now renders in error color alongside `setup-needed`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated shield status color indicator to display in red when in bypass state (previously yellow).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->