### PR TITLE
feat: inject TEROK_LEAKED_CREDENTIALS env var into container on credential leak

### DIFF
--- a/src/terok/lib/orchestration/environment.py
+++ b/src/terok/lib/orchestration/environment.py
@@ -305,6 +305,8 @@ def _credential_proxy_env_and_volumes(
             "Remove these files — containers should only see proxy tokens.",
             file=sys.stderr,
         )
+        # Surface the warning inside the container via hilfe.
+        env["TEROK_LEAKED_CREDENTIALS"] = ",".join(provider for provider, _ in leaked)
 
     return env, []
 

--- a/tests/unit/lib/test_credential_proxy_env.py
+++ b/tests/unit/lib/test_credential_proxy_env.py
@@ -159,8 +159,9 @@ class TestCredentialProxyEnv:
             mock_cfg.proxy_port = 18731
             mock_cfg.effective_envs_dir = tmp_path / "envs"
 
-            _credential_proxy_env_and_volumes(project, "task-1")
+            env, _volumes = _credential_proxy_env_and_volumes(project, "task-1")
 
         err = capsys.readouterr().err
         assert "WARNING" in err
         assert "claude" in err
+        assert env.get("TEROK_LEAKED_CREDENTIALS") == "claude"


### PR DESCRIPTION
## Summary

- When `scan_leaked_credentials()` detects real credential files in shared mounts, adds `TEROK_LEAKED_CREDENTIALS=<provider1>,<provider2>` to the container env dict alongside the existing host-side stderr warning
- Updates `test_leaked_credentials_warning` to assert the env var is present in the returned env

Companion PR in terok-agent (hilfe banner): terok-ai/terok-agent#59 (adds the `hilfe` warning that reads this var).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * When credential files are detected in shared mounts, a new environment variable is now set containing the list of detected credential providers, making this information accessible to containers.

* **Tests**
  * Added assertions to verify the environment variable is correctly populated with detected credential provider names.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->