### PR TITLE
chore: bump terok-agent and terok-sandbox dependency pins

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -2538,7 +2538,7 @@ tomli-w = ">=1.0,<2.0"
 
 [[package]]
 name = "terok-agent"
-version = "0.0.4.post10.dev0+9326eab"
+version = "0.0.4.post13.dev0+456bce7"
 description = "Single-agent task runner for hardened Podman containers"
 optional = false
 python-versions = ">=3.12,<4.0"
@@ -2549,17 +2549,17 @@ develop = false
 [package.dependencies]
 Jinja2 = ">=3.1"
 "ruamel.yaml" = ">=0.18"
-terok-sandbox = {git = "https://github.com/terok-ai/terok-sandbox.git", rev = "85eb3b2228d8e89ccf11ddef4baef4b921a9896d"}
+terok-sandbox = {git = "https://github.com/terok-ai/terok-sandbox.git", rev = "84e5c8def57028ace8ac656bd1bb40046e9a136d"}
 
 [package.source]
 type = "git"
 url = "https://github.com/terok-ai/terok-agent.git"
-reference = "9326eab78fd3c5a4da37bee326f9142f5f586872"
-resolved_reference = "9326eab78fd3c5a4da37bee326f9142f5f586872"
+reference = "456bce7778023f3c1e194227c01255f88653b47b"
+resolved_reference = "456bce7778023f3c1e194227c01255f88653b47b"
 
 [[package]]
 name = "terok-sandbox"
-version = "0.0.6.post3.dev0+85eb3b2"
+version = "0.0.6.post4.dev0+84e5c8d"
 description = "Hardened Podman container runner with gate server and shield integration"
 optional = false
 python-versions = ">=3.12,<4.0"
@@ -2574,8 +2574,8 @@ terok-shield = {url = "https://github.com/terok-ai/terok-shield/releases/downloa
 [package.source]
 type = "git"
 url = "https://github.com/terok-ai/terok-sandbox.git"
-reference = "85eb3b2228d8e89ccf11ddef4baef4b921a9896d"
-resolved_reference = "85eb3b2228d8e89ccf11ddef4baef4b921a9896d"
+reference = "84e5c8def57028ace8ac656bd1bb40046e9a136d"
+resolved_reference = "84e5c8def57028ace8ac656bd1bb40046e9a136d"
 
 [[package]]
 name = "terok-shield"
@@ -3063,4 +3063,4 @@ propcache = ">=0.2.1"
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.12,<4.0"
-content-hash = "939c76204f62d083e4025bae473454192cadcba77f81cc7b5e6242cc28dc9b6d"
+content-hash = "6d4a261c7c8ac015cde24c84d2111b59ad6bf17eee5af3bc4c29d3c5a1c2de20"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,8 +44,8 @@ rich = ">=13.0"
 platformdirs = ">=4.5.1"
 unique-namer = ">=1.3"
 textual-serve = ">=1.1.0"
-terok-agent = {git = "https://github.com/terok-ai/terok-agent.git", rev = "9326eab78fd3c5a4da37bee326f9142f5f586872"}
-terok-sandbox = {git = "https://github.com/terok-ai/terok-sandbox.git", rev = "85eb3b2228d8e89ccf11ddef4baef4b921a9896d"}
+terok-agent = {git = "https://github.com/terok-ai/terok-agent.git", rev = "456bce7778023f3c1e194227c01255f88653b47b"}
+terok-sandbox = {git = "https://github.com/terok-ai/terok-sandbox.git", rev = "84e5c8def57028ace8ac656bd1bb40046e9a136d"}
 
 [tool.poetry.group.dev.dependencies]
 pydevd-pycharm = "261.22158.220"


### PR DESCRIPTION
## Summary
Update dependency pins to pick up all Phase E/F features:

- **terok-agent** `9326eab` → `456bce7`: AgentRunner with security flags (--restricted, --gpu, --bypass-shield-no-protection), gate wiring, auto port allocation, command registry, YAML mounts
- **terok-sandbox** `85eb3b2` → `84e5c8d`: find_free_port / reserve_free_port, Sandbox facade, CLI, command registry

terok's own code is unchanged — this just ensures the installed packages match the latest upstream. Future PRs can incrementally adopt the new APIs (e.g., using AGENT_COMMANDS for CLI namespace #534).

## Test plan
- [x] 1,182 tests pass
- [x] lint + tach clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal component dependencies to latest versions for improved stability and performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->