### PR TITLE
chore: follow agent registry → roster rename

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -2558,13 +2558,13 @@ tomli-w = ">=1.0,<2.0"
 
 [[package]]
 name = "terok-agent"
-version = "0.0.16"
+version = "0.0.17"
 description = "Single-agent task runner for hardened Podman containers"
 optional = false
 python-versions = ">=3.12,<4.0"
 groups = ["main"]
 files = [
-    {file = "terok_agent-0.0.16-py3-none-any.whl", hash = "sha256:4a6cca10325b21a346d12756dd4652ea8190a338af774133eccc74b38f422df8"},
+    {file = "terok_agent-0.0.17-py3-none-any.whl", hash = "sha256:929619b5df3c19dcfcfbd011fc03f0b01a81f47699255073ff6e5083f9441186"},
 ]
 
 [package.dependencies]
@@ -2575,7 +2575,7 @@ tomli-w = ">=1.0"
 
 [package.source]
 type = "url"
-url = "https://github.com/terok-ai/terok-agent/releases/download/v0.0.16/terok_agent-0.0.16-py3-none-any.whl"
+url = "https://github.com/terok-ai/terok-agent/releases/download/v0.0.17/terok_agent-0.0.17-py3-none-any.whl"
 
 [[package]]
 name = "terok-sandbox"
@@ -3084,4 +3084,4 @@ propcache = ">=0.2.1"
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.12,<4.0"
-content-hash = "a913b269d1c2a31cfc3c53e918faba1467c822c50e610669f7dec39ee0a493b0"
+content-hash = "76a50039fc9236a5be97207e93d00150164f9ceb93293859869daf567cb2d0c6"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ rich = ">=13.0"
 platformdirs = ">=4.5.1"
 unique-namer = ">=1.3"
 textual-serve = ">=1.1.0"
-terok-agent = {url = "https://github.com/terok-ai/terok-agent/releases/download/v0.0.16/terok_agent-0.0.16-py3-none-any.whl"}
+terok-agent = {url = "https://github.com/terok-ai/terok-agent/releases/download/v0.0.17/terok_agent-0.0.17-py3-none-any.whl"}
 terok-sandbox = {url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.0.16/terok_sandbox-0.0.16-py3-none-any.whl"}
 
 [tool.poetry.group.dev.dependencies]

--- a/src/terok/lib/orchestration/environment.py
+++ b/src/terok/lib/orchestration/environment.py
@@ -58,8 +58,7 @@ def _build_shared_mounts() -> tuple[SharedMount, ...]:
     from terok_agent import get_roster
 
     return tuple(
-        SharedMount(m.host_dir, m.host_dir, m.label, m.container_path)
-        for m in get_roster().mounts
+        SharedMount(m.host_dir, m.host_dir, m.label, m.container_path) for m in get_roster().mounts
     )
 
 

--- a/src/terok/lib/orchestration/environment.py
+++ b/src/terok/lib/orchestration/environment.py
@@ -48,18 +48,18 @@ class SharedMount:
 
 
 def _build_shared_mounts() -> tuple[SharedMount, ...]:
-    """Derive shared mounts from the agent registry.
+    """Derive shared mounts from the agent roster.
 
-    The YAML agent registry is the single source of truth for all shared
+    The YAML agent roster is the single source of truth for all shared
     mounts — auth dirs, OpenCode state dirs, and Toad config.  Each entry's
     ``auth:`` section and ``mounts:`` section contribute mount definitions,
-    deduplicated by ``host_dir`` in the registry.
+    deduplicated by ``host_dir`` in the roster.
     """
-    from terok_agent import get_registry
+    from terok_agent import get_roster
 
     return tuple(
         SharedMount(m.host_dir, m.host_dir, m.label, m.container_path)
-        for m in get_registry().mounts
+        for m in get_roster().mounts
     )
 
 
@@ -241,7 +241,7 @@ def _credential_proxy_env_and_volumes(
     if get_credential_proxy_bypass():
         return {}, []
 
-    from terok_agent import get_registry
+    from terok_agent import get_roster
     from terok_sandbox import (
         CredentialDB,
         SandboxConfig,
@@ -252,8 +252,8 @@ def _credential_proxy_env_and_volumes(
     cfg = SandboxConfig()
     ensure_proxy_reachable()
 
-    registry = get_registry()
-    proxy_routes = registry.proxy_routes
+    roster = get_roster()
+    proxy_routes = roster.proxy_routes
 
     db = CredentialDB(cfg.proxy_db_path)
     try:
@@ -281,7 +281,7 @@ def _credential_proxy_env_and_volumes(
         # Override OpenCode base URL for proxied providers (the original
         # value from collect_opencode_provider_env points to the real upstream;
         # this override redirects through the proxy instead)
-        oc_provider = registry.providers.get(name)
+        oc_provider = roster.providers.get(name)
         if oc_provider and oc_provider.opencode_config:
             env[f"TEROK_OC_{name.upper()}_BASE_URL"] = f"{proxy_base}/v1"
         if name == "glab":

--- a/tests/integration/credential_proxy/test_proxy_stories.py
+++ b/tests/integration/credential_proxy/test_proxy_stories.py
@@ -8,7 +8,7 @@ These tests run in the matrix runner's disposable containers where a
 real proxy daemon can be started.
 
 Stories use real sqlite DBs, real aiohttp proxy servers (via TestServer),
-and real route configs generated from the YAML registry.
+and real route configs generated from the YAML roster.
 """
 
 import json
@@ -63,7 +63,7 @@ class TestStoryAuthThroughProxy:
         phantom = db.create_proxy_token("proj", "task-1", "default", "vibe")
         db.close()
 
-        # 2. Write routes (simulates registry.generate_routes_json())
+        # 2. Write routes (simulates roster.generate_routes_json())
         routes_path = tmp_path / "routes.json"
         routes_path.write_text(
             json.dumps(

--- a/tests/unit/lib/test_credential_proxy_env.py
+++ b/tests/unit/lib/test_credential_proxy_env.py
@@ -137,11 +137,11 @@ class TestCredentialProxyEnv:
         db.close()
 
         # Create a leaked credential file in the shared mount
-        from terok_agent import get_registry
+        from terok_agent import get_roster
 
-        registry = get_registry()
-        auth = registry.auth_providers["claude"]
-        route = registry.proxy_routes["claude"]
+        roster = get_roster()
+        auth = roster.auth_providers["claude"]
+        route = roster.proxy_routes["claude"]
         cred_dir = tmp_path / "envs" / auth.host_dir_name
         cred_dir.mkdir(parents=True)
         (cred_dir / route.credential_file).write_text('{"leaked": true}')


### PR DESCRIPTION
## Summary

Update all imports from `terok_agent.registry`/`get_registry` to
`terok_agent.roster`/`get_roster`. Companion to terok-ai/terok-agent#53.

Pure import rename, no behavior changes.

## Test plan

- [x] 1249 tests pass (unit + integration)
- [x] Lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Switched internal source for shared mounts and credential-proxy configuration to a new roster-based source to improve configuration accuracy.

* **Tests**
  * Updated unit and integration tests to use the new configuration source and confirm behavior is unchanged.

* **Documentation**
  * Clarified test comments to reference the updated configuration terminology.

* **Chores**
  * Bumped the terok-agent dependency to a newer release.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->