### PR TITLE
refactor: slim facade, dissolve instrumentation layer, clean re-exports

### DIFF
--- a/src/terok/cli/commands/gate_server.py
+++ b/src/terok/cli/commands/gate_server.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 import argparse
 import sys
 
-from ...lib.domain.facade import (
+from terok_sandbox import (
     GateServerStatus,
     check_units_outdated,
     get_server_status,

--- a/src/terok/cli/commands/info.py
+++ b/src/terok/cli/commands/info.py
@@ -77,7 +77,7 @@ def _cmd_config_show(project_id: str, preset: str | None) -> None:
     import json
 
     from ...lib.core.projects import load_project
-    from ...lib.instrumentation.agent_config import build_agent_config_stack
+    from ...lib.domain.agent_config import build_agent_config_stack
 
     color_enabled = _supports_color()
 

--- a/src/terok/cli/commands/setup.py
+++ b/src/terok/cli/commands/setup.py
@@ -7,9 +7,10 @@ from __future__ import annotations
 
 import argparse
 
+from terok_agent import AUTH_PROVIDERS
+
 from ...lib.core.projects import load_project
 from ...lib.domain.facade import (
-    AUTH_PROVIDERS,
     authenticate,
     build_images,
     generate_dockerfiles,

--- a/src/terok/cli/commands/shield.py
+++ b/src/terok/cli/commands/shield.py
@@ -15,9 +15,8 @@ import argparse
 import sys
 from pathlib import Path
 
+from terok_sandbox import make_shield
 from terok_shield import COMMANDS, ArgDef, CommandDef, ExecError
-
-from ...lib.domain.facade import make_shield
 
 
 def _add_arg(parser: argparse.ArgumentParser, arg: ArgDef) -> None:
@@ -110,7 +109,7 @@ def dispatch(args: argparse.Namespace) -> bool:
 
     # setup is standalone_only and needs subprocess passthrough (no registry handler)
     if cmd_name == "setup":
-        from ...lib.domain.facade import shield_run_setup
+        from terok_sandbox import run_setup as shield_run_setup
 
         shield_run_setup(root=args.root, user=args.user)
         return True

--- a/src/terok/cli/commands/sickbay.py
+++ b/src/terok/cli/commands/sickbay.py
@@ -23,14 +23,15 @@ import argparse
 import sys
 from pathlib import Path
 
-from ...lib.core.project_model import ProjectConfig
-from ...lib.core.projects import list_projects, load_project
-from ...lib.domain.facade import (
+from terok_sandbox import (
     check_units_outdated,
     get_container_state,
     get_server_status,
     is_systemd_available,
 )
+
+from ...lib.core.project_model import ProjectConfig
+from ...lib.core.projects import list_projects, load_project
 from ...lib.orchestration.hooks import run_hook
 from ...lib.orchestration.tasks import container_name, tasks_meta_dir
 from ...lib.util.yaml import load as _yaml_load

--- a/src/terok/lib/domain/agent_config.py
+++ b/src/terok/lib/domain/agent_config.py
@@ -5,7 +5,7 @@
 
 Builds a :class:`~terok.lib.util.config_stack.ConfigStack` from up to four
 layers and returns a single merged agent-config dict that can be fed directly
-into :func:`~terok.lib.instrumentation.agents.prepare_agent_config_dir`.
+into :func:`~terok_agent.prepare_agent_config_dir`.
 """
 
 from __future__ import annotations
@@ -13,7 +13,7 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any
 
-from terok_agent import ConfigScope, ConfigStack, resolve_provider_value  # noqa: F401 — re-exported
+from terok_agent import ConfigScope, ConfigStack
 
 from terok.lib.core.config import bundled_presets_dir, get_global_agent_config, global_presets_dir
 

--- a/src/terok/lib/domain/facade.py
+++ b/src/terok/lib/domain/facade.py
@@ -30,51 +30,10 @@ used by CLI commands that operate on ``project_id`` strings directly.
 from __future__ import annotations
 
 from terok_agent import (
-    AUTH_PROVIDERS,
-    AuthProvider,
     authenticate as _authenticate_raw,
 )
-from terok_sandbox import (  # noqa: F401 — re-exported public API
-    EnvironmentCheck,
-    GateServerStatus,
-    GateStalenessInfo,
-    GitGate,
-    NftNotFoundError,
-    ShieldNeedsSetup,
-    ShieldState,
-    SSHManager,
-    check_environment as shield_check_environment,
-    check_units_outdated,
-    down as shield_down,
-    get_container_state,
-    get_gate_base_path,
-    get_gate_server_port,
-    get_project_container_states,
-    get_server_status,
-    gpu_run_args,
-    install_systemd_units,
-    is_container_running,
-    is_daemon_running,
-    is_systemd_available,
-    make_shield,
-    pre_start as shield_pre_start,
-    run_setup as shield_run_setup,
-    setup_hooks_direct as shield_setup_hooks_direct,
-    start_daemon,
-    state as shield_state,
-    status as shield_status,
-    stop_daemon,
-    stop_task_containers,
-    stream_initial_logs,
-    uninstall_systemd_units,
-    up as shield_up,
-    wait_for_exit,
-)
 
-from ..core.config import (
-    SHIELD_SECURITY_HINT,  # noqa: F401 — re-exported for presentation layer
-    get_envs_base_dir,
-)
+from ..core.config import get_envs_base_dir
 from ..core.images import project_cli_image
 from ..core.projects import load_project
 from ..orchestration.docker import build_images, generate_dockerfiles
@@ -215,55 +174,14 @@ __all__ = [
     "task_logs",
     "LogViewOptions",
     # Security setup
-    "SSHManager",
-    "GitGate",
     "make_ssh_manager",
     "make_git_gate",
     # Workflow helpers
     "maybe_pause_for_ssh_key_registration",
     # Auth
-    "AUTH_PROVIDERS",
-    "AuthProvider",
     "authenticate",
-    # Gate server
-    "GateServerStatus",
-    "check_units_outdated",
-    "get_server_status",
-    "get_gate_base_path",
-    "get_gate_server_port",
-    "install_systemd_units",
-    "uninstall_systemd_units",
-    "start_daemon",
-    "stop_daemon",
-    "is_daemon_running",
-    "is_systemd_available",
-    # Git gate
-    "GateStalenessInfo",
-    "find_projects_sharing_gate",
     # Project state
     "get_project_state",
     "is_task_image_old",
-    # Container runtime (from terok_sandbox)
-    "get_container_state",
-    "get_project_container_states",
-    "gpu_run_args",
-    "is_container_running",
-    "stop_task_containers",
-    "stream_initial_logs",
-    "wait_for_exit",
-    # Shield (from terok_sandbox)
-    "SHIELD_SECURITY_HINT",
-    "EnvironmentCheck",
-    "NftNotFoundError",
-    "ShieldNeedsSetup",
-    "ShieldState",
-    "make_shield",
-    "shield_check_environment",
-    "shield_down",
-    "shield_pre_start",
-    "shield_run_setup",
-    "shield_setup_hooks_direct",
-    "shield_up",
-    "shield_state",
-    "shield_status",
+    "find_projects_sharing_gate",
 ]

--- a/src/terok/lib/domain/project.py
+++ b/src/terok/lib/domain/project.py
@@ -60,7 +60,6 @@ from ..core.config import (
 )
 from ..core.project_model import ProjectConfig
 from ..core.projects import list_presets, load_project
-from ..instrumentation.agent_config import resolve_agent_config
 from ..orchestration.docker import build_images, generate_dockerfiles
 from ..orchestration.task_runners import HeadlessRunRequest, task_run_headless
 from ..orchestration.tasks import (
@@ -72,6 +71,7 @@ from ..orchestration.tasks import (
     task_new,
 )
 from ..util.fs import archive_timestamp, create_archive_file
+from .agent_config import resolve_agent_config
 from .project_state import get_project_state, is_task_image_old
 from .task import Task
 

--- a/src/terok/lib/instrumentation/__init__.py
+++ b/src/terok/lib/instrumentation/__init__.py
@@ -1,3 +1,0 @@
-# SPDX-FileCopyrightText: 2026 Jiri Vyskocil
-# SPDX-License-Identifier: Apache-2.0
-"""AI agent config, provider registry, instructions, and auth."""

--- a/src/terok/lib/orchestration/task_runners.py
+++ b/src/terok/lib/orchestration/task_runners.py
@@ -39,7 +39,7 @@ from ..core.config import (
 from ..core.images import project_cli_image
 from ..core.projects import load_project
 from ..core.task_display import has_gpu
-from ..instrumentation.agent_config import resolve_agent_config
+from ..domain.agent_config import resolve_agent_config
 from ..util.ansi import (
     blue as _blue,
     green as _green,

--- a/src/terok/tui/app.py
+++ b/src/terok/tui/app.py
@@ -40,6 +40,14 @@ if _HAS_TEXTUAL:
     # Import textual and our widgets only when available
     from dataclasses import dataclass
 
+    from terok_sandbox import (
+        EnvironmentCheck,
+        GateServerStatus,
+        GateStalenessInfo,
+        check_environment as _shield_check_environment,
+        get_server_status,
+        state as _shield_state,
+    )
     from textual import on
     from textual.app import App, ComposeResult
     from textual.containers import Horizontal, Vertical
@@ -59,14 +67,8 @@ if _HAS_TEXTUAL:
         short_version as _short_version,
     )
     from ..lib.domain.facade import (
-        EnvironmentCheck,
-        GateServerStatus,
-        GateStalenessInfo,
         get_project_state,
-        get_server_status,
         is_task_image_old,
-        shield_check_environment as _shield_check_environment,
-        shield_state as _shield_state,
     )
     from ..lib.orchestration.tasks import get_tasks
 
@@ -869,7 +871,7 @@ if _HAS_TEXTUAL:
                     parts = (worker.name or "").split(":")
                     action = parts[1] if len(parts) >= 2 else ""
                     if action == "down":
-                        from ..lib.domain.facade import SHIELD_SECURITY_HINT
+                        from ..lib.core.config import SHIELD_SECURITY_HINT
 
                         self.notify(f"Shield dropped for task {task_id}. {SHIELD_SECURITY_HINT}")
                     elif action == "up":

--- a/src/terok/tui/polling.py
+++ b/src/terok/tui/polling.py
@@ -116,7 +116,7 @@ class PollingMixin:
 
     def _poll_gate_server(self) -> None:
         """Check gate server status in a background worker."""
-        from ..lib.domain.facade import get_server_status
+        from terok_sandbox import get_server_status
 
         self.run_worker(
             get_server_status,

--- a/src/terok/tui/project_actions.py
+++ b/src/terok/tui/project_actions.py
@@ -14,6 +14,13 @@ import subprocess
 import sys
 from collections.abc import Callable
 
+from terok_sandbox import (
+    install_systemd_units,
+    start_daemon,
+    stop_daemon,
+    uninstall_systemd_units,
+)
+
 from ..lib.core.config import get_envs_base_dir
 from ..lib.core.projects import effective_ssh_key_name, load_project
 from ..lib.domain.facade import (
@@ -22,11 +29,7 @@ from ..lib.domain.facade import (
     delete_project,
     find_projects_sharing_gate,
     generate_dockerfiles,
-    install_systemd_units,
     maybe_pause_for_ssh_key_registration,
-    start_daemon,
-    stop_daemon,
-    uninstall_systemd_units,
 )
 from ..lib.domain.project import make_git_gate, make_ssh_manager
 from .shell_launch import launch_login
@@ -365,7 +368,7 @@ class ProjectActionsMixin:
             """Resolve and print the effective instructions."""
             from terok_agent import resolve_instructions
 
-            from ..lib.instrumentation.agent_config import resolve_agent_config
+            from ..lib.domain.agent_config import resolve_agent_config
 
             project = load_project(pid)
             effective = resolve_agent_config(
@@ -553,7 +556,7 @@ class ProjectActionsMixin:
         """Run hook installation after shield setup modal choice."""
         if result is None:
             return
-        from ..lib.domain.facade import shield_setup_hooks_direct
+        from terok_sandbox import setup_hooks_direct as shield_setup_hooks_direct
 
         await self._run_suspended(
             lambda: shield_setup_hooks_direct(root=result == "root"),

--- a/src/terok/tui/screens.py
+++ b/src/terok/tui/screens.py
@@ -49,15 +49,15 @@ except Exception:  # pragma: no cover - textual may be a stub module
 
 from rich.style import Style
 from rich.text import Text
-
-from ..lib.core.projects import ProjectConfig
-from ..lib.domain.facade import (
+from terok_sandbox import (
     EnvironmentCheck,
     GateServerStatus,
     GateStalenessInfo,
     check_units_outdated,
     get_gate_base_path,
 )
+
+from ..lib.core.projects import ProjectConfig
 from ..lib.orchestration.tasks import sanitize_task_name, validate_task_name
 from .widgets import TaskMeta, render_project_details, render_project_loading, render_task_details
 
@@ -200,7 +200,7 @@ class GateServerScreen(screen.Screen[str | None]):
 
     def _refresh_status(self) -> None:
         """Re-fetch status and update the display."""
-        from ..lib.domain.facade import get_server_status
+        from terok_sandbox import get_server_status
 
         try:
             self._status = get_server_status()
@@ -444,7 +444,7 @@ class AuthActionsScreen(screen.ModalScreen[str | None]):
 
     def compose(self) -> ComposeResult:
         """Build the numbered list of authentication providers."""
-        from ..lib.domain.facade import AUTH_PROVIDERS
+        from terok_agent import AUTH_PROVIDERS
 
         providers = list(AUTH_PROVIDERS.values())
         options: list[Option | None] = [
@@ -475,7 +475,7 @@ class AuthActionsScreen(screen.ModalScreen[str | None]):
 
     def on_key(self, event: events.Key) -> None:
         """Handle number-key shortcuts (1-9) to select a provider or import."""
-        from ..lib.domain.facade import AUTH_PROVIDERS
+        from terok_agent import AUTH_PROVIDERS
 
         if event.character and event.character.isdigit():
             idx = int(event.character) - 1
@@ -1239,7 +1239,8 @@ class TaskLaunchScreen(screen.ModalScreen["tuple[str, str, str, str, str, str | 
         If the container never appears after many polls, updates the status
         to indicate a likely launch failure so the user can dismiss.
         """
-        from ..lib.domain.facade import get_container_state
+        from terok_sandbox import get_container_state
+
         from ..lib.orchestration.tasks import get_task_meta
 
         self._poll_count += 1
@@ -1689,7 +1690,7 @@ class ShieldScreen(screen.Screen[str | None]):
 
     def _load_shield_info(self) -> None:
         """Fetch shield config (mode, audit, profiles) for display."""
-        from ..lib.domain.facade import shield_status
+        from terok_sandbox import status as shield_status
 
         try:
             self._shield_info = shield_status()
@@ -1730,7 +1731,10 @@ class ShieldScreen(screen.Screen[str | None]):
     @staticmethod
     def _fetch_status() -> tuple[EnvironmentCheck | None, dict | None]:
         """Load environment check and shield config in a thread."""
-        from ..lib.domain.facade import shield_check_environment, shield_status
+        from terok_sandbox import (
+            check_environment as shield_check_environment,
+            status as shield_status,
+        )
 
         env: EnvironmentCheck | None = None
         info: dict | None = None

--- a/src/terok/tui/task_actions.py
+++ b/src/terok/tui/task_actions.py
@@ -14,15 +14,17 @@ from contextlib import redirect_stdout
 from pathlib import Path
 
 from terok_agent import parse_md_agent
+from terok_sandbox import (
+    down as shield_down,
+    get_container_state,
+    up as shield_up,
+)
 
 from ..lib.core.config import get_shield_bypass_firewall_no_protection
 from ..lib.core.projects import load_project
 from ..lib.core.task_display import effective_status
 from ..lib.domain.facade import (
     HeadlessRunRequest,
-    get_container_state,
-    shield_down,
-    shield_up,
     task_delete,
     task_followup_headless,
     task_new,
@@ -697,7 +699,7 @@ class TaskActionsMixin:
         """Warn the user and return ``True`` if the shield bypass is active."""
         if not get_shield_bypass_firewall_no_protection():
             return False
-        from ..lib.domain.facade import SHIELD_SECURITY_HINT
+        from ..lib.core.config import SHIELD_SECURITY_HINT
 
         self.notify(f"Shield unavailable (bypass_firewall_no_protection). {SHIELD_SECURITY_HINT}")
         return True

--- a/src/terok/tui/widgets/project_state.py
+++ b/src/terok/tui/widgets/project_state.py
@@ -9,11 +9,11 @@ from typing import Any
 
 from rich.style import Style
 from rich.text import Text
+from terok_sandbox import EnvironmentCheck, GateServerStatus, GateStalenessInfo
 from textual.widgets import Static
 
 from ...lib.core.projects import ProjectConfig
 from ...lib.core.task_display import GPU_DISPLAY, SECURITY_CLASS_DISPLAY, has_gpu
-from ...lib.domain.facade import EnvironmentCheck, GateServerStatus, GateStalenessInfo
 from ...lib.util.emoji import render_emoji
 from .task_detail import _get_css_variables
 

--- a/src/terok/tui/widgets/task_detail.py
+++ b/src/terok/tui/widgets/task_detail.py
@@ -10,9 +10,8 @@ from rich.text import Text
 from textual.app import ComposeResult
 from textual.widgets import Static
 
-from ...lib.core.config import get_public_host
+from ...lib.core.config import SHIELD_SECURITY_HINT, get_public_host
 from ...lib.core.task_display import STATUS_DISPLAY, mode_info
-from ...lib.domain.facade import SHIELD_SECURITY_HINT
 from ...lib.orchestration.tasks import TaskMeta
 from ...lib.util.emoji import render_emoji
 

--- a/tach.toml
+++ b/tach.toml
@@ -18,9 +18,8 @@ ignore_type_checking_imports = true
 # ── Layer Architecture ──────────────────────────────────────────────
 #
 #   presentation      CLI and TUI frontends
-#   domain            Project/Task aggregates, facade, task CRUD
+#   domain            Project/Task aggregates, facade, agent config, task CRUD
 #   orchestration     Container lifecycle, env/volumes, Dockerfile, ports
-#   instrumentation   Agent config, providers, instructions, wrappers
 #   core              Foundation types, config, and pure utilities
 #
 # NOTE: The sandbox layer has been extracted to the external terok-sandbox
@@ -31,7 +30,6 @@ layers = [
     "presentation",
     "domain",
     "orchestration",
-    "instrumentation",
     "core",
 ]
 
@@ -45,7 +43,7 @@ exclude = ["pydevd_pycharm", "pydevd"]
 path = "terok.cli"
 layer = "presentation"
 depends_on = [
-    "terok.lib.instrumentation.agent_config",
+    "terok.lib.domain.agent_config",
     "terok.lib.orchestration.hooks",
     "terok.lib.orchestration.tasks",
     "terok.lib.core.config",
@@ -101,7 +99,7 @@ depends_on = [
 path = "terok.lib.domain.project"
 layer = "domain"
 depends_on = [
-    "terok.lib.instrumentation.agent_config",
+    "terok.lib.domain.agent_config",
     "terok.lib.orchestration.docker",
     "terok.lib.domain.project_state",
     "terok.lib.orchestration.task_runners",
@@ -153,6 +151,13 @@ path = "terok.lib.domain.image_cleanup"
 layer = "domain"
 depends_on = ["terok.lib.core.projects"]
 
+# Agent config resolution (terok-specific stack composition)
+# Lives in domain/ but has orchestration-level layer so that task_runners can import it.
+[[modules]]
+path = "terok.lib.domain.agent_config"
+layer = "orchestration"
+depends_on = ["terok.lib.core.config", "terok.lib.core.projects"]
+
 # Project infrastructure state (queries podman & filesystem)
 [[modules]]
 path = "terok.lib.domain.project_state"
@@ -185,7 +190,7 @@ depends_on = [
 path = "terok.lib.orchestration.task_runners"
 layer = "orchestration"
 depends_on = [
-    "terok.lib.instrumentation.agent_config",
+    "terok.lib.domain.agent_config",
     "terok.lib.orchestration.container_exec",
     "terok.lib.orchestration.environment",
     "terok.lib.orchestration.hooks",
@@ -252,19 +257,6 @@ depends_on = ["terok.lib.util.yaml"]
 path = "terok.lib.orchestration.container_exec"
 layer = "orchestration"
 depends_on = ["terok.lib.util.logging_utils"]
-
-# ── INSTRUMENTATION LAYER ─────────────────────────────────────────
-#
-# NOTE: Most instrumentation modules have been extracted to the external
-# terok-agent package. Only the terok-specific config stack composition
-# (build_agent_config_stack, resolve_agent_config) remains here.
-#
-
-# Agent config resolution (terok-specific stack composition)
-[[modules]]
-path = "terok.lib.instrumentation.agent_config"
-layer = "instrumentation"
-depends_on = ["terok.lib.core.config", "terok.lib.core.projects"]
 
 # ── SANDBOX LAYER ─────────────────────────────────────────────────
 #
@@ -533,7 +525,7 @@ from = ["terok.lib.orchestration.task_runners"]
 
 [[interfaces]]
 expose = ["build_agent_config_stack", "resolve_agent_config"]
-from = ["terok.lib.instrumentation.agent_config"]
+from = ["terok.lib.domain.agent_config"]
 
 [[interfaces]]
 expose = [
@@ -655,50 +647,13 @@ expose = [
     "task_followup_headless",
     "task_logs",
     "LogViewOptions",
-    "SSHManager",
-    "GitGate",
-    "AUTH_PROVIDERS",
-    "AuthProvider",
-    "authenticate",
-    "GateServerStatus",
-    "check_units_outdated",
-    "get_server_status",
-    "get_gate_base_path",
-    "get_gate_server_port",
-    "install_systemd_units",
-    "uninstall_systemd_units",
-    "start_daemon",
-    "stop_daemon",
-    "is_daemon_running",
-    "is_systemd_available",
-    "GateStalenessInfo",
     "find_projects_sharing_gate",
     "make_git_gate",
     "make_ssh_manager",
+    "authenticate",
     "get_project_state",
     "is_task_image_old",
-    "make_shield",
     "maybe_pause_for_ssh_key_registration",
-    "EnvironmentCheck",
-    "NftNotFoundError",
-    "ShieldNeedsSetup",
-    "ShieldState",
-    "shield_check_environment",
-    "shield_down",
-    "shield_run_setup",
-    "shield_setup_hooks_direct",
-    "shield_pre_start",
-    "shield_up",
-    "shield_state",
-    "shield_status",
-    "SHIELD_SECURITY_HINT",
-    "get_container_state",
-    "get_project_container_states",
-    "gpu_run_args",
-    "is_container_running",
-    "stop_task_containers",
-    "stream_initial_logs",
-    "wait_for_exit",
 ]
 from = ["terok.lib.domain.facade"]
 

--- a/tests/unit/cli/test_cli_shield.py
+++ b/tests/unit/cli/test_cli_shield.py
@@ -264,7 +264,7 @@ def test_dispatch_runtime_error_prints_message(
         pytest.param({"root": False, "user": True}, {"root": False, "user": True}, id="setup-user"),
     ],
 )
-@patch("terok.lib.domain.facade.shield_run_setup")
+@patch("terok_sandbox.run_setup")
 def test_setup_dispatch(
     mock_setup: MagicMock,
     kwargs: dict[str, bool],

--- a/tests/unit/lib/test_agent_config.py
+++ b/tests/unit/lib/test_agent_config.py
@@ -14,7 +14,7 @@ import pytest
 from terok_agent import ConfigStack
 
 from terok.lib.core.projects import ProjectConfig, list_presets, load_preset, load_project
-from terok.lib.instrumentation.agent_config import build_agent_config_stack, resolve_agent_config
+from terok.lib.domain.agent_config import build_agent_config_stack, resolve_agent_config
 from tests.test_utils import mock_git_config, write_project
 
 


### PR DESCRIPTION
## Summary

Three architectural simplifications that leverage the modular package structure:

### 1. Slim the facade (70 → 32 symbols)

Remove all pass-through re-exports from `terok_sandbox` and `terok_agent`. Consumers now import directly from those packages. The facade retains only **terok-owned operations**: Project/Task aggregates, task runners, task CRUD, image management, auth wrapper, and project state queries.

### 2. Dissolve `lib/instrumentation/` 

Move `agent_config.py` to `lib/domain/` — config stack composition is a domain concern. Delete the now-empty instrumentation layer entirely.

### 3. Clean agent_config.py re-exports

Stop re-exporting `resolve_provider_value` — callers import it from `terok_agent` directly. Remove misleading `noqa` markers.

## Architecture layers

Before (5 layers):
```
presentation → domain → orchestration → instrumentation → core
```

After (4 layers):
```
presentation → domain → orchestration → core
```

## Impact

| Metric | Before | After |
|--------|--------|-------|
| Facade `__all__` size | 70 symbols | 32 symbols |
| Architecture layers | 5 | 4 |
| `lib/instrumentation/` files | 2 | 0 (deleted) |
| Net lines | — | -119 |

## Verification

- [x] `make check` — 1325 tests pass, all targets green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized internal module dependencies and import structure for improved code architecture and separation of concerns. Functions related to gate servers, shields, and container management are now imported directly from `terok_sandbox` instead of through intermediate facade layers. Agent configuration modules have been relocated within the domain layer for better logical separation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->