### PR TITLE
chore: upgrade mkdocs-terok to v0.2.2

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1349,13 +1349,13 @@ mkdocs = ">=1.2"
 
 [[package]]
 name = "mkdocs-terok"
-version = "0.2.0"
+version = "0.2.2"
 description = "Shared MkDocs documentation generators for terok projects"
 optional = false
 python-versions = ">=3.12,<4.0"
 groups = ["docs"]
 files = [
-    {file = "mkdocs_terok-0.2.0-py3-none-any.whl", hash = "sha256:e56784522fe7feddb22ee2ca8835c874a61e9338499280b79a13f470d590e024"},
+    {file = "mkdocs_terok-0.2.2-py3-none-any.whl", hash = "sha256:42717cc95df894bfcb7a810a9cb559856c857d3fac8050ead0185d3ace6773da"},
 ]
 
 [package.dependencies]
@@ -1363,7 +1363,7 @@ PyYAML = ">=6.0"
 
 [package.source]
 type = "url"
-url = "https://github.com/terok-ai/mkdocs-terok/releases/download/v0.2.0/mkdocs_terok-0.2.0-py3-none-any.whl"
+url = "https://github.com/terok-ai/mkdocs-terok/releases/download/v0.2.2/mkdocs_terok-0.2.2-py3-none-any.whl"
 
 [[package]]
 name = "mkdocstrings"
@@ -2988,4 +2988,4 @@ propcache = ">=0.2.1"
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.12,<4.0"
-content-hash = "9f1098e58e31e96e7ef99d492bae747bbaa610b75efd4be80df7ea6f1ddeac29"
+content-hash = "2051d233520b291b16c981c7b1d035ce7bfc7ad13a2fa8bbff8d3cf31798dcbf"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,7 +70,7 @@ mkdocstrings = {extras = ["python"], version = ">=0.24"}
 mkdocs-gen-files = ">=0.5"
 mkdocs-literate-nav = ">=0.6"
 mkdocs-section-index = ">=0.3"
-mkdocs-terok = {url = "https://github.com/terok-ai/mkdocs-terok/releases/download/v0.2.0/mkdocs_terok-0.2.0-py3-none-any.whl"}
+mkdocs-terok = {url = "https://github.com/terok-ai/mkdocs-terok/releases/download/v0.2.2/mkdocs_terok-0.2.2-py3-none-any.whl"}
 
 [tool.pytest.ini_options]
 testpaths = ["tests/unit", "tests/integration"]


### PR DESCRIPTION
## Summary
- Bump `mkdocs-terok` from v0.2.0 to v0.2.2
- Fixes coverage treemap SVG not rendering (relative path mismatch with `use_directory_urls`)
- Fixes mermaid zoom overlay not attaching (MutationObserver missed SVG insertion by Material 9.x)

## Test plan
- [ ] `make check` passes
- [ ] Coverage treemap visible on quality report page
- [ ] Mermaid diagrams (e.g. module dependency graph) show zoom overlay on click

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated documentation build tool dependency from v0.2.0 to v0.2.2.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->