### PR TITLE
fix: consistent button formatting in shield setup modal

### DIFF
--- a/src/terok/tui/screens.py
+++ b/src/terok/tui/screens.py
@@ -1483,9 +1483,9 @@ class ShieldSetupScreen(screen.ModalScreen[str | None]):
         with Vertical(id="setup-dialog") as dialog:
             yield Static("Install global OCI hooks for podman < 5.6.0")
             with Horizontal(id="setup-buttons"):
-                yield Button("[u] User-local", id="btn-user")
-                yield Button("[r] System-wide", id="btn-root")
-                yield Button("Cancel", id="btn-cancel")
+                yield Button("User-local  [u]", id="btn-user")
+                yield Button("System-wide [r]", id="btn-root")
+                yield Button("Cancel    [Esc]", id="btn-cancel")
         dialog.border_title = "Shield Setup"
         dialog.border_subtitle = "Esc to cancel"
 


### PR DESCRIPTION
## Summary

- Unify button text style in the shield setup modal: all three buttons now use `Label [key]` format
  - `User-local  [u]` / `System-wide [r]` / `Cancel    [Esc]`

## Test plan

- [x] Visual inspection of the shield setup modal

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **UI Improvements**
  * Shield Setup modal button labels now display keyboard shortcuts alongside button names for clearer navigation
  * Added direct keyboard event support for "R" and "U" key inputs in Shield Setup modal
  * Modal focus defaults to the first button upon opening

<!-- end of auto-generated comment: release notes by coderabbit.ai -->