### PR TITLE
docs: fix unrestricted config examples to show agent: nesting

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -450,22 +450,26 @@ config (see below), defaulting to unrestricted.
 
 #### Config
 
-Like other config keys, `unrestricted` follows the resolution stack:
+Like other config keys, `unrestricted` lives inside the `agent:` section
+and follows the resolution stack:
 global config → project config → preset → CLI flag.
 
 ```yaml
-# Flat value — same for all providers
-unrestricted: false  # all agents start restricted
+# In project.yml or global config
+agent:
+  # Flat value — same for all providers
+  unrestricted: false  # all agents start restricted
 ```
 
 Per-provider dict syntax is supported:
 
 ```yaml
-# Per-provider values
-unrestricted:
-  claude: true
-  codex: false
-  _default: true
+agent:
+  # Per-provider values
+  unrestricted:
+    claude: true
+    codex: false
+    _default: true
 ```
 
 Providers not listed in the dict (and without `_default`) default to


### PR DESCRIPTION
## Summary
- The YAML examples for `unrestricted` in usage.md showed it as a top-level key, but the code loads it from the `agent:` section (`cfg.get("agent", {})`)
- Users following the docs would set a top-level key that gets silently ignored, leaving tasks in unrestricted mode
- Fixed examples to show proper `agent:` nesting

## Test plan
- [ ] Verify docs render correctly with `make docs`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated configuration format examples to show `unrestricted` settings under `agent:` section
  * Documented configuration resolution order: global → project → preset → CLI flag
  * Updated per-provider override syntax and clarified default behavior for unlisted providers

<!-- end of auto-generated comment: release notes by coderabbit.ai -->