### PR TITLE
fix: move terok scripts below AGENT_CACHE_BUST in L1 Dockerfile

### DIFF
--- a/src/terok/resources/templates/l1.agent-cli.Dockerfile.template
+++ b/src/terok/resources/templates/l1.agent-cli.Dockerfile.template
@@ -69,6 +69,17 @@ RUN set -eux; \
 # Owned by dev so no sudo is needed at runtime.
 RUN mkdir -p /etc/claude-code && chown dev:dev /etc/claude-code
 
+# === User operations ===
+ENV HOME=/home/dev
+ENV NPM_CONFIG_PREFIX=/home/dev/.npm-packages \
+    PATH=/home/dev/.npm-packages/bin:/home/dev/.local/bin:/home/dev/.opencode/bin:$PATH
+USER dev
+WORKDIR /home/dev
+
+# Cache bust point - changing AGENT_CACHE_BUST invalidates all layers below
+# Used by `terokctl build --agents` to force fresh agent installs
+ARG AGENT_CACHE_BUST=0
+
 # Copy setup script for codex auth (port forwarding for OAuth callbacks)
 COPY scripts/setup-codex-auth.sh /usr/local/bin/setup-codex-auth.sh
 RUN chmod +x /usr/local/bin/setup-codex-auth.sh
@@ -136,17 +147,6 @@ RUN set -eux; \
 
 # Symlink for terok project config (resolved at runtime via mount).
 RUN ln -s /home/dev/.terok/terok-agent.sh /etc/profile.d/zz-terok-project.sh
-
-# === User operations ===
-ENV HOME=/home/dev
-ENV NPM_CONFIG_PREFIX=/home/dev/.npm-packages \
-    PATH=/home/dev/.npm-packages/bin:/home/dev/.local/bin:/home/dev/.opencode/bin:$PATH
-USER dev
-WORKDIR /home/dev
-
-# Cache bust point - changing AGENT_CACHE_BUST invalidates all layers below
-# Used by `terokctl build --agents` to force fresh agent installs
-ARG AGENT_CACHE_BUST=0
 
 # Install AI agent CLIs as dev user
 RUN mkdir -p "$NPM_CONFIG_PREFIX" && npm config set prefix "$NPM_CONFIG_PREFIX"


### PR DESCRIPTION
## Summary

- Fix issue #383: terok-provided scripts in L1 were placed above `AGENT_CACHE_BUST`
- Moving COPY instructions for scripts and shell profile setup below the cache bust point ensures they get properly invalidated on agent-only rebuilds (`terokctl build --agents`)
- Previously, upgrading terok (e.g., v0.5.2 → v0.5.3) and running `build --agents` wouldn't refresh new scripts like `terok-git-identity.sh`

## Changes

- Reorganized `l1.agent-cli.Dockerfile.template` to place all `COPY scripts/...` and shell profile setup below `ARG AGENT_CACHE_BUST=0`
- This ensures `terokctl build --agents` refreshes all terok-provided files, not just agent CLIs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added helper scripts for agent CLI tools, including authentication setup and session management support
  * Introduced build cache management mechanism to optimize development builds

* **Chores**
  * Restructured development environment initialization sequence for improved organization
  * Enhanced configuration setup and tool accessibility

<!-- end of auto-generated comment: release notes by coderabbit.ai -->