### PR TITLE
feat: add ACP wrapper scripts for toad agents

### DIFF
--- a/src/terok/resources/scripts/blablador-acp
+++ b/src/terok/resources/scripts/blablador-acp
@@ -3,9 +3,24 @@
 # SPDX-FileCopyrightText: 2026 Jiri Vyskocil
 # SPDX-License-Identifier: Apache-2.0
 
-# ACP wrapper for Blablador (OpenCode with Helmholtz Blablador config).
-# Points OpenCode's ACP server to Blablador's separate config which
-# includes the Helmholtz API endpoint, credentials, and terok's
-# system instructions (injected by prepare_agent_config_dir).
+# ACP wrapper for Blablador (OpenCode-based with Helmholtz backend).
+#
+# Sets up git identity, unrestricted mode, and Blablador's separate
+# OpenCode config path before exec-ing the opencode acp adapter.
 
-exec env OPENCODE_CONFIG="$HOME/.blablador/opencode/opencode.json" opencode acp "$@"
+set -euo pipefail
+
+_AGENT_NAME="Blablador"
+_AGENT_EMAIL="noreply@hzdr.de"
+. /usr/local/share/terok/terok-acp-env.sh
+
+# Unrestricted mode: same as opencode — env var merged on top of config.
+if [ "${TEROK_UNRESTRICTED:-}" = "1" ]; then
+    export OPENCODE_PERMISSION='{"*":"allow"}'
+fi
+
+# Point OpenCode at Blablador's separate config directory so it picks up
+# the Blablador provider, model list, and API key.
+export OPENCODE_CONFIG="$HOME/.blablador/opencode/opencode.json"
+
+exec opencode acp "$@"

--- a/src/terok/resources/scripts/terok-acp-env.sh
+++ b/src/terok/resources/scripts/terok-acp-env.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+
+# SPDX-FileCopyrightText: 2025 Jiri Vyskocil
+# SPDX-License-Identifier: Apache-2.0
+
+# Common environment setup for terok ACP wrappers.
+#
+# Sourced (not exec'd) by per-agent ACP wrapper scripts.
+# Sets up git identity using the shared helper.
+#
+# Expected environment:
+#   TEROK_UNRESTRICTED  - "1" to enable unrestricted mode
+#   TEROK_GIT_AUTHORSHIP - authorship policy (default: agent-human)
+#   HUMAN_GIT_NAME       - human git name
+#   HUMAN_GIT_EMAIL      - human git email
+#
+# Usage (from a wrapper script):
+#   _AGENT_NAME="Claude" _AGENT_EMAIL="noreply@anthropic.com"
+#   . /usr/local/share/terok/terok-acp-env.sh
+
+# Source git identity helper and apply identity for this agent
+if [ -r /usr/local/share/terok/terok-git-identity.sh ]; then
+    . /usr/local/share/terok/terok-git-identity.sh
+    _terok_apply_git_identity "${_AGENT_NAME:?}" "${_AGENT_EMAIL:?}"
+fi
+
+# Copy per-task instructions to ~/.claude/CLAUDE.md for Claude ACP discovery.
+# This is a shared volume (last writer wins) — acceptable for toad's interactive
+# one-session-at-a-time model.  The CLI path (--append-system-prompt) remains
+# authoritative for headless runs.
+_terok_install_claude_instructions() {
+    local src="/home/dev/.terok/instructions.md"
+    local dst="$HOME/.claude/CLAUDE.md"
+    if [ -f "$src" ]; then
+        mkdir -p "$HOME/.claude"
+        cp "$src" "$dst"
+    fi
+}

--- a/src/terok/resources/scripts/terok-claude-acp
+++ b/src/terok/resources/scripts/terok-claude-acp
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+
+# SPDX-FileCopyrightText: 2025 Jiri Vyskocil
+# SPDX-License-Identifier: Apache-2.0
+
+# ACP wrapper for Claude Code.
+#
+# Sets up git identity, unrestricted mode via managed settings, and
+# per-task instructions before exec-ing the real claude-code-acp adapter.
+
+set -euo pipefail
+
+_AGENT_NAME="Claude"
+_AGENT_EMAIL="noreply@anthropic.com"
+. /usr/local/share/terok/terok-acp-env.sh
+
+# Unrestricted mode: write managed settings (highest precedence in Claude's
+# settings hierarchy — cannot be overridden by user/project settings).
+# init-ssh-and-repo.sh may have already written this, but the ACP wrapper
+# ensures it's present even if init didn't run (e.g. container re-entry).
+if [ "${TEROK_UNRESTRICTED:-}" = "1" ] && [ -d /etc/claude-code ]; then
+    printf '{"permissions":{"defaultMode":"bypassPermissions"}}\n' \
+        > /etc/claude-code/managed-settings.json
+fi
+
+# Instructions: copy to ~/.claude/CLAUDE.md for ACP discovery
+_terok_install_claude_instructions
+
+exec claude-code-acp "$@"

--- a/src/terok/resources/scripts/terok-codex-acp
+++ b/src/terok/resources/scripts/terok-codex-acp
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+# SPDX-FileCopyrightText: 2025 Jiri Vyskocil
+# SPDX-License-Identifier: Apache-2.0
+
+# ACP wrapper for OpenAI Codex.
+#
+# Sets up git identity, unrestricted mode via config.toml, and
+# exec's the real codex-acp adapter via npx.
+
+set -euo pipefail
+
+_AGENT_NAME="Codex"
+_AGENT_EMAIL="noreply@openai.com"
+. /usr/local/share/terok/terok-acp-env.sh
+
+# Unrestricted mode: write ~/.codex/config.toml
+if [ "${TEROK_UNRESTRICTED:-}" = "1" ]; then
+    mkdir -p "$HOME/.codex"
+    cat > "$HOME/.codex/config.toml" <<'TOML'
+approval_policy = "never"
+sandbox_mode = "danger-full-access"
+TOML
+fi
+
+exec npx @zed-industries/codex-acp "$@"

--- a/src/terok/resources/scripts/terok-copilot-acp
+++ b/src/terok/resources/scripts/terok-copilot-acp
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+# SPDX-FileCopyrightText: 2025 Jiri Vyskocil
+# SPDX-License-Identifier: Apache-2.0
+
+# ACP wrapper for GitHub Copilot.
+#
+# Sets up git identity and unrestricted mode via --yolo flag before
+# exec-ing the native copilot ACP adapter.
+
+set -euo pipefail
+
+_AGENT_NAME="Copilot"
+_AGENT_EMAIL="noreply@github.com"
+. /usr/local/share/terok/terok-acp-env.sh
+
+_args=()
+
+# Unrestricted mode: --yolo grants full permissions (tools + paths + URLs).
+if [ "${TEROK_UNRESTRICTED:-}" = "1" ]; then
+    _args+=(--yolo)
+fi
+
+exec copilot "${_args[@]}" --acp "$@"

--- a/src/terok/resources/scripts/terok-opencode-acp
+++ b/src/terok/resources/scripts/terok-opencode-acp
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+# SPDX-FileCopyrightText: 2025 Jiri Vyskocil
+# SPDX-License-Identifier: Apache-2.0
+
+# ACP wrapper for OpenCode.
+#
+# Sets up git identity and unrestricted mode via env var before
+# exec-ing the native opencode acp adapter.
+
+set -euo pipefail
+
+_AGENT_NAME="OpenCode"
+_AGENT_EMAIL="noreply@opencode.ai"
+. /usr/local/share/terok/terok-acp-env.sh
+
+# Unrestricted mode: OPENCODE_PERMISSION env var is merged on top of all
+# config layers (no CLI flag exists for permissions).
+if [ "${TEROK_UNRESTRICTED:-}" = "1" ]; then
+    export OPENCODE_PERMISSION='{"*":"allow"}'
+fi
+
+exec opencode acp "$@"

--- a/src/terok/resources/scripts/terok-vibe-acp
+++ b/src/terok/resources/scripts/terok-vibe-acp
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+# SPDX-FileCopyrightText: 2025 Jiri Vyskocil
+# SPDX-License-Identifier: Apache-2.0
+
+# ACP wrapper for Mistral Vibe.
+#
+# Sets up git identity and unrestricted mode via env var before
+# exec-ing the real vibe-acp adapter (installed via pipx).
+
+set -euo pipefail
+
+_AGENT_NAME="Vibe"
+_AGENT_EMAIL="noreply@mistral.ai"
+. /usr/local/share/terok/terok-acp-env.sh
+
+# Unrestricted mode: VIBE_AUTO_APPROVE env var overrides config via
+# pydantic-settings (case-insensitive, all fields overridable).
+if [ "${TEROK_UNRESTRICTED:-}" = "1" ]; then
+    export VIBE_AUTO_APPROVE=true
+fi
+
+exec vibe-acp "$@"

--- a/src/terok/resources/scripts/toad
+++ b/src/terok/resources/scripts/toad
@@ -1,0 +1,160 @@
+#!/usr/bin/env bash
+
+# SPDX-FileCopyrightText: 2025 Jiri Vyskocil
+# SPDX-License-Identifier: Apache-2.0
+
+# Toad launcher wrapper for terok containers.
+#
+# Seeds launcher.agents into toad.json, injects the Blablador agent TOML,
+# and patches all agent TOMLs to use terok ACP wrappers (which set up git
+# identity, unrestricted mode, and instructions) before launching toad.
+
+set -euo pipefail
+
+TOAD_CONFIG="${HOME}/.config/toad/toad.json"
+TOAD_REAL="${HOME}/.local/share/uv/tools/batrachian-toad/bin/toad"
+
+# Agents pre-installed in the container image (newline-separated identities).
+LAUNCHER_AGENTS="claude.com
+vibe.mistral.ai
+openai.com
+copilot.github.com
+opencode.ai
+blablador.helmholtz.de"
+
+# ---------------------------------------------------------------------------
+# Toad agent data directory (inside the toad package).
+# Resolve dynamically to avoid hardcoding the Python version.
+# ---------------------------------------------------------------------------
+_toad_venv="${HOME}/.local/share/uv/tools/batrachian-toad"
+TOAD_AGENTS_DIR=""
+for _candidate in "${_toad_venv}"/lib/python*/site-packages/toad/data/agents; do
+    [ -d "$_candidate" ] && TOAD_AGENTS_DIR="$_candidate" && break
+done
+unset _candidate _toad_venv
+
+# ---------------------------------------------------------------------------
+# Inject custom agent TOML for Blablador into Toad's package data.
+# Toad only reads agents from its bundled data dir — no user override dir yet.
+# ---------------------------------------------------------------------------
+_inject_blablador_toml() {
+    [[ -n "${TOAD_AGENTS_DIR}" ]] || return 0
+    local toml="${TOAD_AGENTS_DIR}/blablador.helmholtz.de.toml"
+    [[ -f "${toml}" ]] && return 0
+
+    local tmp
+    tmp=$(mktemp "${toml}.XXXXXX" 2>/dev/null) || return 0
+    cat > "${tmp}" << 'TOML_EOF'
+identity = "blablador.helmholtz.de"
+name = "Blablador"
+short_name = "blablador"
+url = "https://helmholtz-blablador.fz-juelich.de/"
+protocol = "acp"
+author_name = "Helmholtz / FZJ"
+author_url = "https://www.fz-juelich.de/"
+publisher_name = "terok"
+publisher_url = "https://github.com/terok-ai/terok"
+type = "coding"
+description = "OpenCode with Helmholtz Blablador — open-source LLMs for German academia."
+tags = []
+run_command."*" = "blablador-acp"
+
+help = '''
+# Blablador
+
+OpenCode powered by Helmholtz Blablador — open-source large language models
+hosted at Forschungszentrum Jülich for the German research community.
+
+Uses the same tools and capabilities as OpenCode, but routes through the
+Blablador API with models like alias-huge and alias-code.
+
+Requires BLABLADOR_API_KEY to be set.
+'''
+
+[actions."*".install]
+command = "echo 'Blablador is pre-installed in terok containers.'"
+description = "Already installed"
+TOML_EOF
+    mv -f "${tmp}" "${toml}" 2>/dev/null \
+        || { echo "Warning: could not install Blablador agent TOML" >&2; rm -f "${tmp}"; }
+}
+
+# ---------------------------------------------------------------------------
+# Patch agent TOMLs to use terok ACP wrappers.
+# Wrappers set up git identity, unrestricted mode, and instructions before
+# exec-ing the real ACP adapter.  Patching is idempotent.
+# ---------------------------------------------------------------------------
+_patch_toml() {
+    local file="$1" original="$2" patched="$3"
+    [ -f "$file" ] || return 0
+    # Skip if already patched
+    grep -qF "\"${patched}\"" "$file" 2>/dev/null && return 0
+    sed -i "s|run_command\\.\"\\*\" = \"${original}\"|run_command.\"*\" = \"${patched}\"|" "$file"
+}
+
+_patch_agent_tomls() {
+    [[ -n "${TOAD_AGENTS_DIR}" ]] || return 0
+
+    _patch_toml "${TOAD_AGENTS_DIR}/claude.com.toml" \
+        "claude-code-acp" "terok-claude-acp"
+
+    _patch_toml "${TOAD_AGENTS_DIR}/openai.com.toml" \
+        'npx @zed-industries/codex-acp' "terok-codex-acp"
+
+    _patch_toml "${TOAD_AGENTS_DIR}/opencode.ai.toml" \
+        "opencode acp" "terok-opencode-acp"
+
+    # blablador-acp: our wrapper is at /usr/local/bin/blablador-acp and the
+    # TOML already points to "blablador-acp" — no patching needed.
+
+    _patch_toml "${TOAD_AGENTS_DIR}/copilot.github.com.toml" \
+        'copilot --acp' "terok-copilot-acp"
+
+    _patch_toml "${TOAD_AGENTS_DIR}/vibe.mistral.ai.toml" \
+        "vibe-acp" "terok-vibe-acp"
+}
+
+# ---------------------------------------------------------------------------
+# Seed launcher.agents into toad.json (ensure all container agents are listed)
+# ---------------------------------------------------------------------------
+_seed_launcher_agents() {
+    command -v jq >/dev/null 2>&1 || return 0
+
+    mkdir -p "$(dirname "${TOAD_CONFIG}")"
+    local existing='{}'
+    if [[ -f "${TOAD_CONFIG}" ]]; then
+        local raw
+        raw=$(cat "${TOAD_CONFIG}" 2>/dev/null || true)
+        existing=$(printf '%s' "${raw}" | jq -e '.' 2>/dev/null) || existing='{}'
+    fi
+
+    local current missing=""
+    current=$(printf '%s' "${existing}" | jq -r '.launcher.agents // ""' 2>/dev/null)
+    while IFS= read -r agent; do
+        [[ -z "${agent}" ]] && continue
+        printf '%s' "${current}" | grep -qF "${agent}" || missing="${missing:+${missing}
+}${agent}"
+    done <<< "${LAUNCHER_AGENTS}"
+
+    if [[ -n "${missing}" ]]; then
+        local new_agents="${current:+${current}
+}${missing}"
+        local updated
+        updated=$(printf '%s' "${existing}" | jq --arg agents "${new_agents}" \
+            '.launcher.agents = $agents' 2>/dev/null) || return 0
+        [[ -n "${updated}" ]] || return 0
+        local tmp
+        tmp=$(mktemp "${TOAD_CONFIG}.XXXXXX") || return 0
+        printf '%s\n' "${updated}" > "${tmp}" && mv -f "${tmp}" "${TOAD_CONFIG}" \
+            || rm -f "${tmp}"
+    fi
+}
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+_inject_blablador_toml
+_patch_agent_tomls
+_seed_launcher_agents
+
+exec "${TOAD_REAL}" "$@"

--- a/src/terok/resources/templates/l1.agent-cli.Dockerfile.template
+++ b/src/terok/resources/templates/l1.agent-cli.Dockerfile.template
@@ -77,11 +77,12 @@ RUN mkdir -p /etc/claude-code && chown dev:dev /etc/claude-code
 COPY scripts/setup-codex-auth.sh /usr/local/bin/setup-codex-auth.sh
 RUN chmod +x /usr/local/bin/setup-codex-auth.sh
 
-# Copy OpenCode session plugin for terok session resume
+# Copy OpenCode session plugin and shared helpers for terok session resume + ACP
 RUN mkdir -p /usr/local/share/terok
 COPY scripts/opencode-session-plugin.mjs /usr/local/share/terok/opencode-session-plugin.mjs
 COPY scripts/terok-git-identity.sh /usr/local/share/terok/terok-git-identity.sh
-RUN chmod +x /usr/local/share/terok/terok-git-identity.sh
+COPY scripts/terok-acp-env.sh /usr/local/share/terok/terok-acp-env.sh
+RUN chmod +x /usr/local/share/terok/terok-git-identity.sh /usr/local/share/terok/terok-acp-env.sh
 
 # Container help banner (available as `hilfe` command, also sourced on login)
 COPY scripts/hilfe /usr/local/bin/hilfe
@@ -93,6 +94,18 @@ COPY scripts/blablador-acp /usr/local/bin/blablador-acp
 COPY scripts/vibe-model-sync.sh /usr/local/bin/vibe-model-sync
 COPY scripts/mistral-model-sync.py /usr/local/bin/mistral-model-sync.py
 RUN chmod +x /usr/local/bin/blablador /usr/local/bin/blablador-acp /usr/local/bin/vibe-model-sync /usr/local/bin/mistral-model-sync.py
+
+# ACP wrappers: set up git identity, unrestricted mode, and instructions
+# before exec-ing the real ACP adapters (used by toad)
+COPY scripts/terok-claude-acp /usr/local/bin/terok-claude-acp
+COPY scripts/terok-codex-acp /usr/local/bin/terok-codex-acp
+COPY scripts/terok-opencode-acp /usr/local/bin/terok-opencode-acp
+COPY scripts/terok-copilot-acp /usr/local/bin/terok-copilot-acp
+COPY scripts/terok-vibe-acp /usr/local/bin/terok-vibe-acp
+COPY scripts/toad /usr/local/bin/toad
+RUN chmod +x /usr/local/bin/terok-claude-acp /usr/local/bin/terok-codex-acp \
+             /usr/local/bin/terok-opencode-acp /usr/local/bin/terok-copilot-acp \
+             /usr/local/bin/terok-vibe-acp /usr/local/bin/toad
 
 # update-all-the-things: refresh all packages without full image rebuild
 COPY scripts/allthethings.sh /usr/local/bin/allthethings.sh


### PR DESCRIPTION
## Summary

Closes #455.

When toad launches agents via ACP, they bypass terok's shell wrappers (`terok-agent.sh` sourced via `/etc/profile.d/`). This means unrestricted mode flags, git identity, and per-task instructions are not applied.

- Add per-agent ACP wrapper scripts that set up the terok environment before `exec`-ing the real ACP adapter
- Add `terok-acp-env.sh` as shared setup (git identity via `terok-git-identity.sh` + instructions helper), sourced by all wrappers
- Formalize the `toad` launcher wrapper: patches agent TOMLs to use terok wrappers, injects Blablador agent TOML, seeds launcher agent list
- Extend `blablador-acp` with git identity and unrestricted mode support

### Per-agent mechanisms

| Wrapper | Unrestricted mechanism | Instructions |
|---------|----------------------|--------------|
| `terok-claude-acp` | `/etc/claude-code/managed-settings.json` (bypassPermissions) | `~/.claude/CLAUDE.md` copy |
| `terok-codex-acp` | `~/.codex/config.toml` (approval_policy=never) | — |
| `terok-opencode-acp` | `OPENCODE_PERMISSION` env var | via opencode.json |
| `blablador-acp` | `OPENCODE_PERMISSION` + `OPENCODE_CONFIG` | via opencode.json |
| `terok-copilot-acp` | `--yolo` flag | — |
| `terok-vibe-acp` | `VIBE_AUTO_APPROVE=true` env var | — |

### Known limitations

- **Claude instructions via ACP**: `~/.claude/CLAUDE.md` is shared across all tasks. Last ACP launch wins. Acceptable for toad (interactive, one session at a time).
- **Codex config**: `~/.codex/config.toml` is shared. Same caveat.

## Test plan

- [x] `make lint` passes
- [x] `make reuse` passes (SPDX headers on all new scripts)
- [x] `make tach` passes (no new cross-module imports)
- [x] `make test` passes (1271 tests)
- [x] Smoke-tested TOML patching: verified idempotent patch + unpatch cycle
- [x] Smoke-tested managed-settings JSON write + Codex config write
- [ ] Manual: build image, start container with `TEROK_UNRESTRICTED=1`, run `toad`, verify Claude session starts without permission prompts and has git identity

🤖 Generated with [Claude Code](https://claude.com/claude-code)