### PR TITLE
refactor: decouple envs_base_dir and image from instrumentation layer

### DIFF
--- a/src/terok/lib/domain/facade.py
+++ b/src/terok/lib/domain/facade.py
@@ -72,9 +72,13 @@ from terok_sandbox.shield import (  # noqa: F401 — re-exported public API
 )
 from terok_sandbox.ssh import SSHManager  # noqa: F401 — re-exported public API
 
-from ..core.config import SHIELD_SECURITY_HINT  # noqa: F401 — re-exported for presentation layer
+from ..core.config import (
+    SHIELD_SECURITY_HINT,  # noqa: F401 — re-exported for presentation layer
+    get_envs_base_dir,
+)
+from ..core.images import project_cli_image
 from ..core.projects import load_project
-from ..instrumentation.auth import AUTH_PROVIDERS, AuthProvider, authenticate
+from ..instrumentation.auth import AUTH_PROVIDERS, AuthProvider, authenticate as _authenticate_raw
 from ..orchestration.docker import build_images, generate_dockerfiles
 from ..orchestration.task_runners import (  # noqa: F401 — re-exported public API
     HeadlessRunRequest,
@@ -157,6 +161,20 @@ def maybe_pause_for_ssh_key_registration(project_id: str) -> None:
         print("deploy key (or to your SSH keys) on the git remote.")
         print("=" * 60)
         input("Press Enter once the key is registered... ")
+
+
+def authenticate(project_id: str, provider: str) -> None:
+    """Run the auth flow for *provider*, injecting terok-specific config.
+
+    Thin wrapper around the instrumentation-layer ``authenticate()`` that
+    supplies ``envs_base_dir`` and ``image`` from terok's config/image system.
+    """
+    _authenticate_raw(
+        project_id,
+        provider,
+        envs_base_dir=get_envs_base_dir(),
+        image=project_cli_image(project_id),
+    )
 
 
 __all__ = [

--- a/src/terok/lib/instrumentation/agents.py
+++ b/src/terok/lib/instrumentation/agents.py
@@ -15,7 +15,6 @@ import tempfile
 from dataclasses import dataclass
 from pathlib import Path
 
-from ..core.config import get_envs_base_dir
 from ..util.fs import ensure_dir, ensure_dir_writable
 from ..util.yaml import load as _yaml_load
 from .headless_providers import WrapperConfig
@@ -397,6 +396,7 @@ class AgentConfigSpec:
     provider: str = "claude"
     instructions: str | None = None
     default_agent: str | None = None
+    envs_base_dir: Path | None = None
 
     def __post_init__(self) -> None:
         """Coerce mutable sequences to tuples for true immutability."""
@@ -462,7 +462,9 @@ def prepare_agent_config_dir(spec: AgentConfigSpec) -> Path:
     # interactive and headless modes).
     from .headless_providers import HEADLESS_PROVIDERS
 
-    envs_base = get_envs_base_dir()
+    envs_base = spec.envs_base_dir
+    if envs_base is None:
+        raise ValueError("envs_base_dir is required in AgentConfigSpec")
     _inject_opencode_instructions(envs_base / "_opencode-config" / "opencode.json")
     for _p in HEADLESS_PROVIDERS.values():
         if _p.opencode_config is not None:
@@ -491,7 +493,7 @@ def prepare_agent_config_dir(spec: AgentConfigSpec) -> Path:
 
     # Write SessionStart hook — only for providers that support it (Claude)
     if resolved.supports_session_hook:
-        shared_claude_dir = get_envs_base_dir() / "_claude-config"
+        shared_claude_dir = envs_base / "_claude-config"
         ensure_dir_writable(shared_claude_dir, "_claude-config")
         _write_session_hook(shared_claude_dir / "settings.json")
 

--- a/src/terok/lib/instrumentation/auth.py
+++ b/src/terok/lib/instrumentation/auth.py
@@ -17,9 +17,8 @@ from __future__ import annotations
 import shutil
 import subprocess
 from dataclasses import dataclass, field
+from pathlib import Path
 
-from ..core.config import get_envs_base_dir
-from ..core.images import project_cli_image
 from ..util.fs import ensure_dir_writable
 from ..util.podman import _podman_userns_args
 
@@ -251,12 +250,17 @@ def _cleanup_existing_container(container_name: str) -> None:
         )
 
 
-def _run_auth_container(project_id: str, provider: AuthProvider) -> None:
+def _run_auth_container(
+    project_id: str,
+    provider: AuthProvider,
+    *,
+    envs_base_dir: Path,
+    image: str,
+) -> None:
     """Run an auth container for the given provider."""
     _check_podman()
 
-    envs_base = get_envs_base_dir()
-    host_dir = envs_base / provider.host_dir_name
+    host_dir = envs_base_dir / provider.host_dir_name
     ensure_dir_writable(host_dir, f"{provider.label} config")
 
     container_name = f"{project_id}-auth-{provider.name}"
@@ -276,7 +280,7 @@ def _run_auth_container(project_id: str, provider: AuthProvider) -> None:
     cmd[3:3] = userns
     if provider.extra_run_args:
         cmd[3 + len(userns) : 3 + len(userns)] = list(provider.extra_run_args)
-    cmd.append(project_cli_image(project_id))
+    cmd.append(image)
     cmd.extend(provider.command)
 
     # Banner
@@ -305,8 +309,20 @@ def _run_auth_container(project_id: str, provider: AuthProvider) -> None:
         )
 
 
-def authenticate(project_id: str, provider: str) -> None:
+def authenticate(
+    project_id: str,
+    provider: str,
+    *,
+    envs_base_dir: Path,
+    image: str,
+) -> None:
     """Run the auth flow for *provider* against *project_id*.
+
+    Args:
+        project_id: Project identifier (for container naming).
+        provider: Auth provider name (e.g. ``"claude"``).
+        envs_base_dir: Base directory for shared env mounts.
+        image: Container image to use for the auth container.
 
     Raises ``SystemExit`` if the provider name is unknown.
     """
@@ -314,4 +330,4 @@ def authenticate(project_id: str, provider: str) -> None:
     if not info:
         available = ", ".join(AUTH_PROVIDERS)
         raise SystemExit(f"Unknown auth provider: {provider}. Available: {available}")
-    _run_auth_container(project_id, info)
+    _run_auth_container(project_id, info, envs_base_dir=envs_base_dir, image=image)

--- a/src/terok/lib/orchestration/task_runners.py
+++ b/src/terok/lib/orchestration/task_runners.py
@@ -26,6 +26,7 @@ from terok_sandbox.shield import (
 
 from ..core.config import (
     SHIELD_SECURITY_HINT,
+    get_envs_base_dir,
     get_gate_server_port,
     get_public_host,
     get_shield_bypass_firewall_no_protection,
@@ -220,6 +221,7 @@ def _prepare_agent_config(
             provider=resolved.name,
             instructions=instr_text,
             default_agent=project.default_agent,
+            envs_base_dir=get_envs_base_dir(),
         )
     )
 
@@ -768,6 +770,7 @@ def task_run_headless(request: HeadlessRunRequest) -> str:
             provider=resolved.name,
             instructions=instr_text,
             default_agent=project.default_agent,
+            envs_base_dir=get_envs_base_dir(),
         )
     )
 

--- a/tests/unit/lib/test_autopilot.py
+++ b/tests/unit/lib/test_autopilot.py
@@ -147,13 +147,7 @@ def prepare_agent_config(
     from terok.lib.instrumentation.agents import AgentConfigSpec, prepare_agent_config_dir
 
     (project.tasks_root / task_id).mkdir(parents=True, exist_ok=True)
-    with (
-        tempfile.TemporaryDirectory() as td,
-        unittest.mock.patch(
-            "terok.lib.instrumentation.agents.get_envs_base_dir",
-            return_value=Path(td),
-        ),
-    ):
+    with tempfile.TemporaryDirectory() as td:
         return prepare_agent_config_dir(
             AgentConfigSpec(
                 project.tasks_root,
@@ -161,6 +155,7 @@ def prepare_agent_config(
                 subagents=[],
                 instructions=instructions,
                 default_agent=project.default_agent,
+                envs_base_dir=Path(td),
             )
         )
 


### PR DESCRIPTION
## Summary

- Complete the instrumentation decoupling started in #512 by parameterizing the two remaining terok-internal dependencies: `get_envs_base_dir()` and `project_cli_image()`
- After this PR, the instrumentation layer has **zero imports** from `core.config` or `core.images` — only `util.fs`, `util.yaml`, and `util.podman` remain (vendored during extraction)

## Changes

| Module | Before | After |
|--------|--------|-------|
| `agents.py` | Calls `get_envs_base_dir()` internally | `envs_base_dir: Path` on `AgentConfigSpec` |
| `auth.py` | Calls `get_envs_base_dir()` + `project_cli_image()` | `envs_base_dir` + `image` keyword params |
| `facade.py` | Re-exports `authenticate()` directly | Wraps with terok-aware defaults |
| `task_runners.py` | N/A | Passes `get_envs_base_dir()` to `AgentConfigSpec` |

## Test plan

- [x] `make lint` — clean
- [x] `make test` — 1509 passed
- [x] `make tach` — all modules validated
- [x] `make docstrings` — 100% coverage
- [x] `make reuse` — compliant

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Authentication now routes through the public facade which supplies environment directory and image values automatically.
  * Agent configuration objects now include an explicit envs base directory; headless runs and agent setup use this value.
* **Tests**
  * Unit tests updated to pass the envs base directory explicitly into agent configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->