### PR TITLE
feat: sickbay diagnostic sweep includes credential proxy

### DIFF
--- a/src/terok/cli/commands/sickbay.py
+++ b/src/terok/cli/commands/sickbay.py
@@ -27,7 +27,9 @@ from terok_sandbox import (
     check_environment,
     check_units_outdated,
     get_container_state,
+    get_proxy_status,
     get_server_status,
+    is_proxy_systemd_available,
     is_systemd_available,
 )
 
@@ -97,6 +99,27 @@ def _check_shield() -> _CheckResult:
         return ("warn", label, f"unexpected health: {ec.health}")
     dns = getattr(ec, "dns_tier", "unknown")
     return ("ok", label, f"active ({ec.hooks}, {dns} DNS)")
+
+
+def _check_credential_proxy() -> _CheckResult:
+    """Check credential proxy status."""
+    label = "Credential proxy"
+    try:
+        status = get_proxy_status()
+    except Exception as exc:  # noqa: BLE001
+        return ("warn", label, f"check failed — {exc}")
+    if status.running:
+        creds = len(status.credentials_stored) if status.credentials_stored else 0
+        return ("ok", label, f"{status.mode}, {creds} credential(s) stored")
+    if status.mode == "systemd":
+        return (
+            "error",
+            label,
+            "socket installed but not active — run 'terokctl credentials start'",
+        )
+    if is_proxy_systemd_available():
+        return ("warn", label, "not running — run 'terokctl credentials install'")
+    return ("warn", label, "not running — run 'terokctl credentials start'")
 
 
 def _check_task_hook(
@@ -187,6 +210,7 @@ def _check_unfired_hooks(
 _GLOBAL_CHECKS = [
     _check_gate_server,
     _check_shield,
+    _check_credential_proxy,
 ]
 
 _STATUS_MARKERS = {

--- a/tests/unit/cli/test_cli_sickbay.py
+++ b/tests/unit/cli/test_cli_sickbay.py
@@ -10,8 +10,23 @@ from unittest.mock import MagicMock, patch
 import pytest
 from terok_sandbox import GateServerStatus
 
-from terok.cli.commands.sickbay import _check_shield, _cmd_sickbay
+from terok.cli.commands.sickbay import _check_credential_proxy, _check_shield, _cmd_sickbay
+from tests.testfs import MOCK_BASE
 from tests.testgate import OUTDATED_UNITS_MESSAGE, make_gate_server_status
+
+MOCK_PROXY_SOCKET = MOCK_BASE / "run" / "credential-proxy.sock"
+MOCK_PROXY_DB = MOCK_BASE / "proxy" / "credentials.db"
+
+
+def _make_proxy_status(*, running: bool = True, mode: str = "systemd") -> MagicMock:
+    """Return a mock CredentialProxyStatus."""
+    s = MagicMock()
+    s.running = running
+    s.mode = mode
+    s.socket_path = MOCK_PROXY_SOCKET
+    s.db_path = MOCK_PROXY_DB
+    s.credentials_stored = ["claude", "gh"]
+    return s
 
 
 @pytest.mark.parametrize(
@@ -74,6 +89,8 @@ def test_cmd_sickbay_reports_health(
         patch("terok.cli.commands.sickbay.check_units_outdated", return_value=outdated),
         patch("terok.cli.commands.sickbay.is_systemd_available", return_value=systemd_available),
         patch("terok.cli.commands.sickbay.check_environment", return_value=mock_ec),
+        patch("terok.cli.commands.sickbay.get_proxy_status", return_value=_make_proxy_status()),
+        patch("terok.cli.commands.sickbay.is_proxy_systemd_available", return_value=False),
     ):
         if exit_code is None:
             _cmd_sickbay()
@@ -171,4 +188,81 @@ def test_check_shield_states(
 
     assert status == expected_status
     assert label == "Shield"
+    assert expected_detail in detail
+
+
+@pytest.mark.parametrize(
+    ("running", "mode", "systemd_avail", "side_effect", "expected_status", "expected_detail"),
+    [
+        pytest.param(
+            True,
+            "systemd",
+            False,
+            None,
+            "ok",
+            "2 credential(s)",
+            id="running-with-creds",
+        ),
+        pytest.param(
+            False,
+            "systemd",
+            True,
+            None,
+            "error",
+            "not active",
+            id="socket-inactive",
+        ),
+        pytest.param(
+            False,
+            "none",
+            True,
+            None,
+            "warn",
+            "install",
+            id="not-running-systemd-available",
+        ),
+        pytest.param(
+            False,
+            "none",
+            False,
+            None,
+            "warn",
+            "start",
+            id="not-running-no-systemd",
+        ),
+        pytest.param(
+            False,
+            "none",
+            False,
+            OSError("socket gone"),
+            "warn",
+            "check failed",
+            id="check-exception",
+        ),
+    ],
+)
+def test_check_credential_proxy_states(
+    running: bool,
+    mode: str,
+    systemd_avail: bool,
+    side_effect: Exception | None,
+    expected_status: str,
+    expected_detail: str,
+) -> None:
+    """_check_credential_proxy maps proxy states to the correct severity and message."""
+    with (
+        patch(
+            "terok.cli.commands.sickbay.get_proxy_status",
+            return_value=_make_proxy_status(running=running, mode=mode),
+            side_effect=side_effect,
+        ),
+        patch(
+            "terok.cli.commands.sickbay.is_proxy_systemd_available",
+            return_value=systemd_avail,
+        ),
+    ):
+        status, label, detail = _check_credential_proxy()
+
+    assert status == expected_status
+    assert label == "Credential proxy"
     assert expected_detail in detail


### PR DESCRIPTION
## Summary

- Adds `_check_credential_proxy()` to the `terokctl sickbay` global check roster
- Running proxy reports mode and stored-credential count; dormant systemd socket is an error; missing proxy surfaces a targeted `install` or `start` hint based on systemd availability; exceptions degrade gracefully to `warn`
- Imports `get_proxy_status` and `is_proxy_systemd_available` from `terok_sandbox` (already used in `credentials.py`)

## Test plan

- [ ] 5 new parametrised cases in `test_check_credential_proxy_states` covering: running with creds, systemd socket inactive (error), not-running+systemd available, not-running without systemd, and exception path
- [ ] `test_cmd_sickbay_reports_health` integration mock extended with `get_proxy_status` / `is_proxy_systemd_available` stubs so gate-server scenario isolation is preserved
- [ ] `make test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a credential-proxy health check to diagnostics that reports running status, mode, and stored-credential count, and gives remediation hints based on systemd availability.

* **Tests**
  * Added tests covering credential-proxy health check behavior across running/stopped states, modes, systemd availability, and failure paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->