### PR TITLE
fix: add toad mode display with frog emoji

### DIFF
--- a/src/terok/lib/containers/task_display.py
+++ b/src/terok/lib/containers/task_display.py
@@ -53,6 +53,7 @@ MODE_DISPLAY: dict[str | None, ModeInfo] = {
     "cli": ModeInfo(emoji="\U0001f4bb", label="CLI"),
     "web": ModeInfo(emoji="\U0001f30d", label="Web"),
     "run": ModeInfo(emoji="\U0001f680", label="Autopilot"),
+    "toad": ModeInfo(emoji="\U0001f438", label="Toad"),
     None: ModeInfo(emoji="\U0001f997", label=""),
 }
 


### PR DESCRIPTION
## Summary

Toad tasks were showing as unassigned with cricket emoji because `MODE_DISPLAY` had no `"toad"` entry. Add `🐸` (U+1F438, natively wide) with label "Toad".

## Test plan

- [x] All 1149 tests pass
- [x] Frog emoji is `East_Asian_Width=W` (no VS16 needed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a new "Toad" display mode option for enhanced task customization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->