### PR TITLE
feat: credential proxy TCP transport, per-provider tokens

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,5 @@ docs/ci_map.md
 .coverage
 plans.md
 .claude/settings.local.json
+terok-agent
+terok-sandbox

--- a/poetry.lock
+++ b/poetry.lock
@@ -2558,46 +2558,44 @@ tomli-w = ">=1.0,<2.0"
 
 [[package]]
 name = "terok-agent"
-version = "0.0.12"
+version = "0.0.13"
 description = "Single-agent task runner for hardened Podman containers"
 optional = false
 python-versions = ">=3.12,<4.0"
 groups = ["main"]
-files = []
-develop = false
+files = [
+    {file = "terok_agent-0.0.13-py3-none-any.whl", hash = "sha256:d21b228f4783ceb0f5903db9d9c6c43c2ae1a34452bdad752f0d5386388d5414"},
+]
 
 [package.dependencies]
 Jinja2 = ">=3.1"
 "ruamel.yaml" = ">=0.18"
-terok-sandbox = {git = "https://github.com/sliwowitz/terok-sandbox.git", rev = "d2aa16c"}
+terok_sandbox = {url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.0.14/terok_sandbox-0.0.14-py3-none-any.whl"}
 tomli-w = ">=1.0"
 
 [package.source]
-type = "git"
-url = "https://github.com/sliwowitz/terok-agent.git"
-reference = "f3b9234"
-resolved_reference = "f3b923496b933d0b28db30228165d9ec337268f9"
+type = "url"
+url = "https://github.com/terok-ai/terok-agent/releases/download/v0.0.13/terok_agent-0.0.13-py3-none-any.whl"
 
 [[package]]
 name = "terok-sandbox"
-version = "0.0.13"
+version = "0.0.14"
 description = "Hardened Podman container runner with gate server and shield integration"
 optional = false
 python-versions = ">=3.12,<4.0"
 groups = ["main"]
-files = []
-develop = false
+files = [
+    {file = "terok_sandbox-0.0.14-py3-none-any.whl", hash = "sha256:429964dea7fbe79525d5c13700d3cfa5b8bea448bb651dfba8e431637956b913"},
+]
 
 [package.dependencies]
 aiohttp = ">=3.9"
 platformdirs = ">=4.0"
-terok-shield = {url = "https://github.com/terok-ai/terok-shield/releases/download/v0.4.1/terok_shield-0.4.1-py3-none-any.whl"}
+terok_shield = {url = "https://github.com/terok-ai/terok-shield/releases/download/v0.4.1/terok_shield-0.4.1-py3-none-any.whl"}
 
 [package.source]
-type = "git"
-url = "https://github.com/sliwowitz/terok-sandbox.git"
-reference = "d2aa16c"
-resolved_reference = "d2aa16c1a0bad30499850e472fe5bc7811d048b1"
+type = "url"
+url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.0.14/terok_sandbox-0.0.14-py3-none-any.whl"
 
 [[package]]
 name = "terok-shield"
@@ -3086,4 +3084,4 @@ propcache = ">=0.2.1"
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.12,<4.0"
-content-hash = "38a5546786aea1b9409f10c88658aefa39d9894d8685a9627f68bce5cf24cb9d"
+content-hash = "694a3b0e4602e1b8da0a6d3ee24749e5ab21f608f1e6b35b4c1ef49adc9f8af0"

--- a/poetry.lock
+++ b/poetry.lock
@@ -2563,18 +2563,20 @@ description = "Single-agent task runner for hardened Podman containers"
 optional = false
 python-versions = ">=3.12,<4.0"
 groups = ["main"]
-files = [
-    {file = "terok_agent-0.0.12-py3-none-any.whl", hash = "sha256:ccc90efe0e3e7282e5af5bc87addb38ca170850b8be3be14e04fb81f6f01c24b"},
-]
+files = []
+develop = false
 
 [package.dependencies]
 Jinja2 = ">=3.1"
 "ruamel.yaml" = ">=0.18"
-terok_sandbox = {url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.0.13/terok_sandbox-0.0.13-py3-none-any.whl"}
+terok-sandbox = {git = "https://github.com/sliwowitz/terok-sandbox.git", rev = "d2aa16c"}
+tomli-w = ">=1.0"
 
 [package.source]
-type = "url"
-url = "https://github.com/terok-ai/terok-agent/releases/download/v0.0.12/terok_agent-0.0.12-py3-none-any.whl"
+type = "git"
+url = "https://github.com/sliwowitz/terok-agent.git"
+reference = "f3b9234"
+resolved_reference = "f3b923496b933d0b28db30228165d9ec337268f9"
 
 [[package]]
 name = "terok-sandbox"
@@ -2583,18 +2585,19 @@ description = "Hardened Podman container runner with gate server and shield inte
 optional = false
 python-versions = ">=3.12,<4.0"
 groups = ["main"]
-files = [
-    {file = "terok_sandbox-0.0.13-py3-none-any.whl", hash = "sha256:58b07aa6ec7964f60fa2644ac40d29baaaa1b951866a91e0f29d6f6d7f683f74"},
-]
+files = []
+develop = false
 
 [package.dependencies]
 aiohttp = ">=3.9"
 platformdirs = ">=4.0"
-terok_shield = {url = "https://github.com/terok-ai/terok-shield/releases/download/v0.4.1/terok_shield-0.4.1-py3-none-any.whl"}
+terok-shield = {url = "https://github.com/terok-ai/terok-shield/releases/download/v0.4.1/terok_shield-0.4.1-py3-none-any.whl"}
 
 [package.source]
-type = "url"
-url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.0.13/terok_sandbox-0.0.13-py3-none-any.whl"
+type = "git"
+url = "https://github.com/sliwowitz/terok-sandbox.git"
+reference = "d2aa16c"
+resolved_reference = "d2aa16c1a0bad30499850e472fe5bc7811d048b1"
 
 [[package]]
 name = "terok-shield"
@@ -2739,7 +2742,7 @@ version = "1.2.0"
 description = "A lil' TOML writer"
 optional = false
 python-versions = ">=3.9"
-groups = ["dev"]
+groups = ["main", "dev"]
 files = [
     {file = "tomli_w-1.2.0-py3-none-any.whl", hash = "sha256:188306098d013b691fcadc011abd66727d3c414c571bb01b1a174ba8c983cf90"},
     {file = "tomli_w-1.2.0.tar.gz", hash = "sha256:2dd14fac5a47c27be9cd4c976af5a12d87fb1f0b4512f81d69cce3b35ae25021"},
@@ -3083,4 +3086,4 @@ propcache = ">=0.2.1"
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.12,<4.0"
-content-hash = "712c1c33f94c926577691131afe22b1553a0aaadbc9bc2337eb4e3b432f0b7f4"
+content-hash = "38a5546786aea1b9409f10c88658aefa39d9894d8685a9627f68bce5cf24cb9d"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,8 +44,8 @@ rich = ">=13.0"
 platformdirs = ">=4.5.1"
 unique-namer = ">=1.3"
 textual-serve = ">=1.1.0"
-terok-agent = {url = "https://github.com/terok-ai/terok-agent/releases/download/v0.0.12/terok_agent-0.0.12-py3-none-any.whl"}
-terok-sandbox = {url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.0.13/terok_sandbox-0.0.13-py3-none-any.whl"}
+terok-agent = {git = "https://github.com/sliwowitz/terok-agent.git", rev = "f3b9234"}
+terok-sandbox = {git = "https://github.com/sliwowitz/terok-sandbox.git", rev = "d2aa16c"}
 
 [tool.poetry.group.dev.dependencies]
 pydevd-pycharm = "261.22158.220"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,8 +44,8 @@ rich = ">=13.0"
 platformdirs = ">=4.5.1"
 unique-namer = ">=1.3"
 textual-serve = ">=1.1.0"
-terok-agent = {git = "https://github.com/sliwowitz/terok-agent.git", rev = "f3b9234"}
-terok-sandbox = {git = "https://github.com/sliwowitz/terok-sandbox.git", rev = "d2aa16c"}
+terok-agent = {url = "https://github.com/terok-ai/terok-agent/releases/download/v0.0.13/terok_agent-0.0.13-py3-none-any.whl"}
+terok-sandbox = {url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.0.14/terok_sandbox-0.0.14-py3-none-any.whl"}
 
 [tool.poetry.group.dev.dependencies]
 pydevd-pycharm = "261.22158.220"

--- a/src/terok/lib/orchestration/environment.py
+++ b/src/terok/lib/orchestration/environment.py
@@ -242,34 +242,56 @@ def _credential_proxy_env_and_volumes(
         return {}, []
 
     from terok_agent import get_registry
-    from terok_sandbox import CredentialDB, SandboxConfig, ensure_proxy_reachable
+    from terok_sandbox import (
+        CredentialDB,
+        SandboxConfig,
+        ensure_proxy_reachable,
+        get_proxy_port,
+    )
 
     cfg = SandboxConfig()
     ensure_proxy_reachable()
 
+    registry = get_registry()
+    proxy_routes = registry.proxy_routes
+
     db = CredentialDB(cfg.proxy_db_path)
     try:
         credential_set = "default"
-        phantom_token = db.create_proxy_token(project.id, task_id, credential_set)
         stored_providers = set(db.list_credentials(credential_set))
+        routed = stored_providers & proxy_routes.keys()
+        tokens = {
+            name: db.create_proxy_token(project.id, task_id, credential_set, name)
+            for name in routed
+        }
     finally:
         db.close()
 
+    port = get_proxy_port(cfg)
+    proxy_base = f"http://host.containers.internal:{port}"
     env: dict[str, str] = {}
-    volumes: list[str] = [f"{cfg.proxy_socket_path}:/run/terok/credential-proxy.sock"]
 
-    registry = get_registry()
-    for name, route in registry.proxy_routes.items():
-        if name not in stored_providers:
+    for name, route in proxy_routes.items():
+        if name not in routed:
             continue
         for env_var in route.phantom_env:
-            env[env_var] = phantom_token
+            env[env_var] = tokens[name]
         if route.base_url_env:
-            env[route.base_url_env] = (
-                f"http+unix:///run/terok/credential-proxy.sock/{route.route_prefix}"
-            )
+            env[route.base_url_env] = proxy_base
+        # Override OpenCode base URL for proxied providers (the original
+        # value from collect_opencode_provider_env points to the real upstream;
+        # this override redirects through the proxy instead)
+        oc_provider = registry.providers.get(name)
+        if oc_provider and oc_provider.opencode_config:
+            env[f"TEROK_OC_{name.upper()}_BASE_URL"] = f"{proxy_base}/v1"
+        if name == "glab":
+            env["GITLAB_API_HOST"] = f"host.containers.internal:{port}"
+            env["API_PROTOCOL"] = "http"
 
-    return env, volumes
+    if routed:
+        env["TEROK_PROXY_PORT"] = str(port)
+
+    return env, []
 
 
 # ---------- Main builder ----------

--- a/tests/unit/lib/test_credential_proxy_env.py
+++ b/tests/unit/lib/test_credential_proxy_env.py
@@ -76,17 +76,18 @@ class TestCredentialProxyEnv:
             mock_cfg = mock_cfg_cls.return_value
             mock_cfg.proxy_db_path = db_path
             mock_cfg.proxy_socket_path = sock_path
+            mock_cfg.proxy_port = 18731
 
             env, volumes = _credential_proxy_env_and_volumes(project, "task-1")
 
         # Phantom token should be injected for Claude
         assert "ANTHROPIC_API_KEY" in env
         assert len(env["ANTHROPIC_API_KEY"]) == 32  # hex token
-        # Base URL override
+        # Base URL override — TCP via host.containers.internal
         assert "ANTHROPIC_BASE_URL" in env
-        assert "credential-proxy.sock/claude" in env["ANTHROPIC_BASE_URL"]
-        # Socket mounted
-        assert any("credential-proxy.sock" in v for v in volumes)
+        assert "host.containers.internal:18731/claude" in env["ANTHROPIC_BASE_URL"]
+        # No socket mount (TCP transport)
+        assert volumes == []
 
     @pytest.mark.usefixtures("_enable_proxy")
     def test_only_stored_providers_get_phantom_tokens(self, tmp_path: Path) -> None:
@@ -113,6 +114,7 @@ class TestCredentialProxyEnv:
             mock_cfg = mock_cfg_cls.return_value
             mock_cfg.proxy_db_path = db_path
             mock_cfg.proxy_socket_path = sock_path
+            mock_cfg.proxy_port = 18731
 
             env, _volumes = _credential_proxy_env_and_volumes(project, "task-1")
 

--- a/tests/unit/lib/test_credential_proxy_env.py
+++ b/tests/unit/lib/test_credential_proxy_env.py
@@ -85,7 +85,7 @@ class TestCredentialProxyEnv:
         assert len(env["ANTHROPIC_API_KEY"]) == 32  # hex token
         # Base URL override — TCP via host.containers.internal
         assert "ANTHROPIC_BASE_URL" in env
-        assert "host.containers.internal:18731/claude" in env["ANTHROPIC_BASE_URL"]
+        assert "host.containers.internal:18731" in env["ANTHROPIC_BASE_URL"]
         # No socket mount (TCP transport)
         assert volumes == []
 

--- a/tests/unit/lib/test_shield.py
+++ b/tests/unit/lib/test_shield.py
@@ -92,7 +92,7 @@ def test_make_shield_maps_config_to_shield_config(
     config = shield.config
     assert config.mode == ShieldMode.HOOK
     assert config.default_profiles == expected_profiles
-    assert config.loopback_ports == (expected_port,)
+    assert config.loopback_ports == (expected_port, cfg.proxy_port)
     assert config.audit_enabled is audit_enabled
     assert config.state_dir == MOCK_TASK_DIR / "shield"
     assert config.profiles_dir == MOCK_CONFIG_ROOT / "shield" / "profiles"


### PR DESCRIPTION
## Summary

Wire the credential proxy into terok's environment builder. Per-provider phantom tokens — routing by token identity, not URL path.

### Changes
- **environment.py**: per-provider phantom tokens, TCP base URLs (no route prefix in URL), OpenCode base URL overrides for proxied providers, glab env var redirect (`GITLAB_API_HOST` + `API_PROTOCOL`), `TEROK_PROXY_PORT` signal for init script socat bridges
- **Dependency pins**: temporary git pins to sliwowitz/terok-agent and sliwowitz/terok-sandbox branches (will revert to release wheels after sibling PRs merge and release)

### Dependencies
- Requires terok-ai/terok-sandbox#36
- Requires terok-ai/terok-agent#48

### Related issues
- #547: warn when shared mounts contain leaked credentials
- #550: Podman custom network architecture (future)
- #551: SSH agent proxy
- #552: Codex proxy blockers
- #553: OAuth token refresh
- #554: CLI commands in terok-agent/terok-sandbox
- #555: Copilot proxy integration

## Test plan
- [x] Full terok stack: CLI task with all agents tested interactively
- [x] Claude, Vibe, KISSKI, Blablador headless runs
- [x] gh and glab API calls from inside terok task containers
- [ ] Revert dependency pins to release wheels after sibling releases

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated two dependency package versions and added entries to .gitignore to exclude local tool directories.

* **Bug Fixes**
  * Credential proxy now uses TCP on a dynamic port (no socket mounts), exposes a proxy-port env var, and issues per-provider phantom tokens and proxied base URLs only when applicable.

* **Tests**
  * Unit tests updated to expect TCP proxy behavior and the proxy port included in loopback ports.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->