### PR TITLE
refactor: decouple sandbox layer from ProjectConfig and core.config

### DIFF
--- a/src/terok/cli/commands/setup.py
+++ b/src/terok/cli/commands/setup.py
@@ -10,13 +10,12 @@ import argparse
 from ...lib.core.projects import load_project
 from ...lib.domain.facade import (
     AUTH_PROVIDERS,
-    GitGate,
-    SSHManager,
     authenticate,
     build_images,
     generate_dockerfiles,
     maybe_pause_for_ssh_key_registration,
 )
+from ...lib.domain.project import make_git_gate, make_ssh_manager
 from ._completers import complete_project_ids as _complete_project_ids, set_completer
 
 
@@ -118,14 +117,14 @@ def dispatch(args: argparse.Namespace) -> bool:
         )
         return True
     if args.cmd == "ssh-init":
-        SSHManager(load_project(args.project_id)).init(
+        make_ssh_manager(load_project(args.project_id)).init(
             key_type=getattr(args, "key_type", "ed25519"),
             key_name=getattr(args, "key_name", None),
             force=getattr(args, "force", False),
         )
         return True
     if args.cmd == "gate-sync":
-        res = GitGate(load_project(args.project_id)).sync(
+        res = make_git_gate(load_project(args.project_id)).sync(
             force_reinit=getattr(args, "force_reinit", False),
         )
         if not res["success"]:
@@ -149,7 +148,7 @@ def cmd_project_init(project_id: str) -> None:
     project = load_project(project_id)
 
     print("==> Initializing SSH...")
-    SSHManager(project).init()
+    make_ssh_manager(project).init()
     maybe_pause_for_ssh_key_registration(project_id)
 
     print("==> Generating Dockerfiles...")
@@ -159,7 +158,7 @@ def cmd_project_init(project_id: str) -> None:
     build_images(project_id)
 
     print("==> Syncing git gate...")
-    res = GitGate(project).sync()
+    res = make_git_gate(project).sync()
     if not res["success"]:
         raise SystemExit(f"Gate sync failed: {', '.join(res['errors'])}")
     print(f"Gate ready at {res['path']}")

--- a/src/terok/cli/commands/shield.py
+++ b/src/terok/cli/commands/shield.py
@@ -42,8 +42,7 @@ def _resolve_task(project_id: str, task_id: str) -> tuple[str, Path]:
         ValueError: If the task has never been run (no container exists).
     """
     from ...lib.core.projects import load_project
-    from ...lib.orchestration.tasks import load_task_meta
-    from ...lib.sandbox.runtime import container_name
+    from ...lib.orchestration.tasks import container_name, load_task_meta
 
     project = load_project(project_id)
     meta, _ = load_task_meta(project.id, task_id)

--- a/src/terok/cli/commands/sickbay.py
+++ b/src/terok/cli/commands/sickbay.py
@@ -27,8 +27,8 @@ from ...lib.core.project_model import ProjectConfig
 from ...lib.core.projects import list_projects, load_project
 from ...lib.domain.facade import check_units_outdated, get_server_status, is_systemd_available
 from ...lib.orchestration.hooks import run_hook
-from ...lib.orchestration.tasks import tasks_meta_dir
-from ...lib.sandbox.runtime import container_name, get_container_state
+from ...lib.orchestration.tasks import container_name, tasks_meta_dir
+from ...lib.sandbox.runtime import get_container_state
 from ...lib.util.yaml import load as _yaml_load
 
 # Type alias for check results: (severity, label, detail)

--- a/src/terok/lib/domain/facade.py
+++ b/src/terok/lib/domain/facade.py
@@ -68,7 +68,6 @@ from ..sandbox.gate_server import (  # noqa: F401 — re-exported public API
 from ..sandbox.git_gate import (
     GateStalenessInfo,
     GitGate,
-    find_projects_sharing_gate,
 )
 from ..sandbox.shield import (  # noqa: F401 — re-exported public API
     EnvironmentCheck,
@@ -94,6 +93,9 @@ from .project import (  # noqa: F401 — re-exported public API
     DeleteProjectResult,
     Project,
     delete_project,
+    find_projects_sharing_gate,
+    make_git_gate,
+    make_ssh_manager,
 )
 from .project_state import get_project_state, is_task_image_old
 from .task import Task  # noqa: F401 — re-exported public API
@@ -187,6 +189,8 @@ __all__ = [
     # Security setup
     "SSHManager",
     "GitGate",
+    "make_ssh_manager",
+    "make_git_gate",
     # Workflow helpers
     "maybe_pause_for_ssh_key_registration",
     # Auth

--- a/src/terok/lib/domain/project.py
+++ b/src/terok/lib/domain/project.py
@@ -70,7 +70,7 @@ from ..orchestration.tasks import (
     task_delete,
     task_new,
 )
-from ..sandbox.git_gate import GitGate, find_projects_sharing_gate
+from ..sandbox.git_gate import GitGate
 from ..sandbox.ssh import SSHManager
 from ..util.fs import archive_timestamp, create_archive_file
 from .project_state import get_project_state, is_task_image_old
@@ -92,6 +92,103 @@ def _is_under_terok_root(path: Path) -> bool:
     resolved = path.resolve()
     managed_roots = [config_root(), state_root(), get_envs_base_dir(), build_root()]
     return any(resolved == root or root in resolved.parents for root in managed_roots)
+
+
+# ---------------------------------------------------------------------------
+# Gate sharing validation (multi-project coordination — terok policy)
+# ---------------------------------------------------------------------------
+
+
+def find_projects_sharing_gate(
+    gate_path: Path, exclude_project: str | None = None
+) -> list[tuple[str, str | None]]:
+    """Find all projects configured to use the same gate path.
+
+    Args:
+        gate_path: The gate path to check for
+        exclude_project: Project ID to exclude from results (usually the current project)
+
+    Returns:
+        List of (project_id, upstream_url) tuples for projects sharing this gate
+    """
+    from ..core.projects import list_projects as _list_projects
+
+    gate_path = gate_path.resolve()
+    return [
+        (project.id, project.upstream_url)
+        for project in _list_projects()
+        if project.id != exclude_project and project.gate_path.resolve() == gate_path
+    ]
+
+
+def validate_gate_upstream_match(project_id: str) -> None:
+    """Validate that no other project uses the same gate with a different upstream.
+
+    Raises SystemExit if another project uses the same gate path but has a
+    different upstream_url configured.
+
+    Args:
+        project_id: The project to validate
+    """
+    project = load_project(project_id)
+    sharing = find_projects_sharing_gate(project.gate_path, exclude_project=project_id)
+
+    for other_id, other_url in sharing:
+        if other_url is None or project.upstream_url is None or other_url != project.upstream_url:
+            this_display = (
+                project.upstream_url if project.upstream_url is not None else "<not configured>"
+            )
+            other_display = other_url if other_url is not None else "<not configured>"
+            missing_note = ""
+            if other_url is None or project.upstream_url is None:
+                missing_note = (
+                    "\nNote: One or more projects sharing this gate do not have an "
+                    "upstream_url configured in project.yml.\n"
+                )
+            raise SystemExit(
+                f"Gate path conflict detected!\n"
+                f"\n"
+                f"  Gate path: {project.gate_path}\n"
+                f"\n"
+                f"  This project ({project_id}):\n"
+                f"    upstream_url: {this_display}\n"
+                f"\n"
+                f"  Conflicting project ({other_id}):\n"
+                f"    upstream_url: {other_display}\n"
+                f"\n"
+                f"Projects sharing a gate must have the same upstream_url.\n"
+                f"Either change the gate.path in one project's project.yml,\n"
+                f"or ensure both projects point to the same upstream repository.\n"
+                f"{missing_note}"
+            )
+
+
+def make_git_gate(config: ProjectConfig) -> GitGate:
+    """Construct a :class:`GitGate` from a :class:`ProjectConfig` (adapter factory).
+
+    Injects ``validate_gate_upstream_match`` as the gate validation callback.
+    """
+    return GitGate(
+        project_id=config.id,
+        gate_path=config.gate_path,
+        upstream_url=config.upstream_url,
+        default_branch=config.default_branch,
+        ssh_host_dir=config.ssh_host_dir,
+        ssh_key_name=config.ssh_key_name,
+        envs_base_dir=get_envs_base_dir(),
+        validate_gate_fn=validate_gate_upstream_match,
+    )
+
+
+def make_ssh_manager(config: ProjectConfig) -> SSHManager:
+    """Construct an :class:`SSHManager` from a :class:`ProjectConfig` (adapter factory)."""
+    return SSHManager(
+        project_id=config.id,
+        ssh_host_dir=config.ssh_host_dir,
+        ssh_key_name=config.ssh_key_name,
+        ssh_config_template=config.ssh_config_template,
+        envs_base_dir=get_envs_base_dir(),
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -411,14 +508,14 @@ class Project:
     def gate(self) -> GitGate:
         """Return the project-scoped git gate manager (lazy-initialized)."""
         if self._gate is None:
-            self._gate = GitGate(self._config)
+            self._gate = make_git_gate(self._config)
         return self._gate
 
     @property
     def ssh(self) -> SSHManager:
         """Return the project-scoped SSH manager (lazy-initialized)."""
         if self._ssh is None:
-            self._ssh = SSHManager(self._config)
+            self._ssh = make_ssh_manager(self._config)
         return self._ssh
 
     # --- Agent config ---

--- a/src/terok/lib/domain/task_logs.py
+++ b/src/terok/lib/domain/task_logs.py
@@ -16,8 +16,8 @@ from dataclasses import dataclass
 from pathlib import Path
 
 from ..core.projects import load_project
-from ..orchestration.tasks import tasks_meta_dir
-from ..sandbox.runtime import container_name, get_container_state
+from ..orchestration.tasks import container_name, tasks_meta_dir
+from ..sandbox.runtime import get_container_state
 from ..util.yaml import load as _yaml_load
 from .log_format import auto_detect_formatter
 

--- a/src/terok/lib/orchestration/container_exec.py
+++ b/src/terok/lib/orchestration/container_exec.py
@@ -10,8 +10,13 @@ scripts executing with host privileges.
 
 import subprocess
 
-from ..sandbox.runtime import container_name, get_container_state
+from ..sandbox.runtime import get_container_state
 from ..util.logging_utils import _log_debug
+
+
+def _container_name(project_id: str, mode: str, task_id: str) -> str:
+    """Inline container naming to avoid circular import with tasks."""
+    return f"{project_id}-{mode}-{task_id}"
 
 
 def _podman_start(cname: str) -> bool:
@@ -67,7 +72,7 @@ def container_git_diff(
     ``/workspace`` path — the host ``workspace-dangerous`` path is never
     passed to any subprocess.
     """
-    cname = container_name(project_id, mode, task_id)
+    cname = _container_name(project_id, mode, task_id)
     state = get_container_state(cname)
 
     if state is None:

--- a/src/terok/lib/orchestration/task_runners.py
+++ b/src/terok/lib/orchestration/task_runners.py
@@ -24,7 +24,6 @@ from ..instrumentation.agent_config import resolve_agent_config, resolve_provide
 from ..instrumentation.agents import AgentConfigSpec, prepare_agent_config_dir
 from ..instrumentation.instructions import resolve_instructions
 from ..sandbox.runtime import (
-    container_name,
     get_container_state,
     gpu_run_args,
     is_container_running,
@@ -50,6 +49,7 @@ from .environment import build_task_env_and_volumes
 from .hooks import run_hook
 from .ports import assign_web_port
 from .tasks import (
+    container_name,
     load_task_meta,
     task_new,
     update_task_exit_code,
@@ -340,7 +340,7 @@ def _run_container(
     else:
         cmd += _shield_pre_start_impl(cname, task_dir)
 
-    cmd += gpu_run_args(project)
+    cmd += gpu_run_args(project.root)
     if extra_args:
         cmd += extra_args
     for v in volumes:

--- a/src/terok/lib/orchestration/tasks.py
+++ b/src/terok/lib/orchestration/tasks.py
@@ -29,7 +29,6 @@ from ..core.task_display import (
 )
 from ..core.work_status import read_work_status
 from ..sandbox.runtime import (
-    container_name,
     get_container_state,
     get_project_container_states,
     stop_task_containers,
@@ -46,6 +45,23 @@ from ..util.host_cmd import WORKSPACE_DANGEROUS_DIRNAME
 from ..util.logging_utils import _log_debug
 from ..util.yaml import dump as _yaml_dump, load as _yaml_load
 from .container_exec import container_git_diff
+
+# ---------- Container naming (orchestration policy) ----------
+
+CONTAINER_MODES = ("cli", "web", "run", "toad")
+
+
+def container_name(project_id: str, mode: str, task_id: str) -> str:
+    """Return the canonical container name for a task."""
+    return f"{project_id}-{mode}-{task_id}"
+
+
+def get_task_container_state(project_id: str, task_id: str, mode: str | None) -> str | None:
+    """Get actual container state for a task (TUI helper)."""
+    if not mode:
+        return None
+    cname = container_name(project_id, mode, task_id)
+    return get_container_state(cname)
 
 
 @dataclass(kw_only=True)
@@ -691,7 +707,8 @@ def _task_delete(project: ProjectConfig, task_id: str) -> None:
         _log_debug(f"task_delete: token revoke failed: {exc}")
 
     _log_debug("task_delete: calling _stop_task_containers")
-    stop_task_containers(project, str(task_id))
+    names = [container_name(project.id, mode, str(task_id)) for mode in CONTAINER_MODES]
+    stop_task_containers(names)
     _log_debug("task_delete: _stop_task_containers returned")
 
     if mode:

--- a/src/terok/lib/sandbox/config.py
+++ b/src/terok/lib/sandbox/config.py
@@ -1,0 +1,83 @@
+# SPDX-FileCopyrightText: 2026 Jiri Vyskocil
+# SPDX-License-Identifier: Apache-2.0
+
+"""Sandbox configuration — plain dataclass for standalone and embedded use.
+
+:class:`SandboxConfig` captures directory paths and settings that sandbox
+modules need.  In standalone ``terok-sandbox`` use, it is resolved from
+environment variables and XDG defaults.  When embedded in terok, the
+orchestration layer constructs it from :func:`core.config` values.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from .paths import (
+    config_root as _config_root,
+    runtime_root as _runtime_root,
+    state_root as _state_root,
+)
+
+
+@dataclass(frozen=True)
+class SandboxConfig:
+    """Immutable configuration for the sandbox layer.
+
+    All paths default to the XDG/FHS-resolved values from ``core.paths``.
+    Override individual fields when constructing from terok's global config
+    or when using terok-sandbox standalone.
+    """
+
+    state_dir: Path = field(default_factory=_state_root)
+    """Writable state root (tokens, gate repos, task data)."""
+
+    runtime_dir: Path = field(default_factory=_runtime_root)
+    """Transient runtime directory (PID files, sockets)."""
+
+    config_dir: Path = field(default_factory=_config_root)
+    """Configuration root (shield profiles)."""
+
+    envs_dir: Path | None = None
+    """Base directory for per-project environment data (SSH dirs, etc.).
+
+    When ``None``, individual modules fall back to ``state_dir / "envs"``.
+    """
+
+    gate_port: int = 9418
+    """HTTP port for the gate server."""
+
+    shield_profiles: tuple[str, ...] = ("dev-standard",)
+    """Shield egress firewall profile names."""
+
+    shield_audit: bool = True
+    """Whether shield audit logging is enabled."""
+
+    shield_bypass: bool = False
+    """DANGEROUS: when True, the egress firewall is completely disabled."""
+
+    @property
+    def effective_envs_dir(self) -> Path:
+        """Return *envs_dir* or the default ``state_dir / "envs"``."""
+        return self.envs_dir or self.state_dir / "envs"
+
+    @property
+    def gate_base_path(self) -> Path:
+        """Return the gate server's repo base path."""
+        return self.state_dir / "gate"
+
+    @property
+    def token_file_path(self) -> Path:
+        """Return the path to the gate token file."""
+        return self.state_dir / "gate" / "tokens.json"
+
+    @property
+    def pid_file_path(self) -> Path:
+        """Return the PID file path for the managed gate daemon."""
+        return self.runtime_dir / "gate-server.pid"
+
+    @property
+    def shield_profiles_dir(self) -> Path:
+        """Return the directory for terok-managed shield profiles."""
+        return self.config_dir / "shield" / "profiles"

--- a/src/terok/lib/sandbox/gate_server.py
+++ b/src/terok/lib/sandbox/gate_server.py
@@ -34,8 +34,7 @@ import subprocess
 from dataclasses import dataclass
 from pathlib import Path
 
-from ..core.config import get_global_section, state_root
-from ..core.paths import runtime_root
+from .config import SandboxConfig
 
 # ---------- Constants ----------
 
@@ -51,19 +50,24 @@ _SOCKET_UNIT = "terok-gate.socket"
 # ---------- Config helpers ----------
 
 
-def _get_port() -> int:
+def _cfg(cfg: SandboxConfig | None = None) -> SandboxConfig:
+    """Return *cfg* or a default :class:`SandboxConfig`."""
+    return cfg or SandboxConfig()
+
+
+def _get_port(cfg: SandboxConfig | None = None) -> int:
     """Return the configured gate server port (default 9418)."""
-    return int(get_global_section("gate_server").get("port", _DEFAULT_PORT))
+    return _cfg(cfg).gate_port
 
 
-def _get_gate_base_path() -> Path:
+def _get_gate_base_path(cfg: SandboxConfig | None = None) -> Path:
     """Return the base path for the gate server (where gate repos live)."""
-    return state_root() / "gate"
+    return _cfg(cfg).gate_base_path
 
 
-def _pid_file() -> Path:
+def _pid_file(cfg: SandboxConfig | None = None) -> Path:
     """Return the path to the PID file for the managed daemon."""
-    return runtime_root() / "gate-server.pid"
+    return _cfg(cfg).pid_file_path
 
 
 def _systemd_unit_dir() -> Path:

--- a/src/terok/lib/sandbox/gate_tokens.py
+++ b/src/terok/lib/sandbox/gate_tokens.py
@@ -23,22 +23,22 @@ import tempfile
 from collections.abc import Iterator
 from pathlib import Path
 
-from ..core.config import state_root
+from .config import SandboxConfig
 
 
-def token_file_path() -> Path:
+def token_file_path(cfg: SandboxConfig | None = None) -> Path:
     """Return the path to the shared token file."""
-    return state_root() / "gate" / "tokens.json"
+    return (cfg or SandboxConfig()).token_file_path
 
 
-def create_token(project_id: str, task_id: str) -> str:
+def create_token(project_id: str, task_id: str, cfg: SandboxConfig | None = None) -> str:
     """Generate a 128-bit hex token, persist atomically, and return it.
 
     Uses ``secrets.token_hex(16)`` for cryptographic randomness.
     Atomic write via ``tempfile`` + ``os.replace()``.
     """
     token = secrets.token_hex(16)
-    path = token_file_path()
+    path = token_file_path(cfg)
     with _token_lock(path):
         tokens = _read_tokens(path)
         tokens[token] = {"project": project_id, "task": task_id}

--- a/src/terok/lib/sandbox/git_gate.py
+++ b/src/terok/lib/sandbox/git_gate.py
@@ -8,14 +8,11 @@ In **gatekeeping mode**, it is the *only* repository the container can access,
 enforcing human review before changes reach upstream.  In **online mode**, it
 serves as a read-only clone accelerator (faster than cloning over the network).
 
-:class:`GitGate` is the main service class — a project-scoped **Repository +
-Gateway** (DDD patterns) that wraps git CLI operations for syncing, comparing,
-and querying the mirror.  Access it via ``project.gate``::
+:class:`GitGate` is the main service class — wraps git CLI operations for
+syncing, comparing, and querying the mirror.
 
-    project = get_project("myproj")
-    result = project.gate.sync()  # fetch from upstream
-    staleness = project.gate.compare_vs_upstream()
-    commit = project.gate.last_commit()
+All constructor parameters are plain values (strings, paths) — no
+terok-specific types like ``ProjectConfig``.
 
 Value types returned by ``GitGate`` methods:
 
@@ -23,11 +20,6 @@ Value types returned by ``GitGate`` methods:
 - :class:`BranchSyncResult` — selective branch sync outcome
 - :class:`CommitInfo` — single commit metadata (hash, date, author, message)
 - :class:`GateStalenessInfo` — frozen comparison of gate HEAD vs upstream HEAD
-
-Module-level utilities:
-
-- :func:`find_projects_sharing_gate` — discover projects that share a gate path
-- :func:`validate_gate_upstream_match` — prevent upstream URL conflicts
 """
 
 import os
@@ -39,8 +31,7 @@ from datetime import datetime
 from pathlib import Path
 from typing import TypedDict
 
-from ..core.config import get_envs_base_dir
-from ..core.projects import ProjectConfig, effective_ssh_key_name, list_projects, load_project
+from .ssh import effective_ssh_key_name
 
 # ---------- Staleness dataclass ----------
 
@@ -87,100 +78,35 @@ class GateStalenessInfo:
     error: str | None
 
 
-# ---------- Gate sharing validation ----------
-
-
-def find_projects_sharing_gate(
-    gate_path: Path, exclude_project: str | None = None
-) -> list[tuple[str, str | None]]:
-    """Find all projects configured to use the same gate path.
-
-    Args:
-        gate_path: The gate path to check for
-        exclude_project: Project ID to exclude from results (usually the current project)
-
-    Returns:
-        List of (project_id, upstream_url) tuples for projects sharing this gate
-    """
-    gate_path = gate_path.resolve()
-    sharing = []
-
-    for project in list_projects():
-        if exclude_project and project.id == exclude_project:
-            continue
-        if project.gate_path.resolve() == gate_path:
-            sharing.append((project.id, project.upstream_url))
-
-    return sharing
-
-
-def validate_gate_upstream_match(project_id: str) -> None:
-    """Validate that no other project uses the same gate with a different upstream.
-
-    Raises SystemExit if another project uses the same gate path but has a
-    different upstream_url configured.
-
-    Args:
-        project_id: The project to validate
-    """
-    project = load_project(project_id)
-    sharing = find_projects_sharing_gate(project.gate_path, exclude_project=project_id)
-
-    for other_id, other_url in sharing:
-        # Treat any difference, including missing upstream_url on either side, as a conflict.
-        if other_url is None or project.upstream_url is None or other_url != project.upstream_url:
-            this_display = (
-                project.upstream_url if project.upstream_url is not None else "<not configured>"
-            )
-            other_display = other_url if other_url is not None else "<not configured>"
-            missing_note = ""
-            if other_url is None or project.upstream_url is None:
-                missing_note = (
-                    "\nNote: One or more projects sharing this gate do not have an "
-                    "upstream_url configured in project.yml.\n"
-                )
-            raise SystemExit(
-                f"Gate path conflict detected!\n"
-                f"\n"
-                f"  Gate path: {project.gate_path}\n"
-                f"\n"
-                f"  This project ({project_id}):\n"
-                f"    upstream_url: {this_display}\n"
-                f"\n"
-                f"  Conflicting project ({other_id}):\n"
-                f"    upstream_url: {other_display}\n"
-                f"\n"
-                f"Projects sharing a gate must have the same upstream_url.\n"
-                f"Either change the gate.path in one project's project.yml,\n"
-                f"or ensure both projects point to the same upstream repository.\n"
-                f"{missing_note}"
-            )
-
-
 # ---------- Private helpers ----------
 
 
-def _git_env_with_ssh(project: ProjectConfig) -> dict:
+def _git_env_with_ssh(
+    *,
+    project_id: str,
+    ssh_host_dir: Path | None,
+    ssh_key_name: str | None,
+    envs_base_dir: Path | None,
+) -> dict:
     """Return an env that forces git to use the project's SSH config only.
 
-    - Sets GIT_SSH_COMMAND to use the per-project ssh config via `-F <config>`.
-    - Adds `-o IdentitiesOnly=yes` to prevent fallback to keys in ~/.ssh or agent.
-    - If a specific private key exists in the project ssh dir (derived from
-      project.ssh_key_name), also adds `-o IdentityFile=<that key>` explicitly.
+    - Sets GIT_SSH_COMMAND to use the per-project ssh config via ``-F <config>``.
+    - Adds ``-o IdentitiesOnly=yes`` to prevent fallback to keys in ``~/.ssh`` or agent.
+    - If a specific private key exists in the ssh dir, adds ``-o IdentityFile=<key>``.
 
-    If the ssh host dir or config is missing, we return the current env.
+    If the ssh host dir or config is missing, returns the current env.
     """
     env = os.environ.copy()
-    ssh_dir = project.ssh_host_dir or (get_envs_base_dir() / f"_ssh-config-{project.id}")
+    if envs_base_dir is None:
+        from .config import SandboxConfig
+
+        envs_base_dir = SandboxConfig().effective_envs_dir
+    ssh_dir = ssh_host_dir or (envs_base_dir / f"_ssh-config-{project_id}")
     cfg = Path(ssh_dir) / "config"
     if cfg.is_file():
         ssh_cmd = ["ssh", "-F", str(cfg), "-o", "IdentitiesOnly=yes"]
-        # Prefer explicit IdentityFile if we can resolve it. Use the same
-        # effective key name logic as ssh-init / containers so that even when
-        # ssh.key_name is omitted we still look for the derived default
-        # (id_<type>_<project_id>), while keeping this best-effort.
-        effective_name = effective_ssh_key_name(project, key_type="ed25519")
-        key_path = Path(ssh_dir) / effective_name
+        eff_name = effective_ssh_key_name(project_id, ssh_key_name=ssh_key_name, key_type="ed25519")
+        key_path = Path(ssh_dir) / eff_name
         if key_path.is_file():
             ssh_cmd += ["-o", f"IdentityFile={key_path}"]
         env["GIT_SSH_COMMAND"] = shlex.join(ssh_cmd)
@@ -189,27 +115,34 @@ def _git_env_with_ssh(project: ProjectConfig) -> dict:
     return env
 
 
-def _require_project_ssh_config(project: ProjectConfig) -> None:
-    """Raise SystemExit if the project uses an SSH upstream but SSH config is missing."""
-    upstream = project.upstream_url or ""
-    is_ssh_upstream = upstream.startswith("git@") or upstream.startswith("ssh://")
-    if not is_ssh_upstream:
+def _require_ssh_config(
+    *,
+    project_id: str,
+    upstream_url: str | None,
+    ssh_host_dir: Path | None,
+    envs_base_dir: Path | None,
+) -> None:
+    """Raise SystemExit if an SSH upstream is configured but SSH config is missing."""
+    upstream = upstream_url or ""
+    if not (upstream.startswith("git@") or upstream.startswith("ssh://")):
         return
+    if envs_base_dir is None:
+        from .config import SandboxConfig
 
-    ssh_dir = project.ssh_host_dir or (get_envs_base_dir() / f"_ssh-config-{project.id}")
+        envs_base_dir = SandboxConfig().effective_envs_dir
+    ssh_dir = ssh_host_dir or (envs_base_dir / f"_ssh-config-{project_id}")
     ssh_cfg_path = Path(ssh_dir) / "config"
     if not ssh_cfg_path.is_file():
         raise SystemExit(
             "SSH upstream detected but project SSH config is missing.\n"
             f"Expected SSH config at: {ssh_cfg_path}\n"
-            f"Run 'terokctl ssh-init {project.id}' first to generate keys and config."
+            f"Run 'terokctl ssh-init {project_id}' first to generate keys and config."
         )
 
 
-def _clone_gate_mirror(project: ProjectConfig, gate_dir: Path) -> None:
+def _clone_gate_mirror(upstream_url: str, gate_dir: Path, env: dict) -> None:
     """Clone the upstream repository as a bare mirror into *gate_dir*."""
-    env = _git_env_with_ssh(project)
-    cmd = ["git", "clone", "--mirror", project.upstream_url, str(gate_dir)]
+    cmd = ["git", "clone", "--mirror", upstream_url, str(gate_dir)]
     try:
         subprocess.run(cmd, check=True, env=env)
     except FileNotFoundError:
@@ -218,34 +151,20 @@ def _clone_gate_mirror(project: ProjectConfig, gate_dir: Path) -> None:
         raise SystemExit(f"git clone --mirror failed: {e}")
 
 
-def _get_upstream_head(project: ProjectConfig, branch: str | None = None) -> dict | None:
+def _get_upstream_head(upstream_url: str, branch: str, env: dict) -> dict | None:
     """Query upstream HEAD ref using git ls-remote (cheap, no object download).
-
-    Args:
-        project: Resolved project configuration
-        branch: Specific branch to check (default: project's default_branch)
 
     Returns:
         Dict with keys: commit_hash, ref_name, upstream_url
-        or None if query fails
+        or None if query fails.
     """
     try:
-        if not project.upstream_url:
-            return None
-
-        branch = branch or project.default_branch
-        if not branch:
-            return None
-        env = _git_env_with_ssh(project)
-
-        # git ls-remote only queries refs, doesn't download objects
-        cmd = ["git", "ls-remote", project.upstream_url, f"refs/heads/{branch}"]
+        cmd = ["git", "ls-remote", upstream_url, f"refs/heads/{branch}"]
         result = subprocess.run(cmd, capture_output=True, text=True, env=env, timeout=30)
 
         if result.returncode != 0:
             return None
 
-        # Parse output: "<commit_hash>\t<ref_name>"
         line = result.stdout.strip()
         if not line:
             return None
@@ -255,59 +174,44 @@ def _get_upstream_head(project: ProjectConfig, branch: str | None = None) -> dic
             return {
                 "commit_hash": parts[0],
                 "ref_name": parts[1],
-                "upstream_url": project.upstream_url,
+                "upstream_url": upstream_url,
             }
         return None
-
     except (subprocess.TimeoutExpired, Exception):
         return None
 
 
-def _get_gate_branch_head(project: ProjectConfig, branch: str | None = None) -> str | None:
+def _get_gate_branch_head(gate_dir: Path, branch: str, env: dict) -> str | None:
     """Get the commit hash for a specific branch in the gate.
 
-    Args:
-        project: Resolved project configuration
-        branch: Branch name (default: project's default_branch)
-
     Returns:
-        Commit hash string or None if not found
+        Commit hash string or None if not found.
     """
     try:
-        gate_dir = project.gate_path
-
         if not gate_dir.exists():
             return None
 
-        branch = branch or project.default_branch
-        if not branch:
-            return None
-        env = _git_env_with_ssh(project)
-
-        # Query the ref in the bare mirror
         cmd = ["git", "-C", str(gate_dir), "rev-parse", f"refs/heads/{branch}"]
         result = subprocess.run(cmd, capture_output=True, text=True, env=env)
 
         if result.returncode == 0:
             return result.stdout.strip()
         return None
-
     except Exception:
         return None
 
 
-def _count_commits_range(project: ProjectConfig, from_ref: str, to_ref: str) -> int | None:
+def _count_commits_range(gate_dir: Path, from_ref: str, to_ref: str, env: dict) -> int | None:
     """Count commits reachable from *to_ref* but not from *from_ref*.
 
     Uses ``git rev-list --count from..to``.  Returns ``None`` when the
     count cannot be determined (e.g. refs not yet fetched).
     """
     try:
-        env = _git_env_with_ssh(project)
         cmd = [
             "git",
             "-C",
-            str(project.gate_path),
+            str(gate_dir),
             "rev-list",
             "--count",
             f"{from_ref}..{to_ref}",
@@ -320,51 +224,85 @@ def _count_commits_range(project: ProjectConfig, from_ref: str, to_ref: str) -> 
         return None
 
 
-def _count_commits_behind(project: ProjectConfig, local_head: str, remote_head: str) -> int | None:
-    """Count how many commits the gate is behind upstream."""
-    return _count_commits_range(project, local_head, remote_head)
-
-
-def _count_commits_ahead(project: ProjectConfig, local_head: str, remote_head: str) -> int | None:
-    """Count how many commits the gate is ahead of upstream."""
-    return _count_commits_range(project, remote_head, local_head)
-
-
 # ---------- GitGate class (Repository + Gateway pattern) ----------
 
 
 class GitGate:
-    """Repository + Gateway for a project's host-side git gate mirror.
+    """Repository + Gateway for a host-side git gate mirror.
 
     Manages the bare git mirror that containers clone from.  Provides
     operations for initial creation, incremental sync from upstream,
     selective branch fetching, and staleness detection.
 
-    This is a **stateful service** — it holds a reference to the project
-    config and uses it to resolve paths, SSH credentials, and upstream
-    URLs.  Access via ``project.gate`` (lazy-initialized by
-    :class:`~terok.lib.domain.project.Project`).
-
-    Design patterns: **Repository** (manages a persistent git mirror on
-    disk) + **Gateway** (wraps external git CLI operations).
+    Constructor takes plain parameters — no terok-specific types.
     """
 
-    def __init__(self, config: ProjectConfig) -> None:
-        """Initialise with a resolved project configuration.
+    def __init__(
+        self,
+        *,
+        project_id: str,
+        gate_path: Path | str,
+        upstream_url: str | None = None,
+        default_branch: str | None = None,
+        ssh_host_dir: Path | str | None = None,
+        ssh_key_name: str | None = None,
+        envs_base_dir: Path | str | None = None,
+        validate_gate_fn: "callable | None" = None,
+    ) -> None:
+        """Initialise with plain parameters.
 
-        Args:
-            config: The project configuration to operate on.
+        Parameters
+        ----------
+        project_id:
+            Identifier for this gate's owner.
+        gate_path:
+            Path to the bare git mirror on the host.
+        upstream_url:
+            Git upstream URL to sync from.
+        default_branch:
+            Branch name used for staleness comparisons.
+        ssh_host_dir:
+            Explicit SSH directory for git operations.
+        ssh_key_name:
+            Explicit SSH key filename.
+        envs_base_dir:
+            Base directory for environment data.
+        validate_gate_fn:
+            Optional callback ``(project_id) -> None`` that validates no other
+            project uses the same gate with a different upstream.  Injected by
+            the orchestration layer; omitted for standalone use.
         """
-        self._config = config
+        self._project_id = project_id
+        self._gate_path = Path(gate_path)
+        self._upstream_url = upstream_url
+        self._default_branch = default_branch
+        self._ssh_host_dir = Path(ssh_host_dir) if ssh_host_dir else None
+        self._ssh_key_name = ssh_key_name
+        self._envs_base_dir = Path(envs_base_dir) if envs_base_dir else None
+        self._validate_gate_fn = validate_gate_fn
+
+    def _ssh_env(self) -> dict:
+        """Return a subprocess env dict with SSH configuration."""
+        return _git_env_with_ssh(
+            project_id=self._project_id,
+            ssh_host_dir=self._ssh_host_dir,
+            ssh_key_name=self._ssh_key_name,
+            envs_base_dir=self._envs_base_dir,
+        )
+
+    def _validate_gate(self) -> None:
+        """Run the injected gate validation callback, if any."""
+        if self._validate_gate_fn:
+            self._validate_gate_fn(self._project_id)
 
     def sync(
         self,
         branches: list[str] | None = None,
         force_reinit: bool = False,
     ) -> GateSyncResult:
-        """Sync the host-side git mirror gate for the project.
+        """Sync the host-side git mirror gate.
 
-        - Uses the project's SSH configuration (from ssh-init) via GIT_SSH_COMMAND.
+        - Uses SSH configuration via GIT_SSH_COMMAND.
         - If gate doesn't exist (or *force_reinit*), performs a fresh ``git clone --mirror``.
         - Always runs the sync logic afterward for consistent side effects.
 
@@ -372,39 +310,40 @@ class GitGate:
             Dict with keys: path, upstream_url, created (bool), success,
             updated_branches, errors.
         """
-        project = self._config
-        if not project.upstream_url:
+        if not self._upstream_url:
             raise SystemExit("Project has no git.upstream_url configured")
 
-        # Validate no other project uses this gate with a different upstream
-        validate_gate_upstream_match(project.id)
+        self._validate_gate()
 
-        gate_dir = project.gate_path
+        gate_dir = self._gate_path
         gate_exists = gate_dir.exists()
         gate_dir.parent.mkdir(parents=True, exist_ok=True)
 
-        _require_project_ssh_config(project)
+        _require_ssh_config(
+            project_id=self._project_id,
+            upstream_url=self._upstream_url,
+            ssh_host_dir=self._ssh_host_dir,
+            envs_base_dir=self._envs_base_dir,
+        )
 
+        env = self._ssh_env()
         created = False
         if force_reinit and gate_exists:
-            # Remove to ensure clean mirror
             try:
                 if gate_dir.is_dir():
                     shutil.rmtree(gate_dir)
             except Exception:
-                # Best-effort cleanup; ignore delete failures.
                 pass
             gate_exists = False
 
         if not gate_exists:
-            # Create a mirror clone
-            _clone_gate_mirror(project, gate_dir)
+            _clone_gate_mirror(self._upstream_url, gate_dir, env)
             created = True
 
         sync_result = self.sync_branches(branches)
         return {
             "path": str(gate_dir),
-            "upstream_url": project.upstream_url,
+            "upstream_url": self._upstream_url,
             "created": created,
             "success": sync_result["success"],
             "updated_branches": sync_result["updated_branches"],
@@ -420,28 +359,24 @@ class GitGate:
         Returns:
             Dict with keys: success, updated_branches, errors
         """
-        project = self._config
-        gate_dir = project.gate_path
+        gate_dir = self._gate_path
 
         if not gate_dir.exists():
             return {"success": False, "updated_branches": [], "errors": ["Gate not initialized"]}
 
-        # Validate no other project uses this gate with a different upstream
-        validate_gate_upstream_match(project.id)
+        self._validate_gate()
 
-        env = _git_env_with_ssh(project)
-        errors = []
-        updated = []
+        env = self._ssh_env()
+        errors: list[str] = []
+        updated: list[str] = []
 
         try:
-            # Use git remote update for efficiency
             cmd = ["git", "-C", str(gate_dir), "remote", "update", "--prune"]
             result = subprocess.run(cmd, capture_output=True, text=True, env=env, timeout=120)
 
             if result.returncode != 0:
                 errors.append(f"remote update failed: {result.stderr}")
             else:
-                # If specific branches requested, verify they were updated
                 updated = branches if branches else ["all"]
 
         except subprocess.TimeoutExpired:
@@ -455,13 +390,12 @@ class GitGate:
         """Compare gate HEAD vs upstream HEAD for a branch.
 
         Args:
-            branch: Branch to compare (default: project's default_branch)
+            branch: Branch to compare (default: configured default_branch)
 
         Returns:
             GateStalenessInfo with comparison results
         """
-        project = self._config
-        branch = branch or project.default_branch
+        branch = branch or self._default_branch
         now = datetime.now().isoformat()
 
         if not branch:
@@ -476,8 +410,10 @@ class GitGate:
                 error="No branch configured",
             )
 
+        env = self._ssh_env()
+
         # Get gate HEAD
-        gate_head = _get_gate_branch_head(project, branch)
+        gate_head = _get_gate_branch_head(self._gate_path, branch, env)
         if gate_head is None:
             return GateStalenessInfo(
                 branch=branch,
@@ -491,7 +427,19 @@ class GitGate:
             )
 
         # Get upstream HEAD
-        upstream_info = _get_upstream_head(project, branch)
+        if not self._upstream_url:
+            return GateStalenessInfo(
+                branch=branch,
+                gate_head=gate_head,
+                upstream_head=None,
+                is_stale=False,
+                commits_behind=None,
+                commits_ahead=None,
+                last_checked=now,
+                error="No upstream URL configured",
+            )
+
+        upstream_info = _get_upstream_head(self._upstream_url, branch, env)
         if upstream_info is None:
             return GateStalenessInfo(
                 branch=branch,
@@ -507,12 +455,11 @@ class GitGate:
         upstream_head = upstream_info["commit_hash"]
         is_stale = gate_head != upstream_head
 
-        # Count commits behind and ahead
         commits_behind = None
         commits_ahead = None
         if is_stale:
-            commits_behind = _count_commits_behind(project, gate_head, upstream_head)
-            commits_ahead = _count_commits_ahead(project, gate_head, upstream_head)
+            commits_behind = _count_commits_range(self._gate_path, gate_head, upstream_head, env)
+            commits_ahead = _count_commits_range(self._gate_path, upstream_head, gate_head, env)
 
         return GateStalenessInfo(
             branch=branch,
@@ -528,23 +475,17 @@ class GitGate:
     def last_commit(self) -> CommitInfo | None:
         """Get information about the last commit on the configured branch.
 
-        Queries the project's ``default_branch`` (falling back to HEAD if not
-        set or not present locally) so the result is consistent with
-        :meth:`compare_vs_upstream`.
-
         Returns ``None`` if the gate doesn't exist or is not accessible.
         """
         try:
-            project = self._config
-            gate_dir = project.gate_path
+            gate_dir = self._gate_path
 
             if not gate_dir.exists() or not gate_dir.is_dir():
                 return None
 
-            env = _git_env_with_ssh(project)
+            env = self._ssh_env()
 
-            # Prefer the configured branch; fall back to HEAD
-            rev = f"refs/heads/{project.default_branch}" if project.default_branch else "HEAD"
+            rev = f"refs/heads/{self._default_branch}" if self._default_branch else "HEAD"
             cmd = [
                 "git",
                 "-C",
@@ -557,14 +498,12 @@ class GitGate:
             ]
 
             result = subprocess.run(cmd, capture_output=True, text=True, env=env)
-            if result.returncode != 0 and project.default_branch:
-                # Branch may not exist locally yet; retry with HEAD
-                cmd[4] = "HEAD"
+            if result.returncode != 0 and self._default_branch:
+                cmd[5] = "HEAD"
                 result = subprocess.run(cmd, capture_output=True, text=True, env=env)
             if result.returncode != 0:
                 return None
 
-            # Parse with null-byte delimiter (subject is last to handle | in messages)
             parts = result.stdout.strip().split("\x00", 3)
             if len(parts) == 4:
                 return {

--- a/src/terok/lib/sandbox/paths.py
+++ b/src/terok/lib/sandbox/paths.py
@@ -1,0 +1,79 @@
+# SPDX-FileCopyrightText: 2025 Jiri Vyskocil
+# SPDX-FileCopyrightText: 2026 Jiri Vyskocil
+# SPDX-License-Identifier: Apache-2.0
+
+"""Platform-aware path resolution for sandbox directories.
+
+Vendored from ``core.paths`` — zero internal dependencies.  Provides
+the same XDG / FHS resolution logic so that ``terok-sandbox`` works
+identically whether embedded in terok or used standalone.
+"""
+
+import getpass
+import os
+from pathlib import Path
+
+try:
+    from platformdirs import (
+        user_config_dir as _user_config_dir,
+        user_data_dir as _user_data_dir,
+    )
+except ImportError:  # optional dependency
+    _user_config_dir = _user_data_dir = None  # type: ignore[assignment]
+
+
+APP_NAME = "terok"
+
+
+def _is_root() -> bool:
+    """Return True if the current process is running as root."""
+    try:
+        return os.geteuid() == 0  # type: ignore[attr-defined]
+    except AttributeError:
+        return getpass.getuser() == "root"
+
+
+def config_root() -> Path:
+    """Base directory for configuration.
+
+    Priority: ``TEROK_CONFIG_DIR`` → ``/etc/terok`` (root) → ``~/.config/terok``.
+    """
+    env = os.getenv("TEROK_CONFIG_DIR")
+    if env:
+        return Path(env).expanduser()
+    if _is_root():
+        return Path("/etc") / APP_NAME
+    if _user_config_dir is not None:
+        return Path(_user_config_dir(APP_NAME))
+    return Path.home() / ".config" / APP_NAME
+
+
+def state_root() -> Path:
+    """Writable state root (tasks, tokens, caches).
+
+    Priority: ``TEROK_STATE_DIR`` → ``/var/lib/terok`` (root) → XDG data dir.
+    """
+    env = os.getenv("TEROK_STATE_DIR")
+    if env:
+        return Path(env).expanduser()
+    if _is_root():
+        return Path("/var/lib") / APP_NAME
+    if _user_data_dir is not None:
+        return Path(_user_data_dir(APP_NAME))
+    xdg = os.getenv("XDG_DATA_HOME")
+    if xdg:
+        return Path(xdg) / APP_NAME
+    return Path.home() / ".local" / "share" / APP_NAME
+
+
+def runtime_root() -> Path:
+    """Transient runtime directory (PID files, sockets).
+
+    Priority: ``TEROK_RUNTIME_DIR`` → ``/run/terok`` (root) → ``~/.cache/terok``.
+    """
+    env = os.getenv("TEROK_RUNTIME_DIR")
+    if env:
+        return Path(env).expanduser()
+    if _is_root():
+        return Path("/run") / APP_NAME
+    return Path.home() / ".cache" / APP_NAME

--- a/src/terok/lib/sandbox/runtime.py
+++ b/src/terok/lib/sandbox/runtime.py
@@ -4,30 +4,22 @@
 """Container runtime gateway wrapping the Podman CLI.
 
 Provides module-level functions for container lifecycle operations
-(naming, state queries, GPU args, log streaming, etc.).
+(state queries, GPU args, log streaming, etc.).
+
+All functions accept plain parameters (strings, paths) — no terok-specific
+types like ``ProjectConfig``.  Container naming is orchestration policy and
+lives in ``orchestration.tasks`` / ``orchestration.task_runners``.
 """
 
 import subprocess
 from collections.abc import Callable
-from typing import Any
-
-from ..core.projects import ProjectConfig, load_project
-
-# ---------- Constants ----------
-
-CONTAINER_MODES = ("cli", "web", "run")
-
+from pathlib import Path
 
 # ---------- Public functions ----------
 
 
-def container_name(project_id: str, mode: str, task_id: str) -> str:
-    """Return the canonical container name for a task."""
-    return f"{project_id}-{mode}-{task_id}"
-
-
-def get_project_container_states(project_id: str) -> dict[str, str]:
-    """Return ``{container_name: state}`` for all containers matching *project_id*.
+def get_project_container_states(name_prefix: str) -> dict[str, str]:
+    """Return ``{container_name: state}`` for all containers matching *name_prefix*.
 
     Uses a single ``podman ps -a`` call with a name filter instead of
     per-container ``podman inspect`` calls.  Returns an empty dict when
@@ -40,7 +32,7 @@ def get_project_container_states(project_id: str) -> dict[str, str]:
                 "ps",
                 "-a",
                 "--filter",
-                f"name=^{project_id}-",
+                f"name=^{name_prefix}-",
                 "--format",
                 "{{.Names}} {{.State}}",
                 "--no-trunc",
@@ -85,16 +77,15 @@ def is_container_running(cname: str) -> bool:
     return out.lower() == "true"
 
 
-def stop_task_containers(project: Any, task_id: str) -> None:
-    """Best-effort ``podman rm -f`` of all mode containers for a task.
+def stop_task_containers(container_names: list[str]) -> None:
+    """Best-effort ``podman rm -f`` of the given containers.
 
     Ignores all errors so that task deletion succeeds even when podman is
     absent or the containers are already gone.
     """
     from ..util.logging_utils import _log_debug
 
-    names = [container_name(project.id, mode, task_id) for mode in CONTAINER_MODES]
-    for name in names:
+    for name in container_names:
         try:
             _log_debug(f"stop_containers: podman rm -f {name} (start)")
             subprocess.run(
@@ -102,19 +93,23 @@ def stop_task_containers(project: Any, task_id: str) -> None:
                 check=False,
                 stdout=subprocess.DEVNULL,
                 stderr=subprocess.DEVNULL,
+                timeout=120,
             )
             _log_debug(f"stop_containers: podman rm -f {name} (done)")
         except Exception:
             pass
 
 
-def gpu_run_args(project: "ProjectConfig") -> list[str]:
-    """Return additional ``podman run`` args to enable NVIDIA GPU if configured."""
+def gpu_run_args(project_root: Path) -> list[str]:
+    """Return additional ``podman run`` args to enable NVIDIA GPU if configured.
+
+    Reads ``run.gpus`` from ``project.yml`` in *project_root*.
+    """
     from terok.lib.util.yaml import load as _yaml_load
 
     enabled = False
     try:
-        proj_cfg = _yaml_load((project.root / "project.yml").read_text()) or {}
+        proj_cfg = _yaml_load((project_root / "project.yml").read_text()) or {}
         run_cfg = proj_cfg.get("run", {}) or {}
         gpus = run_cfg.get("gpus")
         if isinstance(gpus, str):
@@ -244,15 +239,3 @@ def wait_for_exit(cname: str, timeout_sec: float | None = None) -> int:
         return 124
     except (FileNotFoundError, ValueError):
         return 1
-
-
-def get_task_container_state(project_id: str, task_id: str, mode: str | None) -> str | None:
-    """Get actual container state for a task (TUI helper)."""
-    if not mode:
-        return None
-    try:
-        project = load_project(project_id)
-    except (SystemExit, ValueError):
-        return None
-    cname = container_name(project.id, mode, task_id)
-    return get_container_state(cname)

--- a/src/terok/lib/sandbox/shield.py
+++ b/src/terok/lib/sandbox/shield.py
@@ -26,14 +26,7 @@ from terok_shield import (
     system_hooks_dir,
 )
 
-from ..core.config import (
-    get_gate_server_port,
-    get_global_section,
-    get_shield_bypass_firewall_no_protection,
-)
-from ..core.paths import config_root
-
-_DEFAULT_PROFILES = ("dev-standard",)
+from .config import SandboxConfig
 
 # Short hint appended to CLI/TUI messages when the shield is weakened.
 SHIELD_SECURITY_HINT = "See: https://terok-ai.github.io/terok/shield-security/"
@@ -48,68 +41,29 @@ _BYPASS_WARNING = (
 )
 
 
-def _state_dir(task_dir: Path) -> Path:
-    """Return the per-task shield state directory."""
-    return task_dir / "shield"
+def _cfg(cfg: SandboxConfig | None = None) -> SandboxConfig:
+    """Return *cfg* or a default :class:`SandboxConfig`."""
+    return cfg or SandboxConfig()
 
 
-def _profiles_dir() -> Path:
-    """Return the terok-managed shield profiles directory.
+def make_shield(task_dir: Path, cfg: SandboxConfig | None = None) -> Shield:
+    """Construct a per-task :class:`Shield` from sandbox configuration.
 
-    Custom ``.txt`` allowlist files placed here are visible to all
-    terok-managed Shield instances.  This is separate from the
-    standalone ``terok-shield`` CLI's own config directory.
+    Builds a :class:`ShieldConfig` with ``state_dir`` scoped to *task_dir*.
     """
-    return config_root() / "shield" / "profiles"
-
-
-def _normalize_profiles(raw: object) -> tuple[str, ...]:
-    """Normalize a profiles config value to a tuple of strings.
-
-    Raises:
-        TypeError: If *raw* is not a string or list of strings.
-    """
-    if isinstance(raw, str):
-        return (raw,)
-    if isinstance(raw, (list, tuple)):
-        for item in raw:
-            if not isinstance(item, str):
-                raise TypeError(
-                    f"shield.profiles must be a list of strings, "
-                    f"but found {type(item).__name__}: {item!r}"
-                )
-        return tuple(raw)
-    raise TypeError(
-        f"shield.profiles must be a string or a list of strings, "
-        f"but found {type(raw).__name__}: {raw!r}"
-    )
-
-
-def make_shield(task_dir: Path) -> Shield:
-    """Construct a per-task :class:`Shield` from the terok global config.
-
-    Reads the ``shield:`` section of the global config and builds a
-    :class:`ShieldConfig` with ``state_dir`` scoped to *task_dir*.
-
-    The ``Shield`` constructor validates that the ``nft`` binary is
-    available on the host and raises :class:`~terok_shield.NftNotFoundError`
-    if it is missing.
-    """
-    sec = get_global_section("shield")
-    profiles = _normalize_profiles(sec.get("profiles", _DEFAULT_PROFILES))
-
+    c = _cfg(cfg)
     config = ShieldConfig(
-        state_dir=_state_dir(task_dir),
+        state_dir=task_dir / "shield",
         mode=ShieldMode.HOOK,
-        default_profiles=profiles,
-        loopback_ports=(get_gate_server_port(),),
-        audit_enabled=bool(sec.get("audit", True)),
-        profiles_dir=_profiles_dir(),
+        default_profiles=c.shield_profiles,
+        loopback_ports=(c.gate_port,),
+        audit_enabled=c.shield_audit,
+        profiles_dir=c.shield_profiles_dir,
     )
     return Shield(config)
 
 
-def pre_start(container: str, task_dir: Path) -> list[str]:
+def pre_start(container: str, task_dir: Path, cfg: SandboxConfig | None = None) -> list[str]:
     """Return extra ``podman run`` args for egress firewalling.
 
     Returns an empty list (no firewall args) when the dangerous
@@ -118,79 +72,70 @@ def pre_start(container: str, task_dir: Path) -> list[str]:
     Raises :class:`SystemExit` with setup instructions when the
     podman environment requires one-time hook installation.
     """
-    if get_shield_bypass_firewall_no_protection():
+    if _cfg(cfg).shield_bypass:
         warnings.warn(_BYPASS_WARNING, stacklevel=2)
         return []
     try:
-        return make_shield(task_dir).pre_start(container)
+        return make_shield(task_dir, cfg).pre_start(container)
     except ShieldNeedsSetup as exc:
         raise SystemExit(f"{exc}\n\nRun 'terokctl shield setup' to install global hooks.") from None
 
 
-def down(container: str, task_dir: Path, *, allow_all: bool = False) -> None:
+def down(
+    container: str, task_dir: Path, *, allow_all: bool = False, cfg: SandboxConfig | None = None
+) -> None:
     """Set shield to bypass mode (allow egress) for a running container.
 
     When *allow_all* is True, also permits private-range (RFC 1918) traffic.
     """
-    if get_shield_bypass_firewall_no_protection():
+    if _cfg(cfg).shield_bypass:
         return
-    make_shield(task_dir).down(container, allow_all=allow_all)
+    make_shield(task_dir, cfg).down(container, allow_all=allow_all)
 
 
-def up(container: str, task_dir: Path) -> None:
+def up(container: str, task_dir: Path, cfg: SandboxConfig | None = None) -> None:
     """Set shield to deny-all mode for a running container."""
-    if get_shield_bypass_firewall_no_protection():
+    if _cfg(cfg).shield_bypass:
         return
-    make_shield(task_dir).up(container)
+    make_shield(task_dir, cfg).up(container)
 
 
-def state(container: str, task_dir: Path) -> ShieldState:
+def state(container: str, task_dir: Path, cfg: SandboxConfig | None = None) -> ShieldState:
     """Return the live shield state for a running container.
 
-    Queries actual nft state even when ``bypass_firewall_no_protection``
-    is set, because containers started *before* bypass was enabled may
-    still have active firewall rules.
+    Queries actual nft state even when bypass is set, because containers
+    started *before* bypass was enabled may still have active rules.
     """
-    return make_shield(task_dir).state(container)
+    return make_shield(task_dir, cfg).state(container)
 
 
-def status() -> dict:
-    """Return shield status dict from the global config.
-
-    This reads the terok config directly rather than constructing a
-    :class:`Shield`, because ``Shield.status()`` returns *available*
-    profiles (filesystem scan) while terok needs *configured* profiles.
-    """
-    bypassed = get_shield_bypass_firewall_no_protection()
-    sec = get_global_section("shield")
-    profiles = _normalize_profiles(sec.get("profiles", _DEFAULT_PROFILES))
+def status(cfg: SandboxConfig | None = None) -> dict:
+    """Return shield status dict from the sandbox configuration."""
+    c = _cfg(cfg)
     result: dict = {
         "mode": "hook",
-        "profiles": list(profiles),
-        "audit_enabled": bool(sec.get("audit", True)),
+        "profiles": list(c.shield_profiles),
+        "audit_enabled": c.shield_audit,
     }
-    if bypassed:
-        # DANGEROUS TRANSITIONAL OVERRIDE — surface prominently in status output
+    if c.shield_bypass:
         result["bypass_firewall_no_protection"] = True
     return result
 
 
-def check_environment() -> EnvironmentCheck:
+def check_environment(cfg: SandboxConfig | None = None) -> EnvironmentCheck:
     """Check the podman environment for shield compatibility.
 
-    Constructs a temporary :class:`Shield` and calls
-    :meth:`Shield.check_environment`.  Returns a synthetic
-    :class:`EnvironmentCheck` with bypass info when the dangerous
-    ``bypass_firewall_no_protection`` override is active.
+    Returns a synthetic :class:`EnvironmentCheck` with bypass info when the
+    dangerous bypass override is active.
     """
-    if get_shield_bypass_firewall_no_protection():
+    if _cfg(cfg).shield_bypass:
         return EnvironmentCheck(
             ok=False,
             health="bypass",
             issues=["bypass_firewall_no_protection is set — egress firewall disabled"],
         )
     with tempfile.TemporaryDirectory() as tmp:
-        return make_shield(Path(tmp)).check_environment()
+        return make_shield(Path(tmp), cfg).check_environment()
 
 
 def run_setup(*, root: bool = False, user: bool = False) -> None:

--- a/src/terok/lib/sandbox/ssh.py
+++ b/src/terok/lib/sandbox/ssh.py
@@ -1,18 +1,16 @@
 # SPDX-FileCopyrightText: 2025 Jiri Vyskocil
 # SPDX-License-Identifier: Apache-2.0
 
-"""Per-project SSH keypair generation and config directory setup.
+"""SSH keypair generation and config directory setup.
 
-Each project that accesses a private upstream repository needs its own
-SSH keypair and config.  :class:`SSHManager` manages this — generating
-keys, rendering the SSH config from a template, and setting permissions
-so that the container's ``/home/dev/.ssh`` mount works correctly.
+Manages the lifecycle of SSH keypairs and config for sandboxed containers.
+:class:`SSHManager` generates keys, renders the SSH config from a template,
+and sets permissions so that the container's ``/home/dev/.ssh`` mount works
+correctly.
 
-Access via ``project.ssh``::
-
-    project = get_project("myproj")
-    result = project.ssh.init()  # generate keypair + config
-    print(result["public_key"])  # copy to git remote as deploy key
+All constructor parameters are plain values (strings, paths) — no
+terok-specific types.  The orchestration layer constructs the manager
+from project configuration.
 """
 
 import os
@@ -21,10 +19,24 @@ from importlib import resources
 from pathlib import Path
 from typing import TypedDict
 
-from ..core.config import get_envs_base_dir
-from ..core.projects import ProjectConfig, effective_ssh_key_name
 from ..util.fs import ensure_dir_writable
 from ..util.template_utils import render_template
+from .config import SandboxConfig
+
+
+def effective_ssh_key_name(
+    project_id: str, *, ssh_key_name: str | None = None, key_type: str = "ed25519"
+) -> str:
+    """Return the SSH key filename to use.
+
+    Precedence:
+      1. Explicit *ssh_key_name* (from project config)
+      2. Derived default: ``id_<type>_<project_id>``
+    """
+    if ssh_key_name:
+        return ssh_key_name
+    algo = "ed25519" if key_type == "ed25519" else "rsa"
+    return f"id_{algo}_{project_id}"
 
 
 class SSHInitResult(TypedDict):
@@ -38,31 +50,53 @@ class SSHInitResult(TypedDict):
 
 
 class SSHManager:
-    """Project-scoped service for SSH keypair generation and config.
+    """SSH keypair generation and config directory management.
 
     Handles the full SSH setup lifecycle: directory creation, keypair
     generation (ed25519 or RSA), config file rendering from templates, and
     permission hardening.  The generated directory is bind-mounted into task
     containers as ``/home/dev/.ssh``.
-
-    Access via ``project.ssh`` (lazy-initialized by
-    :class:`~terok.lib.domain.project.Project`).
     """
 
-    def __init__(self, config: ProjectConfig) -> None:
-        """Initialize the manager with a resolved project configuration.
+    def __init__(
+        self,
+        *,
+        project_id: str,
+        ssh_host_dir: Path | str | None = None,
+        ssh_key_name: str | None = None,
+        ssh_config_template: Path | str | None = None,
+        envs_base_dir: Path | str | None = None,
+    ) -> None:
+        """Initialize with plain parameters.
 
         Parameters
         ----------
-        config:
-            A fully loaded :class:`ProjectConfig` instance.
+        project_id:
+            Identifier used for key naming and directory layout.
+        ssh_host_dir:
+            Explicit SSH directory (overrides default ``<envs_base>/_ssh-config-<id>``).
+        ssh_key_name:
+            Explicit key filename (overrides derived ``id_<type>_<id>``).
+        ssh_config_template:
+            Path to a user-provided SSH config template file.
+        envs_base_dir:
+            Base directory for environment data.  Falls back to
+            ``SandboxConfig().effective_envs_dir`` when not provided.
         """
-        self._config = config
+        self._project_id = project_id
+        self._ssh_host_dir = Path(ssh_host_dir) if ssh_host_dir else None
+        self._ssh_key_name = ssh_key_name
+        self._ssh_config_template = Path(ssh_config_template) if ssh_config_template else None
+        self._envs_base_dir = Path(envs_base_dir) if envs_base_dir else None
 
     @property
     def key_name(self) -> str:
-        """Return the effective SSH key name for this project."""
-        return effective_ssh_key_name(self._config)
+        """Return the effective SSH key name."""
+        return effective_ssh_key_name(self._project_id, ssh_key_name=self._ssh_key_name)
+
+    def _resolve_envs_base(self) -> Path:
+        """Return the envs base directory, falling back to sandbox defaults."""
+        return self._envs_base_dir or SandboxConfig().effective_envs_dir
 
     def init(
         self,
@@ -70,14 +104,10 @@ class SSHManager:
         key_name: str | None = None,
         force: bool = False,
     ) -> SSHInitResult:
-        """Initialize the shared SSH directory for a project and generate a keypair.
-
-        This prepares the host directory that containers mount read-write at
-        ``/home/dev/.ssh`` and creates an SSH keypair plus a minimal config
-        file if missing.
+        """Initialize the SSH directory and generate a keypair.
 
         Location resolution:
-          - If project.yml defines ``ssh.host_dir``, use that path.
+          - If *ssh_host_dir* was provided, use that path.
           - Otherwise: ``<envs_base>/_ssh-config-<project_id>``
 
         Key name defaults to ``id_<type>_<project_id>`` (e.g. ``id_ed25519_proj``).
@@ -85,14 +115,16 @@ class SSHManager:
         if key_type not in ("ed25519", "rsa"):
             raise SystemExit("Unsupported --key-type. Use 'ed25519' or 'rsa'.")
 
-        project = self._config
-
-        target_dir = project.ssh_host_dir or (get_envs_base_dir() / f"_ssh-config-{project.id}")
+        target_dir = self._ssh_host_dir or (
+            self._resolve_envs_base() / f"_ssh-config-{self._project_id}"
+        )
         target_dir = Path(target_dir).expanduser().resolve()
         ensure_dir_writable(target_dir, "SSH host dir")
 
         if not key_name:
-            key_name = effective_ssh_key_name(project, key_type=key_type)
+            key_name = effective_ssh_key_name(
+                self._project_id, ssh_key_name=self._ssh_key_name, key_type=key_type
+            )
 
         # Reject path-like or reserved key names
         _RESERVED_NAMES = {"config", "known_hosts", "authorized_keys"}
@@ -123,10 +155,12 @@ class SSHManager:
                     )
 
         if force or not priv_path.exists() or not pub_path.exists():
-            self._generate_keypair(key_type, priv_path, pub_path, project.id)
+            self._generate_keypair(key_type, priv_path, pub_path, self._project_id)
 
         if force or not cfg_path.exists():
-            self._render_config(cfg_path, key_name, priv_path, project)
+            self._render_config(
+                cfg_path, key_name, priv_path, self._project_id, self._ssh_config_template
+            )
 
         try:
             _harden_permissions(target_dir, priv_path, pub_path, cfg_path)
@@ -167,15 +201,19 @@ class SSHManager:
 
     @staticmethod
     def _render_config(
-        cfg_path: Path, key_name: str, priv_path: Path, project: ProjectConfig
+        cfg_path: Path,
+        key_name: str,
+        priv_path: Path,
+        project_id: str,
+        config_template: Path | None = None,
     ) -> None:
         """Render the SSH config from a user or packaged template."""
         variables = {
             "KEY_NAME": key_name,
             "IDENTITY_FILE": str(priv_path),
-            "PROJECT_ID": project.id,
+            "PROJECT_ID": project_id,
         }
-        user_config = _try_render_user_template(project, variables)
+        user_config = _try_render_user_template(config_template, variables)
         config_text = (
             user_config if user_config is not None else _try_render_packaged_template(variables)
         )
@@ -195,14 +233,13 @@ class SSHManager:
 # ---------------------------------------------------------------------------
 
 
-def _try_render_user_template(project: ProjectConfig, variables: dict[str, str]) -> str | None:
+def _try_render_user_template(template_path: Path | None, variables: dict[str, str]) -> str | None:
     """Render the user-provided SSH config template, if configured.
 
     Raises ``SystemExit`` if the template path is configured but the file
     is missing or rendering fails — explicit misconfiguration should fail
     fast rather than silently falling back to the packaged template.
     """
-    template_path = getattr(project, "ssh_config_template", None)
     if not template_path:
         return None
     p = Path(template_path)

--- a/src/terok/tui/app.py
+++ b/src/terok/tui/app.py
@@ -62,7 +62,6 @@ if _HAS_TEXTUAL:
         EnvironmentCheck,
         GateServerStatus,
         GateStalenessInfo,
-        GitGate,
         get_project_state,
         get_server_status,
         is_task_image_old,
@@ -545,7 +544,9 @@ if _HAS_TEXTUAL:
             """Load project infrastructure state in a background thread."""
             try:
                 project = load_project(project_id)
-                gate = GitGate(project)
+                from ..lib.domain.project import make_git_gate
+
+                gate = make_git_gate(project)
                 state = get_project_state(
                     project_id,
                     gate_commit_provider=lambda _pid, _g=gate: _g.last_commit(),
@@ -621,7 +622,7 @@ if _HAS_TEXTUAL:
             try:
                 project = load_project(project_id)
                 mode = task.mode or "cli"
-                from ..lib.sandbox.runtime import container_name
+                from ..lib.orchestration.tasks import container_name
 
                 cname = container_name(project_id, mode, task.task_id)
                 task_dir = project.tasks_root / str(task.task_id)

--- a/src/terok/tui/polling.py
+++ b/src/terok/tui/polling.py
@@ -183,12 +183,12 @@ class PollingMixin:
         import asyncio
 
         from ..lib.core.projects import load_project
-        from ..lib.sandbox.git_gate import GitGate
+        from ..lib.domain.project import make_git_gate
 
         try:
             # Run blocking call in thread pool
             staleness = await asyncio.get_event_loop().run_in_executor(
-                None, lambda: GitGate(load_project(project_id)).compare_vs_upstream()
+                None, lambda: make_git_gate(load_project(project_id)).compare_vs_upstream()
             )
 
             # Validate project hasn't changed while we were polling
@@ -277,12 +277,12 @@ class PollingMixin:
         import asyncio
 
         from ..lib.core.projects import load_project
-        from ..lib.sandbox.git_gate import GitGate
+        from ..lib.domain.project import make_git_gate
 
         try:
             # Run blocking sync in thread pool
             result = await asyncio.get_event_loop().run_in_executor(
-                None, lambda: GitGate(load_project(project_id)).sync_branches(branches)
+                None, lambda: make_git_gate(load_project(project_id)).sync_branches(branches)
             )
 
             # Validate project hasn't changed
@@ -295,7 +295,7 @@ class PollingMixin:
 
                 # Re-check staleness after sync
                 staleness = await asyncio.get_event_loop().run_in_executor(
-                    None, lambda: GitGate(load_project(project_id)).compare_vs_upstream()
+                    None, lambda: make_git_gate(load_project(project_id)).compare_vs_upstream()
                 )
 
                 if project_id == self.current_project_id:

--- a/src/terok/tui/project_actions.py
+++ b/src/terok/tui/project_actions.py
@@ -17,8 +17,6 @@ from collections.abc import Callable
 from ..lib.core.config import get_envs_base_dir
 from ..lib.core.projects import effective_ssh_key_name, load_project
 from ..lib.domain.facade import (
-    GitGate,
-    SSHManager,
     authenticate,
     build_images,
     delete_project,
@@ -30,6 +28,7 @@ from ..lib.domain.facade import (
     stop_daemon,
     uninstall_systemd_units,
 )
+from ..lib.domain.project import make_git_gate, make_ssh_manager
 from .shell_launch import launch_login
 
 
@@ -170,7 +169,7 @@ class ProjectActionsMixin:
             return
         pid = self.current_project_id
         await self._run_suspended(
-            lambda: SSHManager(load_project(pid)).init(),
+            lambda: make_ssh_manager(load_project(pid)).init(),
             success_msg=f"Initialized SSH dir for {pid}",
         )
 
@@ -210,14 +209,14 @@ class ProjectActionsMixin:
             nonlocal gate_ok
             print(f"=== Full Setup for {pid} ===\n")
             print("Step 1/4: Initializing SSH...")
-            SSHManager(load_project(pid)).init()
+            make_ssh_manager(load_project(pid)).init()
             maybe_pause_for_ssh_key_registration(pid)
             print("\nStep 2/4: Generating Dockerfiles...")
             generate_dockerfiles(pid)
             print("\nStep 3/4: Building images...")
             build_images(pid)
             print("\nStep 4/4: Syncing git gate...")
-            res = GitGate(load_project(pid)).sync()
+            res = make_git_gate(load_project(pid)).sync()
             if not res["success"]:
                 print(f"\nGate sync warnings: {', '.join(res['errors'])}")
             else:
@@ -261,7 +260,7 @@ class ProjectActionsMixin:
         with self.suspend():
             try:
                 print(f"Syncing gate for {project_id}...")
-                result = GitGate(load_project(project_id)).sync()
+                result = make_git_gate(load_project(project_id)).sync()
                 if result["success"]:
                     sync_ok = True
                     if result["created"]:

--- a/src/terok/tui/task_actions.py
+++ b/src/terok/tui/task_actions.py
@@ -33,12 +33,13 @@ from ..lib.domain.facade import (
 from ..lib.instrumentation.agents import parse_md_agent
 from ..lib.orchestration.autopilot import wait_for_container_exit
 from ..lib.orchestration.tasks import (
+    container_name,
     generate_task_name,
     get_login_command,
     get_workspace_git_diff,
     mark_task_deleting,
 )
-from ..lib.sandbox.runtime import container_name, get_container_state
+from ..lib.sandbox.runtime import get_container_state
 from .clipboard import copy_to_clipboard_detailed
 from .screens import (
     AgentSelectionScreen,

--- a/tach.toml
+++ b/tach.toml
@@ -326,29 +326,41 @@ depends_on = [
 # ·· isolation ··  Container runtime, shield, gate, SSH
 #
 
+# Sandbox path resolution (vendored, zero internal deps)
+[[modules]]
+path = "terok.lib.sandbox.paths"
+layer = "sandbox"
+depends_on = []
+
+# Sandbox configuration dataclass
+[[modules]]
+path = "terok.lib.sandbox.config"
+layer = "sandbox"
+depends_on = ["terok.lib.sandbox.paths"]
+
 # Container state, GPU args, log streaming
 [[modules]]
 path = "terok.lib.sandbox.runtime"
 layer = "sandbox"
-depends_on = ["terok.lib.core.projects", "terok.lib.util.logging_utils", "terok.lib.util.yaml"]
+depends_on = ["terok.lib.util.logging_utils", "terok.lib.util.yaml"]
 
 # Shield egress firewall adapter
 [[modules]]
 path = "terok.lib.sandbox.shield"
 layer = "sandbox"
-depends_on = ["terok.lib.core.config", "terok.lib.core.paths"]
+depends_on = ["terok.lib.sandbox.config"]
 
 # Gate server lifecycle management
 [[modules]]
 path = "terok.lib.sandbox.gate_server"
 layer = "sandbox"
-depends_on = ["terok.lib.core.config", "terok.lib.core.paths", "terok.lib.sandbox.gate_tokens", "terok.lib.util.template_utils", "terok.gate"]
+depends_on = ["terok.lib.sandbox.config", "terok.lib.sandbox.gate_tokens", "terok.lib.util.template_utils", "terok.gate"]
 
 # Gate token CRUD
 [[modules]]
 path = "terok.lib.sandbox.gate_tokens"
 layer = "sandbox"
-depends_on = ["terok.lib.core.config"]
+depends_on = ["terok.lib.sandbox.config"]
 
 # Standalone HTTP gate server (zero terok imports)
 [[modules]]
@@ -362,8 +374,7 @@ utility = true
 path = "terok.lib.sandbox.ssh"
 layer = "sandbox"
 depends_on = [
-    "terok.lib.core.config",
-    "terok.lib.core.projects",
+    "terok.lib.sandbox.config",
     "terok.lib.util.fs",
     "terok.lib.util.template_utils",
 ]
@@ -372,7 +383,7 @@ depends_on = [
 [[modules]]
 path = "terok.lib.sandbox.git_gate"
 layer = "sandbox"
-depends_on = ["terok.lib.core.config", "terok.lib.core.projects"]
+depends_on = ["terok.lib.sandbox.config", "terok.lib.sandbox.ssh"]
 
 # ── CORE LAYER ────────────────────────────────────────────────────
 #
@@ -602,6 +613,9 @@ from = ["terok.lib.domain.task_logs"]
 
 [[interfaces]]
 expose = [
+    "container_name",
+    "CONTAINER_MODES",
+    "get_task_container_state",
     "task_new",
     "task_rename",
     "task_stop",
@@ -695,7 +709,7 @@ expose = ["token_file_path", "create_token", "revoke_token_for_task"]
 from = ["terok.lib.sandbox.gate_tokens"]
 
 [[interfaces]]
-expose = ["SSHManager", "SSHInitResult"]
+expose = ["SSHManager", "SSHInitResult", "effective_ssh_key_name"]
 from = ["terok.lib.sandbox.ssh"]
 
 [[interfaces]]
@@ -724,7 +738,6 @@ expose = [
     "BranchSyncResult",
     "CommitInfo",
     "GitGate",
-    "find_projects_sharing_gate",
 ]
 from = ["terok.lib.sandbox.git_gate"]
 
@@ -790,8 +803,6 @@ from = ["terok.lib.orchestration.environment"]
 
 [[interfaces]]
 expose = [
-    "container_name",
-    "get_task_container_state",
     "get_container_state",
     "gpu_run_args",
     "is_container_running",
@@ -866,6 +877,8 @@ expose = [
     "is_systemd_available",
     "GateStalenessInfo",
     "find_projects_sharing_gate",
+    "make_git_gate",
+    "make_ssh_manager",
     "get_project_state",
     "is_task_image_old",
     "make_shield",
@@ -885,7 +898,7 @@ expose = [
 from = ["terok.lib.domain.facade"]
 
 [[interfaces]]
-expose = ["Project", "AgentManager", "DeleteProjectResult", "delete_project"]
+expose = ["Project", "AgentManager", "DeleteProjectResult", "delete_project", "find_projects_sharing_gate", "validate_gate_upstream_match", "make_git_gate", "make_ssh_manager"]
 from = ["terok.lib.domain.project"]
 
 [[interfaces]]

--- a/tests/integration/test_shield_no_podman.py
+++ b/tests/integration/test_shield_no_podman.py
@@ -192,8 +192,7 @@ class TestTaskRunnerShieldIntegration:
 
         task_dir = shield_env.task_dir
         with (
-            patch("terok.lib.sandbox.shield.get_global_section", return_value={}),
-            patch("terok.lib.sandbox.shield.get_gate_server_port", return_value=GATE_PORT),
+            patch("terok.lib.sandbox.paths.state_root", return_value=shield_env.state_dir),
             patch("os.geteuid", return_value=1000),
             patch("subprocess.run", side_effect=capture_run),
             patch(
@@ -223,7 +222,7 @@ class TestTaskRunnerShieldIntegration:
             from terok.lib.core.projects import ProjectConfig
             from terok.lib.orchestration.task_runners import _run_container
 
-            project = MagicMock(spec=ProjectConfig)
+            project = MagicMock(spec=ProjectConfig, root=task_dir)
 
             _run_container(
                 cname="integ-test-ctr",
@@ -274,7 +273,7 @@ class TestTaskRunnerShieldIntegration:
             from terok.lib.core.projects import ProjectConfig
             from terok.lib.orchestration.task_runners import _run_container
 
-            project = MagicMock(spec=ProjectConfig)
+            project = MagicMock(spec=ProjectConfig, root=task_dir)
 
             _run_container(
                 cname="integ-test-ctr",
@@ -329,7 +328,7 @@ class TestTaskRunnerShieldIntegration:
             from terok.lib.core.projects import ProjectConfig
             from terok.lib.orchestration.task_runners import _run_container
 
-            project = MagicMock(spec=ProjectConfig)
+            project = MagicMock(spec=ProjectConfig, root=task_dir)
 
             _run_container(
                 cname="bypass-test-ctr",

--- a/tests/unit/cli/test_cli_workflows.py
+++ b/tests/unit/cli/test_cli_workflows.py
@@ -19,13 +19,13 @@ def _patch_init_steps[T](func: Callable[..., T]) -> Callable[..., T]:
     Mock args are injected as: mock_ssh_cls, mock_pause, mock_gen, mock_build, mock_gate_cls,
     mock_load.
     """
-    func = unittest.mock.patch("terok.cli.commands.setup.SSHManager")(func)
+    func = unittest.mock.patch("terok.cli.commands.setup.make_ssh_manager")(func)
     func = unittest.mock.patch("terok.cli.commands.setup.maybe_pause_for_ssh_key_registration")(
         func
     )
     func = unittest.mock.patch("terok.cli.commands.setup.generate_dockerfiles")(func)
     func = unittest.mock.patch("terok.cli.commands.setup.build_images")(func)
-    func = unittest.mock.patch("terok.cli.commands.setup.GitGate")(func)
+    func = unittest.mock.patch("terok.cli.commands.setup.make_git_gate")(func)
     func = unittest.mock.patch("terok.cli.commands.setup.load_project")(func)
     return func
 

--- a/tests/unit/lib/test_container_lifecycle.py
+++ b/tests/unit/lib/test_container_lifecycle.py
@@ -16,8 +16,8 @@ from unittest.mock import Mock, patch
 import pytest
 
 from terok.lib.orchestration.task_runners import task_restart
-from terok.lib.orchestration.tasks import task_new, task_status, task_stop
-from terok.lib.sandbox.runtime import get_container_state, get_task_container_state
+from terok.lib.orchestration.tasks import get_task_container_state, task_new, task_status, task_stop
+from terok.lib.sandbox.runtime import get_container_state
 from terok.lib.util.yaml import dump as yaml_dump, load as yaml_load
 from tests.test_utils import mock_git_config, project_env
 
@@ -214,11 +214,8 @@ def test_get_task_container_state_returns_none_without_mode() -> None:
 
 def test_get_task_container_state_uses_project_id_and_mode() -> None:
     """Task container lookup resolves the canonical container name."""
-    with (
-        patch("terok.lib.sandbox.runtime.load_project", return_value=SimpleNamespace(id="proj")),
-        patch(
-            "terok.lib.sandbox.runtime.get_container_state", return_value="running"
-        ) as mock_state,
-    ):
-        assert get_task_container_state("ignored", "1", "cli") == "running"
+    with patch(
+        "terok.lib.orchestration.tasks.get_container_state", return_value="running"
+    ) as mock_state:
+        assert get_task_container_state("proj", "1", "cli") == "running"
         mock_state.assert_called_once_with("proj-cli-1")

--- a/tests/unit/lib/test_gate_server.py
+++ b/tests/unit/lib/test_gate_server.py
@@ -84,7 +84,7 @@ def patched_install_env(unit_dir: Path) -> Iterator[None]:
             return_value=GATE_BASE_PATH,
         ),
         unittest.mock.patch(
-            "terok.lib.sandbox.gate_tokens.state_root",
+            "terok.lib.sandbox.config._state_root",
             return_value=STATE_ROOT_PATH,
         ),
     ):
@@ -105,7 +105,7 @@ def patched_daemon_paths(base: Path) -> Iterator[Path]:
             return_value=pid_file,
         ),
         unittest.mock.patch(
-            "terok.lib.sandbox.gate_tokens.state_root",
+            "terok.lib.sandbox.config._state_root",
             return_value=base,
         ),
     ):

--- a/tests/unit/lib/test_gate_tokens.py
+++ b/tests/unit/lib/test_gate_tokens.py
@@ -52,11 +52,10 @@ class TestTokenFilePath:
     """Tests for token_file_path."""
 
     def test_returns_path_under_state_root(self) -> None:
-        with unittest.mock.patch(
-            "terok.lib.sandbox.gate_tokens.state_root",
-            return_value=FAKE_TEROK_STATE_DIR,
-        ):
-            path = token_file_path()
+        from terok.lib.sandbox.config import SandboxConfig
+
+        cfg = SandboxConfig(state_dir=FAKE_TEROK_STATE_DIR)
+        path = token_file_path(cfg=cfg)
         assert path == FAKE_TEROK_STATE_DIR / "gate" / "tokens.json"
 
 

--- a/tests/unit/lib/test_git_gate.py
+++ b/tests/unit/lib/test_git_gate.py
@@ -12,12 +12,14 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from terok.lib.core.projects import load_project
+from terok.lib.domain.project import (
+    find_projects_sharing_gate,
+    make_git_gate,
+    validate_gate_upstream_match,
+)
 from terok.lib.sandbox.git_gate import (
-    GitGate,
     _get_gate_branch_head,
     _get_upstream_head,
-    find_projects_sharing_gate,
-    validate_gate_upstream_match,
 )
 from tests.test_utils import project_env, write_project
 
@@ -82,7 +84,7 @@ def test_sync_project_gate_ssh_requires_config() -> None:
         ),
         pytest.raises(SystemExit),
     ):
-        GitGate(load_project(project_id)).sync()
+        make_git_gate(load_project(project_id)).sync()
 
 
 def test_sync_project_gate_https_clone() -> None:
@@ -104,7 +106,7 @@ def test_sync_project_gate_https_clone() -> None:
         with patch(
             "terok.lib.sandbox.git_gate.subprocess.run", side_effect=run_side_effect
         ) as run_mock:
-            result = GitGate(load_project(project_id)).sync()
+            result = make_git_gate(load_project(project_id)).sync()
 
     assert result == {
         "path": str(gate_dir),
@@ -147,7 +149,7 @@ def test_last_commit(with_gate: bool, run_result: MagicMock | None, expected: di
         project_id=project_id,
         with_gate=with_gate,
     ):
-        gate = GitGate(load_project(project_id))
+        gate = make_git_gate(load_project(project_id))
         if run_result is None:
             assert gate.last_commit() is None
         else:
@@ -230,11 +232,12 @@ def test_get_upstream_head(
     """Upstream HEAD lookup handles success, missing config, and network failures."""
     with project_env(yaml_text, project_id=project_id):
         project = load_project(project_id)
-        if run_behavior is None:
-            assert _get_upstream_head(project, branch=branch) is None
+        if project.upstream_url is None or run_behavior is None:
+            assert expected is None
         else:
+            effective_branch = branch or project.default_branch
             with patch("terok.lib.sandbox.git_gate.subprocess.run", **run_behavior):
-                assert _get_upstream_head(project, branch=branch) == expected
+                assert _get_upstream_head(project.upstream_url, effective_branch, {}) == expected
 
 
 @pytest.mark.parametrize(
@@ -263,11 +266,12 @@ def test_get_gate_branch_head(
     project_id = "proj-gate-head"
     with project_env(git_project_yaml(project_id), project_id=project_id, with_gate=with_gate):
         project = load_project(project_id)
+        effective_branch = branch or project.default_branch
         if run_result is None:
-            assert _get_gate_branch_head(project, branch=branch) is None
+            assert _get_gate_branch_head(project.gate_path, effective_branch, {}) is None
         else:
             with patch("terok.lib.sandbox.git_gate.subprocess.run", return_value=run_result):
-                assert _get_gate_branch_head(project, branch=branch) == expected
+                assert _get_gate_branch_head(project.gate_path, effective_branch, {}) == expected
 
 
 @pytest.mark.parametrize(
@@ -377,14 +381,26 @@ def test_compare_gate_vs_upstream(
 ) -> None:
     """Gate staleness comparison reports sync, stale, and error states."""
     project_id = "proj-compare"
+
+    def _range_side_effect(_gate_dir, from_ref, to_ref, _env):
+        """Return behind or ahead count depending on ref order."""
+        if gate_head and upstream_info:
+            if from_ref == gate_head and to_ref == upstream_info["commit_hash"]:
+                return count_behind
+            if from_ref == upstream_info["commit_hash"] and to_ref == gate_head:
+                return count_ahead
+        return None
+
     with project_env(git_project_yaml(project_id), project_id=project_id, with_gate=with_gate):
         with (
             patch("terok.lib.sandbox.git_gate._get_gate_branch_head", return_value=gate_head),
             patch("terok.lib.sandbox.git_gate._get_upstream_head", return_value=upstream_info),
-            patch("terok.lib.sandbox.git_gate._count_commits_behind", return_value=count_behind),
-            patch("terok.lib.sandbox.git_gate._count_commits_ahead", return_value=count_ahead),
+            patch(
+                "terok.lib.sandbox.git_gate._count_commits_range",
+                side_effect=_range_side_effect,
+            ),
         ):
-            result = GitGate(load_project(project_id)).compare_vs_upstream()
+            result = make_git_gate(load_project(project_id)).compare_vs_upstream()
 
     assert result.branch == "main"
     for key, value in expected.items():
@@ -444,7 +460,7 @@ def test_sync_branches(
     """Branch sync reports success, initialization problems, and fetch failures."""
     project_id = "proj-sync-branches"
     with project_env(git_project_yaml(project_id), project_id=project_id, with_gate=with_gate):
-        gate = GitGate(load_project(project_id))
+        gate = make_git_gate(load_project(project_id))
         if run_behavior is None:
             assert gate.sync_branches(branches) == expected
         else:
@@ -477,7 +493,7 @@ def test_sync_branches_rejects_mismatched_upstream() -> None:
         )
 
         with pytest.raises(SystemExit, match="Gate path conflict"):
-            GitGate(load_project("new-proj")).sync_branches()
+            make_git_gate(load_project("new-proj")).sync_branches()
 
 
 def test_find_projects_sharing_gate() -> None:
@@ -591,4 +607,4 @@ def test_sync_project_gate_rejects_mismatched_upstream() -> None:
         )
 
         with pytest.raises(SystemExit, match="Gate path conflict"):
-            GitGate(load_project("new-proj")).sync()
+            make_git_gate(load_project("new-proj")).sync()

--- a/tests/unit/lib/test_shield.py
+++ b/tests/unit/lib/test_shield.py
@@ -5,7 +5,7 @@
 
 from __future__ import annotations
 
-from collections.abc import Callable, Iterator
+from collections.abc import Callable
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -20,11 +20,9 @@ from terok_shield import (
     ShieldState,
 )
 
+from terok.lib.sandbox.config import SandboxConfig
 from terok.lib.sandbox.shield import (
     _BYPASS_WARNING,
-    _normalize_profiles,
-    _profiles_dir,
-    _state_dir,
     check_environment,
     down,
     make_shield,
@@ -38,15 +36,7 @@ from terok.lib.sandbox.shield import (
 from tests.testfs import MOCK_BASE, MOCK_CONFIG_ROOT, MOCK_TASK_DIR
 from tests.testnet import GATE_PORT
 
-_BYPASS_PATCH = "terok.lib.sandbox.shield.get_shield_bypass_firewall_no_protection"
 CUSTOM_GATE_PORT = GATE_PORT + 1
-
-
-@pytest.fixture(autouse=True)
-def _bypass_disabled_by_default() -> Iterator[None]:
-    """Keep normal-path shield tests deterministic unless explicitly overridden."""
-    with patch(_BYPASS_PATCH, return_value=False):
-        yield
 
 
 def make_mock_shield(
@@ -63,56 +53,23 @@ def make_mock_shield(
     return mock_shield
 
 
-def test_state_dir_returns_shield_subdir() -> None:
-    """Per-task shield state lives under ``task_dir/shield``."""
-    assert _state_dir(MOCK_TASK_DIR) == MOCK_TASK_DIR / "shield"
-
-
 @pytest.mark.parametrize(
-    ("raw", "expected"),
-    [
-        pytest.param("foo", ("foo",), id="single-string"),
-        pytest.param(["a", "b"], ("a", "b"), id="list"),
-        pytest.param(("x",), ("x",), id="tuple"),
-    ],
-)
-def test_normalize_profiles_success(raw: object, expected: tuple[str, ...]) -> None:
-    """String, list, and tuple profile configs normalize to tuples."""
-    assert _normalize_profiles(raw) == expected
-
-
-@pytest.mark.parametrize(
-    "raw",
-    [
-        pytest.param(123, id="invalid-type"),
-        pytest.param(["ok", 42], id="invalid-list-item"),
-    ],
-)
-def test_normalize_profiles_rejects_invalid_values(raw: object) -> None:
-    """Unsupported profile config values raise ``TypeError``."""
-    with pytest.raises(TypeError):
-        _normalize_profiles(raw)
-
-
-@patch("terok.lib.sandbox.shield.config_root", return_value=MOCK_CONFIG_ROOT)
-def test_profiles_dir_returns_shield_profiles_subdir(_mock: MagicMock) -> None:
-    """Shared shield profiles live under ``config_root()/shield/profiles``."""
-    assert _profiles_dir() == MOCK_CONFIG_ROOT / "shield" / "profiles"
-
-
-@pytest.mark.parametrize(
-    ("global_section", "expected_profiles", "expected_port", "audit_enabled"),
+    ("cfg_kwargs", "expected_profiles", "expected_port", "audit_enabled"),
     [
         pytest.param({}, ("dev-standard",), GATE_PORT, True, id="defaults"),
         pytest.param(
-            {"profiles": ["custom-a", "custom-b"], "audit": False},
+            {
+                "shield_profiles": ("custom-a", "custom-b"),
+                "shield_audit": False,
+                "gate_port": CUSTOM_GATE_PORT,
+            },
             ("custom-a", "custom-b"),
             CUSTOM_GATE_PORT,
             False,
             id="custom-values",
         ),
         pytest.param(
-            {"profiles": "single-profile"},
+            {"shield_profiles": ("single-profile",)},
             ("single-profile",),
             GATE_PORT,
             True,
@@ -121,19 +78,15 @@ def test_profiles_dir_returns_shield_profiles_subdir(_mock: MagicMock) -> None:
     ],
 )
 def test_make_shield_maps_config_to_shield_config(
-    global_section: dict[str, object],
+    cfg_kwargs: dict[str, object],
     expected_profiles: tuple[str, ...],
     expected_port: int,
     audit_enabled: bool,
 ) -> None:
-    """Global shield config is translated into the per-task ``ShieldConfig``."""
-    with (
-        patch("terok_shield.SubprocessRunner", autospec=True),
-        patch("terok.lib.sandbox.shield.config_root", return_value=MOCK_CONFIG_ROOT),
-        patch("terok.lib.sandbox.shield.get_global_section", return_value=global_section),
-        patch("terok.lib.sandbox.shield.get_gate_server_port", return_value=expected_port),
-    ):
-        shield = make_shield(MOCK_TASK_DIR)
+    """SandboxConfig values are translated into the per-task ``ShieldConfig``."""
+    cfg = SandboxConfig(config_dir=MOCK_CONFIG_ROOT, **cfg_kwargs)
+    with patch("terok_shield.SubprocessRunner", autospec=True):
+        shield = make_shield(MOCK_TASK_DIR, cfg=cfg)
 
     assert isinstance(shield, Shield)
     config = shield.config
@@ -143,17 +96,6 @@ def test_make_shield_maps_config_to_shield_config(
     assert config.audit_enabled is audit_enabled
     assert config.state_dir == MOCK_TASK_DIR / "shield"
     assert config.profiles_dir == MOCK_CONFIG_ROOT / "shield" / "profiles"
-
-
-def test_make_shield_rejects_invalid_profiles() -> None:
-    """Invalid ``shield.profiles`` values fail fast."""
-    with (
-        patch("terok_shield.SubprocessRunner", autospec=True),
-        patch("terok.lib.sandbox.shield.get_global_section", return_value={"profiles": 123}),
-        patch("terok.lib.sandbox.shield.get_gate_server_port", return_value=GATE_PORT),
-        pytest.raises(TypeError),
-    ):
-        make_shield(MOCK_TASK_DIR)
 
 
 def test_nft_not_found_is_reexported() -> None:
@@ -192,7 +134,7 @@ def test_shield_functions_delegate_to_per_task_shield(
 
     result = func("my-container", MOCK_TASK_DIR)
 
-    mock_make.assert_called_once_with(MOCK_TASK_DIR)
+    mock_make.assert_called_once_with(MOCK_TASK_DIR, None)
     if method_name == "down":
         getattr(mock_shield, method_name).assert_called_once_with("my-container", allow_all=False)
     else:
@@ -209,27 +151,24 @@ def test_shield_down_allow_all(mock_make: MagicMock) -> None:
 
     down("my-container", MOCK_TASK_DIR, allow_all=True)
 
-    mock_make.assert_called_once_with(MOCK_TASK_DIR)
+    mock_make.assert_called_once_with(MOCK_TASK_DIR, None)
     mock_shield.down.assert_called_once_with("my-container", allow_all=True)
 
 
-@patch("terok.lib.sandbox.shield.get_global_section", return_value={})
-def test_status_defaults(_sec: MagicMock) -> None:
+def test_status_defaults() -> None:
     """Status reflects the default configured shield state."""
-    assert status() == {
+    cfg = SandboxConfig()
+    assert status(cfg=cfg) == {
         "mode": "hook",
         "profiles": ["dev-standard"],
         "audit_enabled": True,
     }
 
 
-@patch(
-    "terok.lib.sandbox.shield.get_global_section",
-    return_value={"profiles": ["custom"], "audit": False},
-)
-def test_status_custom_config(_sec: MagicMock) -> None:
+def test_status_custom_config() -> None:
     """Status reflects custom configured profiles and audit settings."""
-    assert status() == {
+    cfg = SandboxConfig(shield_profiles=("custom",), shield_audit=False)
+    assert status(cfg=cfg) == {
         "mode": "hook",
         "profiles": ["custom"],
         "audit_enabled": False,
@@ -237,36 +176,34 @@ def test_status_custom_config(_sec: MagicMock) -> None:
 
 
 @pytest.mark.parametrize("func", [down, up], ids=["down", "up"])
-@patch(_BYPASS_PATCH, return_value=True)
 @patch("terok.lib.sandbox.shield.make_shield")
 def test_bypass_makes_down_and_up_noops(
     mock_make: MagicMock,
-    _bypass: MagicMock,
     func: Callable[..., object],
 ) -> None:
     """Bypass mode makes the up/down wrapper functions no-ops."""
-    func("ctr", MOCK_TASK_DIR)
+    cfg = SandboxConfig(shield_bypass=True)
+    func("ctr", MOCK_TASK_DIR, cfg=cfg)
     mock_make.assert_not_called()
 
 
-@patch(_BYPASS_PATCH, return_value=True)
-def test_bypass_pre_start_returns_empty_with_warning(_bypass: MagicMock) -> None:
+def test_bypass_pre_start_returns_empty_with_warning() -> None:
     """Bypass mode returns no pre-start Podman args and warns loudly."""
+    cfg = SandboxConfig(shield_bypass=True)
     with pytest.warns(UserWarning) as caught:
-        assert pre_start("ctr", MOCK_TASK_DIR) == []
+        assert pre_start("ctr", MOCK_TASK_DIR, cfg=cfg) == []
     assert any(_BYPASS_WARNING in str(item.message) for item in caught)
 
 
-@patch(_BYPASS_PATCH, return_value=True)
 @patch("terok.lib.sandbox.shield.make_shield")
 def test_bypass_state_still_queries_real_shield(
     mock_make: MagicMock,
-    _bypass: MagicMock,
 ) -> None:
     """State lookup still queries the real shield to handle pre-bypass containers."""
+    cfg = SandboxConfig(shield_bypass=True)
     mock_make.return_value = make_mock_shield(shield_state=ShieldState.UP)
-    assert state("ctr", MOCK_TASK_DIR) == ShieldState.UP
-    mock_make.assert_called_once_with(MOCK_TASK_DIR)
+    assert state("ctr", MOCK_TASK_DIR, cfg=cfg) == ShieldState.UP
+    mock_make.assert_called_once_with(MOCK_TASK_DIR, cfg)
 
 
 @pytest.mark.parametrize(
@@ -276,15 +213,13 @@ def test_bypass_state_still_queries_real_shield(
         pytest.param(False, False, id="bypass-disabled"),
     ],
 )
-@patch("terok.lib.sandbox.shield.get_global_section", return_value={})
 def test_status_includes_bypass_flag_only_when_active(
-    _sec: MagicMock,
     bypass_enabled: bool,
     expected_key: bool,
 ) -> None:
     """Status output surfaces the dangerous bypass flag only when it is active."""
-    with patch(_BYPASS_PATCH, return_value=bypass_enabled):
-        result = status()
+    cfg = SandboxConfig(shield_bypass=bypass_enabled)
+    result = status(cfg=cfg)
     assert ("bypass_firewall_no_protection" in result) is expected_key
     assert result["mode"] == "hook"
     assert "profiles" in result
@@ -302,10 +237,10 @@ def test_check_environment_forwards_result(mock_make: MagicMock) -> None:
     mock_shield.check_environment.assert_called_once()
 
 
-@patch(_BYPASS_PATCH, return_value=True)
-def test_check_environment_bypass_returns_synthetic_result(_bypass: MagicMock) -> None:
+def test_check_environment_bypass_returns_synthetic_result() -> None:
     """Bypass mode surfaces a synthetic degraded environment result."""
-    result = check_environment()
+    cfg = SandboxConfig(shield_bypass=True)
+    result = check_environment(cfg=cfg)
     assert not result.ok
     assert result.health == "bypass"
     assert any("bypass" in issue for issue in result.issues)

--- a/tests/unit/lib/test_ssh.py
+++ b/tests/unit/lib/test_ssh.py
@@ -11,7 +11,7 @@ import unittest.mock
 from pathlib import Path
 
 from terok.lib.core.projects import load_project
-from terok.lib.sandbox.ssh import SSHManager
+from terok.lib.domain.project import make_ssh_manager
 from tests.test_utils import mock_git_config, write_project
 
 
@@ -50,7 +50,7 @@ class TestSsh:
                 mock_git_config(),
                 unittest.mock.patch("terok.lib.sandbox.ssh.subprocess.run") as run_mock,
             ):
-                result = SSHManager(load_project(project_id)).init(key_name=key_name)
+                result = make_ssh_manager(load_project(project_id)).init(key_name=key_name)
 
             run_mock.assert_not_called()
             config_path = Path(result["config_path"])
@@ -69,7 +69,7 @@ class TestSsh:
                 unittest.mock.patch("terok.lib.sandbox.ssh.subprocess.run") as run_mock,
                 unittest.mock.patch("builtins.print") as print_mock,
             ):
-                SSHManager(load_project(project_id)).init()
+                make_ssh_manager(load_project(project_id)).init()
 
             run_mock.assert_not_called()
             printed_lines = [

--- a/tests/unit/tui/test_detail_screens.py
+++ b/tests/unit/tui/test_detail_screens.py
@@ -739,7 +739,7 @@ class TestGateSyncAction:
             mock.patch.dict(
                 action_globals,
                 {
-                    "GitGate": mock.Mock(return_value=fake_gate),
+                    "make_git_gate": mock.Mock(return_value=fake_gate),
                     "load_project": mock.Mock(),
                 },
             ),
@@ -763,7 +763,7 @@ class TestGateSyncAction:
             mock.patch.dict(
                 action_globals,
                 {
-                    "GitGate": mock.Mock(return_value=fake_gate),
+                    "make_git_gate": mock.Mock(return_value=fake_gate),
                     "load_project": mock.Mock(),
                 },
             ),

--- a/tests/unit/tui/test_project_state_staleness.py
+++ b/tests/unit/tui/test_project_state_staleness.py
@@ -31,7 +31,7 @@ def test_staleness_checked_for_online_and_gatekeeping(security_class: str) -> No
     with (
         mock.patch.object(app, "load_project", return_value=project),
         mock.patch.object(app, "get_project_state", return_value=state),
-        mock.patch.object(app, "GitGate", return_value=mock_gate),
+        mock.patch("terok.lib.domain.project.make_git_gate", return_value=mock_gate),
     ):
         result = app.TerokTUI._load_project_state(mock.Mock(), "proj1")
 


### PR DESCRIPTION
## Summary

- **Phase 1**: Remove all `ProjectConfig` / `load_project` imports from sandbox modules. `container_name()` moves to orchestration; `GitGate` and `SSHManager` accept plain keyword params; `find_projects_sharing_gate()` and `validate_gate_upstream_match()` move to `domain/project.py` as terok policy. Adapter factories `make_git_gate()` / `make_ssh_manager()` bridge the gap.
- **Phase 2**: Remove all `core.config` and `core.paths` imports. New `sandbox/paths.py` (vendored XDG/FHS resolution), new `sandbox/config.py` (`SandboxConfig` frozen dataclass). All sandbox modules accept optional `SandboxConfig`, defaulting to env-var resolution.

After both phases, `lib/sandbox/` has **zero imports from core/** — only from `util/` (to be vendored at extraction time) and its own submodules.

Tracked by epic #507. Resolves #503, #504.

## Test plan

- [x] `tach check` — sandbox modules have zero deps on core.projects/core.config/core.paths
- [x] `ruff check . && ruff format --check .` — clean
- [x] 1474 unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Centralized sandbox configuration and platform-aware path resolution for consistent install/runtime locations.
  * SSH, Git gate, and Shield now use config-driven factories and explicit configs for setup, syncing, and key handling; Shield reads settings from the sandbox config.
  * Container naming and lifecycle standardized across modes for consistent state reporting and multi-container shutdown.
* **Bug Fixes**
  * Gate/upstream mismatches are validated earlier to prevent sync conflicts.
* **Tests**
  * Tests updated to exercise factory-based managers and config-driven behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->