### PR TITLE
fix: shield down shows 'unavailable' in bypass mode

### DIFF
--- a/src/terok/tui/task_actions.py
+++ b/src/terok/tui/task_actions.py
@@ -605,6 +605,8 @@ class TaskActionsMixin:
 
     def _action_shield_down(self) -> None:
         """Drop the shield (bypass mode) for the current task."""
+        if self._notify_shield_bypassed():
+            return
         self._action_shield_toggle("down", shield_down)
 
     def _notify_shield_bypassed(self) -> bool:
@@ -634,6 +636,8 @@ class TaskActionsMixin:
 
     def action_shield_down_from_main(self) -> None:
         """Drop the shield from the main screen."""
+        if self._notify_shield_bypassed():
+            return
         self._action_shield_toggle("down", shield_down)
 
     def action_shield_up_from_main(self) -> None:


### PR DESCRIPTION
## Summary

- Add `_notify_shield_bypassed()` check to both shield-down code paths (`_action_shield_down` and `action_shield_down_from_main`), matching the existing shield-up behavior
- Previously, shield-down in bypass mode silently no-oped then showed "Shield dropped for task X" — now correctly shows "Shield unavailable (bypass_firewall_no_protection)"

## Test plan

- [x] Lint passes
- [x] Shield-up already had this check — now both actions are consistent

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Shield-down operations now perform validation checks before execution. Operations are prevented when certain conditions are detected, avoiding unintended behavior across different action contexts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->