### PR TITLE
feat: unified terok/ umbrella directory namespace

### DIFF
--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -142,7 +142,7 @@ The workspace is the task's private copy of the codebase, mounted at
 `/workspace` inside the container. On the host it lives at:
 
 ```text
-~/.local/share/terok/tasks/<project>/<task_id>/workspace-dangerous/
+~/.local/share/terok/core/tasks/<project>/<task_id>/workspace-dangerous/
 ```
 
 The `-dangerous` suffix is a deliberate reminder: this directory contains
@@ -284,7 +284,7 @@ are served to containers via the credential proxy's SSH agent.
 ```mermaid
 graph TB
     subgraph HOST ["Host"]
-        SSH["Per-project SSH key<br/><code>~/.local/share/terok/<br/>ssh-keys/&lt;project&gt;/</code>"]
+        SSH["Per-project SSH key<br/><code>~/.local/share/terok/core/<br/>ssh-keys/&lt;project&gt;/</code>"]
         PROXY["SSH Agent Proxy"]
         GATE["Git Gate"]
     end
@@ -431,7 +431,7 @@ These are shared by **all tasks across all projects** and contain
 agent credentials and configuration:
 
 ```text
-~/.local/share/terok/envs/
+~/.local/share/terok/agent/mounts/
 ├── _claude-config/    → /home/dev/.claude      (Claude Code)
 ├── _codex-config/     → /home/dev/.codex       (Codex)
 ├── _vibe-config/      → /home/dev/.vibe        (Mistral Vibe)
@@ -448,7 +448,7 @@ credentials are available in all future containers.
 SSH keys are scoped per project and stored on the host only:
 
 ```text
-~/.local/share/terok/ssh-keys/
+~/.local/share/terok/core/ssh-keys/
 └── myproject/
     ├── id_ed25519        (private — never leaves the host)
     ├── id_ed25519.pub
@@ -463,7 +463,7 @@ Keys are served to containers via the SSH agent proxy.
 The workspace itself is private to each task:
 
 ```text
-~/.local/share/terok/tasks/<project>/<task_id>/
+~/.local/share/terok/core/tasks/<project>/<task_id>/
 ├── workspace-dangerous/  → /workspace          (repo clone)
 ├── agent-config/                                (agent state)
 └── shield/                                      (firewall audit logs)

--- a/docs/developer.md
+++ b/docs/developer.md
@@ -120,16 +120,16 @@ When a task container starts, terok mounts:
 
 | Container Path | Host Source | Purpose |
 |----------------|-------------|---------|
-| `/workspace` | `<state_root>/tasks/<project>/<task>/workspace-dangerous` | Per-task workspace |
-| `/home/dev/.codex` | `<envs_base>/_codex-config` | Codex credentials |
-| `/home/dev/.claude` | `<envs_base>/_claude-config` | Claude Code credentials |
-| `/home/dev/.vibe` | `<envs_base>/_vibe-config` | Mistral Vibe credentials |
-| `/home/dev/.blablador` | `<envs_base>/_blablador-config` | Blablador credentials + isolated OpenCode config (via `OPENCODE_CONFIG`) |
-| `/home/dev/.config/opencode` | `<envs_base>/_opencode-config` | Plain OpenCode config (use `terok config import-opencode`) |
-| `/home/dev/.local/share/opencode` | `<envs_base>/_opencode-data` | OpenCode data (shared by Blablador and plain OpenCode) |
-| `/home/dev/.local/state` | `<envs_base>/_opencode-state` | OpenCode/Bun state (shared by both) |
-| `/home/dev/.config/gh` | `<envs_base>/_gh-config` | GitHub CLI config |
-| `/home/dev/.config/glab-cli` | `<envs_base>/_glab-config` | GitLab CLI config |
+| `/workspace` | `<state_dir>/tasks/<project>/<task>/workspace-dangerous` | Per-task workspace |
+| `/home/dev/.codex` | `<mounts_dir>/_codex-config` | Codex credentials |
+| `/home/dev/.claude` | `<mounts_dir>/_claude-config` | Claude Code credentials |
+| `/home/dev/.vibe` | `<mounts_dir>/_vibe-config` | Mistral Vibe credentials |
+| `/home/dev/.blablador` | `<mounts_dir>/_blablador-config` | Blablador credentials + isolated OpenCode config (via `OPENCODE_CONFIG`) |
+| `/home/dev/.config/opencode` | `<mounts_dir>/_opencode-config` | Plain OpenCode config (use `terok config import-opencode`) |
+| `/home/dev/.local/share/opencode` | `<mounts_dir>/_opencode-data` | OpenCode data (shared by Blablador and plain OpenCode) |
+| `/home/dev/.local/state` | `<mounts_dir>/_opencode-state` | OpenCode/Bun state (shared by both) |
+| `/home/dev/.config/gh` | `<mounts_dir>/_gh-config` | GitHub CLI config |
+| `/home/dev/.config/glab-cli` | `<mounts_dir>/_glab-config` | GitLab CLI config |
 
 SSH keys are **not** mounted — the credential proxy's SSH agent serves them over TCP.
 

--- a/docs/shared-dirs.md
+++ b/docs/shared-dirs.md
@@ -6,7 +6,7 @@ When a task starts, terok mounts host directories into the container for workspa
 
 ## Per-Task Workspace
 
-- Host path: `<state_root>/tasks/<project_id>/<task_id>/workspace-dangerous`
+- Host path: `<state_dir>/tasks/<project_id>/<task_id>/workspace-dangerous`
 - Mounted as: `<host_dir>:/workspace:Z`
 - Created automatically when the task runs (permissions `700`).
 - The project repository is cloned or synced here by `init-ssh-and-repo.sh`.

--- a/docs/shared-dirs.md
+++ b/docs/shared-dirs.md
@@ -23,10 +23,10 @@ When a task starts, terok mounts host directories into the container for workspa
 These directories are bind-mounted into every task container so that agents and
 tools find their config on startup.  They are created automatically
 on first task launch.  The base dir defaults to
-`~/.local/share/terok-agent/mounts` (override via `TEROK_AGENT_STATE_DIR`).
+`~/.local/share/terok/agent/mounts` (override via `TEROK_AGENT_STATE_DIR`).
 
 > **Trust boundary:** Mount directories are intentionally separated from the
-> credentials store (`~/.local/share/terok-credentials/`) since containers have
+> credentials store (`~/.local/share/terok/credentials/`) since containers have
 > read-write access to mounts and could potentially poison them.
 
 | Host Dir | Container Mount | Purpose |

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -977,7 +977,7 @@ When enabled, terok adds:
 ## Tips
 
 - **Show resolved paths:** `terok config`
-- **Where credentials live:** `~/.local/share/terok-credentials` (or `/var/lib/terok-credentials` if root, or as configured under `credentials.dir`)
+- **Where credentials live:** `~/.local/share/terok/credentials` (or `/var/lib/terok/credentials` if root, or as configured under `credentials.dir`)
 - **Shared directories:** See [shared-dirs.md](shared-dirs.md)
 - **Security modes:** See [git-gate-and-security-modes.md](git-gate-and-security-modes.md)
 - **Copying text from the terminal:** TUI and tmux can intercept mouse

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -770,18 +770,18 @@ global presets directory. It's shared across all projects.
 
 ```bash
 # Create the directory (first time only)
-mkdir -p ~/.config/terok/presets
+mkdir -p ~/.config/terok/core/presets
 
 # Copy a bundled preset and customize it
 terok config | grep "Bundled presets"   # find the path
-cp <bundled-path>/solo.yml ~/.config/terok/presets/solo.yml
+cp <bundled-path>/solo.yml ~/.config/terok/core/presets/solo.yml
 # Edit to taste — your version now shadows the bundled one
 ```
 
 Or create one from scratch:
 
 ```bash
-cat > ~/.config/terok/presets/quick-review.yml << 'EOF'
+cat > ~/.config/terok/core/presets/quick-review.yml << 'EOF'
 model: sonnet
 max_turns: 10
 subagents:
@@ -802,7 +802,7 @@ Now use it anywhere: `terok run anyproject "Review PR #42" --preset quick-review
 When you use `--preset fast`, terok searches:
 
 1. **Project** — `<project>/presets/fast.yml` (per-project override)
-2. **Global** — `~/.config/terok/presets/fast.yml` (shared across projects)
+2. **Global** — `~/.config/terok/core/presets/fast.yml` (shared across projects)
 3. **Bundled** — shipped with terok (always available)
 
 First match wins. This means a global preset shadows a bundled one with the

--- a/poetry.lock
+++ b/poetry.lock
@@ -2757,55 +2757,55 @@ tomli-w = ">=1.0,<2.0"
 
 [[package]]
 name = "terok-agent"
-version = "0.0.25"
+version = "0.0.26"
 description = "Single-agent task runner for hardened Podman containers"
 optional = false
 python-versions = ">=3.12,<4.0"
 groups = ["main"]
 files = [
-    {file = "terok_agent-0.0.25-py3-none-any.whl", hash = "sha256:8095b6cb4993d134fa488b917a00b5b1ca316c1280b2c9b99c28954ee7047875"},
+    {file = "terok_agent-0.0.26-py3-none-any.whl", hash = "sha256:56ea3f77d418f71fed826196825ab4212f4139261c4e6fa5963188758a0b89ed"},
 ]
 
 [package.dependencies]
 Jinja2 = ">=3.1"
 "ruamel.yaml" = ">=0.18"
-terok_sandbox = {url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.0.22/terok_sandbox-0.0.22-py3-none-any.whl"}
+terok_sandbox = {url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.0.23/terok_sandbox-0.0.23-py3-none-any.whl"}
 tomli-w = ">=1.0"
 
 [package.source]
 type = "url"
-url = "https://github.com/terok-ai/terok-agent/releases/download/v0.0.25/terok_agent-0.0.25-py3-none-any.whl"
+url = "https://github.com/terok-ai/terok-agent/releases/download/v0.0.26/terok_agent-0.0.26-py3-none-any.whl"
 
 [[package]]
 name = "terok-sandbox"
-version = "0.0.22"
+version = "0.0.23"
 description = "Hardened Podman container runner with gate server and shield integration"
 optional = false
 python-versions = ">=3.12,<4.0"
 groups = ["main"]
 files = [
-    {file = "terok_sandbox-0.0.22-py3-none-any.whl", hash = "sha256:7712ea22a0cea65a43d051073a5aee7d8cdcc1f765c5e2e72e9e18b69de4d62d"},
+    {file = "terok_sandbox-0.0.23-py3-none-any.whl", hash = "sha256:144aeb72518b476bf05b5c9b8abfce881351b4f85d64643d0483450307ce3e19"},
 ]
 
 [package.dependencies]
 aiohttp = ">=3.9"
 cryptography = ">=43.0"
 platformdirs = ">=4.0"
-terok_shield = {url = "https://github.com/terok-ai/terok-shield/releases/download/v0.5.2/terok_shield-0.5.2-py3-none-any.whl"}
+terok_shield = {url = "https://github.com/terok-ai/terok-shield/releases/download/v0.5.3/terok_shield-0.5.3-py3-none-any.whl"}
 
 [package.source]
 type = "url"
-url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.0.22/terok_sandbox-0.0.22-py3-none-any.whl"
+url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.0.23/terok_sandbox-0.0.23-py3-none-any.whl"
 
 [[package]]
 name = "terok-shield"
-version = "0.5.2"
+version = "0.5.3"
 description = "nftables-based egress firewalling for Podman containers"
 optional = false
 python-versions = ">=3.12,<4.0"
 groups = ["main"]
 files = [
-    {file = "terok_shield-0.5.2-py3-none-any.whl", hash = "sha256:efe934014e5c4844d3067324775cfb5dac2182f2c595b4eb7ce40c31993351e1"},
+    {file = "terok_shield-0.5.3-py3-none-any.whl", hash = "sha256:37ee4a330044150cdb7a300afbc416ca8dda8aa5a89ea658f6e356931b7c154a"},
 ]
 
 [package.dependencies]
@@ -2813,7 +2813,7 @@ PyYAML = ">=6.0"
 
 [package.source]
 type = "url"
-url = "https://github.com/terok-ai/terok-shield/releases/download/v0.5.2/terok_shield-0.5.2-py3-none-any.whl"
+url = "https://github.com/terok-ai/terok-shield/releases/download/v0.5.3/terok_shield-0.5.3-py3-none-any.whl"
 
 [[package]]
 name = "textual"
@@ -3284,4 +3284,4 @@ propcache = ">=0.2.1"
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.12,<4.0"
-content-hash = "cd7b57c60e3bcc2e6e9b622eb47b717b5f25562942c96972d52b4bba1c38f04b"
+content-hash = "3e6a44c8c219dd38e28a95fcf038619f371b9783946e88562866c99e68f24f1b"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,8 +44,8 @@ rich = ">=13.0"
 platformdirs = ">=4.5.1"
 unique-namer = ">=1.3"
 textual-serve = ">=1.1.0"
-terok-agent = {url = "https://github.com/terok-ai/terok-agent/releases/download/v0.0.25/terok_agent-0.0.25-py3-none-any.whl"}
-terok-sandbox = {url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.0.22/terok_sandbox-0.0.22-py3-none-any.whl"}
+terok-agent = {url = "https://github.com/terok-ai/terok-agent/releases/download/v0.0.26/terok_agent-0.0.26-py3-none-any.whl"}
+terok-sandbox = {url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.0.23/terok_sandbox-0.0.23-py3-none-any.whl"}
 
 [tool.poetry.group.dev.dependencies]
 pydevd-pycharm = "261.22158.340"

--- a/src/terok/lib/core/config.py
+++ b/src/terok/lib/core/config.py
@@ -171,9 +171,11 @@ def state_dir() -> Path:
     Precedence:
     - Environment variable TEROK_STATE_DIR (handled first)
     - If set in global config (paths.state_dir), use it.
-    - Otherwise, use terok.lib.paths.state_root() (FHS/XDG handling).
+    - Otherwise, ``state_root() / "core"`` (umbrella subdir for terok-core data).
     """
-    return _resolve_path("TEROK_STATE_DIR", ("paths", "state_dir"), _state_root_base)
+    return _resolve_path(
+        "TEROK_STATE_DIR", ("paths", "state_dir"), lambda: _state_root_base() / "core"
+    )
 
 
 def gate_repos_dir() -> Path:
@@ -213,10 +215,12 @@ def user_presets_dir() -> Path:
 
     Precedence:
     - Global config: paths.user_presets_dir
-    - XDG_CONFIG_HOME/terok/presets
-    - ~/.config/terok/presets
+    - XDG_CONFIG_HOME/terok/core/presets
+    - ~/.config/terok/core/presets
     """
-    return _resolve_path(None, ("paths", "user_presets_dir"), lambda: _xdg_config_subdir("presets"))
+    return _resolve_path(
+        None, ("paths", "user_presets_dir"), lambda: _xdg_config_subdir("core") / "presets"
+    )
 
 
 def bundled_presets_dir() -> Path:

--- a/src/terok/lib/core/config.py
+++ b/src/terok/lib/core/config.py
@@ -257,11 +257,11 @@ def get_ui_base_port() -> int:
 def credentials_dir() -> Path:
     """Return the base directory for shared credentials.
 
-    Global config (terok-config.yml):
-      credentials:
-        dir: ~/.local/share/terok-credentials  # or /var/lib/terok-credentials for root
-
-    Default: ``credentials_root()`` from ``terok.lib.paths``.
+    Precedence:
+    - ``TEROK_CREDENTIALS_DIR`` environment variable.
+    - Global config ``credentials.dir``.
+    - ``credentials_root()`` → ``~/.local/share/terok/credentials``
+      (or ``/var/lib/terok/credentials`` for root).
     """
     return _resolve_path("TEROK_CREDENTIALS_DIR", ("credentials", "dir"), _credentials_root_base)
 

--- a/src/terok/lib/core/paths.py
+++ b/src/terok/lib/core/paths.py
@@ -17,7 +17,7 @@ except ImportError:  # optional dependency
 
 
 APP_NAME = "terok"
-CREDENTIALS_APP_NAME = "terok-credentials"
+_CREDENTIALS_SUBDIR = "credentials"
 
 
 def _is_root() -> bool:
@@ -97,17 +97,20 @@ def runtime_root() -> Path:
 def credentials_root() -> Path:
     """Shared credentials directory used by all terok ecosystem packages.
 
-    Priority: ``TEROK_CREDENTIALS_DIR`` → ``/var/lib/terok-credentials`` (root)
+    Lives under the ``terok/`` umbrella so a single ``rm -rf`` or backup
+    captures everything.
+
+    Priority: ``TEROK_CREDENTIALS_DIR`` → ``/var/lib/terok/credentials`` (root)
     → XDG data dir.
     """
     env = os.getenv("TEROK_CREDENTIALS_DIR")
     if env:
         return Path(env).expanduser()
     if _is_root():
-        return Path("/var/lib") / CREDENTIALS_APP_NAME
+        return Path("/var/lib") / APP_NAME / _CREDENTIALS_SUBDIR
     if _user_data_dir is not None:
-        return Path(_user_data_dir(CREDENTIALS_APP_NAME))
+        return Path(_user_data_dir(APP_NAME)) / _CREDENTIALS_SUBDIR
     xdg = os.getenv("XDG_DATA_HOME")
     if xdg:
-        return Path(xdg) / CREDENTIALS_APP_NAME
-    return Path.home() / ".local" / "share" / CREDENTIALS_APP_NAME
+        return Path(xdg) / APP_NAME / _CREDENTIALS_SUBDIR
+    return Path.home() / ".local" / "share" / APP_NAME / _CREDENTIALS_SUBDIR

--- a/tests/unit/lib/test_agent_config.py
+++ b/tests/unit/lib/test_agent_config.py
@@ -92,7 +92,7 @@ def write_project_preset(
 
 def user_presets_dir(layout: AgentConfigLayout) -> Path:
     """Return the global XDG presets directory."""
-    presets_dir = layout.xdg_config_home / "terok" / "presets"
+    presets_dir = layout.xdg_config_home / "terok" / "core" / "presets"
     presets_dir.mkdir(parents=True, exist_ok=True)
     return presets_dir
 

--- a/tests/unit/lib/test_paths.py
+++ b/tests/unit/lib/test_paths.py
@@ -61,12 +61,18 @@ class TestCredentialsRoot:
         )
 
 
-class TestCredentialsSubdir:
-    """Verify the credentials subdir constant."""
+class TestCredentialsUmbrella:
+    """Verify credentials live under the terok/ umbrella."""
 
-    def test_value(self) -> None:
-        """_CREDENTIALS_SUBDIR is 'credentials', distinct from APP_NAME."""
-        assert paths._CREDENTIALS_SUBDIR == "credentials"
+    def test_default_is_under_umbrella(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Default credentials_root() nests under the terok/ umbrella, not a sibling."""
+        monkeypatch.delenv("TEROK_CREDENTIALS_DIR", raising=False)
+        monkeypatch.delenv("XDG_DATA_HOME", raising=False)
+        monkeypatch.setattr(paths, "_is_root", lambda: False)
+        monkeypatch.setattr(paths, "_user_data_dir", None)
+        result = paths.credentials_root()
+        assert result.parent.name == "terok"
+        assert result.name == "credentials"
 
 
 class TestConfigRoot:

--- a/tests/unit/lib/test_paths.py
+++ b/tests/unit/lib/test_paths.py
@@ -30,17 +30,17 @@ class TestCredentialsRoot:
         assert result == Path.home() / "my-creds"
 
     def test_root_fallback(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        """Root user gets /var/lib/terok-credentials."""
+        """Root user gets /var/lib/terok/credentials."""
         monkeypatch.delenv("TEROK_CREDENTIALS_DIR", raising=False)
         monkeypatch.setattr(paths, "_is_root", lambda: True)
-        assert paths.credentials_root() == Path("/var/lib/terok-credentials")
+        assert paths.credentials_root() == Path("/var/lib/terok/credentials")
 
     def test_platformdirs_fallback(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Non-root with platformdirs delegates to user_data_dir."""
         monkeypatch.delenv("TEROK_CREDENTIALS_DIR", raising=False)
         monkeypatch.setattr(paths, "_is_root", lambda: False)
         monkeypatch.setattr(paths, "_user_data_dir", lambda name: f"{MOCK_BASE}/data/{name}")
-        assert paths.credentials_root() == Path(f"{MOCK_BASE}/data/terok-credentials")
+        assert paths.credentials_root() == MOCK_BASE / "data" / "terok" / "credentials"
 
     def test_xdg_data_home_fallback(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Without platformdirs, XDG_DATA_HOME is honored."""
@@ -48,24 +48,25 @@ class TestCredentialsRoot:
         monkeypatch.setattr(paths, "_is_root", lambda: False)
         monkeypatch.setattr(paths, "_user_data_dir", None)
         monkeypatch.setenv("XDG_DATA_HOME", str(MOCK_BASE / "xdg-data"))
-        assert paths.credentials_root() == MOCK_BASE / "xdg-data" / "terok-credentials"
+        assert paths.credentials_root() == MOCK_BASE / "xdg-data" / "terok" / "credentials"
 
     def test_bare_fallback(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        """Last resort: ~/.local/share/terok-credentials."""
+        """Last resort: ~/.local/share/terok/credentials."""
         monkeypatch.delenv("TEROK_CREDENTIALS_DIR", raising=False)
         monkeypatch.delenv("XDG_DATA_HOME", raising=False)
         monkeypatch.setattr(paths, "_is_root", lambda: False)
         monkeypatch.setattr(paths, "_user_data_dir", None)
-        assert paths.credentials_root() == Path.home() / ".local" / "share" / "terok-credentials"
+        assert (
+            paths.credentials_root() == Path.home() / ".local" / "share" / "terok" / "credentials"
+        )
 
 
-class TestCredentialsAppName:
-    """Verify the credentials namespace constant."""
+class TestCredentialsSubdir:
+    """Verify the credentials subdir constant."""
 
     def test_value(self) -> None:
-        """CREDENTIALS_APP_NAME is separate from APP_NAME."""
-        assert paths.CREDENTIALS_APP_NAME == "terok-credentials"
-        assert paths.CREDENTIALS_APP_NAME != paths.APP_NAME
+        """_CREDENTIALS_SUBDIR is 'credentials', distinct from APP_NAME."""
+        assert paths._CREDENTIALS_SUBDIR == "credentials"
 
 
 class TestConfigRoot:

--- a/tests/unit/lib/test_shield.py
+++ b/tests/unit/lib/test_shield.py
@@ -85,7 +85,10 @@ def test_make_shield_maps_config_to_shield_config(
 ) -> None:
     """SandboxConfig values are translated into the per-task ``ShieldConfig``."""
     cfg = SandboxConfig(config_dir=MOCK_CONFIG_ROOT, **cfg_kwargs)
-    with patch("terok_shield.SubprocessRunner", autospec=True):
+    with (
+        patch("terok_shield.SubprocessRunner", autospec=True),
+        patch("terok_sandbox.config.umbrella_config_root", return_value=MOCK_CONFIG_ROOT),
+    ):
         shield = make_shield(MOCK_TASK_DIR, cfg=cfg)
 
     assert isinstance(shield, Shield)

--- a/tests/unit/lib/test_shield.py
+++ b/tests/unit/lib/test_shield.py
@@ -87,7 +87,7 @@ def test_make_shield_maps_config_to_shield_config(
     cfg = SandboxConfig(config_dir=MOCK_CONFIG_ROOT, **cfg_kwargs)
     with (
         patch("terok_shield.SubprocessRunner", autospec=True),
-        patch("terok_sandbox.config.umbrella_config_root", return_value=MOCK_CONFIG_ROOT),
+        patch("terok_sandbox.paths.umbrella_config_root", return_value=MOCK_CONFIG_ROOT),
     ):
         shield = make_shield(MOCK_TASK_DIR, cfg=cfg)
 


### PR DESCRIPTION
## Summary

- Nest credentials under `terok/credentials` (was `terok-credentials` sibling)
- Scope core state under `terok/core/` (tasks, gate, build, deleted-projects)
- Move presets to `~/.config/terok/core/presets/` (was `~/.config/terok/presets/`)
- Keep `config.yml` and `projects/` at top-level in `~/.config/terok/` (user-facing)
- Update all docs (shared-dirs, concepts, developer, usage) for new paths

Part of the umbrella namespace initiative — companion PRs in terok-shield, terok-sandbox, and terok-agent move their directories under `terok/{shield,sandbox,agent}` respectively.

### Directory layout after all PRs merge

```
~/.local/share/terok/
├── core/             # tasks, gate, build, deleted-projects
├── agent/            # mounts/
├── credentials/      # credentials.db, routes.json, ssh-keys.json
└── sandbox/          # ssh-keys/

~/.config/terok/
├── config.yml        # top-level (user entrypoint)
├── projects/         # top-level (user entrypoint)
├── core/presets/     # user presets
└── shield/profiles/  # shield DNS profiles
```

## Test plan
- [x] `ruff check` + `ruff format --check` pass
- [x] 1335 unit tests pass (3 shield tests deferred until terok-sandbox is updated with `umbrella_config_root()`)
- [ ] Full `make check` in CI


🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated docs and diagrams to reflect reorganized on-host paths for task workspaces, SSH keys, credentials, and shared-agent mounts.

* **Chores**
  * Standardized default storage locations for state, presets, and credentials under a unified core/agent namespace.

* **Tests**
  * Updated test expectations and fixtures to align with the new path layout.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->