### PR TITLE
fix: repoint terok-gate entry point + restore pasta default port forwarding

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -91,7 +91,7 @@ markers = [
 terokctl = "terok.cli.main:main"
 terok = "terok.tui.app:main"
 terok-web = "terok.tui.serve:main"
-terok-gate = "terok.gate.server:main"
+terok-gate = "terok_sandbox.gate.server:main"
 
 [tool.ruff]
 target-version = "py312"


### PR DESCRIPTION
## Summary

Two fixes:

1. **Stale entry point**: Repoint `terok-gate` console script from deleted `terok.gate.server:main` to `terok_sandbox.gate.server:main` (broken since #510). Keeping the entry point (rather than deleting) is necessary because `pipx install` only exposes console scripts from the main package.

2. **Pasta networking**: Specifying `-T,9418` via `--network pasta:OPTS` causes podman to stop injecting its default `-t auto -u auto` flags, leaving the container with no inbound TCP/UDP forwarding — breaking DNS, gate access, and all connectivity. Fixed by explicitly setting `-t,auto,-u,auto,-T,{port},-U,auto`.

The same pasta bug exists in terok-shield's `mode_hook.py` — filed as terok-ai/terok-shield#129.

**User action after upgrade:** Run `terokctl gate-server install` to re-render the systemd unit with the corrected binary path.

## Test plan

- [x] `podman run --network pasta` works (confirms pasta itself is fine)
- [x] `podman run --network pasta:-T,9418` breaks all connectivity (confirms the bug)
- [ ] `pipx install --force .` → `terok-gate --help` works
- [ ] `terokctl task run-cli` with `bypass_firewall_no_protection: true` clones successfully
- [ ] After terok-shield fix: `terokctl task run-cli` without bypass also works

🤖 Generated with [Claude Code](https://claude.com/claude-code)