### PR TITLE
ci: skip SonarQube scan on dependabot PRs

### DIFF
--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -154,7 +154,7 @@ jobs:
   # artifacts uploaded above, because GitHub does not expose secrets to fork PR runs.
   sonar:
     name: SonarQube Cloud
-    if: github.repository == 'terok-ai/terok' && (github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository)
+    if: github.repository == 'terok-ai/terok' && (github.event_name == 'push' || (github.actor != 'dependabot[bot]' && github.event.pull_request.head.repo.full_name == github.repository))
     needs: [unit-tests, ruff, bandit]
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## Summary
- Gate the `sonar` job on `github.actor != 'dependabot[bot]'` so it doesn't fire on dependabot PRs (which lack `SONAR_TOKEN` access)
- Pushes to master and human-authored PRs are unaffected
- The `sonar_pr.yml` workflow (for fork PRs) already excludes dependabot by design

## Test plan
- [ ] Verify next dependabot PR no longer shows a failed SonarQube check
- [ ] Verify a human PR still triggers the SonarQube scan

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflow to refine job execution conditions: the affected job will now skip runs for automated dependency pull requests while preserving existing same-repo push and PR behavior. This reduces unnecessary CI runs for automated updates and shortens overall pipeline time for human-initiated changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->