### PR TITLE
fix: use wrapper script to seed toad launcher agents

### DIFF
--- a/src/terok/lib/containers/environment.py
+++ b/src/terok/lib/containers/environment.py
@@ -120,7 +120,6 @@ SHARED_MOUNTS: tuple[SharedMount, ...] = (
         "opencode_data", "_opencode-data", "OpenCode data", "/home/dev/.local/share/opencode"
     ),
     SharedMount("opencode_state", "_opencode-state", "OpenCode state", "/home/dev/.local/state"),
-    SharedMount("toad", "_toad-config", "Toad config", "/home/dev/.config/toad"),
     SharedMount("gh", "_gh-config", "GitHub CLI config", "/home/dev/.config/gh"),
     SharedMount("glab", "_glab-config", "GitLab CLI config", "/home/dev/.config/glab-cli"),
 )

--- a/src/terok/resources/scripts/init-ssh-and-repo.sh
+++ b/src/terok/resources/scripts/init-ssh-and-repo.sh
@@ -320,20 +320,6 @@ if [[ "${TEROK_UNRESTRICTED:-}" == "1" ]]; then
   fi
 fi
 
-# Pre-populate Toad launcher with agents already installed in the image.
-# Only on first run (shared volume, persists across tasks).
-TOAD_CONFIG="${HOME}/.config/toad/toad.json"
-if [[ ! -f "${TOAD_CONFIG}" ]]; then
-  mkdir -p "$(dirname "${TOAD_CONFIG}")"
-  cat > "${TOAD_CONFIG}" << 'TOAD_EOF'
-{
-    "launcher": {
-        "agents": "claude.com\nvibe.mistral.ai\nopenai.com\ncopilot.github.com\nopencode.ai"
-    }
-}
-TOAD_EOF
-fi
-
 # Signal readiness for host tools that watch initial logs
 echo ">> init complete"
 exec bash

--- a/src/terok/resources/scripts/toad
+++ b/src/terok/resources/scripts/toad
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+
+# SPDX-FileCopyrightText: 2026 Jiri Vyskocil
+# SPDX-License-Identifier: Apache-2.0
+
+# Toad launcher wrapper.
+# Seeds launcher.agents into toad.json before exec-ing the real binary.
+# This runs on every invocation so the agent list survives toad's own
+# config writes (which drop keys it doesn't manage internally).
+
+set -euo pipefail
+
+TOAD_CONFIG="${HOME}/.config/toad/toad.json"
+TOAD_REAL="${HOME}/.local/share/uv/tools/batrachian-toad/bin/toad"
+
+# Agents pre-installed in the container image (newline-separated identities).
+LAUNCHER_AGENTS="claude.com
+vibe.mistral.ai
+openai.com
+copilot.github.com
+opencode.ai"
+
+if command -v jq >/dev/null 2>&1; then
+  mkdir -p "$(dirname "${TOAD_CONFIG}")"
+  existing='{}'
+  if [[ -f "${TOAD_CONFIG}" ]]; then
+    raw=$(cat "${TOAD_CONFIG}" 2>/dev/null || true)
+    # Reset to empty object if file is corrupt / not valid JSON.
+    existing=$(printf '%s' "${raw}" | jq -e '.' 2>/dev/null) || existing='{}'
+  fi
+
+  if [[ -z "$(printf '%s' "${existing}" | jq -r '.launcher.agents // empty' 2>/dev/null)" ]]; then
+    updated=$(printf '%s' "${existing}" | jq --arg agents "${LAUNCHER_AGENTS}" \
+      '.launcher.agents = $agents' 2>/dev/null) || true
+    if [[ -n "${updated}" ]]; then
+      tmpfile=$(mktemp "${TOAD_CONFIG}.XXXXXX") || true
+      if [[ -n "${tmpfile}" ]]; then
+        printf '%s\n' "${updated}" > "${tmpfile}" && mv -f "${tmpfile}" "${TOAD_CONFIG}" \
+          || rm -f "${tmpfile}"
+      fi
+    fi
+  fi
+fi
+
+exec "${TOAD_REAL}" "$@"

--- a/src/terok/resources/scripts/update-all-the-things
+++ b/src/terok/resources/scripts/update-all-the-things
@@ -41,7 +41,8 @@ echo -e "\n=== Update ALL the Things: pip (ast-grep-cli) ===\n" \
     && pip install --break-system-packages --upgrade ast-grep-cli
 
 echo -e "\n=== Update ALL the Things: Toad ===\n" \
-    && sudo -u dev uv tool upgrade batrachian-toad
+    && sudo -u dev uv tool upgrade batrachian-toad \
+    && rm -f /home/dev/.local/bin/toad
 
 echo -e "\n=== Update ALL the Things: uv ===\n" \
     && curl -LsSf https://astral.sh/uv/install.sh | env UV_INSTALL_DIR=/usr/local/bin sh

--- a/src/terok/resources/templates/l1.agent-cli.Dockerfile.template
+++ b/src/terok/resources/templates/l1.agent-cli.Dockerfile.template
@@ -87,13 +87,14 @@ RUN chmod +x /usr/local/share/terok/terok-git-identity.sh
 COPY scripts/hilfe /usr/local/bin/hilfe
 RUN chmod +x /usr/local/bin/hilfe
 
-# Copy blablador wrappers (OpenCode-based CLI + ACP) and blablatoad (toad + blablador ACP)
+# Copy agent wrappers (blablador CLI + ACP, blablatoad, toad launcher)
 COPY scripts/blablador /usr/local/bin/blablador
 COPY scripts/blablador-acp /usr/local/bin/blablador-acp
 COPY scripts/blablatoad /usr/local/bin/blablatoad
+COPY scripts/toad /usr/local/bin/toad
 COPY scripts/vibe-model-sync.sh /usr/local/bin/vibe-model-sync
 COPY scripts/mistral-model-sync.py /usr/local/bin/mistral-model-sync.py
-RUN chmod +x /usr/local/bin/blablador /usr/local/bin/blablador-acp /usr/local/bin/blablatoad /usr/local/bin/vibe-model-sync /usr/local/bin/mistral-model-sync.py
+RUN chmod +x /usr/local/bin/blablador /usr/local/bin/blablador-acp /usr/local/bin/blablatoad /usr/local/bin/toad /usr/local/bin/vibe-model-sync /usr/local/bin/mistral-model-sync.py
 
 # update-all-the-things: refresh all packages without full image rebuild
 COPY scripts/allthethings.sh /usr/local/bin/allthethings.sh
@@ -165,7 +166,10 @@ RUN npm cache clean --force
 
 # Toad — universal multi-agent TUI via ACP (requires Python >=3.14)
 # uv downloads a standalone Python 3.14, leaving system Python untouched.
-RUN uv tool install batrachian-toad --python 3.14
+# The uv-created symlink is removed so the wrapper at /usr/local/bin/toad
+# (which seeds launcher agents) takes precedence in PATH.
+RUN uv tool install batrachian-toad --python 3.14 \
+    && rm -f ~/.local/bin/toad
 
 WORKDIR /workspace
 # No CMD: reuse init-ssh-and-repo.sh from base image


### PR DESCRIPTION
## Summary

- Toad overwrites `toad.json` when saving its own settings (theme, anon_id, etc.), dropping the `launcher.agents` key that was seeded by the init script. Since `~/.config/toad` was a shared volume, the init guard (`if ! -f`) prevented re-seeding on subsequent containers.
- Replace the shared-volume + first-run-seed approach with a wrapper script (matching the blablador pattern) that injects `launcher.agents` via `jq` on every invocation if the key is missing or empty. This ensures agents always appear in the launcher regardless of toad's own config writes.

### Changes
- **New**: `src/terok/resources/scripts/toad` — bash wrapper that merges `launcher.agents` into `toad.json` before exec-ing the real binary
- **Removed**: toad shared mount from `environment.py` (no longer needed)
- **Removed**: init-script seeding block from `init-ssh-and-repo.sh`
- **Updated**: Dockerfile template to install wrapper and remove uv symlink so wrapper takes PATH precedence
- **Updated**: `update-all-the-things` to clean up uv symlink after upgrades

## Test plan

- [ ] Build L1 image, launch toad — verify agents appear numbered in launcher
- [ ] Change a toad setting (e.g. theme), exit, relaunch — verify agents still appear
- [ ] Delete `~/.config/toad/toad.json` inside container, launch toad — verify agents are seeded fresh
- [ ] Run `update-all-the-things`, verify `which toad` still resolves to `/usr/local/bin/toad`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a launcher wrapper that seeds and preserves preinstalled agents on every launch.

* **Bug Fixes**
  * Switched from one-time pre-population to runtime-managed agent initialization to avoid lost entries.
  * Removed an unnecessary per-task shared mount to reduce mounted config exposure.

* **Chores**
  * Installer/update flow adjusted to prefer the new launcher and remove an older local launcher binary.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->