### PR TITLE
fix: skip shield hook tests when hooks not installed

### DIFF
--- a/tests/integration/test_shield_hooks.py
+++ b/tests/integration/test_shield_hooks.py
@@ -16,9 +16,12 @@ terok_shield = pytest.importorskip("terok_shield")
 has_global_hooks = terok_shield.has_global_hooks
 find_hooks_dirs = terok_shield.find_hooks_dirs
 
+from .conftest import hooks_unavailable
+
 pytestmark = [pytest.mark.needs_host_features, pytest.mark.needs_hooks]
 
 
+@hooks_unavailable
 class TestHooksInstalled:
     """Verify global hooks are present after ``terokctl shield setup --user``."""
 


### PR DESCRIPTION
## Summary

- `TestHooksInstalled` had `@pytest.mark.needs_hooks` but was missing the `@hooks_unavailable` skip decorator, so the tests were selected by CI (`needs_host_features`) but failed because no hooks are installed on the GH runner
- Adds the missing `@hooks_unavailable` decorator — tests now skip gracefully on hookless environments and run inside disposable matrix containers where hooks are installed

## Test plan

- [x] Unit tests pass (1517)
- [x] Lint clean
- [x] Tests pass when hooks are present
- [x] Tests will skip when hooks are absent (CI runner)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test infrastructure to conditionally enable or disable tests based on hook availability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->