### PR TITLE
chore: remove legacy per-agent instruction files

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,3 +1,0 @@
-# Copilot Instructions for terok
-
-Read the instructions in the project's root `/AGENTS.md` for quick reference.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,3 +1,0 @@
-# Project Instructions
-
-@AGENTS.md


### PR DESCRIPTION
## Summary
- Delete `CLAUDE.md` (was `@AGENTS.md` redirect)
- Delete `.github/copilot-instructions.md` (was `AGENTS.md` pointer)

All supported agents now discover `AGENTS.md` natively — the per-agent relay files are redundant.

## Test plan
- [ ] `make check` passes
- [ ] Agents still pick up `AGENTS.md` without the relay files

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed internal documentation references from project configuration files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->