### PR TITLE
fix: create /usr/local/share/terok/ before symlinking terok-env-wrappers.sh

### DIFF
--- a/src/terok/resources/templates/l1.agent-cli.Dockerfile.template
+++ b/src/terok/resources/templates/l1.agent-cli.Dockerfile.template
@@ -68,7 +68,8 @@ RUN chmod +x /etc/profile.d/terok-env.sh; \
     printf '\n# Mistral model sync (interactive login only)\nif [ -t 1 ] && [ -z "$_MISTRAL_MODEL_SYNC_RUN" ]; then\n  export _MISTRAL_MODEL_SYNC_RUN=1\n  if command -v vibe-model-sync >/dev/null 2>&1; then\n    vibe-model-sync >/dev/null 2>&1 || true\n  fi\nfi\n' >> /etc/bash.bashrc
 
 # Symlink for per-task agent wrappers (resolved at runtime via mount).
-RUN ln -s /home/dev/.terok/terok-agent.sh /usr/local/share/terok/terok-env-wrappers.sh
+RUN mkdir -p /usr/local/share/terok && \
+    ln -s /home/dev/.terok/terok-agent.sh /usr/local/share/terok/terok-env-wrappers.sh
 
 # === Cache bust point ===
 # Changing AGENT_CACHE_BUST invalidates all layers below: terok scripts,


### PR DESCRIPTION
## Summary

Fixes image build failure introduced by #460. The `terok-env-wrappers.sh` symlink (step 13) needs `/usr/local/share/terok/` to exist, but the `mkdir -p` for that directory was only at step 18 (below the cache bust point).

```
STEP 13/45: RUN ln -s /home/dev/.terok/terok-agent.sh /usr/local/share/terok/terok-env-wrappers.sh
ln: failed to create symbolic link '/usr/local/share/terok/terok-env-wrappers.sh': No such file or directory
```

One-line fix: add `mkdir -p` to the symlink RUN.

## Test plan

- [x] `make lint` passes
- [x] `make test` — 1361 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Docker build reliability by ensuring target directories exist before symlink creation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->