### PR TITLE
chore: bump deps to test OAuth token refresh

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -2558,46 +2558,44 @@ tomli-w = ">=1.0,<2.0"
 
 [[package]]
 name = "terok-agent"
-version = "0.0.13"
+version = "0.0.14"
 description = "Single-agent task runner for hardened Podman containers"
 optional = false
 python-versions = ">=3.12,<4.0"
 groups = ["main"]
-files = []
-develop = false
+files = [
+    {file = "terok_agent-0.0.14-py3-none-any.whl", hash = "sha256:148517d81ba9a3b4fb27bd802551e96a202a606b95f9e7e4f47e009cbcdc3888"},
+]
 
 [package.dependencies]
 Jinja2 = ">=3.1"
 "ruamel.yaml" = ">=0.18"
-terok-sandbox = {git = "https://github.com/sliwowitz/terok-sandbox.git", rev = "b0c556a03058ccdd105a041f93f3287dc164eeb4"}
+terok_sandbox = {url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.0.15/terok_sandbox-0.0.15-py3-none-any.whl"}
 tomli-w = ">=1.0"
 
 [package.source]
-type = "git"
-url = "https://github.com/sliwowitz/terok-agent.git"
-reference = "6c306a4"
-resolved_reference = "6c306a4dd9c1ebcac8743b4d953c422bab679705"
+type = "url"
+url = "https://github.com/terok-ai/terok-agent/releases/download/v0.0.14/terok_agent-0.0.14-py3-none-any.whl"
 
 [[package]]
 name = "terok-sandbox"
-version = "0.0.14"
+version = "0.0.15"
 description = "Hardened Podman container runner with gate server and shield integration"
 optional = false
 python-versions = ">=3.12,<4.0"
 groups = ["main"]
-files = []
-develop = false
+files = [
+    {file = "terok_sandbox-0.0.15-py3-none-any.whl", hash = "sha256:c9f2af16a3138dacb805697ef6a09af026ed36322d34aae9dee5b64a9be83425"},
+]
 
 [package.dependencies]
 aiohttp = ">=3.9"
 platformdirs = ">=4.0"
-terok-shield = {url = "https://github.com/terok-ai/terok-shield/releases/download/v0.4.1/terok_shield-0.4.1-py3-none-any.whl"}
+terok_shield = {url = "https://github.com/terok-ai/terok-shield/releases/download/v0.4.1/terok_shield-0.4.1-py3-none-any.whl"}
 
 [package.source]
-type = "git"
-url = "https://github.com/sliwowitz/terok-sandbox.git"
-reference = "b0c556a"
-resolved_reference = "b0c556a03058ccdd105a041f93f3287dc164eeb4"
+type = "url"
+url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.0.15/terok_sandbox-0.0.15-py3-none-any.whl"
 
 [[package]]
 name = "terok-shield"
@@ -3086,4 +3084,4 @@ propcache = ">=0.2.1"
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.12,<4.0"
-content-hash = "3d0ffed3dee0af2625027841930c77da651005379d4a63cc5e97e57892d508d2"
+content-hash = "5f723eb189c4dba4584e54c39a5aeeb76e36c3e799ca28a8828fc60c013822df"

--- a/poetry.lock
+++ b/poetry.lock
@@ -3086,4 +3086,4 @@ propcache = ">=0.2.1"
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.12,<4.0"
-content-hash = "3acf04e13229fa0d1826dc61ef44007f9dc3c2561e1997a922ab1bd0b288c3f0"
+content-hash = "3d0ffed3dee0af2625027841930c77da651005379d4a63cc5e97e57892d508d2"

--- a/poetry.lock
+++ b/poetry.lock
@@ -2563,19 +2563,20 @@ description = "Single-agent task runner for hardened Podman containers"
 optional = false
 python-versions = ">=3.12,<4.0"
 groups = ["main"]
-files = [
-    {file = "terok_agent-0.0.13-py3-none-any.whl", hash = "sha256:d21b228f4783ceb0f5903db9d9c6c43c2ae1a34452bdad752f0d5386388d5414"},
-]
+files = []
+develop = false
 
 [package.dependencies]
 Jinja2 = ">=3.1"
 "ruamel.yaml" = ">=0.18"
-terok_sandbox = {url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.0.14/terok_sandbox-0.0.14-py3-none-any.whl"}
+terok-sandbox = {git = "https://github.com/sliwowitz/terok-sandbox.git", rev = "b0c556a03058ccdd105a041f93f3287dc164eeb4"}
 tomli-w = ">=1.0"
 
 [package.source]
-type = "url"
-url = "https://github.com/terok-ai/terok-agent/releases/download/v0.0.13/terok_agent-0.0.13-py3-none-any.whl"
+type = "git"
+url = "https://github.com/sliwowitz/terok-agent.git"
+reference = "6c306a4"
+resolved_reference = "6c306a4dd9c1ebcac8743b4d953c422bab679705"
 
 [[package]]
 name = "terok-sandbox"
@@ -2584,18 +2585,19 @@ description = "Hardened Podman container runner with gate server and shield inte
 optional = false
 python-versions = ">=3.12,<4.0"
 groups = ["main"]
-files = [
-    {file = "terok_sandbox-0.0.14-py3-none-any.whl", hash = "sha256:429964dea7fbe79525d5c13700d3cfa5b8bea448bb651dfba8e431637956b913"},
-]
+files = []
+develop = false
 
 [package.dependencies]
 aiohttp = ">=3.9"
 platformdirs = ">=4.0"
-terok_shield = {url = "https://github.com/terok-ai/terok-shield/releases/download/v0.4.1/terok_shield-0.4.1-py3-none-any.whl"}
+terok-shield = {url = "https://github.com/terok-ai/terok-shield/releases/download/v0.4.1/terok_shield-0.4.1-py3-none-any.whl"}
 
 [package.source]
-type = "url"
-url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.0.14/terok_sandbox-0.0.14-py3-none-any.whl"
+type = "git"
+url = "https://github.com/sliwowitz/terok-sandbox.git"
+reference = "b0c556a"
+resolved_reference = "b0c556a03058ccdd105a041f93f3287dc164eeb4"
 
 [[package]]
 name = "terok-shield"
@@ -3084,4 +3086,4 @@ propcache = ">=0.2.1"
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.12,<4.0"
-content-hash = "694a3b0e4602e1b8da0a6d3ee24749e5ab21f608f1e6b35b4c1ef49adc9f8af0"
+content-hash = "3acf04e13229fa0d1826dc61ef44007f9dc3c2561e1997a922ab1bd0b288c3f0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,8 +44,8 @@ rich = ">=13.0"
 platformdirs = ">=4.5.1"
 unique-namer = ">=1.3"
 textual-serve = ">=1.1.0"
-terok-agent = {git = "https://github.com/sliwowitz/terok-agent.git", rev = "6c306a4dd9c1ebcac8743b4d953c422bab679705"}
-terok-sandbox = {git = "https://github.com/sliwowitz/terok-sandbox.git", rev = "b0c556a03058ccdd105a041f93f3287dc164eeb4"}
+terok-agent = {url = "https://github.com/terok-ai/terok-agent/releases/download/v0.0.14/terok_agent-0.0.14-py3-none-any.whl"}
+terok-sandbox = {url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.0.15/terok_sandbox-0.0.15-py3-none-any.whl"}
 
 [tool.poetry.group.dev.dependencies]
 pydevd-pycharm = "261.22158.220"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,8 +44,8 @@ rich = ">=13.0"
 platformdirs = ">=4.5.1"
 unique-namer = ">=1.3"
 textual-serve = ">=1.1.0"
-terok-agent = {url = "https://github.com/terok-ai/terok-agent/releases/download/v0.0.13/terok_agent-0.0.13-py3-none-any.whl"}
-terok-sandbox = {url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.0.14/terok_sandbox-0.0.14-py3-none-any.whl"}
+terok-agent = {git = "https://github.com/sliwowitz/terok-agent.git", rev = "6c306a4"}
+terok-sandbox = {git = "https://github.com/sliwowitz/terok-sandbox.git", rev = "b0c556a"}
 
 [tool.poetry.group.dev.dependencies]
 pydevd-pycharm = "261.22158.220"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,8 +44,8 @@ rich = ">=13.0"
 platformdirs = ">=4.5.1"
 unique-namer = ">=1.3"
 textual-serve = ">=1.1.0"
-terok-agent = {git = "https://github.com/sliwowitz/terok-agent.git", rev = "6c306a4"}
-terok-sandbox = {git = "https://github.com/sliwowitz/terok-sandbox.git", rev = "b0c556a"}
+terok-agent = {git = "https://github.com/sliwowitz/terok-agent.git", rev = "6c306a4dd9c1ebcac8743b4d953c422bab679705"}
+terok-sandbox = {git = "https://github.com/sliwowitz/terok-sandbox.git", rev = "b0c556a03058ccdd105a041f93f3287dc164eeb4"}
 
 [tool.poetry.group.dev.dependencies]
 pydevd-pycharm = "261.22158.220"


### PR DESCRIPTION
## Summary

- Bump terok-agent to v0.0.14 and terok-sandbox to v0.0.15 (release wheels)
- Brings in proactive OAuth token refresh for Claude

Closes #553

## What changed

**terok-sandbox v0.0.15** — Background asyncio task in the credential proxy that
refreshes OAuth tokens before they expire. Runs on startup + every 5 min.

**terok-agent v0.0.14** — `oauth_refresh` YAML config for Claude (token endpoint,
client_id, scopes) propagated to routes.json.

## Test plan

- [x] Auth as Claude, verify proxy logs show refresh activity
- [x] Current functionality not broken
- [ ] Token refresh observed near expiry window

🤖 Generated with [Claude Code](https://claude.com/claude-code)