### PR TITLE
docs: fix stale install instructions in index.md

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -28,13 +28,8 @@ A tool for managing containerized AI coding agent projects using Podman. Provide
 ### Installation
 
 ```bash
-# Clone and install
-git clone git@github.com:terok-ai/terok.git
-cd terok
-pip install .
-
-# With TUI support
-pip install '.[tui]'
+# Download the latest .whl from the GitHub Releases page, then:
+pipx install ./terok-*.whl
 ```
 
 ### Basic Workflow
@@ -100,7 +95,6 @@ per-project in `<project>/presets/`. See the
 - [Shared Directories](shared-dirs.md) — Volume mounts and SSH configuration
 - [Security Modes](git-gate-and-security-modes.md) — Online vs gatekeeping modes
 - [Login Design](login-design.md) — Login session architecture
-- [Packaging](packaging.md) — pip, deb, and rpm packaging
 - [Developer Guide](developer.md) — Architecture and contributing
 - [API Reference](reference/) — Auto-generated API documentation
 


### PR DESCRIPTION
## Summary

- Replace obsolete clone-and-pip-install flow with canonical `pipx install ./terok-*.whl` (matching usage.md)
- Remove dead `.[tui]` extra reference (TUI is always included since 0.6.0)
- Remove broken link to `packaging.md` (deleted in #420)

These were missed when #420 cleaned up the other docs files.

## Test plan

- [ ] Verify `mkdocs serve` renders correctly
- [ ] Confirm no other docs reference `.[tui]` or `packaging.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Installation instructions updated to use a simpler pipx-based installation method with pre-built wheels instead of git clone
  * Removed outdated Packaging documentation link

<!-- end of auto-generated comment: release notes by coderabbit.ai -->