### PR TITLE
feat: add blablador-acp wrapper for Blablador via Toad

### DIFF
--- a/src/terok/resources/scripts/blablador-acp
+++ b/src/terok/resources/scripts/blablador-acp
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+# SPDX-FileCopyrightText: 2026 Jiri Vyskocil
+# SPDX-License-Identifier: Apache-2.0
+
+# ACP wrapper for Blablador (OpenCode with Helmholtz Blablador config).
+# Points OpenCode's ACP server to Blablador's separate config which
+# includes the Helmholtz API endpoint, credentials, and terok's
+# system instructions (injected by prepare_agent_config_dir).
+
+exec env OPENCODE_CONFIG="$HOME/.blablador/opencode/opencode.json" opencode acp "$@"

--- a/src/terok/resources/scripts/hilfe
+++ b/src/terok/resources/scripts/hilfe
@@ -25,6 +25,7 @@ _terok_show_banner() {
     printf '  \033[36mblablador\033[0m - OpenCode with Helmholtz Blablador\n'
     printf '  \033[36mopencode\033[0m  - OpenCode CLI\n'
     printf '  \033[36mtoad\033[0m      - Multi-agent TUI (ACP)\n'
+    printf '              \033[2mtoad acp blablador-acp\033[0m for Blablador via Toad\n'
 
     # Login hint (only on first login, not when running `hilfe`)
     if [[ -n "$login" ]]; then

--- a/src/terok/resources/templates/l1.agent-cli.Dockerfile.template
+++ b/src/terok/resources/templates/l1.agent-cli.Dockerfile.template
@@ -87,11 +87,12 @@ RUN chmod +x /usr/local/share/terok/terok-git-identity.sh
 COPY scripts/hilfe /usr/local/bin/hilfe
 RUN chmod +x /usr/local/bin/hilfe
 
-# Copy blablador wrapper (OpenCode-based)
+# Copy blablador wrappers (OpenCode-based CLI + ACP)
 COPY scripts/blablador /usr/local/bin/blablador
+COPY scripts/blablador-acp /usr/local/bin/blablador-acp
 COPY scripts/vibe-model-sync.sh /usr/local/bin/vibe-model-sync
 COPY scripts/mistral-model-sync.py /usr/local/bin/mistral-model-sync.py
-RUN chmod +x /usr/local/bin/blablador /usr/local/bin/vibe-model-sync /usr/local/bin/mistral-model-sync.py
+RUN chmod +x /usr/local/bin/blablador /usr/local/bin/blablador-acp /usr/local/bin/vibe-model-sync /usr/local/bin/mistral-model-sync.py
 
 # update-all-the-things: refresh all packages without full image rebuild
 COPY scripts/allthethings.sh /usr/local/bin/allthethings.sh


### PR DESCRIPTION
## Summary

Ship `/usr/local/bin/blablador-acp` — a thin wrapper that sets `OPENCODE_CONFIG` to Blablador's separate config and execs `opencode acp`.

System instructions already work: `prepare_agent_config_dir` injects `/home/dev/.terok/instructions.md` into Blablador's `opencode.json` `instructions` array, which OpenCode reads regardless of launch path.

Usage: `toad acp blablador-acp`

Partially addresses #410

## Changes

- New script: `scripts/blablador-acp` (one-liner wrapper)
- Dockerfile: copy + chmod alongside existing `blablador` CLI wrapper
- `hilfe` banner: hint about `toad acp blablador-acp`

## Test plan

- [x] All 1149 tests pass
- [ ] Build image, run `toad acp blablador-acp` with Blablador API key set

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a new Blablador ACP wrapper command for execution.
  * Updated help documentation to reflect the newly available Blablador ACP command.

* **Chores**
  * Updated container image configuration to include the new wrapper script with proper permissions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->