### PR TITLE
feat: warn at task creation when shared mounts contain real credentials

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -2558,25 +2558,24 @@ tomli-w = ">=1.0,<2.0"
 
 [[package]]
 name = "terok-agent"
-version = "0.0.15"
+version = "0.0.16"
 description = "Single-agent task runner for hardened Podman containers"
 optional = false
 python-versions = ">=3.12,<4.0"
 groups = ["main"]
-files = []
-develop = false
+files = [
+    {file = "terok_agent-0.0.16-py3-none-any.whl", hash = "sha256:4a6cca10325b21a346d12756dd4652ea8190a338af774133eccc74b38f422df8"},
+]
 
 [package.dependencies]
 Jinja2 = ">=3.1"
 "ruamel.yaml" = ">=0.18"
-terok-sandbox = {url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.0.16/terok_sandbox-0.0.16-py3-none-any.whl"}
+terok_sandbox = {url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.0.16/terok_sandbox-0.0.16-py3-none-any.whl"}
 tomli-w = ">=1.0"
 
 [package.source]
-type = "git"
-url = "https://github.com/sliwowitz/terok-agent.git"
-reference = "381c74d0407c62726231f924798ef7163fb2dc42"
-resolved_reference = "381c74d0407c62726231f924798ef7163fb2dc42"
+type = "url"
+url = "https://github.com/terok-ai/terok-agent/releases/download/v0.0.16/terok_agent-0.0.16-py3-none-any.whl"
 
 [[package]]
 name = "terok-sandbox"
@@ -3085,4 +3084,4 @@ propcache = ">=0.2.1"
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.12,<4.0"
-content-hash = "67d104084a1cb5b1e09a87b236d2f9923e4db3c2b690a92e63aafe51817a1b3d"
+content-hash = "a913b269d1c2a31cfc3c53e918faba1467c822c50e610669f7dec39ee0a493b0"

--- a/poetry.lock
+++ b/poetry.lock
@@ -2563,19 +2563,20 @@ description = "Single-agent task runner for hardened Podman containers"
 optional = false
 python-versions = ">=3.12,<4.0"
 groups = ["main"]
-files = [
-    {file = "terok_agent-0.0.15-py3-none-any.whl", hash = "sha256:60721fea7e47c8e67c4920e1d0041da5921696c8abe84d3b68fc37fedeefea98"},
-]
+files = []
+develop = false
 
 [package.dependencies]
 Jinja2 = ">=3.1"
 "ruamel.yaml" = ">=0.18"
-terok_sandbox = {url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.0.16/terok_sandbox-0.0.16-py3-none-any.whl"}
+terok-sandbox = {url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.0.16/terok_sandbox-0.0.16-py3-none-any.whl"}
 tomli-w = ">=1.0"
 
 [package.source]
-type = "url"
-url = "https://github.com/terok-ai/terok-agent/releases/download/v0.0.15/terok_agent-0.0.15-py3-none-any.whl"
+type = "git"
+url = "https://github.com/sliwowitz/terok-agent.git"
+reference = "381c74d0407c62726231f924798ef7163fb2dc42"
+resolved_reference = "381c74d0407c62726231f924798ef7163fb2dc42"
 
 [[package]]
 name = "terok-sandbox"
@@ -3084,4 +3085,4 @@ propcache = ">=0.2.1"
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.12,<4.0"
-content-hash = "87d778cdb50c0cd80c994c031e6bacebae2f10743dc159c48febff39e519665c"
+content-hash = "67d104084a1cb5b1e09a87b236d2f9923e4db3c2b690a92e63aafe51817a1b3d"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ rich = ">=13.0"
 platformdirs = ">=4.5.1"
 unique-namer = ">=1.3"
 textual-serve = ">=1.1.0"
-terok-agent = {git = "https://github.com/sliwowitz/terok-agent.git", rev = "381c74d0407c62726231f924798ef7163fb2dc42"}
+terok-agent = {url = "https://github.com/terok-ai/terok-agent/releases/download/v0.0.16/terok_agent-0.0.16-py3-none-any.whl"}
 terok-sandbox = {url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.0.16/terok_sandbox-0.0.16-py3-none-any.whl"}
 
 [tool.poetry.group.dev.dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ rich = ">=13.0"
 platformdirs = ">=4.5.1"
 unique-namer = ">=1.3"
 textual-serve = ">=1.1.0"
-terok-agent = {url = "https://github.com/terok-ai/terok-agent/releases/download/v0.0.15/terok_agent-0.0.15-py3-none-any.whl"}
+terok-agent = {git = "https://github.com/sliwowitz/terok-agent.git", rev = "381c74d0407c62726231f924798ef7163fb2dc42"}
 terok-sandbox = {url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.0.16/terok_sandbox-0.0.16-py3-none-any.whl"}
 
 [tool.poetry.group.dev.dependencies]

--- a/src/terok/lib/orchestration/environment.py
+++ b/src/terok/lib/orchestration/environment.py
@@ -291,6 +291,22 @@ def _credential_proxy_env_and_volumes(
     if routed:
         env["TEROK_PROXY_PORT"] = str(port)
 
+    # Warn about real credential files in shared mounts that will be visible
+    # to the container alongside proxy phantom tokens.
+    from terok_agent import scan_leaked_credentials
+
+    leaked = scan_leaked_credentials(cfg.effective_envs_dir)
+    if leaked:
+        import sys as _sys
+
+        print("WARNING: Real credentials in shared mounts:", file=_sys.stderr)
+        for provider, path in leaked:
+            print(f"  {provider}: {path}", file=_sys.stderr)
+        print(
+            "Remove these files — containers should only see proxy tokens.",
+            file=_sys.stderr,
+        )
+
     return env, []
 
 

--- a/src/terok/lib/orchestration/environment.py
+++ b/src/terok/lib/orchestration/environment.py
@@ -297,14 +297,14 @@ def _credential_proxy_env_and_volumes(
 
     leaked = scan_leaked_credentials(cfg.effective_envs_dir)
     if leaked:
-        import sys as _sys
+        import sys
 
-        print("WARNING: Real credentials in shared mounts:", file=_sys.stderr)
+        print("WARNING: Real credentials in shared mounts:", file=sys.stderr)
         for provider, path in leaked:
-            print(f"  {provider}: {path}", file=_sys.stderr)
+            print(f"  {provider}: {path}", file=sys.stderr)
         print(
             "Remove these files — containers should only see proxy tokens.",
-            file=_sys.stderr,
+            file=sys.stderr,
         )
 
     return env, []

--- a/tests/unit/lib/test_credential_proxy_env.py
+++ b/tests/unit/lib/test_credential_proxy_env.py
@@ -122,3 +122,44 @@ class TestCredentialProxyEnv:
         assert "MISTRAL_API_KEY" in env
         # Claude NOT stored → no phantom token
         assert "ANTHROPIC_API_KEY" not in env
+
+    @pytest.mark.usefixtures("_enable_proxy")
+    def test_leaked_credentials_warning(self, tmp_path: Path, capsys) -> None:
+        """Leaked credential files in shared mounts trigger a stderr warning."""
+        from terok_sandbox import CredentialDB
+
+        from terok.lib.orchestration.environment import _credential_proxy_env_and_volumes
+
+        db_path = tmp_path / "proxy" / "credentials.db"
+        db = CredentialDB(db_path)
+        db.store_credential("default", "claude", {"type": "api_key", "key": "sk-test"})
+        db.close()
+
+        # Create a leaked credential file in the shared mount
+        from terok_agent import get_registry
+
+        registry = get_registry()
+        auth = registry.auth_providers["claude"]
+        route = registry.proxy_routes["claude"]
+        cred_dir = tmp_path / "envs" / auth.host_dir_name
+        cred_dir.mkdir(parents=True)
+        (cred_dir / route.credential_file).write_text('{"leaked": true}')
+
+        project = MagicMock()
+        project.id = "test-project"
+
+        with (
+            patch("terok_sandbox.credential_proxy_lifecycle.is_daemon_running", return_value=True),
+            patch("terok_sandbox.SandboxConfig") as mock_cfg_cls,
+        ):
+            mock_cfg = mock_cfg_cls.return_value
+            mock_cfg.proxy_db_path = db_path
+            mock_cfg.proxy_socket_path = tmp_path / "proxy.sock"
+            mock_cfg.proxy_port = 18731
+            mock_cfg.effective_envs_dir = tmp_path / "envs"
+
+            _credential_proxy_env_and_volumes(project, "task-1")
+
+        err = capsys.readouterr().err
+        assert "WARNING" in err
+        assert "claude" in err

--- a/tests/unit/lib/test_credential_proxy_env.py
+++ b/tests/unit/lib/test_credential_proxy_env.py
@@ -13,6 +13,7 @@ from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
+from pytest import CaptureFixture
 
 
 @pytest.fixture()
@@ -124,7 +125,7 @@ class TestCredentialProxyEnv:
         assert "ANTHROPIC_API_KEY" not in env
 
     @pytest.mark.usefixtures("_enable_proxy")
-    def test_leaked_credentials_warning(self, tmp_path: Path, capsys) -> None:
+    def test_leaked_credentials_warning(self, tmp_path: Path, capsys: CaptureFixture[str]) -> None:
         """Leaked credential files in shared mounts trigger a stderr warning."""
         from terok_sandbox import CredentialDB
 


### PR DESCRIPTION
## Summary

- Call `scan_leaked_credentials()` from `_credential_proxy_env_and_volumes()` at task creation
- Emits stderr warning listing providers and file paths when real credential files found
- Warning is informational — task still starts

Companion PR: terok-ai/terok-agent PR (scan function)
Relates-to: #547

## Test plan

- [x] 1248 tests pass (unit + integration)
- [x] Lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automatic credential-leak detection during environment setup; scans monitored locations and emits warnings listing provider and path for any exposed credentials.
* **Chores**
  * Updated an internal dependency to terok-agent v0.0.16 for consistent behavior.
* **Tests**
  * Added a unit test validating that leaked credentials produce a warning on stderr.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->