### PR TITLE
refactor: migrate all imports to top-level package APIs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -101,6 +101,24 @@ make spdx NAME="Real Human Name" FILES="src/terok/new_file.py"  # Add SPDX heade
 - **Existing Tests**: Never remove or modify unrelated tests
 - **Dependencies**: Use Poetry for dependency management; avoid adding unnecessary dependencies
 
+## External Package Dependencies
+
+terok depends on three sibling packages, each pinned to a GitHub release wheel:
+
+```text
+terok → terok-agent → terok-sandbox → terok-shield
+```
+
+Both `terok-agent` and `terok-sandbox` are listed as **explicit** dependencies in `pyproject.toml` — even though sandbox is pulled transitively via agent. This is intentional: terok imports directly from both packages, so the dependency must be declared, not just inherited.
+
+**Version sync rules:**
+
+- When bumping `terok-sandbox` in terok, the same version must be pinned in `terok-agent`. Otherwise Poetry will reject conflicting URL pins. Bump terok-agent first, release it, then bump both in terok.
+- When bumping `terok-shield` in terok-sandbox, no direct impact on terok (transitive). But if terok-sandbox re-exports shield types that terok uses, the shield version must be compatible.
+- After any version bump: run `poetry lock` and commit both `pyproject.toml` and `poetry.lock`.
+
+**Import convention:** always import from the top-level package API (`from terok_agent import X`, `from terok_sandbox import X`), never from internal submodules. This keeps the coupling surface minimal and allows internal reorganization without breaking consumers.
+
 ## Module Boundaries (tach)
 
 The project uses [tach](https://github.com/gauge-sh/tach) to enforce module boundary rules defined in `tach.toml`. Each module declares its allowed dependencies and public interface. When adding new cross-module imports:

--- a/poetry.lock
+++ b/poetry.lock
@@ -2505,32 +2505,32 @@ tomli-w = ">=1.0,<2.0"
 
 [[package]]
 name = "terok-agent"
-version = "0.0.3"
+version = "0.0.4"
 description = "Single-agent task runner for hardened Podman containers"
 optional = false
 python-versions = ">=3.12,<4.0"
 groups = ["main"]
 files = [
-    {file = "terok_agent-0.0.3-py3-none-any.whl", hash = "sha256:ece1751bc521b41f08a6e7b6ac2a3e4d1e8fef62746a8b28269dc1266894b88e"},
+    {file = "terok_agent-0.0.4-py3-none-any.whl", hash = "sha256:ec1102d0dcd24ace80be13f06508e8428088cc5d10b083d7a0edf63eff4d1a03"},
 ]
 
 [package.dependencies]
 "ruamel.yaml" = ">=0.18"
-terok_sandbox = {url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.0.5/terok_sandbox-0.0.5-py3-none-any.whl"}
+terok_sandbox = {url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.0.6/terok_sandbox-0.0.6-py3-none-any.whl"}
 
 [package.source]
 type = "url"
-url = "https://github.com/terok-ai/terok-agent/releases/download/v0.0.3/terok_agent-0.0.3-py3-none-any.whl"
+url = "https://github.com/terok-ai/terok-agent/releases/download/v0.0.4/terok_agent-0.0.4-py3-none-any.whl"
 
 [[package]]
 name = "terok-sandbox"
-version = "0.0.5"
+version = "0.0.6"
 description = "Hardened Podman container runner with gate server and shield integration"
 optional = false
 python-versions = ">=3.12,<4.0"
 groups = ["main"]
 files = [
-    {file = "terok_sandbox-0.0.5-py3-none-any.whl", hash = "sha256:1f70bf88938c107b868f401a8102e57ee9d72f413cfdb111a5d014dd59577ecc"},
+    {file = "terok_sandbox-0.0.6-py3-none-any.whl", hash = "sha256:918a6e840999c6fd1c9180edfdbe8ec7e91699e7e05388eb6f012501435b43ab"},
 ]
 
 [package.dependencies]
@@ -2539,7 +2539,7 @@ terok_shield = {url = "https://github.com/terok-ai/terok-shield/releases/downloa
 
 [package.source]
 type = "url"
-url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.0.5/terok_sandbox-0.0.5-py3-none-any.whl"
+url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.0.6/terok_sandbox-0.0.6-py3-none-any.whl"
 
 [[package]]
 name = "terok-shield"
@@ -3027,4 +3027,4 @@ propcache = ">=0.2.1"
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.12,<4.0"
-content-hash = "85c4a357fa64463dde2ea3926f6c697602fa58908b129b629f392bf0e0146b32"
+content-hash = "18f153e18bcb4eba19155a167794ece2f3b92f525faba5472e3052fd6610922c"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,8 @@ rich = ">=13.0"
 platformdirs = ">=4.5.1"
 unique-namer = ">=1.3"
 textual-serve = ">=1.1.0"
-terok-agent = {url = "https://github.com/terok-ai/terok-agent/releases/download/v0.0.3/terok_agent-0.0.3-py3-none-any.whl"}
+terok-agent = {url = "https://github.com/terok-ai/terok-agent/releases/download/v0.0.4/terok_agent-0.0.4-py3-none-any.whl"}
+terok-sandbox = {url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.0.6/terok_sandbox-0.0.6-py3-none-any.whl"}
 
 [tool.poetry.group.dev.dependencies]
 pydevd-pycharm = "261.22158.126"

--- a/src/terok/cli/commands/task.py
+++ b/src/terok/cli/commands/task.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 
 import argparse
 
-from terok_agent.headless_providers import PROVIDER_NAMES as _PROVIDER_NAMES
+from terok_agent import PROVIDER_NAMES as _PROVIDER_NAMES
 
 from ...lib.core.config import get_logs_partial_streaming as _get_logs_partial_streaming
 from ...lib.domain.facade import (

--- a/src/terok/lib/core/projects.py
+++ b/src/terok/lib/core/projects.py
@@ -10,7 +10,7 @@ from pathlib import Path
 from typing import Any
 
 from pydantic import ValidationError
-from terok_agent.config_stack import ConfigScope, ConfigStack
+from terok_agent import ConfigScope, ConfigStack
 
 from ..util.yaml import YAMLError, dump as _yaml_dump, load as _yaml_load
 from .config import (

--- a/src/terok/lib/domain/facade.py
+++ b/src/terok/lib/domain/facade.py
@@ -29,49 +29,47 @@ used by CLI commands that operate on ``project_id`` strings directly.
 
 from __future__ import annotations
 
-from terok_agent.auth import AUTH_PROVIDERS, AuthProvider, authenticate as _authenticate_raw
-from terok_sandbox.gate_server import (  # noqa: F401 — re-exported public API
-    GateServerStatus,
-    check_units_outdated,
-    get_gate_base_path,
-    get_gate_server_port,
-    get_server_status,
-    install_systemd_units,
-    is_daemon_running,
-    is_systemd_available,
-    start_daemon,
-    stop_daemon,
-    uninstall_systemd_units,
+from terok_agent import (
+    AUTH_PROVIDERS,
+    AuthProvider,
+    authenticate as _authenticate_raw,
 )
-from terok_sandbox.git_gate import (  # noqa: F401 — re-exported public API
+from terok_sandbox import (  # noqa: F401 — re-exported public API
+    EnvironmentCheck,
+    GateServerStatus,
     GateStalenessInfo,
     GitGate,
-)
-from terok_sandbox.runtime import (  # noqa: F401 — re-exported public API
-    get_container_state,
-    get_project_container_states,
-    gpu_run_args,
-    is_container_running,
-    stop_task_containers,
-    stream_initial_logs,
-    wait_for_exit,
-)
-from terok_sandbox.shield import (  # noqa: F401 — re-exported public API
-    EnvironmentCheck,
     NftNotFoundError,
     ShieldNeedsSetup,
     ShieldState,
+    SSHManager,
     check_environment as shield_check_environment,
+    check_units_outdated,
     down as shield_down,
+    get_container_state,
+    get_gate_base_path,
+    get_gate_server_port,
+    get_project_container_states,
+    get_server_status,
+    gpu_run_args,
+    install_systemd_units,
+    is_container_running,
+    is_daemon_running,
+    is_systemd_available,
     make_shield,
     pre_start as shield_pre_start,
     run_setup as shield_run_setup,
     setup_hooks_direct as shield_setup_hooks_direct,
+    start_daemon,
     state as shield_state,
     status as shield_status,
+    stop_daemon,
+    stop_task_containers,
+    stream_initial_logs,
+    uninstall_systemd_units,
     up as shield_up,
+    wait_for_exit,
 )
-from terok_sandbox.ssh import SSHManager  # noqa: F401 — re-exported public API
 
 from ..core.config import (
     SHIELD_SECURITY_HINT,  # noqa: F401 — re-exported for presentation layer

--- a/src/terok/lib/domain/project.py
+++ b/src/terok/lib/domain/project.py
@@ -49,8 +49,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any, TypedDict
 
 from terok_agent import HeadlessProvider, get_provider, resolve_instructions
-from terok_sandbox.git_gate import GitGate
-from terok_sandbox.ssh import SSHManager
+from terok_sandbox import GitGate, SSHManager
 
 from ..core.config import (
     build_root,

--- a/src/terok/lib/domain/task_logs.py
+++ b/src/terok/lib/domain/task_logs.py
@@ -15,7 +15,7 @@ import subprocess
 from dataclasses import dataclass
 from pathlib import Path
 
-from terok_sandbox.runtime import get_container_state
+from terok_sandbox import get_container_state
 
 from ..core.projects import load_project
 from ..orchestration.tasks import container_name, tasks_meta_dir

--- a/src/terok/lib/instrumentation/agent_config.py
+++ b/src/terok/lib/instrumentation/agent_config.py
@@ -13,8 +13,7 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any
 
-from terok_agent.agent_config import resolve_provider_value  # noqa: F401 — re-exported
-from terok_agent.config_stack import ConfigScope, ConfigStack
+from terok_agent import ConfigScope, ConfigStack, resolve_provider_value  # noqa: F401 — re-exported
 
 from terok.lib.core.config import bundled_presets_dir, get_global_agent_config, global_presets_dir
 

--- a/src/terok/lib/orchestration/container_exec.py
+++ b/src/terok/lib/orchestration/container_exec.py
@@ -10,7 +10,7 @@ scripts executing with host privileges.
 
 import subprocess
 
-from terok_sandbox.runtime import get_container_state
+from terok_sandbox import get_container_state
 
 from ..util.logging_utils import _log_debug
 

--- a/src/terok/lib/orchestration/environment.py
+++ b/src/terok/lib/orchestration/environment.py
@@ -15,8 +15,8 @@ import os
 from dataclasses import dataclass
 from pathlib import Path
 
-from terok_agent.headless_providers import collect_opencode_provider_env
-from terok_sandbox.gate_server import (
+from terok_agent import collect_opencode_provider_env
+from terok_sandbox import (
     ensure_server_reachable,
     get_gate_base_path,
     get_gate_server_port,
@@ -66,7 +66,7 @@ _STATIC_SHARED_MOUNTS: tuple[SharedMount, ...] = (
 
 def _build_shared_mounts() -> tuple[SharedMount, ...]:
     """Build complete shared mounts including dynamically generated OpenCode provider mounts."""
-    from terok_agent.headless_providers import HEADLESS_PROVIDERS
+    from terok_agent import HEADLESS_PROVIDERS
 
     dynamic = tuple(
         SharedMount(
@@ -123,7 +123,7 @@ def _security_mode_env_and_volumes(
     project: ProjectConfig, ssh_host_dir: Path, task_id: str
 ) -> tuple[dict[str, str], list[str]]:
     """Return env vars and volumes for the project's security mode."""
-    from terok_sandbox.gate_tokens import create_token
+    from terok_sandbox import create_token
 
     env: dict[str, str] = {}
     volumes: list[str] = []

--- a/src/terok/lib/orchestration/task_runners.py
+++ b/src/terok/lib/orchestration/task_runners.py
@@ -14,21 +14,19 @@ from typing import TYPE_CHECKING
 
 from terok_agent import (
     AgentConfigSpec,
+    podman_userns_args as _podman_userns_args,
     prepare_agent_config_dir,
     resolve_instructions,
     resolve_provider_value,
 )
-from terok_agent._util import podman_userns_args as _podman_userns_args
-from terok_sandbox.runtime import (
+from terok_sandbox import (
+    down as _shield_down_impl,
     get_container_state,
     gpu_run_args,
     is_container_running,
+    pre_start as _shield_pre_start_impl,
     stream_initial_logs,
     wait_for_exit,
-)
-from terok_sandbox.shield import (
-    down as _shield_down_impl,
-    pre_start as _shield_pre_start_impl,
 )
 
 from ..core.config import (
@@ -136,7 +134,7 @@ def _apply_unrestricted_env(env: dict[str, str]) -> None:
     it is launched (CLI wrapper or ACP).  Setting them at the container
     level provides a single, unified permission mechanism.
     """
-    from terok_agent.headless_providers import collect_all_auto_approve_env
+    from terok_agent import collect_all_auto_approve_env
 
     env["TEROK_UNRESTRICTED"] = "1"
     env.update(collect_all_auto_approve_env())
@@ -212,7 +210,7 @@ def _prepare_agent_config(
         preset=preset,
     )
     subagents = list(effective.get("subagents") or [])
-    from terok_agent.headless_providers import get_provider as _get_provider
+    from terok_agent import get_provider as _get_provider
 
     resolved = _get_provider(provider_name, default_agent=project.default_agent)
     instr_text = resolve_instructions(effective, resolved.name, project_root=project.root)
@@ -698,7 +696,7 @@ def task_run_headless(request: HeadlessRunRequest) -> str:
 
     Returns the task_id.
     """
-    from terok_agent.headless_providers import (
+    from terok_agent import (
         CLIOverrides,
         apply_provider_config,
         build_headless_command,
@@ -898,7 +896,7 @@ def task_followup_headless(
     original ``task_run_headless`` invocation since ``podman start``
     re-executes the same container command.
     """
-    from terok_agent.headless_providers import HEADLESS_PROVIDERS
+    from terok_agent import HEADLESS_PROVIDERS
 
     project = load_project(project_id)
     meta, meta_path = load_task_meta(project.id, task_id)

--- a/src/terok/lib/orchestration/tasks.py
+++ b/src/terok/lib/orchestration/tasks.py
@@ -19,7 +19,7 @@ import subprocess
 from dataclasses import dataclass
 from pathlib import Path
 
-from terok_sandbox.runtime import (
+from terok_sandbox import (
     get_container_state,
     get_project_container_states,
     stop_task_containers,
@@ -700,7 +700,7 @@ def _task_delete(project: ProjectConfig, task_id: str) -> None:
         _archive_task(project, task_id, meta)
 
     _log_debug("task_delete: revoking gate tokens")
-    from terok_sandbox.gate_tokens import revoke_token_for_task
+    from terok_sandbox import revoke_token_for_task
 
     try:
         revoke_token_for_task(project.id, task_id)

--- a/src/terok/tui/screens.py
+++ b/src/terok/tui/screens.py
@@ -796,7 +796,7 @@ class AgentSelectionScreen(screen.ModalScreen[tuple[str, list[str] | None] | Non
         super().__init__()
         self._subagents = subagents or []
 
-        from terok_agent.headless_providers import HEADLESS_PROVIDERS
+        from terok_agent import HEADLESS_PROVIDERS
 
         if default_agent in HEADLESS_PROVIDERS:
             self._default_agent = default_agent
@@ -806,7 +806,7 @@ class AgentSelectionScreen(screen.ModalScreen[tuple[str, list[str] | None] | Non
 
     def compose(self) -> ComposeResult:
         """Build the agent list, optional sub-agent checkboxes, and buttons."""
-        from terok_agent.headless_providers import HEADLESS_PROVIDERS
+        from terok_agent import HEADLESS_PROVIDERS
 
         with Vertical(id="agent-dialog") as dialog:
             options = []
@@ -835,7 +835,7 @@ class AgentSelectionScreen(screen.ModalScreen[tuple[str, list[str] | None] | Non
     def on_mount(self) -> None:
         """Focus the agent list and highlight the default entry."""
         agent_list = self.query_one("#agent-list", OptionList)
-        from terok_agent.headless_providers import HEADLESS_PROVIDERS
+        from terok_agent import HEADLESS_PROVIDERS
 
         for idx, name in enumerate(HEADLESS_PROVIDERS):
             if name == self._default_agent:
@@ -875,7 +875,7 @@ class AgentSelectionScreen(screen.ModalScreen[tuple[str, list[str] | None] | Non
 
     def on_key(self, event: events.Key) -> None:
         """Handle number-key shortcuts (1-9) to select an agent."""
-        from terok_agent.headless_providers import HEADLESS_PROVIDERS
+        from terok_agent import HEADLESS_PROVIDERS
 
         if event.character and event.character.isdigit():
             idx = int(event.character) - 1
@@ -1196,7 +1196,7 @@ class TaskLaunchScreen(screen.ModalScreen["tuple[str, str, str, str, str, str | 
 
     def compose(self) -> ComposeResult:
         """Build status, agent selector, prompt input, and action buttons."""
-        from terok_agent.headless_providers import HEADLESS_PROVIDERS
+        from terok_agent import HEADLESS_PROVIDERS
 
         with Vertical(id="launch-dialog") as dialog:
             yield Static("Status: Starting container\u2026", id="launch-status")

--- a/src/terok/tui/task_actions.py
+++ b/src/terok/tui/task_actions.py
@@ -13,7 +13,7 @@ from collections.abc import Callable
 from contextlib import redirect_stdout
 from pathlib import Path
 
-from terok_agent.agents import parse_md_agent
+from terok_agent import parse_md_agent
 
 from ..lib.core.config import get_shield_bypass_firewall_no_protection
 from ..lib.core.projects import load_project
@@ -257,7 +257,7 @@ class TaskActionsMixin:
         if agent == "bash":
             cmd = base_cmd
         else:
-            from terok_agent.headless_providers import HEADLESS_PROVIDERS
+            from terok_agent import HEADLESS_PROVIDERS
 
             provider = HEADLESS_PROVIDERS.get(agent)
             if not provider:
@@ -378,7 +378,7 @@ class TaskActionsMixin:
         agent_name, selected_subagents = result
 
         # Only pass sub-agents if the agent supports them
-        from terok_agent.headless_providers import HEADLESS_PROVIDERS
+        from terok_agent import HEADLESS_PROVIDERS
 
         provider = HEADLESS_PROVIDERS.get(agent_name)
         agents = selected_subagents if provider and provider.supports_agents_json else None

--- a/tests/integration/test_bypass_connectivity.py
+++ b/tests/integration/test_bypass_connectivity.py
@@ -137,7 +137,7 @@ class TestBypassContainerConnectivity:
 
         # Simulate what _maybe_drop_shield does: call shield.down() on a
         # container that was started WITHOUT shield pre_start.
-        from terok_sandbox.shield import down as shield_down
+        from terok_sandbox import down as shield_down
 
         with tempfile.TemporaryDirectory() as td:
             task_dir = Path(td)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -11,7 +11,7 @@ from contextlib import contextmanager
 from pathlib import Path
 from typing import Any
 
-from terok_sandbox.git_gate import GateStalenessInfo
+from terok_sandbox import GateStalenessInfo
 
 
 def mock_git_config():

--- a/tests/testgate.py
+++ b/tests/testgate.py
@@ -5,7 +5,7 @@
 
 from __future__ import annotations
 
-from terok_sandbox.gate_server import GateServerStatus
+from terok_sandbox import GateServerStatus
 
 from tests.testnet import GATE_PORT
 

--- a/tests/unit/cli/test_cli_gate_server.py
+++ b/tests/unit/cli/test_cli_gate_server.py
@@ -9,7 +9,7 @@ from collections.abc import Callable
 from unittest.mock import patch
 
 import pytest
-from terok_sandbox.gate_server import GateServerStatus
+from terok_sandbox import GateServerStatus
 
 from terok.cli.commands.gate_server import (
     _cmd_install,

--- a/tests/unit/cli/test_cli_sickbay.py
+++ b/tests/unit/cli/test_cli_sickbay.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 from unittest.mock import patch
 
 import pytest
-from terok_sandbox.gate_server import GateServerStatus
+from terok_sandbox import GateServerStatus
 
 from terok.cli.commands.sickbay import _cmd_sickbay
 from tests.testgate import OUTDATED_UNITS_MESSAGE, make_gate_server_status

--- a/tests/unit/lib/test_agent_config.py
+++ b/tests/unit/lib/test_agent_config.py
@@ -12,7 +12,7 @@ from dataclasses import dataclass
 from pathlib import Path
 
 import pytest
-from terok_agent.config_stack import ConfigStack
+from terok_agent import ConfigStack
 
 from terok.lib.core.projects import ProjectConfig, list_presets, load_preset, load_project
 from terok.lib.instrumentation.agent_config import build_agent_config_stack, resolve_agent_config

--- a/tests/unit/lib/test_autopilot.py
+++ b/tests/unit/lib/test_autopilot.py
@@ -33,13 +33,12 @@ from tests.testfs import (
 if TYPE_CHECKING:
     from terok.lib.core.projects import ProjectConfig
 
+from terok_agent import WrapperConfig, parse_md_agent
 from terok_agent.agents import (
     _generate_claude_wrapper,
     _subagents_to_json,
     _write_session_hook,
-    parse_md_agent,
 )
-from terok_agent.headless_providers import WrapperConfig
 
 from terok.lib.core.projects import load_project
 from terok.lib.orchestration.task_runners import (
@@ -145,7 +144,7 @@ def prepare_agent_config(
     instructions: str | None = None,
 ) -> Path:
     """Build an agent-config directory for the given task."""
-    from terok_agent.agents import AgentConfigSpec, prepare_agent_config_dir
+    from terok_agent import AgentConfigSpec, prepare_agent_config_dir
 
     (project.tasks_root / task_id).mkdir(parents=True, exist_ok=True)
     with tempfile.TemporaryDirectory() as td:

--- a/tests/unit/lib/test_config_stack.py
+++ b/tests/unit/lib/test_config_stack.py
@@ -12,7 +12,7 @@ from collections.abc import Callable
 from pathlib import Path
 
 import pytest
-from terok_agent.config_stack import (
+from terok_agent import (
     ConfigScope,
     ConfigStack,
     deep_merge,

--- a/tests/unit/lib/test_container_lifecycle.py
+++ b/tests/unit/lib/test_container_lifecycle.py
@@ -14,7 +14,7 @@ from types import SimpleNamespace
 from unittest.mock import Mock, patch
 
 import pytest
-from terok_sandbox.runtime import get_container_state
+from terok_sandbox import get_container_state
 
 from terok.lib.orchestration.task_runners import task_restart
 from terok.lib.orchestration.tasks import get_task_container_state, task_new, task_status, task_stop

--- a/tests/unit/lib/test_effective_status.py
+++ b/tests/unit/lib/test_effective_status.py
@@ -9,7 +9,7 @@ import subprocess
 from unittest.mock import patch
 
 import pytest
-from terok_sandbox.runtime import get_project_container_states
+from terok_sandbox import get_project_container_states
 
 from terok.lib.core.task_display import (
     STATUS_DISPLAY,

--- a/tests/unit/lib/test_environment_gate_server.py
+++ b/tests/unit/lib/test_environment_gate_server.py
@@ -61,7 +61,7 @@ def resolve_security_env(
             "terok.lib.orchestration.environment.get_gate_base_path",
             return_value=ctx.state_dir / "gate",
         ),
-        patch("terok_sandbox.gate_tokens.create_token", return_value=token),
+        patch("terok_sandbox.create_token", return_value=token),
     ):
         project = load_project(project_id)
         env, volumes = _security_mode_env_and_volumes(project, Path(ctx.base / "ssh"), "1")

--- a/tests/unit/lib/test_gate_server.py
+++ b/tests/unit/lib/test_gate_server.py
@@ -15,22 +15,24 @@ from contextlib import contextmanager
 from pathlib import Path
 
 import pytest
-from terok_sandbox.gate_server import (
-    _UNIT_VERSION,
+from terok_sandbox import (
     GateServerStatus,
-    _installed_unit_version,
-    _is_managed_server,
     check_units_outdated,
     ensure_server_reachable,
     get_server_status,
     install_systemd_units,
     is_daemon_running,
-    is_socket_active,
-    is_socket_installed,
     is_systemd_available,
     start_daemon,
     stop_daemon,
     uninstall_systemd_units,
+)
+from terok_sandbox.gate_server import (
+    _UNIT_VERSION,
+    _installed_unit_version,
+    _is_managed_server,
+    is_socket_active,
+    is_socket_installed,
 )
 
 from tests.testfs import FAKE_GATE_DIR, FAKE_STATE_DIR, NONEXISTENT_DIR

--- a/tests/unit/lib/test_gate_tokens.py
+++ b/tests/unit/lib/test_gate_tokens.py
@@ -13,11 +13,13 @@ from contextlib import contextmanager
 from pathlib import Path
 
 import pytest
+from terok_sandbox import (
+    create_token,
+    revoke_token_for_task,
+)
 from terok_sandbox.gate_tokens import (
     _read_tokens,
     _write_tokens,
-    create_token,
-    revoke_token_for_task,
     token_file_path,
 )
 
@@ -52,7 +54,7 @@ class TestTokenFilePath:
     """Tests for token_file_path."""
 
     def test_returns_path_under_state_root(self) -> None:
-        from terok_sandbox.config import SandboxConfig
+        from terok_sandbox import SandboxConfig
 
         cfg = SandboxConfig(state_dir=FAKE_TEROK_STATE_DIR)
         path = token_file_path(cfg=cfg)

--- a/tests/unit/lib/test_git_gate.py
+++ b/tests/unit/lib/test_git_gate.py
@@ -10,10 +10,7 @@ from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
-from terok_sandbox.git_gate import (
-    _get_gate_branch_head,
-    _get_upstream_head,
-)
+from terok_sandbox.git_gate import _get_gate_branch_head, _get_upstream_head
 
 from terok.lib.core.projects import load_project
 from terok.lib.domain.project import (

--- a/tests/unit/lib/test_headless_providers.py
+++ b/tests/unit/lib/test_headless_providers.py
@@ -7,19 +7,18 @@
 from dataclasses import FrozenInstanceError
 
 import pytest
-from terok_agent.agent_config import resolve_provider_value
-from terok_agent.agents import _generate_claude_wrapper
-from terok_agent.headless_providers import (
+from terok_agent import (
     HEADLESS_PROVIDERS,
     PROVIDER_NAMES,
     CLIOverrides,
     apply_provider_config,
     build_headless_command,
     collect_all_auto_approve_env,
-    generate_agent_wrapper,
-    generate_all_wrappers,
     get_provider,
+    resolve_provider_value,
 )
+from terok_agent.agents import _generate_claude_wrapper
+from terok_agent.headless_providers import generate_agent_wrapper, generate_all_wrappers
 
 from tests.testfs import CONTAINER_TEROK_DIR
 

--- a/tests/unit/lib/test_instructions.py
+++ b/tests/unit/lib/test_instructions.py
@@ -9,11 +9,8 @@ import tempfile
 from pathlib import Path
 
 import pytest
-from terok_agent.instructions import (
-    bundled_default_instructions,
-    has_custom_instructions,
-    resolve_instructions,
-)
+from terok_agent import bundled_default_instructions, resolve_instructions
+from terok_agent.instructions import has_custom_instructions
 
 from tests.testfs import NONEXISTENT_PROJECT_ROOT, WORKSPACE_ROOT
 

--- a/tests/unit/lib/test_shield.py
+++ b/tests/unit/lib/test_shield.py
@@ -10,9 +10,8 @@ from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
-from terok_sandbox.config import SandboxConfig
-from terok_sandbox.shield import (
-    _BYPASS_WARNING,
+from terok_sandbox import (
+    SandboxConfig,
     check_environment,
     down,
     make_shield,
@@ -23,6 +22,7 @@ from terok_sandbox.shield import (
     status,
     up,
 )
+from terok_sandbox.shield import _BYPASS_WARNING
 from terok_shield import (
     USER_HOOKS_DIR,
     EnvironmentCheck,
@@ -100,14 +100,14 @@ def test_make_shield_maps_config_to_shield_config(
 
 def test_nft_not_found_is_reexported() -> None:
     """``NftNotFoundError`` is re-exported from the adapter module."""
-    from terok_sandbox.shield import NftNotFoundError as error_type
+    from terok_sandbox import NftNotFoundError as error_type
 
     assert error_type is NftNotFoundError
 
 
 def test_shield_state_is_reexported() -> None:
     """``ShieldState`` is re-exported from the adapter module."""
-    from terok_sandbox.shield import ShieldState as shield_state_type
+    from terok_sandbox import ShieldState as shield_state_type
 
     assert shield_state_type is ShieldState
 

--- a/tests/unit/lib/test_tasks.py
+++ b/tests/unit/lib/test_tasks.py
@@ -338,7 +338,7 @@ class TestTask:
         "terok.lib.orchestration.environment.get_gate_server_port",
         return_value=GATE_PORT,
     )
-    @unittest.mock.patch("terok_sandbox.gate_tokens.create_token", return_value="tok" * 10 + "ab")
+    @unittest.mock.patch("terok_sandbox.create_token", return_value="tok" * 10 + "ab")
     def test_build_task_env_gatekeeping(self, *_mocks) -> None:
         project_id = "proj9"
         with project_env(
@@ -366,7 +366,7 @@ class TestTask:
         "terok.lib.orchestration.environment.get_gate_server_port",
         return_value=GATE_PORT,
     )
-    @unittest.mock.patch("terok_sandbox.gate_tokens.create_token", return_value="tok" * 10 + "ab")
+    @unittest.mock.patch("terok_sandbox.create_token", return_value="tok" * 10 + "ab")
     def test_build_task_env_gatekeeping_with_ssh(self, *_mocks) -> None:
         """Gatekeeping mode with mount_in_gatekeeping enabled should mount SSH."""
         project_id = "proj_gatekeeping_ssh"
@@ -401,7 +401,7 @@ class TestTask:
         "terok.lib.orchestration.environment.get_gate_server_port",
         return_value=GATE_PORT,
     )
-    @unittest.mock.patch("terok_sandbox.gate_tokens.create_token", return_value="tok" * 10 + "ab")
+    @unittest.mock.patch("terok_sandbox.create_token", return_value="tok" * 10 + "ab")
     def test_build_task_env_online(self, *_mocks) -> None:
         project_id = "proj10"
         with project_env(
@@ -884,7 +884,7 @@ class TestTask:
         "terok.lib.orchestration.environment.get_gate_server_port",
         return_value=GATE_PORT,
     )
-    @unittest.mock.patch("terok_sandbox.gate_tokens.create_token", return_value="tok" * 10 + "ab")
+    @unittest.mock.patch("terok_sandbox.create_token", return_value="tok" * 10 + "ab")
     def test_build_task_env_gatekeeping_expose_external_remote_enabled(self, *_mocks) -> None:
         """Test expose_external_remote=true with upstream_url sets EXTERNAL_REMOTE_URL."""
         project_id = "proj_external_remote_enabled"
@@ -911,7 +911,7 @@ class TestTask:
         "terok.lib.orchestration.environment.get_gate_server_port",
         return_value=GATE_PORT,
     )
-    @unittest.mock.patch("terok_sandbox.gate_tokens.create_token", return_value="tok" * 10 + "ab")
+    @unittest.mock.patch("terok_sandbox.create_token", return_value="tok" * 10 + "ab")
     def test_build_task_env_gatekeeping_expose_external_remote_disabled(self, *_mocks) -> None:
         """Test expose_external_remote=false does not set EXTERNAL_REMOTE_URL."""
         project_id = "proj_external_remote_disabled"
@@ -938,7 +938,7 @@ class TestTask:
         "terok.lib.orchestration.environment.get_gate_server_port",
         return_value=GATE_PORT,
     )
-    @unittest.mock.patch("terok_sandbox.gate_tokens.create_token", return_value="tok" * 10 + "ab")
+    @unittest.mock.patch("terok_sandbox.create_token", return_value="tok" * 10 + "ab")
     def test_build_task_env_gatekeeping_expose_external_remote_no_upstream(self, *_mocks) -> None:
         """Test expose_external_remote=true without upstream_url does not set EXTERNAL_REMOTE_URL."""
         project_id = "proj_external_remote_no_upstream"

--- a/tests/unit/scripts/test_opencode_provider.py
+++ b/tests/unit/scripts/test_opencode_provider.py
@@ -75,7 +75,7 @@ class TestCollectProviderEnv:
 
     def test_contains_blablador_and_kisski(self) -> None:
         """Env dict has entries for all registered OpenCode providers."""
-        from terok_agent.headless_providers import collect_opencode_provider_env
+        from terok_agent import collect_opencode_provider_env
 
         env = collect_opencode_provider_env()
         assert "TEROK_OC_BLABLADOR_BASE_URL" in env
@@ -85,7 +85,7 @@ class TestCollectProviderEnv:
 
     def test_values_match_registry(self) -> None:
         """Env var values match the HeadlessProvider registry."""
-        from terok_agent.headless_providers import collect_opencode_provider_env
+        from terok_agent import collect_opencode_provider_env
 
         env = collect_opencode_provider_env()
         assert env["TEROK_OC_BLABLADOR_BASE_URL"] == (
@@ -95,7 +95,7 @@ class TestCollectProviderEnv:
 
     def test_to_env_all_fields_present(self) -> None:
         """OpenCodeProviderConfig.to_env() emits all required fields."""
-        from terok_agent.headless_providers import OpenCodeProviderConfig
+        from terok_agent import OpenCodeProviderConfig
 
         cfg = OpenCodeProviderConfig(
             display_name="Test",
@@ -141,14 +141,14 @@ class TestDynamicRegistration:
 
     def test_auth_providers_include_opencode_providers(self) -> None:
         """AUTH_PROVIDERS includes dynamically generated OpenCode provider entries."""
-        from terok_agent.auth import AUTH_PROVIDERS
+        from terok_agent import AUTH_PROVIDERS
 
         assert "blablador" in AUTH_PROVIDERS
         assert "kisski" in AUTH_PROVIDERS
 
     def test_auth_provider_key_url(self) -> None:
         """Auth provider key URLs come from the OpenCodeProviderConfig registry."""
-        from terok_agent.auth import AUTH_PROVIDERS
+        from terok_agent import AUTH_PROVIDERS
 
         blablador = AUTH_PROVIDERS["blablador"]
         assert "helmholtz" in blablador.banner_hint.lower() or "codebase" in blablador.banner_hint

--- a/tests/unit/tui/test_detail_screens.py
+++ b/tests/unit/tui/test_detail_screens.py
@@ -141,7 +141,7 @@ def _task_action_cases() -> list[tuple[str, str]]:
 
 
 def _auth_providers() -> list[str]:
-    from terok_agent.auth import AUTH_PROVIDERS
+    from terok_agent import AUTH_PROVIDERS
 
     return list(AUTH_PROVIDERS)
 
@@ -573,7 +573,7 @@ class TestAuthScreenOptions:
 
     def test_auth_screen_number_key_triggers_import(self) -> None:
         """Verify the number key after last provider selects import option."""
-        from terok_agent.auth import AUTH_PROVIDERS
+        from terok_agent import AUTH_PROVIDERS
 
         screens, _ = import_screens()
         screen = screens.AuthActionsScreen()

--- a/tests/unit/tui/test_polling.py
+++ b/tests/unit/tui/test_polling.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 import time
 
 import pytest
-from terok_sandbox.git_gate import GateStalenessInfo
+from terok_sandbox import GateStalenessInfo
 
 from tests.test_utils import make_staleness_info
 


### PR DESCRIPTION
## Summary

- Replace all submodule imports (`from terok_agent.headless_providers import X`, `from terok_sandbox.runtime import X`) with top-level imports (`from terok_agent import X`, `from terok_sandbox import X`)
- Re-add `terok-sandbox` as explicit dependency (was transitive-only since #517)
- Bump `terok-agent` to v0.0.4 and `terok-sandbox` to v0.0.6 (expanded public APIs)
- Document dependency chain and version sync rules in AGENTS.md

## Import convention (now enforced)

```python
# Good — top-level API
from terok_agent import HEADLESS_PROVIDERS, get_provider
from terok_sandbox import get_container_state, GitGate

# Bad — reaching into submodules (only for private _symbols in tests)
from terok_agent.headless_providers import HEADLESS_PROVIDERS  # don't do this
```

## Files changed

- **36 files** across src/ and tests/ — import rewrites only
- **pyproject.toml** — bump agent v0.0.4, add sandbox v0.0.6 explicit dep
- **AGENTS.md** — new "External Package Dependencies" section

## Verification

- [x] `make lint` — clean
- [x] `make test` — 1509 passed
- [x] `make tach` — all modules validated
- [x] `make docstrings` — 100% coverage
- [x] `make reuse` — compliant

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Dependencies**
  * Updated `terok-agent` to v0.0.4
  * Added `terok-sandbox` v0.0.6 as a new runtime dependency

* **Documentation**
  * Added external package dependency documentation covering dependency chains and version synchronization requirements
  * Added import conventions for consuming public package APIs

<!-- end of auto-generated comment: release notes by coderabbit.ai -->