### PR TITLE
fix: recalibrate hilfe output for accuracy and clarity

### DIFF
--- a/src/terok/resources/scripts/hilfe
+++ b/src/terok/resources/scripts/hilfe
@@ -44,8 +44,9 @@ _terok_notes() {
     printf '  - \033[36m/home/dev\033[0m  home dir; several config dirs here are mounted from the host\n'
     printf '                 (.claude, .codex, gh/glab, opencode, optional .ssh)\n'
     printf '  - agent CLI commands above are terok wrappers with git/session defaults\n'
-    printf '  - \033[36msudo update-all-the-things\033[0m updates this running container only\n'
-    printf '  - host/TUI: \033[36mRebuild from L0 with fresh agents\033[0m / \033[36mterokctl build --agents <project>\033[0m\n'
+    printf '  - \033[36msudo update-all-the-things\033[0m updates system packages and agent installs\n'
+    printf '    in this running container only\n'
+    printf '  - host/TUI: \033[36mRebuild from L1 with fresh agents\033[0m / \033[36mterokctl build --agents <project>\033[0m\n'
     printf '    refreshes agent installs for new containers only\n'
     printf '  - host/TUI: \033[36mRebuild from L0 (no cache)\033[0m / \033[36mterokctl build --full-rebuild <project>\033[0m\n'
     printf '    refreshes the base image + apt packages for new containers only\n'
@@ -57,12 +58,7 @@ _terok_permission_mode
 _terok_agents
 
 if [[ "$_mode" == "--kurz" ]]; then
-    if [[ -n "${_TEROK_LOGIN:-}" ]]; then
-        printf '\nRun \033[1mhilfe\033[0m for container tips.\n'
-    else
-        printf '\nRun \033[1mhilfe\033[0m for more container tips.\n'
-    fi
-    printf '\n'
+    printf '\nRun \033[1mhilfe\033[0m for more container tips.\n\n'
     exit 0
 fi
 

--- a/tests/unit/scripts/test_hilfe.py
+++ b/tests/unit/scripts/test_hilfe.py
@@ -46,19 +46,17 @@ def test_hilfe_kurz_keeps_banner_compact() -> None:
     assert "Available AI agents:" in text
     assert "OpenCode with Helmholtz Blablador" in text
     assert "Run hilfe for more container tips." in text
-    assert "Run hilfe for container tips." not in text
     assert "/workspace" not in text
     assert "update-all-the-things" not in text
 
 
 def test_hilfe_kurz_login_flow_message() -> None:
-    """``hilfe --kurz`` uses the shorter hint on login."""
+    """``hilfe --kurz`` uses the same hint on login."""
     result = _run_hilfe("--kurz", _TEROK_LOGIN="1")
     text = _plain(result.stdout)
 
     assert result.returncode == 0
-    assert "Run hilfe for container tips." in text
-    assert "Run hilfe for more container tips." not in text
+    assert "Run hilfe for more container tips." in text
 
 
 def test_hilfe_full_includes_container_notes() -> None:
@@ -70,7 +68,8 @@ def test_hilfe_full_includes_container_notes() -> None:
     assert "/workspace" in text
     assert "/home/dev" in text
     assert "update-all-the-things" in text
-    assert "Rebuild from L0 with fresh agents" in text
+    assert "system packages and agent installs" in text
+    assert "Rebuild from L1 with fresh agents" in text
     assert "Rebuild from L0 (no cache)" in text
     assert "new containers only" in text
     assert "^a" in text


### PR DESCRIPTION
## Summary
- Fix "Rebuild from L0" → "Rebuild from L1" for the `--agents` rebuild hint (L1 is the agent layer)
- Clarify `update-all-the-things` description: "updates system packages and agent installs in this running container only"
- Unify `--kurz` banner to always say "Run hilfe for more container tips." (removes dead login/non-login branch)

## Test plan
- [ ] `hilfe` full output shows corrected L1 reference and expanded update-all-the-things note
- [ ] `hilfe --kurz` shows "Run hilfe for more container tips." in both login and non-login modes
- [ ] Unit tests in `tests/unit/scripts/test_hilfe.py` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified help messages: "update-all-the-things" now specifies it applies only within the running container and updates system packages and agent installs
  * Updated container rebuild instructions to use L1 instead of L0 when working with fresh agents
  * Improved quick help mode to consistently display container tips for better accessibility

<!-- end of auto-generated comment: release notes by coderabbit.ai -->