### PR TITLE
fix: harden matrix runner for rootless podman nesting

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all lint format test test-unit ruff-report bandit-report sonar-inputs test-integration test-integration-host test-integration-network test-integration-podman test-integration-map test-matrix test-matrix-build ci-map tach security docstrings complexity deadcode reuse check install install-dev docs docs-build clean spdx
+.PHONY: all lint format test test-unit ruff-report bandit-report sonar-inputs test-integration test-integration-host test-integration-network test-integration-podman test-integration-map test-matrix ci-map tach security docstrings complexity deadcode reuse check install install-dev docs docs-build clean spdx
 
 REPORTS_DIR ?= reports
 COVERAGE_XML ?= $(REPORTS_DIR)/coverage.xml
@@ -73,11 +73,16 @@ test-integration-map:
 	poetry run python docs/test_map.py
 
 # Multi-distro integration test matrix (Debian 12/13, Ubuntu 24.04, Fedora 43)
+#   NO_CACHE=1 make test-matrix           — force full image rebuild
+#   BUILD_ONLY=1 make test-matrix         — build images only
+#   SCOPE=host-only make test-matrix      — run only needs_host_features tests
+#   DISTROS="debian12 fedora43" make test-matrix — run specific distros
 test-matrix:
-	./tests/containers/run-matrix.sh
-
-test-matrix-build:
-	./tests/containers/run-matrix.sh --build-only
+	./tests/containers/run-matrix.sh \
+		$(if $(NO_CACHE),--no-cache) \
+		$(if $(BUILD_ONLY),--build-only) \
+		$(if $(SCOPE),--$(SCOPE)) \
+		$(DISTROS)
 
 # Generate CI workflow map (Markdown tables from .github/workflows/*.yml)
 ci-map:

--- a/docs/developer.md
+++ b/docs/developer.md
@@ -323,7 +323,7 @@ make test-integration-podman   # Podman-dependent integration tests
 make test-integration          # All integration tests
 make test-integration-map      # Generate docs/test_map.md from pytest collection
 make test-matrix               # Run the cross-distro integration matrix locally
-make test-matrix-build         # Build the matrix container images without running tests
+make test-matrix BUILD_ONLY=1  # Build the matrix container images without running tests
 make ci-map                    # Generate docs/ci_map.md from workflow YAML
 ```
 
@@ -364,7 +364,8 @@ make sonar-inputs  # Generate coverage + Ruff + Bandit reports under reports/
 | `make test-integration` | Run all integration tests | Before opening a PR that changes integration flows |
 | `make test-integration-map` | Generate the integration test map page | After reorganizing integration tests |
 | `make test-matrix` | Run the multi-distro integration matrix locally | Before changing matrix/container compatibility |
-| `make test-matrix-build` | Build the multi-distro matrix images without running tests | When iterating on matrix containerfiles |
+| `make test-matrix BUILD_ONLY=1` | Build the multi-distro matrix images without running tests | When iterating on matrix containerfiles |
+| `make test-matrix NO_CACHE=1` | Rebuild matrix images from scratch, then run tests | After changing Containerfiles |
 | `make ci-map` | Generate the CI workflow map page | After changing GitHub workflows |
 | `make tach` | Check module boundary rules | After changing imports |
 | `make security` | Run the Bandit SAST scan | Before opening a PR that changes CI/security-sensitive code |

--- a/poetry.lock
+++ b/poetry.lock
@@ -2558,33 +2558,33 @@ tomli-w = ">=1.0,<2.0"
 
 [[package]]
 name = "terok-agent"
-version = "0.0.8"
+version = "0.0.9"
 description = "Single-agent task runner for hardened Podman containers"
 optional = false
 python-versions = ">=3.12,<4.0"
 groups = ["main"]
 files = [
-    {file = "terok_agent-0.0.8-py3-none-any.whl", hash = "sha256:0081ffbbdcec76c93370cf1b93a2098ce247d5b6734d9ab22da36b963cc98a90"},
+    {file = "terok_agent-0.0.9-py3-none-any.whl", hash = "sha256:57e0f750f88c398503838722238d20d3dbd10483c86e6d9ca0eb4bcfd1e7915d"},
 ]
 
 [package.dependencies]
 Jinja2 = ">=3.1"
 "ruamel.yaml" = ">=0.18"
-terok_sandbox = {url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.0.9/terok_sandbox-0.0.9-py3-none-any.whl"}
+terok_sandbox = {url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.0.10/terok_sandbox-0.0.10-py3-none-any.whl"}
 
 [package.source]
 type = "url"
-url = "https://github.com/terok-ai/terok-agent/releases/download/v0.0.8/terok_agent-0.0.8-py3-none-any.whl"
+url = "https://github.com/terok-ai/terok-agent/releases/download/v0.0.9/terok_agent-0.0.9-py3-none-any.whl"
 
 [[package]]
 name = "terok-sandbox"
-version = "0.0.9"
+version = "0.0.10"
 description = "Hardened Podman container runner with gate server and shield integration"
 optional = false
 python-versions = ">=3.12,<4.0"
 groups = ["main"]
 files = [
-    {file = "terok_sandbox-0.0.9-py3-none-any.whl", hash = "sha256:4795511d36572538706694e799fa032ff1748c91efd52c08e23e4ea9d786c26f"},
+    {file = "terok_sandbox-0.0.10-py3-none-any.whl", hash = "sha256:6508b64411a7643c95a62d50ff553a223a1d6277d7134aa9c15d7ce5715b63b7"},
 ]
 
 [package.dependencies]
@@ -2594,7 +2594,7 @@ terok_shield = {url = "https://github.com/terok-ai/terok-shield/releases/downloa
 
 [package.source]
 type = "url"
-url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.0.9/terok_sandbox-0.0.9-py3-none-any.whl"
+url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.0.10/terok_sandbox-0.0.10-py3-none-any.whl"
 
 [[package]]
 name = "terok-shield"
@@ -3083,4 +3083,4 @@ propcache = ">=0.2.1"
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.12,<4.0"
-content-hash = "288d04761c332902bf45d6da271cec3e5bf8a334a8dade0b97dc99ed9430e683"
+content-hash = "fdc7c0e74af698a1cd14545bd59f346e9e219ccd7644ec1fbfa88e2d5f8a4754"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,8 +44,8 @@ rich = ">=13.0"
 platformdirs = ">=4.5.1"
 unique-namer = ">=1.3"
 textual-serve = ">=1.1.0"
-terok-agent = {url = "https://github.com/terok-ai/terok-agent/releases/download/v0.0.8/terok_agent-0.0.8-py3-none-any.whl"}
-terok-sandbox = {url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.0.9/terok_sandbox-0.0.9-py3-none-any.whl"}
+terok-agent = {url = "https://github.com/terok-ai/terok-agent/releases/download/v0.0.9/terok_agent-0.0.9-py3-none-any.whl"}
+terok-sandbox = {url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.0.10/terok_sandbox-0.0.10-py3-none-any.whl"}
 
 [tool.poetry.group.dev.dependencies]
 pydevd-pycharm = "261.22158.220"

--- a/tests/containers/Containerfile.debian12
+++ b/tests/containers/Containerfile.debian12
@@ -5,12 +5,30 @@
 FROM docker.io/library/debian:12
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    podman slirp4netns nftables uidmap fuse-overlayfs \
-    python3 python3-venv git curl ca-certificates \
+    podman slirp4netns nftables uidmap fuse-overlayfs crun \
+    python3 python3-venv \
+    git curl ca-certificates dnsutils openssh-client \
     && rm -rf /var/lib/apt/lists/*
 
 # Debian 12 ships Python 3.11 — use uv to get 3.12+
 COPY --from=ghcr.io/astral-sh/uv:latest /uv /usr/local/bin/uv
 RUN uv python install 3.12
+
+# ── Rootless podman nesting setup (mirrors quay.io/podman/stable) ────
+# Subordinate UID/GID ranges MUST stay within 0-65535 so they fit inside
+# the outer rootless-podman container's user-namespace mapping.
+RUN useradd -m testrunner \
+    && uid=$(id -u testrunner) \
+    && printf "testrunner:1:%d\ntestrunner:%d:%d\n" \
+        $((uid - 1)) $((uid + 1)) $((65535 - uid)) > /etc/subuid \
+    && cp /etc/subuid /etc/subgid \
+    && chmod 4755 /usr/bin/newuidmap /usr/bin/newgidmap \
+    && mkdir -p /etc/containers \
+    && printf '[storage]\ndriver = "overlay"\n\n[storage.options.overlay]\nmount_program = "/usr/bin/fuse-overlayfs"\nmountopt = "nodev,fsync=0"\n' \
+        > /etc/containers/storage.conf \
+    && printf '[engine]\ncgroup_manager = "cgroupfs"\nevents_logger = "file"\n' \
+        > /etc/containers/containers.conf \
+    && mkdir -p /run/user/$uid \
+    && chown testrunner:testrunner /run/user/$uid
 
 WORKDIR /src

--- a/tests/containers/Containerfile.debian13
+++ b/tests/containers/Containerfile.debian13
@@ -5,9 +5,26 @@
 FROM docker.io/library/debian:trixie
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    podman passt slirp4netns nftables uidmap fuse-overlayfs \
+    podman passt slirp4netns nftables uidmap fuse-overlayfs crun \
     python3 python3-pip python3-venv \
-    git curl ca-certificates \
+    git curl ca-certificates dnsutils openssh-client \
     && rm -rf /var/lib/apt/lists/*
+
+# ── Rootless podman nesting setup (mirrors quay.io/podman/stable) ────
+# Subordinate UID/GID ranges MUST stay within 0-65535 so they fit inside
+# the outer rootless-podman container's user-namespace mapping.
+RUN useradd -m testrunner \
+    && uid=$(id -u testrunner) \
+    && printf "testrunner:1:%d\ntestrunner:%d:%d\n" \
+        $((uid - 1)) $((uid + 1)) $((65535 - uid)) > /etc/subuid \
+    && cp /etc/subuid /etc/subgid \
+    && chmod 4755 /usr/bin/newuidmap /usr/bin/newgidmap \
+    && mkdir -p /etc/containers \
+    && printf '[storage]\ndriver = "overlay"\n\n[storage.options.overlay]\nmount_program = "/usr/bin/fuse-overlayfs"\nmountopt = "nodev,fsync=0"\n' \
+        > /etc/containers/storage.conf \
+    && printf '[engine]\ncgroup_manager = "cgroupfs"\nevents_logger = "file"\n' \
+        > /etc/containers/containers.conf \
+    && mkdir -p /run/user/$uid \
+    && chown testrunner:testrunner /run/user/$uid
 
 WORKDIR /src

--- a/tests/containers/Containerfile.fedora43
+++ b/tests/containers/Containerfile.fedora43
@@ -5,9 +5,25 @@
 FROM registry.fedoraproject.org/fedora:43
 
 RUN dnf install -y \
-    podman passt nftables slirp4netns fuse-overlayfs \
+    podman passt nftables slirp4netns fuse-overlayfs crun \
     python3 python3-pip \
-    git curl \
+    git curl bind-utils openssh-clients \
     && dnf clean all
+
+# ── Rootless podman nesting setup (mirrors quay.io/podman/stable) ────
+# Subordinate UID/GID ranges MUST stay within 0-65535 so they fit inside
+# the outer rootless-podman container's user-namespace mapping.
+RUN useradd -m testrunner \
+    && uid=$(id -u testrunner) \
+    && printf "testrunner:1:%d\ntestrunner:%d:%d\n" \
+        $((uid - 1)) $((uid + 1)) $((65535 - uid)) > /etc/subuid \
+    && cp /etc/subuid /etc/subgid \
+    && chmod 4755 /usr/bin/newuidmap /usr/bin/newgidmap \
+    && printf '[storage]\ndriver = "overlay"\n\n[storage.options.overlay]\nmount_program = "/usr/bin/fuse-overlayfs"\nmountopt = "nodev,fsync=0"\n' \
+        > /etc/containers/storage.conf \
+    && printf '[engine]\ncgroup_manager = "cgroupfs"\nevents_logger = "file"\n' \
+        > /etc/containers/containers.conf \
+    && mkdir -p /run/user/$uid \
+    && chown testrunner:testrunner /run/user/$uid
 
 WORKDIR /src

--- a/tests/containers/Containerfile.podman
+++ b/tests/containers/Containerfile.podman
@@ -1,11 +1,17 @@
 # SPDX-FileCopyrightText: 2026 Jiri Vyskocil
 # SPDX-License-Identifier: Apache-2.0
 
-# Latest upstream podman (quay.io/podman/stable) for tracking bleeding-edge
+# Official podman image — tracks the latest upstream release.
+# Already ships user 'podman' (uid 1000) with full rootless setup
+# (subuid/subgid, storage.conf, containers.conf, setuid newuidmap).
 FROM quay.io/podman/stable:latest
 
 RUN dnf install -y \
-    nftables python3 python3-pip git curl \
+    nftables python3 python3-pip \
+    git curl bind-utils openssh-clients \
     && dnf clean all
+
+# Ensure runtime dir exists for the pre-existing 'podman' user
+RUN mkdir -p /run/user/$(id -u podman) && chown podman:podman /run/user/$(id -u podman)
 
 WORKDIR /src

--- a/tests/containers/Containerfile.ubuntu2404
+++ b/tests/containers/Containerfile.ubuntu2404
@@ -5,9 +5,26 @@
 FROM docker.io/library/ubuntu:24.04
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    podman slirp4netns passt nftables uidmap fuse-overlayfs \
+    podman slirp4netns passt nftables uidmap fuse-overlayfs crun \
     python3 python3-pip python3-venv \
-    git curl ca-certificates \
+    git curl ca-certificates dnsutils openssh-client \
     && rm -rf /var/lib/apt/lists/*
+
+# ── Rootless podman nesting setup (mirrors quay.io/podman/stable) ────
+# Subordinate UID/GID ranges MUST stay within 0-65535 so they fit inside
+# the outer rootless-podman container's user-namespace mapping.
+RUN useradd -m testrunner \
+    && uid=$(id -u testrunner) \
+    && printf "testrunner:1:%d\ntestrunner:%d:%d\n" \
+        $((uid - 1)) $((uid + 1)) $((65535 - uid)) > /etc/subuid \
+    && cp /etc/subuid /etc/subgid \
+    && chmod 4755 /usr/bin/newuidmap /usr/bin/newgidmap \
+    && mkdir -p /etc/containers \
+    && printf '[storage]\ndriver = "overlay"\n\n[storage.options.overlay]\nmount_program = "/usr/bin/fuse-overlayfs"\nmountopt = "nodev,fsync=0"\n' \
+        > /etc/containers/storage.conf \
+    && printf '[engine]\ncgroup_manager = "cgroupfs"\nevents_logger = "file"\n' \
+        > /etc/containers/containers.conf \
+    && mkdir -p /run/user/$uid \
+    && chown testrunner:testrunner /run/user/$uid
 
 WORKDIR /src

--- a/tests/containers/run-matrix.sh
+++ b/tests/containers/run-matrix.sh
@@ -13,6 +13,7 @@
 #   ./tests/containers/run-matrix.sh debian12      # run one distro
 #   ./tests/containers/run-matrix.sh --build-only  # build images only
 #   ./tests/containers/run-matrix.sh --list        # list available distros
+#   ./tests/containers/run-matrix.sh --no-cache    # force full rebuild
 #
 # The host must support nested podman (rootless or --privileged).
 
@@ -26,6 +27,19 @@ WORKSPACE_DIR="/workspace"
 PYTHON_VERSION="3.12"
 DEFAULT_MARKER="needs_host_features"
 TEROK_DIAGNOSTIC_COMMAND="poetry run terokctl config"
+
+# ── Terminal colors (disabled when stdout is not a tty) ──
+if [[ -t 1 ]]; then
+    C_BOLD='\033[1m'
+    C_CYAN='\033[1;36m'
+    C_YELLOW='\033[1;33m'
+    C_GREEN='\033[1;32m'
+    C_RED='\033[1;31m'
+    C_DIM='\033[2m'
+    C_RESET='\033[0m'
+else
+    C_BOLD='' C_CYAN='' C_YELLOW='' C_GREEN='' C_RED='' C_DIM='' C_RESET=''
+fi
 
 # Target distros: name -> Containerfile suffix
 declare -A DISTROS=(
@@ -45,16 +59,29 @@ declare -A EXPECTED_VERSIONS=(
     [podman]="latest"
 )
 
+# Non-root user baked into each Containerfile (uid 1000).
+# The podman image uses its pre-existing 'podman' user.
+declare -A TEST_USERS=(
+    [debian12]="testrunner"
+    [ubuntu2404]="testrunner"
+    [debian13]="testrunner"
+    [fedora43]="testrunner"
+    [podman]="podman"
+)
+
 usage() {
     echo "Usage: $0 [OPTIONS] [DISTRO...]"
     echo ""
     echo "Options:"
     echo "  --build-only   Build images without running tests"
+    echo "  --no-cache     Rebuild images from scratch (ignore layer cache)"
     echo "  --list         List available distros"
     echo "  --host-only    Run only needs_host_features tests (fast)"
     echo "  --podman       Run only needs_podman tests"
     echo "  --all-markers  Run the full integration suite"
     echo "  -h, --help     Show this help"
+    echo ""
+    echo "Default: install full infrastructure, run tests with marker '$DEFAULT_MARKER'."
     echo ""
     echo "Available distros: ${!DISTROS[*]}"
     return 0
@@ -64,12 +91,13 @@ build_image() {
     local name="$1"
     local file="$SCRIPT_DIR/Containerfile.${DISTROS[$name]}"
     local image="$IMAGE_PREFIX:$name"
-    local status
+    local -a build_args=()
 
-    echo "==> Building $image from $file"
-    podman build -t "$image" -f "$file" "$REPO_ROOT"
-    status=$?
-    return "$status"
+    $NO_CACHE && build_args+=(--no-cache)
+
+    echo -e "${C_CYAN}==> Building ${C_BOLD}$image${C_CYAN} from $file${C_RESET}"
+    podman build "${build_args[@]}" -t "$image" -f "$file" "$REPO_ROOT"
+    return $?
 }
 
 run_tests() {
@@ -77,79 +105,120 @@ run_tests() {
     local marker="${2:-$DEFAULT_MARKER}"
     local image="$IMAGE_PREFIX:$name"
     local ctr_name="$IMAGE_PREFIX-$name"
-    local status
+    local test_user="${TEST_USERS[$name]}"
 
     echo ""
-    echo "==> Testing $name (expected podman ${EXPECTED_VERSIONS[$name]})"
-    echo "    marker: ${marker:-<all>}"
+    echo -e "${C_CYAN}==> Testing ${C_BOLD}$name${C_CYAN} (expected podman ${EXPECTED_VERSIONS[$name]})${C_RESET}"
+    echo -e "    ${C_DIM}marker: ${marker:-<all>}, user: $test_user${C_RESET}"
     echo ""
 
     # Three-phase flow:
     #   Phase 1: tests that do NOT need hooks
     #   Phase 2: install global hooks via terokctl shield setup --user
     #   Phase 3: tests that need hooks
+    #
+    # Privileged mode gives the outer container the capabilities needed
+    # for nested podman, but tests run as uid 1000 (rootless podman).
     podman run --rm --name "$ctr_name" \
         --privileged \
         --security-opt label=disable \
+        --device /dev/fuse:rw \
+        -e container=podman \
         -v "$REPO_ROOT:$SOURCE_MOUNT:ro,Z" \
         "$image" \
         bash -c "
             set -e
-            echo '--- podman version ---'
-            podman --version || echo 'podman not available'
 
+            # ── Prepare workspace (as root) ──
             cp -a $SOURCE_MOUNT $WORKSPACE_DIR
-            cd $WORKSPACE_DIR
+            chown -R $test_user:$test_user $WORKSPACE_DIR
 
-            if command -v uv &>/dev/null; then
-                uv venv --python $PYTHON_VERSION .venv
-                . .venv/bin/activate
-                uv pip install poetry
-            else
-                python3 -m venv .venv
-                . .venv/bin/activate
-                pip install --quiet --upgrade pip
-                pip install --quiet poetry
-            fi
+            # Strip IPv6 zone-ID nameservers — they reference host interfaces
+            # (e.g. eno1) that don't exist inside the container, causing dig
+            # to reject the entire resolv.conf.  Fixed upstream in podman 5.4+
+            # (https://github.com/containers/common/pull/2233).
+            # Remove once we drop < 5.4 support.
+            cp /etc/resolv.conf /tmp/resolv.conf.clean
+            grep -v '^nameserver.*%' /tmp/resolv.conf.clean > /etc/resolv.conf
 
-            echo '--- python version ---'
-            python --version
-            poetry install --with test --quiet 2>&1 | tail -3
+            # ── Run everything as the rootless test user ──
+            su - $test_user -c '
+                set -e
+                export XDG_RUNTIME_DIR=/run/user/\$(id -u)
 
-            echo ''
-            echo '--- phase 1: tests without hooks ---'
-            poetry run pytest tests/integration/ -v --tb=short -m '$marker and not needs_hooks'
+                cd $WORKSPACE_DIR
 
-            echo ''
-            echo '--- phase 2: installing global hooks ---'
-            poetry run terokctl shield setup --user
+                echo \"--- podman version ---\"
+                podman --version || echo \"podman not available\"
 
-            echo ''
-            echo '--- phase 3: tests with hooks ---'
-            poetry run pytest tests/integration/ -v --tb=short -m '$marker and needs_hooks'
+                echo \"--- rootless podman preflight ---\"
+                podman info --format \"podman={{.Version.Version}} storage={{.Store.GraphDriverName}}\" \
+                    || { echo \"FATAL: rootless podman not functional\" >&2; exit 1; }
 
-            echo ''
-            echo '--- terokctl config ---'
-            $TEROK_DIAGNOSTIC_COMMAND 2>&1 || true
+                if command -v uv >/dev/null 2>&1; then
+                    uv venv --python $PYTHON_VERSION .venv
+                    . .venv/bin/activate
+                    uv pip install poetry
+                else
+                    python\${PYTHON_VERSION} -m venv .venv 2>/dev/null \
+                        || python3 -m venv .venv
+                    . .venv/bin/activate
+                    pip install --quiet --upgrade pip
+                    pip install --quiet poetry
+                fi
+
+                echo \"--- python version ---\"
+                python --version
+                poetry install --with test --no-interaction
+                echo \"--- deps installed ---\"
+
+                # ── Phase 1: tests without hooks ──
+                echo \"\"
+                echo \"--- phase 1: tests without hooks ---\"
+                poetry run pytest tests/integration/ -v --tb=short -m \"$marker and not needs_hooks\"
+
+                # ── Phase 2: install global hooks ──
+                echo \"\"
+                echo \"--- phase 2: installing shield hooks ---\"
+                poetry run terokctl shield setup --user
+
+                # Verify hooks are detectable — fail fast if setup did not work
+                poetry run python3 -c \"
+from terok_shield import has_global_hooks
+assert has_global_hooks(), \\\"Shield hooks not detected after setup\\\"
+print(\\\"Shield hooks verified.\\\")
+\"
+
+                # ── Phase 3: tests with hooks ──
+                echo \"\"
+                echo \"--- phase 3: tests with hooks ---\"
+                poetry run pytest tests/integration/ -v --tb=short -m \"$marker and needs_hooks\"
+
+                echo \"\"
+                echo \"--- terokctl config ---\"
+                $TEROK_DIAGNOSTIC_COMMAND 2>&1 || true
+            '
         "
 
-    status=$?
+    local status=$?
     if [[ $status -eq 0 ]]; then
-        echo "==> $name: done"
+        echo -e "${C_GREEN}==> $name: PASS${C_RESET}"
     else
-        echo "==> $name: failed" >&2
+        echo -e "${C_RED}==> $name: FAIL${C_RESET}" >&2
     fi
     return "$status"
 }
 
 BUILD_ONLY=false
 LIST_ONLY=false
+NO_CACHE=false
 MARKER="$DEFAULT_MARKER"
 TARGETS=()
 
 while [[ $# -gt 0 ]]; do
     case "$1" in
         --build-only) BUILD_ONLY=true ;;
+        --no-cache) NO_CACHE=true ;;
         --list) LIST_ONLY=true ;;
         --host-only) MARKER="$DEFAULT_MARKER" ;;
         --podman) MARKER="needs_podman" ;;
@@ -173,7 +242,7 @@ fi
 
 for target in "${TARGETS[@]}"; do
     if [[ -z "${DISTROS[$target]+x}" ]]; then
-        echo "Error: unknown distro '$target'. Available: ${!DISTROS[*]}" >&2
+        echo -e "${C_RED}Error: unknown distro '$target'. Available: ${!DISTROS[*]}${C_RESET}" >&2
         exit 1
     fi
 done
@@ -183,7 +252,7 @@ for target in "${TARGETS[@]}"; do
 done
 
 if $BUILD_ONLY; then
-    echo "Images built. Use '$0' without --build-only to run tests."
+    echo -e "${C_GREEN}Images built.${C_RESET} Use '$0' without --build-only to run tests."
     exit 0
 fi
 
@@ -199,12 +268,12 @@ for target in "${TARGETS[@]}"; do
 done
 
 echo ""
-echo "===== Matrix Summary ====="
+echo -e "${C_BOLD}===== Matrix Summary =====${C_RESET}"
 for target in "${PASSED[@]}"; do
-    echo "  PASS: $target (podman ${EXPECTED_VERSIONS[$target]})"
+    echo -e "  ${C_GREEN}PASS${C_RESET}: $target ${C_DIM}(podman ${EXPECTED_VERSIONS[$target]})${C_RESET}"
 done
 for target in "${FAILED[@]}"; do
-    echo "  FAIL: $target (podman ${EXPECTED_VERSIONS[$target]})"
+    echo -e "  ${C_RED}FAIL${C_RESET}: $target ${C_DIM}(podman ${EXPECTED_VERSIONS[$target]})${C_RESET}"
 done
 
 if [[ ${#FAILED[@]} -gt 0 ]]; then

--- a/tests/containers/run-matrix.sh
+++ b/tests/containers/run-matrix.sh
@@ -25,7 +25,6 @@ IMAGE_PREFIX="terok-test"
 SOURCE_MOUNT="/src"
 WORKSPACE_DIR="/workspace"
 PYTHON_VERSION="3.12"
-DEFAULT_MARKER="needs_host_features"
 TEROK_DIAGNOSTIC_COMMAND="poetry run terokctl config"
 
 # ── Terminal colors (disabled when stdout is not a tty) ──
@@ -76,12 +75,9 @@ usage() {
     echo "  --build-only   Build images without running tests"
     echo "  --no-cache     Rebuild images from scratch (ignore layer cache)"
     echo "  --list         List available distros"
-    echo "  --host-only    Run only needs_host_features tests (fast)"
-    echo "  --podman       Run only needs_podman tests"
-    echo "  --all-markers  Run the full integration suite"
     echo "  -h, --help     Show this help"
     echo ""
-    echo "Default: install full infrastructure, run tests with marker '$DEFAULT_MARKER'."
+    echo "Default: install full infrastructure, run all integration tests."
     echo ""
     echo "Available distros: ${!DISTROS[*]}"
     return 0
@@ -102,14 +98,13 @@ build_image() {
 
 run_tests() {
     local name="$1"
-    local marker="${2:-$DEFAULT_MARKER}"
     local image="$IMAGE_PREFIX:$name"
     local ctr_name="$IMAGE_PREFIX-$name"
     local test_user="${TEST_USERS[$name]}"
 
     echo ""
     echo -e "${C_CYAN}==> Testing ${C_BOLD}$name${C_CYAN} (expected podman ${EXPECTED_VERSIONS[$name]})${C_RESET}"
-    echo -e "    ${C_DIM}marker: ${marker:-<all>}, user: $test_user${C_RESET}"
+    echo -e "    ${C_DIM}user: $test_user${C_RESET}"
     echo ""
 
     # Three-phase flow:
@@ -175,7 +170,7 @@ run_tests() {
                 # ── Phase 1: tests without hooks ──
                 echo \"\"
                 echo \"--- phase 1: tests without hooks ---\"
-                poetry run pytest tests/integration/ -v --tb=short -m \"$marker and not needs_hooks\"
+                poetry run pytest tests/integration/ -v --tb=short -m \"not needs_hooks\"
 
                 # ── Phase 2: install global hooks ──
                 echo \"\"
@@ -192,7 +187,7 @@ print(\\\"Shield hooks verified.\\\")
                 # ── Phase 3: tests with hooks ──
                 echo \"\"
                 echo \"--- phase 3: tests with hooks ---\"
-                poetry run pytest tests/integration/ -v --tb=short -m \"$marker and needs_hooks\"
+                poetry run pytest tests/integration/ -v --tb=short -m \"needs_hooks\"
 
                 echo \"\"
                 echo \"--- terokctl config ---\"
@@ -212,7 +207,6 @@ print(\\\"Shield hooks verified.\\\")
 BUILD_ONLY=false
 LIST_ONLY=false
 NO_CACHE=false
-MARKER="$DEFAULT_MARKER"
 TARGETS=()
 
 while [[ $# -gt 0 ]]; do
@@ -220,9 +214,6 @@ while [[ $# -gt 0 ]]; do
         --build-only) BUILD_ONLY=true ;;
         --no-cache) NO_CACHE=true ;;
         --list) LIST_ONLY=true ;;
-        --host-only) MARKER="$DEFAULT_MARKER" ;;
-        --podman) MARKER="needs_podman" ;;
-        --all-markers) MARKER="" ;;
         -h|--help) usage; exit 0 ;;
         *) TARGETS+=("$1") ;;
     esac
@@ -260,7 +251,7 @@ PASSED=()
 FAILED=()
 
 for target in "${TARGETS[@]}"; do
-    if run_tests "$target" "$MARKER"; then
+    if run_tests "$target"; then
         PASSED+=("$target")
     else
         FAILED+=("$target")

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -36,6 +36,7 @@ from tests.testfs import CONFIG_ROOT_NAME, HOME_DIR_NAME, STATE_ROOT_NAME, XDG_C
 from tests.testnet import ALLOWED_TARGET_DOMAIN, ALLOWED_TARGET_HTTP, GATE_PORT, TEST_IP
 
 from .helpers import (
+    PODMAN_BASE_IMAGE,
     PODMAN_CONTAINER_PREFIX,
     PODMAN_TEST_IMAGE,
     TerokIntegrationEnv,
@@ -182,11 +183,24 @@ class MockRunner:
 
 @pytest.fixture(scope="session")
 def _pull_image() -> None:
-    """Pull the podman integration image once per test session."""
+    """Build the podman integration test image once per session.
+
+    Extends Alpine with git so shielded-container tests can clone
+    without needing outbound access to the Alpine package repos.
+    """
     if not _has("podman"):
         pytest.skip("podman not installed")
-    if not _image_available():
-        subprocess.run(["podman", "pull", PODMAN_TEST_IMAGE], check=True, timeout=120)
+    if _image_available():
+        return
+    subprocess.run(
+        [
+            "podman", "build", "-t", PODMAN_TEST_IMAGE, "-f", "-", ".",
+        ],
+        input=f"FROM {PODMAN_BASE_IMAGE}\nRUN apk add --no-cache git\n",
+        check=True,
+        text=True,
+        timeout=120,
+    )
 
 
 @pytest.fixture(scope="session")

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -194,7 +194,13 @@ def _pull_image() -> None:
         return
     subprocess.run(
         [
-            "podman", "build", "-t", PODMAN_TEST_IMAGE, "-f", "-", ".",
+            "podman",
+            "build",
+            "-t",
+            PODMAN_TEST_IMAGE,
+            "-f",
+            "-",
+            ".",
         ],
         input=f"FROM {PODMAN_BASE_IMAGE}\nRUN apk add --no-cache git\n",
         check=True,

--- a/tests/integration/containers/conftest.py
+++ b/tests/integration/containers/conftest.py
@@ -100,8 +100,8 @@ def shell_test_image(tmp_path_factory: pytest.TempPathFactory) -> Iterator[str]:
 
     build_dir = tmp_path_factory.mktemp("container-build")
 
-    # Read L0 template from package resources (ARG BASE_IMAGE defaults to ubuntu:24.04).
-    tmpl_pkg = resources.files("terok") / "resources" / "templates"
+    # Read L0 template from terok_agent (moved there in 065a7b8).
+    tmpl_pkg = resources.files("terok_agent") / "resources" / "templates"
     l0_content = (tmpl_pkg / "l0.dev.Dockerfile.template").read_text()
     (build_dir / "L0.Dockerfile").write_text(l0_content)
 

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -19,7 +19,8 @@ SRC_DIR = ROOT / "src"
 PROJECT_FILENAME = "project.yml"
 WORKSPACE_DIRNAME = "workspace-dangerous"
 NEW_TASK_MARKER = ".new-task-marker"
-PODMAN_TEST_IMAGE = "docker.io/library/alpine:latest"
+PODMAN_BASE_IMAGE = "docker.io/library/alpine:latest"
+PODMAN_TEST_IMAGE = "terok-itest:latest"
 PODMAN_CONTAINER_PREFIX = "terok-itest"
 PODMAN_SLEEP_COMMAND = ("sleep", "300")
 

--- a/tests/integration/test_bypass_connectivity.py
+++ b/tests/integration/test_bypass_connectivity.py
@@ -39,7 +39,11 @@ pytestmark = [pytest.mark.needs_podman, pytest.mark.needs_internet]
 
 
 def _detect_rootless_network_mode() -> str:
-    """Detect whether podman uses pasta or slirp4netns."""
+    """Detect whether podman uses pasta or slirp4netns.
+
+    Falls back to slirp4netns — the safe default that works on all
+    podman versions (podman < 4.4 lacks ``RootlessNetworkCmd``).
+    """
     try:
         out = subprocess.run(
             ["podman", "info", "-f", "{{.Host.RootlessNetworkCmd}}"],
@@ -48,9 +52,9 @@ def _detect_rootless_network_mode() -> str:
             timeout=10,
         )
         cmd = out.stdout.strip()
-        return cmd if cmd in ("pasta", "slirp4netns") else "pasta"
+        return cmd if cmd in ("pasta", "slirp4netns") else "slirp4netns"
     except (FileNotFoundError, subprocess.TimeoutExpired):
-        return "pasta"
+        return "slirp4netns"
 
 
 def _bypass_network_args() -> list[str]:

--- a/tests/integration/test_container_e2e.py
+++ b/tests/integration/test_container_e2e.py
@@ -38,6 +38,42 @@ from .helpers import (
 
 pytestmark = [pytest.mark.needs_podman, pytest.mark.needs_internet]
 
+# Podman version that ships the containers/common fix for IPv6 zone-ID
+# nameservers in resolv.conf (https://github.com/containers/common/pull/2233).
+_PODMAN_ZONE_ID_FIX = (5, 4)
+
+
+def _host_podman_version() -> tuple[int, ...]:
+    """Return the host podman version as a tuple of ints."""
+    r = subprocess.run(
+        ["podman", "version", "--format", "{{.Client.Version}}"],
+        capture_output=True, text=True, timeout=10,
+    )
+    parts: list[int] = []
+    for seg in (r.stdout.strip().split(".") if r.returncode == 0 else []):
+        digits = "".join(c for c in seg if c.isdigit())
+        if digits:
+            parts.append(int(digits))
+    return tuple(parts) or (0,)
+
+
+def _strip_zone_id_nameservers(container: str) -> None:
+    """Remove nameserver entries with IPv6 zone-ID suffixes from a container.
+
+    These entries reference host interfaces (e.g. eno1) that don't exist
+    inside the container, causing BIND-based DNS tools to reject the entire
+    resolv.conf.  Only needed on podman < 5.4.
+    """
+    if _host_podman_version() >= _PODMAN_ZONE_ID_FIX:
+        return
+    subprocess.run(
+        [
+            "podman", "exec", container, "sh", "-c",
+            "grep -v '^nameserver.*%' /etc/resolv.conf > /tmp/rc && cat /tmp/rc > /etc/resolv.conf",
+        ],
+        capture_output=True, timeout=10,
+    )
+
 
 # ── In-process gate server ────────────────────────────────
 
@@ -151,12 +187,24 @@ def shielded_e2e(_pull_image: None, gate_env: dict) -> Iterator[ShieldedContaine
             raise RuntimeError(
                 f"podman run failed (exit {result.returncode}):\n  stderr: {result.stderr.strip()}"
             )
-        # Install git in the alpine container
-        subprocess.run(
-            ["podman", "exec", name, "apk", "add", "--no-cache", "git"],
+
+        # Podman < 5.4 copies IPv6 zone-ID nameservers (fe80::1%eno1) into
+        # the container where the interface doesn't exist, breaking BIND-based
+        # DNS tools.  Fixed upstream: https://github.com/containers/common/pull/2233
+        _strip_zone_id_nameservers(name)
+
+        # Install git + DNS tools in the alpine container
+        apk_result = subprocess.run(
+            ["podman", "exec", name, "apk", "add", "--no-cache", "git", "bind-tools"],
             capture_output=True,
+            text=True,
             timeout=60,
         )
+        if apk_result.returncode != 0:
+            raise RuntimeError(
+                f"apk add failed (exit {apk_result.returncode}):\n"
+                f"  stderr: {apk_result.stderr.strip()}"
+            )
         yield ShieldedContainer(name=name, shield=shield)
     finally:
         try:

--- a/tests/integration/test_container_e2e.py
+++ b/tests/integration/test_container_e2e.py
@@ -47,10 +47,12 @@ def _host_podman_version() -> tuple[int, ...]:
     """Return the host podman version as a tuple of ints."""
     r = subprocess.run(
         ["podman", "version", "--format", "{{.Client.Version}}"],
-        capture_output=True, text=True, timeout=10,
+        capture_output=True,
+        text=True,
+        timeout=10,
     )
     parts: list[int] = []
-    for seg in (r.stdout.strip().split(".") if r.returncode == 0 else []):
+    for seg in r.stdout.strip().split(".") if r.returncode == 0 else []:
         digits = "".join(c for c in seg if c.isdigit())
         if digits:
             parts.append(int(digits))
@@ -68,10 +70,15 @@ def _strip_zone_id_nameservers(container: str) -> None:
         return
     subprocess.run(
         [
-            "podman", "exec", container, "sh", "-c",
+            "podman",
+            "exec",
+            container,
+            "sh",
+            "-c",
             "grep -v '^nameserver.*%' /etc/resolv.conf > /tmp/rc && cat /tmp/rc > /etc/resolv.conf",
         ],
-        capture_output=True, timeout=10,
+        capture_output=True,
+        timeout=10,
     )
 
 

--- a/tests/integration/test_container_e2e.py
+++ b/tests/integration/test_container_e2e.py
@@ -193,18 +193,6 @@ def shielded_e2e(_pull_image: None, gate_env: dict) -> Iterator[ShieldedContaine
         # DNS tools.  Fixed upstream: https://github.com/containers/common/pull/2233
         _strip_zone_id_nameservers(name)
 
-        # Install git + DNS tools in the alpine container
-        apk_result = subprocess.run(
-            ["podman", "exec", name, "apk", "add", "--no-cache", "git", "bind-tools"],
-            capture_output=True,
-            text=True,
-            timeout=60,
-        )
-        if apk_result.returncode != 0:
-            raise RuntimeError(
-                f"apk add failed (exit {apk_result.returncode}):\n"
-                f"  stderr: {apk_result.stderr.strip()}"
-            )
         yield ShieldedContainer(name=name, shield=shield)
     finally:
         try:
@@ -246,7 +234,7 @@ class TestShieldedContainerLifecycle:
 
     def test_dns_resolves(self, shielded_e2e: ShieldedContainer) -> None:
         """DNS resolution works inside a shielded container."""
-        result = exec_in_container(shielded_e2e.name, "nslookup", "example.com", timeout=10)
+        result = exec_in_container(shielded_e2e.name, "getent", "hosts", "example.com", timeout=10)
         assert result.returncode == 0, f"DNS resolution failed: {result.stderr}"
 
     def test_allowed_domain_reachable(self, shielded_e2e: ShieldedContainer) -> None:


### PR DESCRIPTION
## Summary

Port matrix runner hardening from terok-shield [PR #132](https://github.com/terok-ai/terok-shield/pull/132). Also incorporates the Containerfile dependency additions from #542.

- Subordinate UID ranges within 0–65535 for nested user-namespace compatibility
- setuid on newuidmap/newgidmap, fuse-overlayfs storage, cgroupfs engine config
- dnsutils/openssh in all matrix Containerfiles
- Colored output, `--no-cache` support, Makefile env var consolidation
- resolv.conf zone-ID cleanup for hosts with IPv6 link-local DNS ([containers/common#2233](https://github.com/containers/common/pull/2233))
- POSIX shell compatibility in `su -c` blocks

Supersedes #542.

## Test plan

- [x] `make test-matrix` passes on all distros
- [x] `make test-matrix NO_CACHE=1` forces full rebuild

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a --no-cache build option and simplified test-matrix CLI (removed several marker-selection flags).
  * Test workflow now performs unified prep as root then runs tests as a mapped non-root user.

* **Chores**
  * Container images include additional tooling (crun, DNS/SSH utilities) and runtime setup for nested rootless containers; runtime exposes fuse.

* **Bug Fixes**
  * Improved workspace ownership handling and fixed DNS/resolv.conf issues that removed problematic IPv6 zone-ID nameservers; output now shows colored PASS/FAIL.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->