### PR TITLE
fix: disable systemd options in gate/proxy screens when unavailable

### DIFF
--- a/src/terok/tui/screens.py
+++ b/src/terok/tui/screens.py
@@ -56,6 +56,7 @@ from terok_sandbox import (
     GateStalenessInfo,
     check_units_outdated,
     get_gate_base_path,
+    is_systemd_available,
 )
 
 from ..lib.core.projects import ProjectConfig
@@ -92,6 +93,19 @@ _DETAIL_SCREEN_CSS = """
         margin: 0 1;
     }
 """
+
+
+# ---------------------------------------------------------------------------
+# Shared helpers
+# ---------------------------------------------------------------------------
+
+
+def _disable_options(actions: OptionList, option_ids: frozenset[str]) -> None:
+    """Disable OptionList entries whose ``id`` is in *option_ids*."""
+    for idx in range(actions.option_count):
+        opt = actions.get_option_at_index(idx)
+        if opt.id in option_ids:
+            actions.disable_option_at_index(idx)
 
 
 # ---------------------------------------------------------------------------
@@ -188,10 +202,14 @@ class GateServerScreen(screen.Screen[str | None]):
             id="actions-list",
         )
 
+    _SYSTEMD_OPTIONS = frozenset({"gate_install", "gate_uninstall"})
+
     def on_mount(self) -> None:
         """Render gate server status and focus the action list."""
         self._render_status()
         actions = self.query_one("#actions-list", OptionList)
+        if not is_systemd_available():
+            _disable_options(actions, self._SYSTEMD_OPTIONS)
         actions.focus()
 
     def _render_status(self) -> None:
@@ -1949,10 +1967,14 @@ class CredentialProxyScreen(screen.Screen[str | None]):
             id="actions-list",
         )
 
+    _SYSTEMD_OPTIONS = frozenset({"proxy_install", "proxy_uninstall"})
+
     def on_mount(self) -> None:
         """Render proxy status and focus the action list."""
         self._render_status()
         actions = self.query_one("#actions-list", OptionList)
+        if not is_systemd_available():
+            _disable_options(actions, self._SYSTEMD_OPTIONS)
         actions.focus()
 
     def _render_status(self) -> None:

--- a/tests/unit/tui/test_detail_screens.py
+++ b/tests/unit/tui/test_detail_screens.py
@@ -826,6 +826,37 @@ class TestGateServerScreen:
         screen.dismiss.assert_called_once_with(expected)
 
 
+class TestDisableOptions:
+    """Tests for the _disable_options helper used by systemd-dependent screens."""
+
+    def test_disable_options_disables_matching_ids(self) -> None:
+        """Options whose id is in the frozenset are disabled."""
+        screens, _ = import_screens()
+        option_list = mock.Mock()
+        opts = [mock.Mock(id="a"), mock.Mock(id="b"), mock.Mock(id="c")]
+        option_list.option_count = len(opts)
+        option_list.get_option_at_index = lambda idx: opts[idx]
+
+        screens._disable_options(option_list, frozenset({"a", "c"}))
+
+        option_list.disable_option_at_index.assert_any_call(0)
+        option_list.disable_option_at_index.assert_any_call(2)
+        assert option_list.disable_option_at_index.call_count == 2
+
+    def test_gate_server_systemd_option_ids(self) -> None:
+        """GateServerScreen declares the correct systemd option ids."""
+        screens, _ = import_screens()
+        assert {"gate_install", "gate_uninstall"} == screens.GateServerScreen._SYSTEMD_OPTIONS
+
+    def test_credential_proxy_systemd_option_ids(self) -> None:
+        """CredentialProxyScreen declares the correct systemd option ids."""
+        screens, _ = import_screens()
+        assert {
+            "proxy_install",
+            "proxy_uninstall",
+        } == screens.CredentialProxyScreen._SYSTEMD_OPTIONS
+
+
 class TestCommandPalette:
     """Tests for command palette customization."""
 


### PR DESCRIPTION
## Summary

- On systems without systemd user services, the gate server and credential proxy TUI screens offered install/uninstall options that would crash on selection
- Both screens now check `is_systemd_available()` on mount and disable the systemd-dependent options
- Extracts a shared `_disable_options()` helper following the existing `ShieldScreen._update_setup_option` pattern
- Also fixes `CredentialProxyScreen` which had the identical vulnerability

## Changes

- **screens.py**: Add `_disable_options()` helper, `_SYSTEMD_OPTIONS` frozensets on both screens, systemd check in `on_mount()`
- **test_detail_screens.py**: Add `TestDisableOptions` with 3 tests (helper behavior, option id declarations)

## Test plan

- [x] All 1266 unit tests pass (3 new)
- [x] Lint clean (ruff)
- [x] Module boundaries valid (tach)
- [ ] Manual: verify options are greyed out in Docker/non-systemd environment

Closes #472

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Install and uninstall options for gate server and credential proxy are now disabled when systemd is unavailable on the system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->