### PR TITLE
feat: credential proxy CLI subcommand and TUI screen

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -2558,33 +2558,33 @@ tomli-w = ">=1.0,<2.0"
 
 [[package]]
 name = "terok-agent"
-version = "0.0.9"
+version = "0.0.10"
 description = "Single-agent task runner for hardened Podman containers"
 optional = false
 python-versions = ">=3.12,<4.0"
 groups = ["main"]
 files = [
-    {file = "terok_agent-0.0.9-py3-none-any.whl", hash = "sha256:57e0f750f88c398503838722238d20d3dbd10483c86e6d9ca0eb4bcfd1e7915d"},
+    {file = "terok_agent-0.0.10-py3-none-any.whl", hash = "sha256:90fcdf157c33c6754b09f48f2288fcd1b32d5cf10a304f594c30493562ee3811"},
 ]
 
 [package.dependencies]
 Jinja2 = ">=3.1"
 "ruamel.yaml" = ">=0.18"
-terok_sandbox = {url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.0.10/terok_sandbox-0.0.10-py3-none-any.whl"}
+terok_sandbox = {url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.0.11/terok_sandbox-0.0.11-py3-none-any.whl"}
 
 [package.source]
 type = "url"
-url = "https://github.com/terok-ai/terok-agent/releases/download/v0.0.9/terok_agent-0.0.9-py3-none-any.whl"
+url = "https://github.com/terok-ai/terok-agent/releases/download/v0.0.10/terok_agent-0.0.10-py3-none-any.whl"
 
 [[package]]
 name = "terok-sandbox"
-version = "0.0.10"
+version = "0.0.11"
 description = "Hardened Podman container runner with gate server and shield integration"
 optional = false
 python-versions = ">=3.12,<4.0"
 groups = ["main"]
 files = [
-    {file = "terok_sandbox-0.0.10-py3-none-any.whl", hash = "sha256:6508b64411a7643c95a62d50ff553a223a1d6277d7134aa9c15d7ce5715b63b7"},
+    {file = "terok_sandbox-0.0.11-py3-none-any.whl", hash = "sha256:17806f4ae7ae5940104388fdebc90bb2767d42711386fc83a1744077610df102"},
 ]
 
 [package.dependencies]
@@ -2594,7 +2594,7 @@ terok_shield = {url = "https://github.com/terok-ai/terok-shield/releases/downloa
 
 [package.source]
 type = "url"
-url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.0.10/terok_sandbox-0.0.10-py3-none-any.whl"
+url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.0.11/terok_sandbox-0.0.11-py3-none-any.whl"
 
 [[package]]
 name = "terok-shield"
@@ -3083,4 +3083,4 @@ propcache = ">=0.2.1"
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.12,<4.0"
-content-hash = "fdc7c0e74af698a1cd14545bd59f346e9e219ccd7644ec1fbfa88e2d5f8a4754"
+content-hash = "a54c3bcc1fb82595b8efdd34349e1d696562a8107f910505eb1f7bf3bf549344"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,8 +44,8 @@ rich = ">=13.0"
 platformdirs = ">=4.5.1"
 unique-namer = ">=1.3"
 textual-serve = ">=1.1.0"
-terok-agent = {url = "https://github.com/terok-ai/terok-agent/releases/download/v0.0.9/terok_agent-0.0.9-py3-none-any.whl"}
-terok-sandbox = {url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.0.10/terok_sandbox-0.0.10-py3-none-any.whl"}
+terok-agent = {url = "https://github.com/terok-ai/terok-agent/releases/download/v0.0.10/terok_agent-0.0.10-py3-none-any.whl"}
+terok-sandbox = {url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.0.11/terok_sandbox-0.0.11-py3-none-any.whl"}
 
 [tool.poetry.group.dev.dependencies]
 pydevd-pycharm = "261.22158.220"

--- a/src/terok/cli/commands/proxy.py
+++ b/src/terok/cli/commands/proxy.py
@@ -14,7 +14,6 @@ from __future__ import annotations
 import argparse
 import sys
 
-from terok_agent import ensure_proxy_routes
 from terok_sandbox import (
     CredentialProxyStatus,
     get_proxy_status,
@@ -53,6 +52,8 @@ def dispatch(args: argparse.Namespace) -> bool:
 
 def _cmd_start() -> None:
     """Generate routes and start the credential proxy daemon."""
+    from terok_agent import ensure_proxy_routes
+
     if is_proxy_running():
         print("Credential proxy is already running.")
         sys.exit(1)

--- a/src/terok/cli/commands/proxy.py
+++ b/src/terok/cli/commands/proxy.py
@@ -52,11 +52,12 @@ def dispatch(args: argparse.Namespace) -> bool:
 
 def _cmd_start() -> None:
     """Generate routes and start the credential proxy daemon."""
-    from terok_agent import ensure_proxy_routes
-
     if is_proxy_running():
         print("Credential proxy is already running.")
         sys.exit(1)
+
+    from terok_agent import ensure_proxy_routes
+
     path = ensure_proxy_routes()
     print(f"Routes:  {path}")
     start_proxy()

--- a/src/terok/cli/commands/proxy.py
+++ b/src/terok/cli/commands/proxy.py
@@ -1,0 +1,85 @@
+# SPDX-FileCopyrightText: 2026 Jiri Vyskocil
+# SPDX-License-Identifier: Apache-2.0
+
+"""Credential proxy management commands: start, stop, status.
+
+Wraps the terok-sandbox proxy lifecycle with route generation from the
+agent registry — ``terokctl proxy start`` writes ``routes.json`` before
+launching the daemon so the proxy is always up-to-date with the YAML
+agent definitions.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+
+from terok_agent import ensure_proxy_routes
+from terok_sandbox import (
+    CredentialProxyStatus,
+    get_proxy_status,
+    is_proxy_running,
+    start_proxy,
+    stop_proxy,
+)
+
+
+def register(subparsers: argparse._SubParsersAction[argparse.ArgumentParser]) -> None:
+    """Register the ``proxy`` subcommand group."""
+    p = subparsers.add_parser("proxy", help="Credential proxy commands")
+    sub = p.add_subparsers(dest="proxy_cmd", required=True)
+
+    sub.add_parser("start", help="Start the credential proxy daemon")
+    sub.add_parser("stop", help="Stop the credential proxy daemon")
+    sub.add_parser("status", help="Show credential proxy status")
+
+
+def dispatch(args: argparse.Namespace) -> bool:
+    """Handle proxy commands.  Returns True if handled."""
+    if args.cmd != "proxy":
+        return False
+
+    cmd = args.proxy_cmd
+    if cmd == "start":
+        _cmd_start()
+    elif cmd == "stop":
+        _cmd_stop()
+    elif cmd == "status":
+        _cmd_status()
+    else:
+        return False
+    return True
+
+
+def _cmd_start() -> None:
+    """Generate routes and start the credential proxy daemon."""
+    if is_proxy_running():
+        print("Credential proxy is already running.")
+        sys.exit(1)
+    path = ensure_proxy_routes()
+    print(f"Routes:  {path}")
+    start_proxy()
+    print("Credential proxy started.")
+
+
+def _cmd_stop() -> None:
+    """Stop the credential proxy daemon."""
+    if not is_proxy_running():
+        print("Credential proxy is not running.")
+        return
+    stop_proxy()
+    print("Credential proxy stopped.")
+
+
+def _cmd_status() -> None:
+    """Show credential proxy status."""
+    status: CredentialProxyStatus = get_proxy_status()
+    state = "running" if status.running else "stopped"
+    print(f"Status:      {state}")
+    print(f"Socket:      {status.socket_path}")
+    print(f"DB:          {status.db_path}")
+    print(f"Routes:      {status.routes_path} ({status.routes_configured} configured)")
+    if status.credentials_stored:
+        print(f"Credentials: {', '.join(status.credentials_stored)}")
+    else:
+        print("Credentials: none stored")

--- a/src/terok/cli/main.py
+++ b/src/terok/cli/main.py
@@ -14,7 +14,7 @@ import argparse
 
 from ..lib.core.config import set_experimental
 from ..lib.core.version import format_version_string, get_version_info
-from .commands import completions, image, info, project, setup, shield, sickbay, task
+from .commands import completions, image, info, project, proxy, setup, shield, sickbay, task
 from .wiring import wire_dispatch, wire_group
 
 # Optional: bash completion via argcomplete
@@ -28,6 +28,7 @@ except ImportError:  # pragma: no cover - optional dep
 _DISPATCHERS = [
     task.dispatch,
     project.dispatch,
+    proxy.dispatch,
     setup.dispatch,
     image.dispatch,
     wire_dispatch,
@@ -91,6 +92,7 @@ def main() -> None:
     # Register subcommands from each module
     task.register(sub)
     project.register(sub)
+    proxy.register(sub)
     setup.register(sub)
     image.register(sub)
     shield.register(sub)
@@ -100,11 +102,10 @@ def main() -> None:
 
     # Mount sub-package command registries under scoped prefixes
     from terok_agent import AGENT_COMMANDS
-    from terok_sandbox import GATE_COMMANDS, PROXY_COMMANDS
+    from terok_sandbox import GATE_COMMANDS
 
     wire_group(sub, "agent", AGENT_COMMANDS, help="Agent container commands")
     wire_group(sub, "gate", GATE_COMMANDS, help="Gate server commands")
-    wire_group(sub, "proxy", PROXY_COMMANDS, help="Credential proxy commands")
 
     # Enable bash completion if argcomplete is present and activated
     if argcomplete is not None:  # pragma: no cover - shell integration

--- a/src/terok/tui/app.py
+++ b/src/terok/tui/app.py
@@ -1056,7 +1056,7 @@ if _HAS_TEXTUAL:
             try:
                 self._last_proxy_status = get_proxy_status()
             except Exception:
-                pass
+                self._last_proxy_status = None
             await self.push_screen(
                 CredentialProxyScreen(self._last_proxy_status),
                 self._on_proxy_action_result,

--- a/src/terok/tui/app.py
+++ b/src/terok/tui/app.py
@@ -41,10 +41,12 @@ if _HAS_TEXTUAL:
     from dataclasses import dataclass
 
     from terok_sandbox import (
+        CredentialProxyStatus,
         EnvironmentCheck,
         GateServerStatus,
         GateStalenessInfo,
         check_environment as _shield_check_environment,
+        get_proxy_status,
         get_server_status,
         state as _shield_state,
     )
@@ -87,7 +89,13 @@ if _HAS_TEXTUAL:
     from .clipboard import get_clipboard_helper_status
     from .polling import PollingMixin
     from .project_actions import ProjectActionsMixin
-    from .screens import GateServerScreen, ProjectDetailsScreen, ShieldScreen, TaskDetailsScreen
+    from .screens import (
+        CredentialProxyScreen,
+        GateServerScreen,
+        ProjectDetailsScreen,
+        ShieldScreen,
+        TaskDetailsScreen,
+    )
     from .task_actions import TaskActionsMixin
     from .widgets import (
         ProjectList,
@@ -127,6 +135,11 @@ if _HAS_TEXTUAL:
 
     SHIELD_ACTION_HANDLERS: dict[str, str] = {
         "shield_setup": "_action_shield_setup",
+    }
+
+    PROXY_ACTION_HANDLERS: dict[str, str] = {
+        "proxy_start": "_action_proxy_start",
+        "proxy_stop": "_action_proxy_stop",
     }
 
     TASK_ACTION_HANDLERS: dict[str, str] = {
@@ -248,6 +261,7 @@ if _HAS_TEXTUAL:
             self._last_gate_server_running: bool | None = None
             self._last_gate_server_status: GateServerStatus | None = None
             self._last_shield_env: EnvironmentCheck | None = None
+            self._last_proxy_status: CredentialProxyStatus | None = None
             # Cached state for detail screens
             self._last_project_state: dict | None = None
             self._last_image_old: bool | None = None
@@ -987,7 +1001,7 @@ if _HAS_TEXTUAL:
         # ---------- Command palette ----------
 
         def get_system_commands(self, screen):
-            """Add gate server and shield management to the command palette."""
+            """Add gate, shield, and proxy management to the command palette."""
             from textual.app import SystemCommand
 
             yield from super().get_system_commands(screen)
@@ -1000,6 +1014,11 @@ if _HAS_TEXTUAL:
                 "Shield Status",
                 "View shield environment and install hooks",
                 self.action_show_shield,
+            )
+            yield SystemCommand(
+                "Credential Proxy",
+                "Manage credential proxy status and operations",
+                self.action_show_proxy,
             )
 
         async def action_show_gate_server(self) -> None:
@@ -1029,6 +1048,25 @@ if _HAS_TEXTUAL:
             if not result:
                 return
             handler = SHIELD_ACTION_HANDLERS.get(result)
+            if handler:
+                await getattr(self, handler)()
+
+        async def action_show_proxy(self) -> None:
+            """Open the credential proxy management screen."""
+            try:
+                self._last_proxy_status = get_proxy_status()
+            except Exception:
+                pass
+            await self.push_screen(
+                CredentialProxyScreen(self._last_proxy_status),
+                self._on_proxy_action_result,
+            )
+
+        async def _on_proxy_action_result(self, result: str | None) -> None:
+            """Handle result from proxy screen."""
+            if not result:
+                return
+            handler = PROXY_ACTION_HANDLERS.get(result)
             if handler:
                 await getattr(self, handler)()
 

--- a/src/terok/tui/project_actions.py
+++ b/src/terok/tui/project_actions.py
@@ -17,7 +17,9 @@ from collections.abc import Callable
 from terok_sandbox import (
     install_systemd_units,
     start_daemon,
+    start_proxy,
     stop_daemon,
+    stop_proxy,
     uninstall_systemd_units,
 )
 
@@ -561,4 +563,26 @@ class ProjectActionsMixin:
         await self._run_suspended(
             lambda: shield_setup_hooks_direct(root=result == "root"),
             success_msg="Shield hooks installed",
+        )
+
+    # ---------- Credential proxy actions ----------
+
+    async def _action_proxy_start(self) -> None:
+        """Generate routes and start the credential proxy daemon."""
+        from terok_agent import ensure_proxy_routes
+
+        def _start() -> None:
+            ensure_proxy_routes()
+            start_proxy()
+
+        await self._run_suspended(
+            _start,
+            success_msg="Credential proxy started",
+        )
+
+    async def _action_proxy_stop(self) -> None:
+        """Stop the credential proxy daemon."""
+        await self._run_suspended(
+            stop_proxy,
+            success_msg="Credential proxy stopped",
         )

--- a/src/terok/tui/screens.py
+++ b/src/terok/tui/screens.py
@@ -50,6 +50,7 @@ except Exception:  # pragma: no cover - textual may be a stub module
 from rich.style import Style
 from rich.text import Text
 from terok_sandbox import (
+    CredentialProxyStatus,
     EnvironmentCheck,
     GateServerStatus,
     GateStalenessInfo,
@@ -1851,3 +1852,137 @@ class ShieldSetupScreen(screen.ModalScreen[str | None]):
     def action_dismiss(self) -> None:
         """Cancel without choosing."""
         self.dismiss(None)
+
+
+# ---------------------------------------------------------------------------
+# Credential Proxy helpers
+# ---------------------------------------------------------------------------
+
+
+def render_proxy_status(status: CredentialProxyStatus | None) -> Text:
+    """Render credential proxy status details as a Rich Text object."""
+    if status is None:
+        return Text("Credential proxy status unknown.")
+
+    ok = Style(color="green")
+    err = Style(color="red")
+    dim = Style(dim=True)
+
+    running_s = Text("running", style=ok) if status.running else Text("stopped", style=err)
+
+    lines: list[Text] = [
+        Text.assemble("Status:      ", running_s),
+        Text(f"Socket:      {status.socket_path}"),
+        Text(f"DB:          {status.db_path}"),
+        Text(f"Routes:      {status.routes_path} ({status.routes_configured} configured)"),
+    ]
+
+    if status.credentials_stored:
+        lines.append(Text(f"Credentials: {', '.join(status.credentials_stored)}"))
+    else:
+        lines.append(Text.assemble("Credentials: ", Text("none stored", style=dim)))
+
+    if not status.running:
+        lines.append(Text(""))
+        lines.append(
+            Text(
+                "The credential proxy injects real API credentials into container\n"
+                "requests without exposing secrets to the container filesystem.\n"
+                "Use the actions below to start it.",
+                style=dim,
+            )
+        )
+
+    return Text("\n").join(lines)
+
+
+# ---------------------------------------------------------------------------
+# Credential Proxy Screen
+# ---------------------------------------------------------------------------
+
+
+class CredentialProxyScreen(screen.Screen[str | None]):
+    """Full-page screen for managing the credential proxy."""
+
+    BINDINGS = [
+        _modal_binding("escape", "dismiss", "Back"),
+        _modal_binding("q", "dismiss", "Back"),
+        _modal_binding("s", "proxy_start", "Start proxy"),
+        _modal_binding("p", "proxy_stop", "Stop proxy"),
+        _modal_binding("r", "proxy_refresh", "Refresh status"),
+    ]
+
+    CSS = (
+        """
+    CredentialProxyScreen {
+        layout: vertical;
+        background: $background;
+    }
+    """
+        + _DETAIL_SCREEN_CSS
+    )
+
+    def __init__(self, status: CredentialProxyStatus | None = None) -> None:
+        """Store proxy status for rendering."""
+        super().__init__()
+        self._status = status
+
+    def compose(self) -> ComposeResult:
+        """Build the detail pane and action list for proxy management."""
+        detail_pane = Static(id="detail-content")
+        detail_pane.border_title = "Credential Proxy"
+        detail_pane.border_subtitle = "Esc to close"
+        yield detail_pane
+
+        yield OptionList(
+            Option("\\[s]tart proxy", id="proxy_start"),
+            Option("sto\\[p] proxy", id="proxy_stop"),
+            None,
+            Option("\\[r]efresh status", id="proxy_refresh"),
+            id="actions-list",
+        )
+
+    def on_mount(self) -> None:
+        """Render proxy status and focus the action list."""
+        self._render_status()
+        actions = self.query_one("#actions-list", OptionList)
+        actions.focus()
+
+    def _render_status(self) -> None:
+        """Update the detail pane with current status."""
+        detail_widget = self.query_one("#detail-content", Static)
+        detail_widget.update(render_proxy_status(self._status))
+
+    def _refresh_status(self) -> None:
+        """Re-fetch status and update the display."""
+        from terok_sandbox import get_proxy_status
+
+        try:
+            self._status = get_proxy_status()
+        except Exception:
+            self._status = None
+        self._render_status()
+
+    def on_option_list_option_selected(self, event: OptionList.OptionSelected) -> None:
+        """Handle action selection from the option list."""
+        option_id = event.option_id
+        if option_id == "proxy_refresh":
+            self._refresh_status()
+        elif option_id:
+            self.dismiss(option_id)
+
+    def action_dismiss(self) -> None:
+        """Close the screen without selecting an action."""
+        self.dismiss(None)
+
+    def action_proxy_start(self) -> None:
+        """Trigger proxy start."""
+        self.dismiss("proxy_start")
+
+    def action_proxy_stop(self) -> None:
+        """Trigger proxy stop."""
+        self.dismiss("proxy_stop")
+
+    def action_proxy_refresh(self) -> None:
+        """Refresh the status display."""
+        self._refresh_status()

--- a/tests/unit/cli/test_cli_proxy.py
+++ b/tests/unit/cli/test_cli_proxy.py
@@ -71,7 +71,7 @@ class TestProxyDispatch:
         assert "3 configured" in out
 
     @patch("terok.cli.commands.proxy.start_proxy")
-    @patch("terok.cli.commands.proxy.ensure_proxy_routes")
+    @patch("terok_agent.ensure_proxy_routes")
     @patch("terok.cli.commands.proxy.is_proxy_running", return_value=False)
     def test_dispatch_start(self, mock_running, mock_routes, mock_start, capsys) -> None:
         """'proxy start' generates routes and starts the daemon."""

--- a/tests/unit/cli/test_cli_proxy.py
+++ b/tests/unit/cli/test_cli_proxy.py
@@ -1,0 +1,110 @@
+# SPDX-FileCopyrightText: 2026 Jiri Vyskocil
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the ``terokctl proxy`` CLI subcommand."""
+
+from __future__ import annotations
+
+import argparse
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from terok.cli.commands.proxy import dispatch, register
+from tests.testfs import MOCK_BASE
+
+MOCK_PROXY_SOCKET = MOCK_BASE / "run" / "credential-proxy.sock"
+MOCK_PROXY_DB = MOCK_BASE / "proxy" / "credentials.db"
+MOCK_PROXY_ROUTES = MOCK_BASE / "proxy" / "routes.json"
+
+
+def _make_parser() -> argparse.ArgumentParser:
+    """Build a minimal parser with the proxy subcommand registered."""
+    parser = argparse.ArgumentParser()
+    sub = parser.add_subparsers(dest="cmd")
+    register(sub)
+    return parser
+
+
+def _make_status(*, running: bool = False) -> MagicMock:
+    """Build a proxy status mock."""
+    status = MagicMock()
+    status.running = running
+    status.socket_path = MOCK_PROXY_SOCKET
+    status.db_path = MOCK_PROXY_DB
+    status.routes_path = MOCK_PROXY_ROUTES
+    status.routes_configured = 3
+    status.credentials_stored = ("claude", "gh")
+    return status
+
+
+class TestProxyRegister:
+    """Verify subcommand registration."""
+
+    def test_proxy_subcommands_registered(self) -> None:
+        """All proxy subcommands are parseable."""
+        parser = _make_parser()
+        for sub in ("start", "stop", "status"):
+            args = parser.parse_args(["proxy", sub])
+            assert args.cmd == "proxy"
+            assert args.proxy_cmd == sub
+
+
+class TestProxyDispatch:
+    """Verify dispatch routing."""
+
+    def test_dispatch_ignores_other_commands(self) -> None:
+        """dispatch returns False for non-proxy commands."""
+        args = argparse.Namespace(cmd="task")
+        assert dispatch(args) is False
+
+    @patch("terok.cli.commands.proxy.get_proxy_status")
+    def test_dispatch_status(self, mock_status, capsys) -> None:
+        """'proxy status' prints status info."""
+        mock_status.return_value = _make_status()
+        parser = _make_parser()
+        args = parser.parse_args(["proxy", "status"])
+        assert dispatch(args) is True
+        out = capsys.readouterr().out
+        assert "stopped" in out
+        assert "claude" in out
+        assert "3 configured" in out
+
+    @patch("terok.cli.commands.proxy.start_proxy")
+    @patch("terok.cli.commands.proxy.ensure_proxy_routes")
+    @patch("terok.cli.commands.proxy.is_proxy_running", return_value=False)
+    def test_dispatch_start(self, mock_running, mock_routes, mock_start, capsys) -> None:
+        """'proxy start' generates routes and starts the daemon."""
+        mock_routes.return_value = MOCK_PROXY_ROUTES
+        parser = _make_parser()
+        args = parser.parse_args(["proxy", "start"])
+        assert dispatch(args) is True
+        mock_routes.assert_called_once()
+        mock_start.assert_called_once()
+        assert "started" in capsys.readouterr().out
+
+    @patch("terok.cli.commands.proxy.is_proxy_running", return_value=True)
+    def test_dispatch_start_already_running(self, mock_running) -> None:
+        """'proxy start' exits if already running."""
+        parser = _make_parser()
+        args = parser.parse_args(["proxy", "start"])
+        with pytest.raises(SystemExit):
+            dispatch(args)
+
+    @patch("terok.cli.commands.proxy.stop_proxy")
+    @patch("terok.cli.commands.proxy.is_proxy_running", return_value=True)
+    def test_dispatch_stop(self, mock_running, mock_stop, capsys) -> None:
+        """'proxy stop' calls stop_proxy."""
+        parser = _make_parser()
+        args = parser.parse_args(["proxy", "stop"])
+        assert dispatch(args) is True
+        mock_stop.assert_called_once()
+        assert "stopped" in capsys.readouterr().out
+
+    @patch("terok.cli.commands.proxy.is_proxy_running", return_value=False)
+    def test_dispatch_stop_not_running(self, mock_running, capsys) -> None:
+        """'proxy stop' prints info when not running."""
+        parser = _make_parser()
+        args = parser.parse_args(["proxy", "stop"])
+        assert dispatch(args) is True
+        assert "not running" in capsys.readouterr().out

--- a/tests/unit/cli/test_cli_proxy.py
+++ b/tests/unit/cli/test_cli_proxy.py
@@ -108,3 +108,28 @@ class TestProxyDispatch:
         args = parser.parse_args(["proxy", "stop"])
         assert dispatch(args) is True
         assert "not running" in capsys.readouterr().out
+
+    @patch("terok.cli.commands.proxy.get_proxy_status")
+    def test_dispatch_status_no_credentials(self, mock_status, capsys) -> None:
+        """'proxy status' shows 'none stored' when no credentials exist."""
+        status = _make_status()
+        status.credentials_stored = ()
+        mock_status.return_value = status
+        parser = _make_parser()
+        args = parser.parse_args(["proxy", "status"])
+        dispatch(args)
+        assert "none stored" in capsys.readouterr().out
+
+    @patch("terok.cli.commands.proxy.get_proxy_status")
+    def test_dispatch_status_running(self, mock_status, capsys) -> None:
+        """'proxy status' shows 'running' when proxy is up."""
+        mock_status.return_value = _make_status(running=True)
+        parser = _make_parser()
+        args = parser.parse_args(["proxy", "status"])
+        dispatch(args)
+        assert "running" in capsys.readouterr().out
+
+    def test_dispatch_unknown_subcommand(self) -> None:
+        """Unknown proxy subcommand returns False."""
+        args = argparse.Namespace(cmd="proxy", proxy_cmd="bogus")
+        assert dispatch(args) is False

--- a/tests/unit/cli/test_cli_proxy.py
+++ b/tests/unit/cli/test_cli_proxy.py
@@ -71,7 +71,7 @@ class TestProxyDispatch:
         assert "3 configured" in out
 
     @patch("terok.cli.commands.proxy.start_proxy")
-    @patch("terok_agent.ensure_proxy_routes")
+    @patch("terok_agent.ensure_proxy_routes", create=True)
     @patch("terok.cli.commands.proxy.is_proxy_running", return_value=False)
     def test_dispatch_start(self, mock_running, mock_routes, mock_start, capsys) -> None:
         """'proxy start' generates routes and starts the daemon."""

--- a/tests/unit/tui/test_detail_screens.py
+++ b/tests/unit/tui/test_detail_screens.py
@@ -1118,11 +1118,16 @@ class TestProxyActionDispatch:
         ],
     )
     def test_proxy_action_dispatch_all(self, action: str, handler: str) -> None:
-        """Every proxy action maps to a handler method."""
-        app_mod, _ = import_app()
-        assert app_mod.PROXY_ACTION_HANDLERS[action] == handler
+        """Every proxy action routes through the callback to its handler."""
+        _, app_class = import_app()
+        instance = mock.Mock(spec=app_class)
+        run(app_class._on_proxy_action_result(instance, action))
+        getattr(instance, handler).assert_called_once()
 
     def test_proxy_action_dispatch_none(self) -> None:
-        """Unknown action key is not in the handlers dict."""
-        app_mod, _ = import_app()
-        assert "bogus" not in app_mod.PROXY_ACTION_HANDLERS
+        """None result does not dispatch any handler."""
+        _, app_class = import_app()
+        instance = mock.Mock(spec=app_class)
+        run(app_class._on_proxy_action_result(instance, None))
+        instance._action_proxy_start.assert_not_called()
+        instance._action_proxy_stop.assert_not_called()

--- a/tests/unit/tui/test_detail_screens.py
+++ b/tests/unit/tui/test_detail_screens.py
@@ -1091,6 +1091,40 @@ class TestRenderProxyStatus:
         assert "none stored" in str(result)
 
 
+class TestCredentialProxyScreenRefresh:
+    """Tests for proxy screen refresh logic."""
+
+    def test_refresh_status_updates_status(self) -> None:
+        """_refresh_status fetches new status from terok_sandbox."""
+        screens, _ = import_screens()
+        screen = screens.CredentialProxyScreen(make_proxy_status(running=False))
+        detail = mock.Mock()
+        screen.query_one = mock.Mock(return_value=detail)
+        new_status = make_proxy_status(running=True)
+        with mock.patch("terok_sandbox.get_proxy_status", return_value=new_status):
+            screen._refresh_status()
+        assert screen._status is new_status
+        detail.update.assert_called_once()
+
+    def test_refresh_status_handles_exception(self) -> None:
+        """_refresh_status sets status to None on failure."""
+        screens, _ = import_screens()
+        screen = screens.CredentialProxyScreen(make_proxy_status())
+        detail = mock.Mock()
+        screen.query_one = mock.Mock(return_value=detail)
+        with mock.patch("terok_sandbox.get_proxy_status", side_effect=RuntimeError):
+            screen._refresh_status()
+        assert screen._status is None
+
+    def test_proxy_screen_refresh_action(self) -> None:
+        """action_proxy_refresh calls _refresh_status."""
+        screens, _ = import_screens()
+        screen = screens.CredentialProxyScreen()
+        screen._refresh_status = mock.Mock()
+        screen.action_proxy_refresh()
+        screen._refresh_status.assert_called_once()
+
+
 class TestProxyCommandPalette:
     """Tests for proxy in the command palette."""
 

--- a/tests/unit/tui/test_detail_screens.py
+++ b/tests/unit/tui/test_detail_screens.py
@@ -986,3 +986,143 @@ class TestDeleteTaskResult:
         """Empty task name is preserved through the round-trip."""
         result = self._call_delete(task_name="")
         assert result == ("proj1", "3", "", None)
+
+
+# ---------------------------------------------------------------------------
+# Credential Proxy Screen
+# ---------------------------------------------------------------------------
+
+MOCK_PROXY_SOCKET = MOCK_BASE / "run" / "credential-proxy.sock"
+MOCK_PROXY_DB = MOCK_BASE / "proxy" / "credentials.db"
+MOCK_PROXY_ROUTES = MOCK_BASE / "proxy" / "routes.json"
+
+
+def make_proxy_status(
+    *,
+    running: bool = True,
+    routes_configured: int = 3,
+    credentials_stored: tuple[str, ...] = ("claude", "gh"),
+) -> mock.Mock:
+    """Build a credential proxy status mock with common defaults."""
+    status = mock.Mock()
+    status.running = running
+    status.socket_path = MOCK_PROXY_SOCKET
+    status.db_path = MOCK_PROXY_DB
+    status.routes_path = MOCK_PROXY_ROUTES
+    status.routes_configured = routes_configured
+    status.credentials_stored = credentials_stored
+    return status
+
+
+class TestCredentialProxyScreen:
+    """Tests for the CredentialProxyScreen."""
+
+    def test_proxy_screen_construction(self) -> None:
+        """Screen stores the provided status."""
+        screens, _ = import_screens()
+        status = make_proxy_status()
+        screen = screens.CredentialProxyScreen(status)
+        assert screen._status == status
+
+    def test_proxy_screen_construction_default(self) -> None:
+        """Screen defaults to None status."""
+        screens, _ = import_screens()
+        screen = screens.CredentialProxyScreen()
+        assert screen._status is None
+
+    def test_proxy_screen_dismiss(self) -> None:
+        """action_dismiss sends None result."""
+        screens, _ = import_screens()
+        screen = screens.CredentialProxyScreen()
+        screen.dismiss = mock.Mock()
+        screen.action_dismiss()
+        screen.dismiss.assert_called_once_with(None)
+
+    @pytest.mark.parametrize(
+        ("method_name", "expected"),
+        [
+            pytest.param("action_proxy_start", "proxy_start", id="start"),
+            pytest.param("action_proxy_stop", "proxy_stop", id="stop"),
+        ],
+    )
+    def test_proxy_screen_actions(self, method_name: str, expected: str) -> None:
+        """Action methods dismiss with the expected result string."""
+        screens, _ = import_screens()
+        screen = screens.CredentialProxyScreen()
+        screen.dismiss = mock.Mock()
+        getattr(screen, method_name)()
+        screen.dismiss.assert_called_once_with(expected)
+
+
+class TestRenderProxyStatus:
+    """Tests for the render_proxy_status helper."""
+
+    def test_render_proxy_status_none(self) -> None:
+        """None status renders an 'unknown' message."""
+        screens, _ = import_screens()
+        result = screens.render_proxy_status(None)
+        assert isinstance(result, Text)
+        assert "unknown" in str(result)
+
+    def test_render_proxy_status_running(self) -> None:
+        """Running proxy shows status and credential details."""
+        screens, _ = import_screens()
+        status = make_proxy_status()
+        result = screens.render_proxy_status(status)
+        text_str = str(result)
+        assert "running" in text_str
+        assert "claude" in text_str
+        assert "3 configured" in text_str
+
+    def test_render_proxy_status_stopped(self) -> None:
+        """Stopped proxy shows hint text."""
+        screens, _ = import_screens()
+        status = make_proxy_status(running=False)
+        result = screens.render_proxy_status(status)
+        text_str = str(result)
+        assert "stopped" in text_str
+        assert "actions below" in text_str
+
+    def test_render_proxy_status_no_credentials(self) -> None:
+        """Empty credentials tuple renders 'none stored'."""
+        screens, _ = import_screens()
+        status = make_proxy_status(credentials_stored=())
+        result = screens.render_proxy_status(status)
+        assert "none stored" in str(result)
+
+
+class TestProxyCommandPalette:
+    """Tests for proxy in the command palette."""
+
+    def test_get_system_commands_includes_proxy(self) -> None:
+        """Command palette includes 'Credential Proxy' entry."""
+        from tests.unit.tui.tui_test_helpers import build_textual_stubs
+
+        stubs = build_textual_stubs()
+        _, app_class = import_app(stubs)
+        instance = app_class()
+        with mock.patch.dict(sys.modules, stubs):
+            commands = list(app_class.get_system_commands(instance, screen=mock.Mock()))
+        titles = [cmd.title for cmd in commands]
+        assert "Credential Proxy" in titles
+
+
+class TestProxyActionDispatch:
+    """Tests for proxy action handler dispatch."""
+
+    @pytest.mark.parametrize(
+        ("action", "handler"),
+        [
+            ("proxy_start", "_action_proxy_start"),
+            ("proxy_stop", "_action_proxy_stop"),
+        ],
+    )
+    def test_proxy_action_dispatch_all(self, action: str, handler: str) -> None:
+        """Every proxy action maps to a handler method."""
+        app_mod, _ = import_app()
+        assert app_mod.PROXY_ACTION_HANDLERS[action] == handler
+
+    def test_proxy_action_dispatch_none(self) -> None:
+        """Unknown action key is not in the handlers dict."""
+        app_mod, _ = import_app()
+        assert "bogus" not in app_mod.PROXY_ACTION_HANDLERS


### PR DESCRIPTION
## Summary
- Add `terokctl proxy start/stop/status` as a dedicated CLI module (replaces wire_group passthrough) with automatic `routes.json` generation from the agent registry before daemon launch
- Add `CredentialProxyScreen` to the TUI command palette alongside gate server and shield — shows proxy status, configured routes, and stored credentials with start/stop actions
- Full test coverage: CLI dispatch tests + TUI screen/render/action tests

## Dependencies
- **terok-ai/terok-sandbox#31** — graceful proxy start without routes.json
- **terok-ai/terok-agent** (PR pending) — `ensure_proxy_routes()` function

## Test plan
- [x] 7 CLI proxy tests pass
- [x] 150 TUI detail screen tests pass (including 13 new proxy tests)
- [x] Full suite: 1218 unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * CLI: Added proxy subcommands — start, stop, status — to manage the credential proxy daemon and view running state, routes, and stored credentials.
  * TUI: Added a "Credential Proxy" screen, command-palette entry, and Start/Stop/Refresh actions with status display and app integration.
* **Tests**
  * Added unit tests covering CLI proxy commands and TUI proxy screen rendering, actions, refresh, and command-palette integration.
* **Chores**
  * Updated dependency pins for agent and sandbox components.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->