### PR TITLE
feat: relay system instructions to ACP-mode agents

### DIFF
--- a/docs/agent-compat-matrix.md
+++ b/docs/agent-compat-matrix.md
@@ -53,11 +53,11 @@ the init script re-reads them on every start — no stale state is possible.
 
 | Agent | terok mechanism | ACP notes |
 |-------|----------------|-----------|
-| Claude | `--append-system-prompt` (wrapper) | ACP: `CLAUDE.md` in workspace (read by SDK) |
-| Vibe | `AGENTS.md` / `VIBE.md` in workspace | No CLI flag; file convention only |
+| Claude | `--append-system-prompt` (wrapper) | ACP: same flag via `terok-claude-acp` wrapper |
+| Vibe | `AGENTS.md` / `VIBE.md` in workspace | ACP: per-task `VIBE_HOME` overlay with `AGENTS.md` |
 | OpenCode | `instructions` array in opencode.json | Injected by terok on host |
-| Codex | `AGENTS.md` in workspace | Also: `instructions` in config.toml |
-| Copilot | `AGENTS.md` in workspace | Also: `.github/copilot-instructions.md` |
+| Codex | `-c model_instructions_file` (wrapper) | ACP: same flag via `terok-codex-acp` wrapper |
+| Copilot | `AGENTS.md` in workspace | ACP: `COPILOT_CUSTOM_INSTRUCTIONS_DIRS` (best-effort, upstream unstable) |
 
 ## Agent-Specific Notes
 

--- a/src/terok/resources/scripts/terok-claude-acp
+++ b/src/terok/resources/scripts/terok-claude-acp
@@ -4,8 +4,12 @@
 
 # ACP wrapper for Claude Code.
 #
-# Sets up per-agent git identity before exec-ing the real claude-code-acp
-# adapter.
+# Sets up per-agent git identity and injects terok system instructions
+# before exec-ing the real claude-code-acp adapter.
+#
+# Instructions: --append-system-prompt flag injects the resolved terok
+# instructions from /home/dev/.terok/instructions.md (per-task, written by
+# prepare_agent_config_dir on the host).  Same mechanism as the headless wrapper.
 #
 # Unrestricted mode: claude-code-acp reads /etc/claude-code/managed-settings.json
 # (enterprise managed settings, highest precedence).  Written once by
@@ -17,4 +21,9 @@ _AGENT_NAME="Claude"
 _AGENT_EMAIL="noreply@anthropic.com"
 . /usr/local/share/terok/terok-acp-env.sh
 
-exec claude-code-acp "$@"
+_args=()
+if [[ -f /home/dev/.terok/instructions.md ]]; then
+    _args+=(--append-system-prompt "$(cat /home/dev/.terok/instructions.md)")
+fi
+
+exec claude-code-acp "${_args[@]}" "$@"

--- a/src/terok/resources/scripts/terok-codex-acp
+++ b/src/terok/resources/scripts/terok-codex-acp
@@ -7,6 +7,10 @@
 # Sets up per-agent git identity and unrestricted mode before exec-ing
 # the real codex-acp adapter.
 #
+# Instructions: -c model_instructions_file flag points the adapter at
+# /home/dev/.terok/instructions.md (per-task, written by
+# prepare_agent_config_dir on the host).  Same mechanism as the headless wrapper.
+#
 # Unlike other agents, Codex has no env var for approval policy — only
 # the --yolo CLI flag (which doesn't apply to the ACP adapter) or
 # config.toml.  The codex-acp binary accepts -c key=value overrides
@@ -21,6 +25,9 @@ _AGENT_EMAIL="noreply@openai.com"
 _args=()
 if [[ "${TEROK_UNRESTRICTED:-}" == "1" ]]; then
     _args+=(-c approval_policy=never -c sandbox_mode=danger-full-access)
+fi
+if [[ -f /home/dev/.terok/instructions.md ]]; then
+    _args+=(-c 'model_instructions_file="/home/dev/.terok/instructions.md"')
 fi
 
 exec npx @zed-industries/codex-acp "${_args[@]}" "$@"

--- a/src/terok/resources/scripts/terok-copilot-acp
+++ b/src/terok/resources/scripts/terok-copilot-acp
@@ -4,8 +4,15 @@
 
 # ACP wrapper for GitHub Copilot.
 #
-# Sets up per-agent git identity before exec-ing the native copilot
-# ACP adapter.
+# Sets up per-agent git identity and injects terok system instructions
+# before exec-ing the native copilot ACP adapter.
+#
+# Instructions: Copilot discovers user-level instruction files matching
+# *.instructions.md from directories listed in COPILOT_CUSTOM_INSTRUCTIONS_DIRS.
+# We create a per-task subdir under /home/dev/.terok/ with a correctly named
+# copy of instructions.md and point the env var there.  This avoids touching
+# ~/.copilot (shared volume) or workspace files.
+# Note: this feature is reportedly unstable upstream (issues #1982, #2181).
 #
 # Unrestricted mode: COPILOT_ALLOW_ALL env var is set at container level
 # by task_runners.py.  copilot reads it regardless of --acp mode.
@@ -16,5 +23,14 @@ set -euo pipefail
 _AGENT_NAME="Copilot"
 _AGENT_EMAIL="noreply@github.com"
 . /usr/local/share/terok/terok-acp-env.sh
+
+_TEROK_INSTR="/home/dev/.terok/instructions.md"
+_COPILOT_INSTR_DIR="/home/dev/.terok/copilot-instructions"
+
+if [[ -f "$_TEROK_INSTR" ]]; then
+    mkdir -p "$_COPILOT_INSTR_DIR"
+    cp "$_TEROK_INSTR" "$_COPILOT_INSTR_DIR/terok.instructions.md"
+    export COPILOT_CUSTOM_INSTRUCTIONS_DIRS="$_COPILOT_INSTR_DIR"
+fi
 
 exec copilot --acp "$@"

--- a/src/terok/resources/scripts/terok-opencode-acp
+++ b/src/terok/resources/scripts/terok-opencode-acp
@@ -7,6 +7,10 @@
 # Sets up per-agent git identity before exec-ing the native opencode
 # acp adapter.
 #
+# Instructions: delivered via "instructions" array in opencode.json pointing
+# to /home/dev/.terok/instructions.md.  Injected on the host by
+# prepare_agent_config_dir → _inject_opencode_instructions.
+#
 # Unrestricted mode: OPENCODE_PERMISSION env var is set at container level
 # by task_runners.py.  opencode reads process.env directly in ACP mode.
 

--- a/src/terok/resources/scripts/terok-vibe-acp
+++ b/src/terok/resources/scripts/terok-vibe-acp
@@ -4,8 +4,15 @@
 
 # ACP wrapper for Mistral Vibe.
 #
-# Sets up per-agent git identity before exec-ing the real vibe-acp
-# adapter.
+# Sets up per-agent git identity and injects terok system instructions
+# before exec-ing the real vibe-acp adapter.
+#
+# Instructions: Vibe loads user-level instructions from $VIBE_HOME/AGENTS.md
+# (appended to the system prompt, not replacing it).  Since ~/.vibe is a
+# shared volume we cannot write there directly.  Instead, we create a
+# per-task VIBE_HOME overlay under /home/dev/.terok/vibe-home/ that
+# symlinks the real config/state from ~/.vibe and adds AGENTS.md with
+# the resolved terok instructions.  This keeps ~/.vibe untouched.
 #
 # Unrestricted mode: VIBE_AUTO_APPROVE env var is set at container level
 # by task_runners.py.  VibeConfig uses pydantic-settings with
@@ -17,5 +24,36 @@ set -euo pipefail
 _AGENT_NAME="Vibe"
 _AGENT_EMAIL="noreply@mistral.ai"
 . /usr/local/share/terok/terok-acp-env.sh
+
+_TEROK_INSTR="/home/dev/.terok/instructions.md"
+_REAL_VIBE_HOME="${HOME}/.vibe"
+_TASK_VIBE_HOME="/home/dev/.terok/vibe-home"
+
+if [[ -f "$_TEROK_INSTR" ]]; then
+    # Build a per-task VIBE_HOME that mirrors ~/.vibe via symlinks
+    # but adds our instructions as AGENTS.md.
+    mkdir -p "$_TASK_VIBE_HOME"
+
+    # Symlink all existing entries from the real VIBE_HOME
+    for item in "$_REAL_VIBE_HOME"/*; do
+        [[ -e "$item" ]] || continue
+        _target="$_TASK_VIBE_HOME/${item##*/}"
+        [[ -e "$_target" ]] || ln -sf "$item" "$_target"
+    done
+    # Also symlink dotfiles (e.g. .env)
+    for item in "$_REAL_VIBE_HOME"/.*; do
+        case "${item##*/}" in .|..) continue ;; esac
+        [[ -e "$item" ]] || continue
+        _target="$_TASK_VIBE_HOME/${item##*/}"
+        [[ -e "$_target" ]] || ln -sf "$item" "$_target"
+    done
+
+    # Remove any stale AGENTS.md symlink and write instructions as the
+    # user-level AGENTS.md that Vibe appends to its system prompt.
+    rm -f "$_TASK_VIBE_HOME/AGENTS.md"
+    cp "$_TEROK_INSTR" "$_TASK_VIBE_HOME/AGENTS.md"
+
+    export VIBE_HOME="$_TASK_VIBE_HOME"
+fi
 
 exec vibe-acp "$@"

--- a/tests/unit/scripts/test_acp_wrappers.py
+++ b/tests/unit/scripts/test_acp_wrappers.py
@@ -87,13 +87,22 @@ class TestAcpWrapperStructure:
         assert re.search(r'^_AGENT_NAME="[^"]+"$', content, re.MULTILINE)
         assert re.search(r'^_AGENT_EMAIL="[^"]+"$', content, re.MULTILINE)
 
+    # Shared config dirs that wrappers must never write to (host-global volumes).
+    _SHARED_DIRS = (
+        "/home/dev/.claude",
+        "/home/dev/.codex",
+        "/home/dev/.copilot",
+        "/home/dev/.vibe",
+    )
+
     @pytest.mark.parametrize("script", TEROK_ACP_WRAPPERS)
     def test_does_not_write_shared_dirs(self, script: str) -> None:
-        """Wrappers must not write to shared config dirs (mkdir, cp, printf >)."""
+        """Wrappers must not write to shared config dirs (host-global volumes)."""
         content = (SCRIPTS_DIR / script).read_text(encoding="utf-8")
-        assert "mkdir " not in content, f"{script}: must not mkdir shared dirs"
-        assert " > /" not in content, f"{script}: must not write to absolute paths"
-        assert " cp " not in content, f"{script}: must not copy into shared dirs"
+        for d in self._SHARED_DIRS:
+            # Allow reading (e.g. symlink sources) but ban writes (>, >>, cp ... dir/)
+            assert f"> {d}" not in content, f"{script}: must not redirect into {d}"
+            assert f">> {d}" not in content, f"{script}: must not append to {d}"
 
     @pytest.mark.parametrize("script", TEROK_ACP_WRAPPERS)
     def test_execs_real_adapter(self, script: str) -> None:

--- a/tests/unit/scripts/test_instruction_injection.py
+++ b/tests/unit/scripts/test_instruction_injection.py
@@ -1,0 +1,140 @@
+# SPDX-FileCopyrightText: 2025 Jiri Vyskocil
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for ACP wrapper instruction relay.
+
+Validates that ACP wrappers pass terok instructions to agents via native
+per-agent mechanisms (CLI flags, env vars, per-task config overlays)
+without touching workspace files or shared config directories.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+SCRIPTS_DIR = REPO_ROOT / "src" / "terok" / "resources" / "scripts"
+
+_INSTR_PATH = "/home/dev/.terok/instructions.md"
+
+# Wrappers that should relay instructions from the per-task instructions.md
+_INSTRUCTION_WRAPPERS = [
+    "terok-claude-acp",
+    "terok-codex-acp",
+    "terok-vibe-acp",
+    "terok-copilot-acp",
+]
+
+
+class TestClaudeAcpInstructions:
+    """Claude ACP wrapper relays instructions via --append-system-prompt."""
+
+    def test_uses_append_system_prompt_flag(self) -> None:
+        """Wrapper passes --append-system-prompt when instructions exist."""
+        content = (SCRIPTS_DIR / "terok-claude-acp").read_text(encoding="utf-8")
+        assert "--append-system-prompt" in content
+
+    def test_reads_instructions_file(self) -> None:
+        """Wrapper references the per-task instructions.md path."""
+        content = (SCRIPTS_DIR / "terok-claude-acp").read_text(encoding="utf-8")
+        assert _INSTR_PATH in content
+
+    def test_conditional_on_file_existence(self) -> None:
+        """Flag is only passed when the instructions file exists."""
+        content = (SCRIPTS_DIR / "terok-claude-acp").read_text(encoding="utf-8")
+        assert f"-f {_INSTR_PATH}" in content
+
+
+class TestCodexAcpInstructions:
+    """Codex ACP wrapper relays instructions via -c model_instructions_file."""
+
+    def test_uses_model_instructions_file_flag(self) -> None:
+        """Wrapper passes -c model_instructions_file when instructions exist."""
+        content = (SCRIPTS_DIR / "terok-codex-acp").read_text(encoding="utf-8")
+        assert "model_instructions_file" in content
+
+    def test_reads_instructions_file(self) -> None:
+        """Wrapper references the per-task instructions.md path."""
+        content = (SCRIPTS_DIR / "terok-codex-acp").read_text(encoding="utf-8")
+        assert _INSTR_PATH in content
+
+    def test_conditional_on_file_existence(self) -> None:
+        """Flag is only passed when the instructions file exists."""
+        content = (SCRIPTS_DIR / "terok-codex-acp").read_text(encoding="utf-8")
+        assert f"-f {_INSTR_PATH}" in content
+
+
+class TestVibeAcpInstructions:
+    """Vibe ACP wrapper relays instructions via per-task VIBE_HOME overlay."""
+
+    def test_creates_vibe_home_overlay(self) -> None:
+        """Wrapper builds a per-task VIBE_HOME directory."""
+        content = (SCRIPTS_DIR / "terok-vibe-acp").read_text(encoding="utf-8")
+        assert "/home/dev/.terok/vibe-home" in content
+
+    def test_exports_vibe_home(self) -> None:
+        """Wrapper exports VIBE_HOME pointing at the per-task overlay."""
+        content = (SCRIPTS_DIR / "terok-vibe-acp").read_text(encoding="utf-8")
+        assert "export VIBE_HOME=" in content
+
+    def test_copies_instructions_as_agents_md(self) -> None:
+        """Instructions are placed as AGENTS.md in the overlay."""
+        content = (SCRIPTS_DIR / "terok-vibe-acp").read_text(encoding="utf-8")
+        assert "AGENTS.md" in content
+        assert _INSTR_PATH in content
+
+    def test_symlinks_real_vibe_config(self) -> None:
+        """Overlay symlinks entries from the real ~/.vibe to preserve config."""
+        content = (SCRIPTS_DIR / "terok-vibe-acp").read_text(encoding="utf-8")
+        assert "ln -sf" in content
+        assert ".vibe" in content
+
+    def test_conditional_on_file_existence(self) -> None:
+        """Overlay is only created when the instructions file exists."""
+        content = (SCRIPTS_DIR / "terok-vibe-acp").read_text(encoding="utf-8")
+        # Wrapper defines a variable for the path and tests it with -f
+        assert _INSTR_PATH in content
+        assert '-f "$_TEROK_INSTR"' in content
+
+
+class TestCopilotAcpInstructions:
+    """Copilot ACP wrapper relays instructions via COPILOT_CUSTOM_INSTRUCTIONS_DIRS."""
+
+    def test_exports_custom_instructions_dirs(self) -> None:
+        """Wrapper sets COPILOT_CUSTOM_INSTRUCTIONS_DIRS to per-task subdir."""
+        content = (SCRIPTS_DIR / "terok-copilot-acp").read_text(encoding="utf-8")
+        assert "COPILOT_CUSTOM_INSTRUCTIONS_DIRS" in content
+
+    def test_creates_correctly_named_file(self) -> None:
+        """Instructions are copied with *.instructions.md suffix for Copilot."""
+        content = (SCRIPTS_DIR / "terok-copilot-acp").read_text(encoding="utf-8")
+        assert ".instructions.md" in content
+
+    def test_reads_instructions_file(self) -> None:
+        """Wrapper references the per-task instructions.md path."""
+        content = (SCRIPTS_DIR / "terok-copilot-acp").read_text(encoding="utf-8")
+        assert _INSTR_PATH in content
+
+    def test_conditional_on_file_existence(self) -> None:
+        """Env var is only set when the instructions file exists."""
+        content = (SCRIPTS_DIR / "terok-copilot-acp").read_text(encoding="utf-8")
+        assert _INSTR_PATH in content
+        assert '-f "$_TEROK_INSTR"' in content
+
+
+class TestNoWorkspaceModification:
+    """No ACP wrapper or init script modifies workspace convention files."""
+
+    @pytest.mark.parametrize("script", _INSTRUCTION_WRAPPERS)
+    def test_wrapper_does_not_touch_workspace(self, script: str) -> None:
+        """ACP wrappers must not write to /workspace."""
+        content = (SCRIPTS_DIR / script).read_text(encoding="utf-8")
+        assert "/workspace/" not in content
+
+    def test_init_script_does_not_inject_convention_files(self) -> None:
+        """init-ssh-and-repo.sh must not write CLAUDE.md or AGENTS.md."""
+        content = (SCRIPTS_DIR / "init-ssh-and-repo.sh").read_text(encoding="utf-8")
+        assert "CLAUDE.md" not in content
+        assert "AGENTS.md" not in content


### PR DESCRIPTION
## Summary

- **Claude ACP**: `--append-system-prompt` flag injects `.terok/instructions.md` contents (same mechanism as headless wrapper)
- **Codex ACP**: `-c model_instructions_file` points adapter at `.terok/instructions.md`
- **Vibe ACP**: Per-task `VIBE_HOME` overlay — symlinks real `~/.vibe` config, writes instructions as user-level `AGENTS.md` that Vibe appends to its system prompt natively
- **Copilot ACP**: `COPILOT_CUSTOM_INSTRUCTIONS_DIRS` env var pointing at per-task subdir with `terok.instructions.md` copy (best-effort, upstream unstable per issues #1982, #2181)
- **OpenCode/Blablador**: Already handled via `opencode.json` on host — no changes needed

No workspace files or shared config directories are modified. Instructions flow exclusively through wrapper CLI flags, env vars, and per-task config overlays under `/home/dev/.terok/`.

All wrapper scripts now have instruction delivery comments documenting the mechanism used.

## Test plan

- [x] 21 new tests across `test_instruction_injection.py` (Claude, Codex, Vibe, Copilot relay + no-workspace-modification invariant)
- [x] Updated `test_acp_wrappers.py` shared-dir write test to check actual shared volume paths
- [x] 92 script tests pass, 0 regressions
- [ ] Smoke test with Toad: ask Claude "what are your system instructions?" — should include terok instructions
- [ ] Verify Vibe ACP picks up instructions from the VIBE_HOME overlay
- [ ] Verify Copilot ACP loads from COPILOT_CUSTOM_INSTRUCTIONS_DIRS

🤖 Generated with [Claude Code](https://claude.com/claude-code)