### PR TITLE
chore: rename Code Quality nav link to Code Quality Report

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -107,7 +107,7 @@ nav:
     - Agent Compatibility Matrix: agent-compat-matrix.md
     - Integration Test Map: test_map.md
     - CI Workflow Map: ci_map.md
-    - Code Quality: quality-report.md
+    - Code Quality Report: quality-report.md
     - Brainstorming:
       - Agent Helpers: brainstorming/todo-agent-helpers.md
       - Per-Task Context Isolation: brainstorming/per-task-context-isolation.md


### PR DESCRIPTION
## Summary
Rename nav link "Code Quality" → "Code Quality Report" to match the generated page header (consistent with terok-agent and terok-sandbox).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated the navigation label for the Code Quality documentation section to provide clearer reference to users browsing the documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->