### PR TITLE
fix: add dnsutils and openssh to matrix Containerfiles

### DIFF
--- a/tests/containers/Containerfile.debian12
+++ b/tests/containers/Containerfile.debian12
@@ -6,7 +6,7 @@ FROM docker.io/library/debian:12
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     podman slirp4netns nftables uidmap fuse-overlayfs \
-    python3 python3-venv git curl ca-certificates \
+    python3 python3-venv git curl ca-certificates dnsutils openssh-client \
     && rm -rf /var/lib/apt/lists/*
 
 # Debian 12 ships Python 3.11 — use uv to get 3.12+

--- a/tests/containers/Containerfile.debian13
+++ b/tests/containers/Containerfile.debian13
@@ -7,7 +7,7 @@ FROM docker.io/library/debian:trixie
 RUN apt-get update && apt-get install -y --no-install-recommends \
     podman passt slirp4netns nftables uidmap fuse-overlayfs \
     python3 python3-pip python3-venv \
-    git curl ca-certificates \
+    git curl ca-certificates dnsutils openssh-client \
     && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /src

--- a/tests/containers/Containerfile.fedora43
+++ b/tests/containers/Containerfile.fedora43
@@ -7,7 +7,7 @@ FROM registry.fedoraproject.org/fedora:43
 RUN dnf install -y \
     podman passt nftables slirp4netns fuse-overlayfs \
     python3 python3-pip \
-    git curl \
+    git curl bind-utils openssh-clients \
     && dnf clean all
 
 WORKDIR /src

--- a/tests/containers/Containerfile.podman
+++ b/tests/containers/Containerfile.podman
@@ -5,7 +5,7 @@
 FROM quay.io/podman/stable:latest
 
 RUN dnf install -y \
-    nftables python3 python3-pip git curl \
+    nftables python3 python3-pip git curl bind-utils openssh-clients \
     && dnf clean all
 
 WORKDIR /src

--- a/tests/containers/Containerfile.ubuntu2404
+++ b/tests/containers/Containerfile.ubuntu2404
@@ -7,7 +7,7 @@ FROM docker.io/library/ubuntu:24.04
 RUN apt-get update && apt-get install -y --no-install-recommends \
     podman slirp4netns passt nftables uidmap fuse-overlayfs \
     python3 python3-pip python3-venv \
-    git curl ca-certificates \
+    git curl ca-certificates dnsutils openssh-client \
     && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /src


### PR DESCRIPTION
## Summary

- Adds `dnsutils` (Debian/Ubuntu) / `bind-utils` (Fedora) to all 5 matrix Containerfiles — required by terok-shield's DNS resolver (`dig`)
- Adds `openssh-client` / `openssh-clients` so ssh-keygen integration tests run instead of skipping

**Root cause of ~34 matrix failures:** Shield DNS resolution shells out to `dig` which wasn't installed, causing all domain allowlists to be empty. Companion PR: terok-ai/terok-shield#132 (adds `DigNotFoundError` for fail-fast).

## Test plan
- [ ] Re-run `make test-matrix` — shield hook tests should pass with DNS resolution working
- [ ] SSH init tests should no longer skip on Ubuntu

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated test container images across multiple distributions with additional DNS and SSH utilities to enhance testing infrastructure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->