### PR TITLE
feat: credential-type-aware phantom environment injection

### DIFF
--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,1 +1,0 @@
-{"sessionId":"c0d5dd7b-981b-4cb7-90d9-32ead48af469","pid":34,"acquiredAt":1775159274981}

--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,0 +1,1 @@
+{"sessionId":"c0d5dd7b-981b-4cb7-90d9-32ead48af469","pid":34,"acquiredAt":1775159274981}

--- a/poetry.lock
+++ b/poetry.lock
@@ -2757,25 +2757,24 @@ tomli-w = ">=1.0,<2.0"
 
 [[package]]
 name = "terok-agent"
-version = "0.0.26"
+version = "0.0.27"
 description = "Single-agent task runner for hardened Podman containers"
 optional = false
 python-versions = ">=3.12,<4.0"
 groups = ["main"]
-files = []
-develop = false
+files = [
+    {file = "terok_agent-0.0.27-py3-none-any.whl", hash = "sha256:d1c5f0a45067ae9d6f0850614e700640bbf9366d08417d5f19040faa4d5ad301"},
+]
 
 [package.dependencies]
 Jinja2 = ">=3.1"
 "ruamel.yaml" = ">=0.18"
-terok-sandbox = {url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.0.23/terok_sandbox-0.0.23-py3-none-any.whl"}
+terok_sandbox = {url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.0.23/terok_sandbox-0.0.23-py3-none-any.whl"}
 tomli-w = ">=1.0"
 
 [package.source]
-type = "git"
-url = "https://github.com/sliwowitz/terok-agent.git"
-reference = "1ed051a"
-resolved_reference = "1ed051a2dd360fed708f868d4b1cf7d70ae882ba"
+type = "url"
+url = "https://github.com/terok-ai/terok-agent/releases/download/v0.0.27/terok_agent-0.0.27-py3-none-any.whl"
 
 [[package]]
 name = "terok-sandbox"
@@ -3285,4 +3284,4 @@ propcache = ">=0.2.1"
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.12,<4.0"
-content-hash = "7f24140f9dd366a87cfa5a1f6298ff0765ae2038c9ef18d6d353854d2e820421"
+content-hash = "24c231ddfdb8e911cf6ee657dacc328123e813f1d346730aec8cea08a8712d64"

--- a/poetry.lock
+++ b/poetry.lock
@@ -2762,19 +2762,20 @@ description = "Single-agent task runner for hardened Podman containers"
 optional = false
 python-versions = ">=3.12,<4.0"
 groups = ["main"]
-files = [
-    {file = "terok_agent-0.0.26-py3-none-any.whl", hash = "sha256:56ea3f77d418f71fed826196825ab4212f4139261c4e6fa5963188758a0b89ed"},
-]
+files = []
+develop = false
 
 [package.dependencies]
 Jinja2 = ">=3.1"
 "ruamel.yaml" = ">=0.18"
-terok_sandbox = {url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.0.23/terok_sandbox-0.0.23-py3-none-any.whl"}
+terok-sandbox = {url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.0.23/terok_sandbox-0.0.23-py3-none-any.whl"}
 tomli-w = ">=1.0"
 
 [package.source]
-type = "url"
-url = "https://github.com/terok-ai/terok-agent/releases/download/v0.0.26/terok_agent-0.0.26-py3-none-any.whl"
+type = "git"
+url = "https://github.com/sliwowitz/terok-agent.git"
+reference = "3579dabc02c1b4caf31294624adbc72e76b699c1"
+resolved_reference = "3579dabc02c1b4caf31294624adbc72e76b699c1"
 
 [[package]]
 name = "terok-sandbox"
@@ -3284,4 +3285,4 @@ propcache = ">=0.2.1"
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.12,<4.0"
-content-hash = "3e6a44c8c219dd38e28a95fcf038619f371b9783946e88562866c99e68f24f1b"
+content-hash = "646644222a81d1d6f6647644f7e6c1711324fdd66f10da9be934cca8e0598971"

--- a/poetry.lock
+++ b/poetry.lock
@@ -2774,8 +2774,8 @@ tomli-w = ">=1.0"
 [package.source]
 type = "git"
 url = "https://github.com/sliwowitz/terok-agent.git"
-reference = "3579dabc02c1b4caf31294624adbc72e76b699c1"
-resolved_reference = "3579dabc02c1b4caf31294624adbc72e76b699c1"
+reference = "83bcaae"
+resolved_reference = "83bcaae506fcec2cf5e35471d48333b09465ef81"
 
 [[package]]
 name = "terok-sandbox"
@@ -3285,4 +3285,4 @@ propcache = ">=0.2.1"
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.12,<4.0"
-content-hash = "646644222a81d1d6f6647644f7e6c1711324fdd66f10da9be934cca8e0598971"
+content-hash = "e15c52c00a558fef3d68873e0a4a339d3ea76a6cfadeae1e865d83ea5c7e27fc"

--- a/poetry.lock
+++ b/poetry.lock
@@ -2774,8 +2774,8 @@ tomli-w = ">=1.0"
 [package.source]
 type = "git"
 url = "https://github.com/sliwowitz/terok-agent.git"
-reference = "83bcaae"
-resolved_reference = "83bcaae506fcec2cf5e35471d48333b09465ef81"
+reference = "1ed051a"
+resolved_reference = "1ed051a2dd360fed708f868d4b1cf7d70ae882ba"
 
 [[package]]
 name = "terok-sandbox"
@@ -3285,4 +3285,4 @@ propcache = ">=0.2.1"
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.12,<4.0"
-content-hash = "e15c52c00a558fef3d68873e0a4a339d3ea76a6cfadeae1e865d83ea5c7e27fc"
+content-hash = "7f24140f9dd366a87cfa5a1f6298ff0765ae2038c9ef18d6d353854d2e820421"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ rich = ">=13.0"
 platformdirs = ">=4.5.1"
 unique-namer = ">=1.3"
 textual-serve = ">=1.1.0"
-terok-agent = {git = "https://github.com/sliwowitz/terok-agent.git", rev = "c07e22f06382ed81b3e1aecce82e410530740ad3"}
+terok-agent = {git = "https://github.com/sliwowitz/terok-agent.git", rev = "3579dabc02c1b4caf31294624adbc72e76b699c1"}
 terok-sandbox = {url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.0.23/terok_sandbox-0.0.23-py3-none-any.whl"}
 
 [tool.poetry.group.dev.dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ rich = ">=13.0"
 platformdirs = ">=4.5.1"
 unique-namer = ">=1.3"
 textual-serve = ">=1.1.0"
-terok-agent = {git = "https://github.com/sliwowitz/terok-agent.git", rev = "1ed051a"}
+terok-agent = {url = "https://github.com/terok-ai/terok-agent/releases/download/v0.0.27/terok_agent-0.0.27-py3-none-any.whl"}
 terok-sandbox = {url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.0.23/terok_sandbox-0.0.23-py3-none-any.whl"}
 
 [tool.poetry.group.dev.dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ rich = ">=13.0"
 platformdirs = ">=4.5.1"
 unique-namer = ">=1.3"
 textual-serve = ">=1.1.0"
-terok-agent = {url = "https://github.com/terok-ai/terok-agent/releases/download/v0.0.26/terok_agent-0.0.26-py3-none-any.whl"}
+terok-agent = {git = "https://github.com/sliwowitz/terok-agent.git", rev = "c07e22f06382ed81b3e1aecce82e410530740ad3"}
 terok-sandbox = {url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.0.23/terok_sandbox-0.0.23-py3-none-any.whl"}
 
 [tool.poetry.group.dev.dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ rich = ">=13.0"
 platformdirs = ">=4.5.1"
 unique-namer = ">=1.3"
 textual-serve = ">=1.1.0"
-terok-agent = {git = "https://github.com/sliwowitz/terok-agent.git", rev = "3579dabc02c1b4caf31294624adbc72e76b699c1"}
+terok-agent = {git = "https://github.com/sliwowitz/terok-agent.git", rev = "83bcaae"}
 terok-sandbox = {url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.0.23/terok_sandbox-0.0.23-py3-none-any.whl"}
 
 [tool.poetry.group.dev.dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ rich = ">=13.0"
 platformdirs = ">=4.5.1"
 unique-namer = ">=1.3"
 textual-serve = ">=1.1.0"
-terok-agent = {git = "https://github.com/sliwowitz/terok-agent.git", rev = "83bcaae"}
+terok-agent = {git = "https://github.com/sliwowitz/terok-agent.git", rev = "1ed051a"}
 terok-sandbox = {url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.0.23/terok_sandbox-0.0.23-py3-none-any.whl"}
 
 [tool.poetry.group.dev.dependencies]

--- a/src/terok/lib/core/config.py
+++ b/src/terok/lib/core/config.py
@@ -349,6 +349,17 @@ def get_credential_proxy_bypass() -> bool:
     return _load_validated().credential_proxy.bypass_no_secret_protection
 
 
+def get_credential_proxy_transport() -> str:
+    """Return the credential proxy transport mode (``"direct"`` or ``"socket"``).
+
+    Global config (config.yml)::
+
+        credential_proxy:
+          transport: socket   # or "direct"
+    """
+    return _load_validated().credential_proxy.transport
+
+
 def get_shield_bypass_firewall_no_protection() -> bool:
     """Return whether the shield firewall is globally bypassed.
 

--- a/src/terok/lib/core/yaml_schema.py
+++ b/src/terok/lib/core/yaml_schema.py
@@ -343,7 +343,7 @@ class RawCredentialProxySection(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
     bypass_no_secret_protection: bool = False
-    transport: Literal["direct", "socket"] = "direct"
+    transport: Literal["direct", "socket"] = "socket"
 
 
 class RawGateServerSection(BaseModel):

--- a/src/terok/lib/core/yaml_schema.py
+++ b/src/terok/lib/core/yaml_schema.py
@@ -343,6 +343,7 @@ class RawCredentialProxySection(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
     bypass_no_secret_protection: bool = False
+    transport: Literal["direct", "socket"] = "socket"
 
 
 class RawGateServerSection(BaseModel):

--- a/src/terok/lib/core/yaml_schema.py
+++ b/src/terok/lib/core/yaml_schema.py
@@ -343,7 +343,7 @@ class RawCredentialProxySection(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
     bypass_no_secret_protection: bool = False
-    transport: Literal["direct", "socket"] = "socket"
+    transport: Literal["direct", "socket"] = "direct"
 
 
 class RawGateServerSection(BaseModel):

--- a/src/terok/lib/orchestration/environment.py
+++ b/src/terok/lib/orchestration/environment.py
@@ -312,18 +312,9 @@ def _credential_proxy_env_and_volumes(
         # Providers with oauth_phantom_env get OAuth-specific env vars;
         # others fall back to phantom_env (same env var for both auth types).
         is_oauth = credential_types[name] == "oauth"
-        if is_oauth and route.oauth_phantom_env:
-            token_vars = route.oauth_phantom_env
-        else:
-            if is_oauth and not route.oauth_phantom_env:
-                import sys
-
-                print(
-                    f"WARNING: '{name}' has OAuth credential but no oauth_phantom_env "
-                    f"in roster — using API-key env vars for '{name}'.",
-                    file=sys.stderr,
-                )
-            token_vars = route.phantom_env
+        token_vars = (
+            route.oauth_phantom_env if (is_oauth and route.oauth_phantom_env) else route.phantom_env
+        )
         for env_var in token_vars:
             env[env_var] = tokens[name]
 

--- a/src/terok/lib/orchestration/environment.py
+++ b/src/terok/lib/orchestration/environment.py
@@ -234,11 +234,8 @@ def _load_ssh_keys_json(path: Path) -> dict[str, list[dict[str, str]]]:
 
 
 def _credential_type(cred: dict) -> str:
-    """Determine credential type, handling legacy rows without a ``type`` field."""
-    ctype = cred.get("type", "")
-    if not ctype and "access_token" in cred:
-        return "oauth"
-    return ctype or "api_key"
+    """Return the credential type from the stored ``type`` field."""
+    return cred.get("type") or "api_key"
 
 
 def _credential_proxy_env_and_volumes(
@@ -313,9 +310,15 @@ def _credential_proxy_env_and_volumes(
 
         # Auth dimension: select phantom env vars by credential type
         is_oauth = credential_types[name] == "oauth"
-        token_vars = (
-            route.oauth_phantom_env if (is_oauth and route.oauth_phantom_env) else route.phantom_env
-        )
+        if is_oauth:
+            if not route.oauth_phantom_env:
+                raise SystemExit(
+                    f"OAuth credential stored for '{name}' but agent roster lacks "
+                    f"oauth_phantom_env.\nUpdate terok-agent to a version with OAuth support."
+                )
+            token_vars = route.oauth_phantom_env
+        else:
+            token_vars = route.phantom_env
         for env_var in token_vars:
             env[env_var] = tokens[name]
 

--- a/src/terok/lib/orchestration/environment.py
+++ b/src/terok/lib/orchestration/environment.py
@@ -313,7 +313,11 @@ def _credential_proxy_env_and_volumes(
 
         # Auth dimension: select phantom env vars by credential type
         is_oauth = credential_types[name] == "oauth"
-        token_vars = route.oauth_phantom_env if (is_oauth and route.oauth_phantom_env) else route.phantom_env
+        token_vars = (
+            route.oauth_phantom_env
+            if (is_oauth and route.oauth_phantom_env)
+            else route.phantom_env
+        )
         for env_var in token_vars:
             env[env_var] = tokens[name]
 

--- a/src/terok/lib/orchestration/environment.py
+++ b/src/terok/lib/orchestration/environment.py
@@ -233,19 +233,33 @@ def _load_ssh_keys_json(path: Path) -> dict[str, list[dict[str, str]]]:
 # ---------- Credential proxy ----------
 
 
+def _credential_type(cred: dict) -> str:
+    """Determine credential type, handling legacy rows without a ``type`` field."""
+    ctype = cred.get("type", "")
+    if not ctype and "access_token" in cred:
+        return "oauth"
+    return ctype or "api_key"
+
+
 def _credential_proxy_env_and_volumes(
     project: ProjectConfig, task_id: str
 ) -> tuple[dict[str, str], list[str]]:
     """Return env vars and volumes for the credential proxy.
 
-    Injects phantom API key env vars and base URL overrides pointing to
-    the proxy socket, and mounts the socket into the container.
+    Injects phantom token env vars and transport overrides (HTTP base URL or
+    Unix socket path) pointing to the proxy.  The choice of env vars depends
+    on two orthogonal dimensions:
+
+    - **Auth**: stored credential type (``api_key`` → :attr:`phantom_env`,
+      ``oauth`` → :attr:`oauth_phantom_env`).
+    - **Transport**: global config ``credential_proxy.transport``
+      (``direct`` → :attr:`base_url_env`, ``socket`` → :attr:`socket_env`).
 
     Raises ``SystemExit`` if the proxy is not running — no silent fallback.
     The only way to skip the proxy is the explicit bypass flag
     ``credential_proxy.bypass_no_secret_protection`` in global config.
     """
-    from ..core.config import get_credential_proxy_bypass
+    from ..core.config import get_credential_proxy_bypass, get_credential_proxy_transport
 
     if get_credential_proxy_bypass():
         return {}, []
@@ -263,16 +277,19 @@ def _credential_proxy_env_and_volumes(
 
     roster = get_roster()
     proxy_routes = roster.proxy_routes
+    use_socket = get_credential_proxy_transport() == "socket"
 
     db = CredentialDB(cfg.proxy_db_path)
     try:
         credential_set = "default"
         stored_providers = set(db.list_credentials(credential_set))
         routed = stored_providers & proxy_routes.keys()
-        tokens = {
-            name: db.create_proxy_token(project.id, task_id, credential_set, name)
-            for name in routed
-        }
+        tokens: dict[str, str] = {}
+        credential_types: dict[str, str] = {}
+        for name in routed:
+            tokens[name] = db.create_proxy_token(project.id, task_id, credential_set, name)
+            cred = db.load_credential(credential_set, name)
+            credential_types[name] = _credential_type(cred) if cred else "api_key"
 
         # SSH agent: create phantom token if project has at least one valid key registered
         ssh_keys = _load_ssh_keys_json(cfg.ssh_keys_json_path)
@@ -293,10 +310,19 @@ def _credential_proxy_env_and_volumes(
     for name, route in proxy_routes.items():
         if name not in routed:
             continue
-        for env_var in route.phantom_env:
+
+        # Auth dimension: select phantom env vars by credential type
+        is_oauth = credential_types[name] == "oauth"
+        token_vars = route.oauth_phantom_env if (is_oauth and route.oauth_phantom_env) else route.phantom_env
+        for env_var in token_vars:
             env[env_var] = tokens[name]
-        if route.base_url_env:
+
+        # Transport dimension: Unix socket or HTTP base URL
+        if use_socket and route.socket_path and route.socket_env:
+            env[route.socket_env] = route.socket_path
+        elif route.base_url_env:
             env[route.base_url_env] = proxy_base
+
         # Override OpenCode base URL for proxied providers (the original
         # value from collect_opencode_provider_env points to the real upstream;
         # this override redirects through the proxy instead)

--- a/src/terok/lib/orchestration/environment.py
+++ b/src/terok/lib/orchestration/environment.py
@@ -310,13 +310,18 @@ def _credential_proxy_env_and_volumes(
 
         # Auth dimension: select phantom env vars by credential type
         is_oauth = credential_types[name] == "oauth"
-        if is_oauth:
-            if not route.oauth_phantom_env:
-                raise SystemExit(
-                    f"OAuth credential stored for '{name}' but agent roster lacks "
-                    f"oauth_phantom_env.\nUpdate terok-agent to a version with OAuth support."
-                )
+        if is_oauth and route.oauth_phantom_env:
             token_vars = route.oauth_phantom_env
+        elif is_oauth:
+            import sys
+
+            print(
+                f"WARNING: OAuth credential for '{name}' but agent roster lacks "
+                f"oauth_phantom_env — falling back to API-key env vars.\n"
+                f"  Update terok-agent to enable subscription mode.",
+                file=sys.stderr,
+            )
+            token_vars = route.phantom_env
         else:
             token_vars = route.phantom_env
         for env_var in token_vars:

--- a/src/terok/lib/orchestration/environment.py
+++ b/src/terok/lib/orchestration/environment.py
@@ -308,21 +308,21 @@ def _credential_proxy_env_and_volumes(
         if name not in routed:
             continue
 
-        # Auth dimension: select phantom env vars by credential type
+        # Auth dimension: select phantom env vars by credential type.
+        # Providers with oauth_phantom_env get OAuth-specific env vars;
+        # others fall back to phantom_env (same env var for both auth types).
         is_oauth = credential_types[name] == "oauth"
         if is_oauth and route.oauth_phantom_env:
             token_vars = route.oauth_phantom_env
-        elif is_oauth:
-            import sys
-
-            print(
-                f"WARNING: OAuth credential for '{name}' but agent roster lacks "
-                f"oauth_phantom_env — falling back to API-key env vars.\n"
-                f"  Update terok-agent to enable subscription mode.",
-                file=sys.stderr,
-            )
-            token_vars = route.phantom_env
         else:
+            if is_oauth and not route.oauth_phantom_env:
+                import sys
+
+                print(
+                    f"WARNING: '{name}' has OAuth credential but no oauth_phantom_env "
+                    f"in roster — using API-key env vars for '{name}'.",
+                    file=sys.stderr,
+                )
             token_vars = route.phantom_env
         for env_var in token_vars:
             env[env_var] = tokens[name]

--- a/src/terok/lib/orchestration/environment.py
+++ b/src/terok/lib/orchestration/environment.py
@@ -314,9 +314,7 @@ def _credential_proxy_env_and_volumes(
         # Auth dimension: select phantom env vars by credential type
         is_oauth = credential_types[name] == "oauth"
         token_vars = (
-            route.oauth_phantom_env
-            if (is_oauth and route.oauth_phantom_env)
-            else route.phantom_env
+            route.oauth_phantom_env if (is_oauth and route.oauth_phantom_env) else route.phantom_env
         )
         for env_var in token_vars:
             env[env_var] = tokens[name]

--- a/src/terok/lib/orchestration/environment.py
+++ b/src/terok/lib/orchestration/environment.py
@@ -318,10 +318,13 @@ def _credential_proxy_env_and_volumes(
         for env_var in token_vars:
             env[env_var] = tokens[name]
 
-        # Transport dimension: Unix socket or HTTP base URL
+        # Transport dimension: socket flag + HTTP base URL.
+        # ANTHROPIC_UNIX_SOCKET is a subscription-mode flag for Claude Code
+        # (its UD() function checks it), but actual HTTP traffic still routes
+        # through ANTHROPIC_BASE_URL — the SDK only uses unix sockets on Bun.
         if use_socket and route.socket_path and route.socket_env:
             env[route.socket_env] = route.socket_path
-        elif route.base_url_env:
+        if route.base_url_env:
             env[route.base_url_env] = proxy_base
 
         # Override OpenCode base URL for proxied providers (the original

--- a/src/terok/tui/screens.py
+++ b/src/terok/tui/screens.py
@@ -1877,6 +1877,25 @@ class ShieldSetupScreen(screen.ModalScreen[str | None]):
 # ---------------------------------------------------------------------------
 
 
+def _format_credentials_typed(status: CredentialProxyStatus) -> str:
+    """Format stored credentials as ``name (type), ...`` for status display."""
+    try:
+        from terok_sandbox import CredentialDB
+
+        db = CredentialDB(status.db_path)
+        try:
+            parts = []
+            for name in status.credentials_stored:
+                cred = db.load_credential("default", name)
+                ctype = cred.get("type", "unknown") if cred else "unknown"
+                parts.append(f"{name} ({ctype})")
+        finally:
+            db.close()
+        return ", ".join(parts)
+    except Exception:  # noqa: BLE001
+        return ", ".join(status.credentials_stored)
+
+
 def render_proxy_status(status: CredentialProxyStatus | None) -> Text:
     """Render credential proxy status details as a Rich Text object."""
     if status is None:
@@ -1898,7 +1917,7 @@ def render_proxy_status(status: CredentialProxyStatus | None) -> Text:
     ]
 
     if status.credentials_stored:
-        lines.append(Text(f"Credentials: {', '.join(status.credentials_stored)}"))
+        lines.append(Text(f"Credentials: {_format_credentials_typed(status)}"))
     else:
         lines.append(Text.assemble("Credentials: ", Text("none stored", style=dim)))
 

--- a/tach.toml
+++ b/tach.toml
@@ -577,6 +577,7 @@ expose = [
     "set_experimental",
     "get_global_hooks",
     "get_credential_proxy_bypass",
+    "get_credential_proxy_transport",
     "get_shield_bypass_firewall_no_protection",
     "get_shield_drop_on_task_run",
     "get_shield_on_task_restart",

--- a/tests/integration/credential_proxy/test_proxy_env_integration.py
+++ b/tests/integration/credential_proxy/test_proxy_env_integration.py
@@ -117,7 +117,7 @@ class TestProxyEnvIntegration:
                 "terok_sandbox.credential_proxy_lifecycle.is_daemon_running",
                 return_value=False,
             ),
-            pytest.raises(SystemExit, match="not running"),
+            pytest.raises(SystemExit, match="not reachable"),
         ):
             _credential_proxy_env_and_volumes(project, "task-1")
 

--- a/tests/integration/credential_proxy/test_proxy_env_integration.py
+++ b/tests/integration/credential_proxy/test_proxy_env_integration.py
@@ -44,14 +44,16 @@ class TestProxyEnvIntegration:
                 "terok_sandbox.credential_proxy_lifecycle.is_daemon_running",
                 return_value=True,
             ),
-            patch("terok_sandbox.SandboxConfig") as mock_cfg_cls,
+            patch("terok_sandbox.ensure_proxy_reachable"),
+            patch("terok.lib.orchestration.environment.make_sandbox_config") as mock_cfg_fn,
             patch(
                 "terok.lib.core.config.get_credential_proxy_transport", return_value="direct"
             ),
         ):
-            mock_cfg = mock_cfg_cls.return_value
+            mock_cfg = mock_cfg_fn.return_value
             mock_cfg.proxy_db_path = db_path
             mock_cfg.proxy_socket_path = sock_path
+            mock_cfg.proxy_port = 18731
             mock_cfg.ssh_keys_json_path = tmp_path / "ssh-keys.json"
 
             env, volumes = _credential_proxy_env_and_volumes(project, "task-1")
@@ -90,14 +92,16 @@ class TestProxyEnvIntegration:
                 "terok_sandbox.credential_proxy_lifecycle.is_daemon_running",
                 return_value=True,
             ),
-            patch("terok_sandbox.SandboxConfig") as mock_cfg_cls,
+            patch("terok_sandbox.ensure_proxy_reachable"),
+            patch("terok.lib.orchestration.environment.make_sandbox_config") as mock_cfg_fn,
             patch(
                 "terok.lib.core.config.get_credential_proxy_transport", return_value="direct"
             ),
         ):
-            mock_cfg = mock_cfg_cls.return_value
+            mock_cfg = mock_cfg_fn.return_value
             mock_cfg.proxy_db_path = db_path
             mock_cfg.proxy_socket_path = sock_path
+            mock_cfg.proxy_port = 18731
             mock_cfg.ssh_keys_json_path = tmp_path / "ssh-keys.json"
 
             env, _ = _credential_proxy_env_and_volumes(project, "task-1")
@@ -145,15 +149,19 @@ class TestProxyEnvIntegration:
                     "terok_sandbox.credential_proxy_lifecycle.is_daemon_running",
                     return_value=True,
                 ),
-                patch("terok_sandbox.SandboxConfig") as mock_cfg_cls,
+                patch("terok_sandbox.ensure_proxy_reachable"),
+                patch(
+                    "terok.lib.orchestration.environment.make_sandbox_config"
+                ) as mock_cfg_fn,
                 patch(
                     "terok.lib.core.config.get_credential_proxy_transport",
                     return_value="direct",
                 ),
             ):
-                mock_cfg = mock_cfg_cls.return_value
+                mock_cfg = mock_cfg_fn.return_value
                 mock_cfg.proxy_db_path = db_path
                 mock_cfg.proxy_socket_path = sock_path
+                mock_cfg.proxy_port = 18731
                 mock_cfg.ssh_keys_json_path = tmp_path / "ssh-keys.json"
 
                 env, _ = _credential_proxy_env_and_volumes(project, task_id)
@@ -184,14 +192,17 @@ class TestProxyEnvIntegration:
                 "terok_sandbox.credential_proxy_lifecycle.is_daemon_running",
                 return_value=True,
             ),
-            patch("terok_sandbox.SandboxConfig") as mock_cfg_cls,
+            patch("terok_sandbox.ensure_proxy_reachable"),
+            patch("terok.lib.orchestration.environment.make_sandbox_config") as mock_cfg_fn,
             patch(
                 "terok.lib.core.config.get_credential_proxy_transport", return_value="socket"
             ),
         ):
-            mock_cfg = mock_cfg_cls.return_value
+            mock_cfg = mock_cfg_fn.return_value
             mock_cfg.proxy_db_path = db_path
             mock_cfg.proxy_socket_path = sock_path
+            mock_cfg.proxy_port = 18731
+            mock_cfg.ssh_keys_json_path = tmp_path / "ssh-keys.json"
 
             env, _ = _credential_proxy_env_and_volumes(project, "task-1")
 

--- a/tests/integration/credential_proxy/test_proxy_env_integration.py
+++ b/tests/integration/credential_proxy/test_proxy_env_integration.py
@@ -22,7 +22,7 @@ class TestProxyEnvIntegration:
     """Verify _credential_proxy_env_and_volumes with real DB."""
 
     def test_phantom_tokens_injected_for_stored_provider(self, tmp_path: Path) -> None:
-        """Stored credentials produce phantom env vars and proxy volumes."""
+        """Stored API key credentials produce phantom env vars (direct transport)."""
         from terok_sandbox import CredentialDB
 
         from terok.lib.orchestration.environment import _credential_proxy_env_and_volumes
@@ -45,6 +45,9 @@ class TestProxyEnvIntegration:
                 return_value=True,
             ),
             patch("terok_sandbox.SandboxConfig") as mock_cfg_cls,
+            patch(
+                "terok.lib.core.config.get_credential_proxy_transport", return_value="direct"
+            ),
         ):
             mock_cfg = mock_cfg_cls.return_value
             mock_cfg.proxy_db_path = db_path
@@ -88,6 +91,9 @@ class TestProxyEnvIntegration:
                 return_value=True,
             ),
             patch("terok_sandbox.SandboxConfig") as mock_cfg_cls,
+            patch(
+                "terok.lib.core.config.get_credential_proxy_transport", return_value="direct"
+            ),
         ):
             mock_cfg = mock_cfg_cls.return_value
             mock_cfg.proxy_db_path = db_path
@@ -140,6 +146,10 @@ class TestProxyEnvIntegration:
                     return_value=True,
                 ),
                 patch("terok_sandbox.SandboxConfig") as mock_cfg_cls,
+                patch(
+                    "terok.lib.core.config.get_credential_proxy_transport",
+                    return_value="direct",
+                ),
             ):
                 mock_cfg = mock_cfg_cls.return_value
                 mock_cfg.proxy_db_path = db_path
@@ -151,6 +161,44 @@ class TestProxyEnvIntegration:
 
         assert tokens[0] != tokens[1]
         assert len(tokens[0]) == 32
+
+    def test_oauth_credential_uses_oauth_phantom_env(self, tmp_path: Path) -> None:
+        """OAuth credentials inject CLAUDE_CODE_OAUTH_TOKEN, not ANTHROPIC_API_KEY."""
+        from terok_sandbox import CredentialDB
+
+        from terok.lib.orchestration.environment import _credential_proxy_env_and_volumes
+
+        db_path = tmp_path / "proxy" / "credentials.db"
+        db = CredentialDB(db_path)
+        db.store_credential("default", "claude", {"type": "oauth", "access_token": "tok"})
+        db.close()
+
+        sock_path = tmp_path / "proxy.sock"
+        sock_path.touch()
+
+        project = MagicMock()
+        project.id = "test-project"
+
+        with (
+            patch(
+                "terok_sandbox.credential_proxy_lifecycle.is_daemon_running",
+                return_value=True,
+            ),
+            patch("terok_sandbox.SandboxConfig") as mock_cfg_cls,
+            patch(
+                "terok.lib.core.config.get_credential_proxy_transport", return_value="socket"
+            ),
+        ):
+            mock_cfg = mock_cfg_cls.return_value
+            mock_cfg.proxy_db_path = db_path
+            mock_cfg.proxy_socket_path = sock_path
+
+            env, _ = _credential_proxy_env_and_volumes(project, "task-1")
+
+        assert "CLAUDE_CODE_OAUTH_TOKEN" in env
+        assert len(env["CLAUDE_CODE_OAUTH_TOKEN"]) == 32
+        assert "ANTHROPIC_API_KEY" not in env
+        assert env["ANTHROPIC_UNIX_SOCKET"] == "/tmp/terok-claude-proxy.sock"
 
 
 class TestProxyBypassConfig:

--- a/tests/integration/credential_proxy/test_proxy_env_integration.py
+++ b/tests/integration/credential_proxy/test_proxy_env_integration.py
@@ -203,6 +203,46 @@ class TestProxyEnvIntegration:
         assert "ANTHROPIC_API_KEY" not in env
         assert env["ANTHROPIC_UNIX_SOCKET"] == "/tmp/terok-claude-proxy.sock"
 
+    def test_oauth_credential_direct_transport(self, tmp_path: Path) -> None:
+        """OAuth + direct transport → CLAUDE_CODE_OAUTH_TOKEN + ANTHROPIC_BASE_URL."""
+        from terok_sandbox import CredentialDB
+
+        from terok.lib.orchestration.environment import _credential_proxy_env_and_volumes
+
+        db_path = tmp_path / "proxy" / "credentials.db"
+        db = CredentialDB(db_path)
+        db.store_credential("default", "claude", {"type": "oauth", "access_token": "tok"})
+        db.close()
+
+        sock_path = tmp_path / "proxy.sock"
+        sock_path.touch()
+
+        project = MagicMock()
+        project.id = "test-project"
+
+        with (
+            patch(
+                "terok_sandbox.credential_proxy_lifecycle.is_daemon_running",
+                return_value=True,
+            ),
+            patch("terok_sandbox.ensure_proxy_reachable"),
+            patch("terok.lib.orchestration.environment.make_sandbox_config") as mock_cfg_fn,
+            patch("terok.lib.core.config.get_credential_proxy_transport", return_value="direct"),
+        ):
+            mock_cfg = mock_cfg_fn.return_value
+            mock_cfg.proxy_db_path = db_path
+            mock_cfg.proxy_socket_path = sock_path
+            mock_cfg.proxy_port = 18731
+            mock_cfg.ssh_keys_json_path = tmp_path / "ssh-keys.json"
+
+            env, _ = _credential_proxy_env_and_volumes(project, "task-1")
+
+        assert "CLAUDE_CODE_OAUTH_TOKEN" in env
+        assert len(env["CLAUDE_CODE_OAUTH_TOKEN"]) == 32
+        assert "ANTHROPIC_API_KEY" not in env
+        assert "ANTHROPIC_BASE_URL" in env
+        assert "ANTHROPIC_UNIX_SOCKET" not in env
+
 
 class TestProxyBypassConfig:
     """Verify the bypass flag skips proxy entirely."""

--- a/tests/integration/credential_proxy/test_proxy_env_integration.py
+++ b/tests/integration/credential_proxy/test_proxy_env_integration.py
@@ -46,9 +46,7 @@ class TestProxyEnvIntegration:
             ),
             patch("terok_sandbox.ensure_proxy_reachable"),
             patch("terok.lib.orchestration.environment.make_sandbox_config") as mock_cfg_fn,
-            patch(
-                "terok.lib.core.config.get_credential_proxy_transport", return_value="direct"
-            ),
+            patch("terok.lib.core.config.get_credential_proxy_transport", return_value="direct"),
         ):
             mock_cfg = mock_cfg_fn.return_value
             mock_cfg.proxy_db_path = db_path
@@ -94,9 +92,7 @@ class TestProxyEnvIntegration:
             ),
             patch("terok_sandbox.ensure_proxy_reachable"),
             patch("terok.lib.orchestration.environment.make_sandbox_config") as mock_cfg_fn,
-            patch(
-                "terok.lib.core.config.get_credential_proxy_transport", return_value="direct"
-            ),
+            patch("terok.lib.core.config.get_credential_proxy_transport", return_value="direct"),
         ):
             mock_cfg = mock_cfg_fn.return_value
             mock_cfg.proxy_db_path = db_path
@@ -150,9 +146,7 @@ class TestProxyEnvIntegration:
                     return_value=True,
                 ),
                 patch("terok_sandbox.ensure_proxy_reachable"),
-                patch(
-                    "terok.lib.orchestration.environment.make_sandbox_config"
-                ) as mock_cfg_fn,
+                patch("terok.lib.orchestration.environment.make_sandbox_config") as mock_cfg_fn,
                 patch(
                     "terok.lib.core.config.get_credential_proxy_transport",
                     return_value="direct",
@@ -194,9 +188,7 @@ class TestProxyEnvIntegration:
             ),
             patch("terok_sandbox.ensure_proxy_reachable"),
             patch("terok.lib.orchestration.environment.make_sandbox_config") as mock_cfg_fn,
-            patch(
-                "terok.lib.core.config.get_credential_proxy_transport", return_value="socket"
-            ),
+            patch("terok.lib.core.config.get_credential_proxy_transport", return_value="socket"),
         ):
             mock_cfg = mock_cfg_fn.return_value
             mock_cfg.proxy_db_path = db_path

--- a/tests/integration/credential_proxy/test_proxy_env_integration.py
+++ b/tests/integration/credential_proxy/test_proxy_env_integration.py
@@ -202,6 +202,8 @@ class TestProxyEnvIntegration:
         assert len(env["CLAUDE_CODE_OAUTH_TOKEN"]) == 32
         assert "ANTHROPIC_API_KEY" not in env
         assert env["ANTHROPIC_UNIX_SOCKET"] == "/tmp/terok-claude-proxy.sock"
+        # Socket flag AND base URL — SDK needs base URL for HTTP on Node.js
+        assert "ANTHROPIC_BASE_URL" in env
 
     def test_oauth_credential_direct_transport(self, tmp_path: Path) -> None:
         """OAuth + direct transport → CLAUDE_CODE_OAUTH_TOKEN + ANTHROPIC_BASE_URL."""

--- a/tests/unit/lib/test_credential_proxy_env.py
+++ b/tests/unit/lib/test_credential_proxy_env.py
@@ -172,10 +172,8 @@ class TestCredentialProxyEnv:
         assert "ANTHROPIC_UNIX_SOCKET" not in env
 
     @pytest.mark.usefixtures("_enable_proxy")
-    def test_oauth_without_roster_support_warns_per_provider(
-        self, tmp_path: Path, capsys: CaptureFixture[str]
-    ) -> None:
-        """OAuth credential + empty oauth_phantom_env warns and falls back per-provider."""
+    def test_oauth_without_roster_support_falls_back(self, tmp_path: Path) -> None:
+        """OAuth credential + empty oauth_phantom_env silently uses phantom_env."""
         from terok_sandbox import CredentialDB
 
         from terok.lib.orchestration.environment import _credential_proxy_env_and_volumes
@@ -218,11 +216,8 @@ class TestCredentialProxyEnv:
 
             env, _ = _credential_proxy_env_and_volumes(project, "task-1")
 
-        err = capsys.readouterr().err
-        # Warning is scoped to the specific provider
-        assert "'claude'" in err
-        assert "for 'claude'" in err
-        # Falls back to API-key env var for this provider
+        # Falls back to API-key env var silently (valid path for providers
+        # that use the same env var for both auth types)
         assert "ANTHROPIC_API_KEY" in env
         assert "CLAUDE_CODE_OAUTH_TOKEN" not in env
 

--- a/tests/unit/lib/test_credential_proxy_env.py
+++ b/tests/unit/lib/test_credential_proxy_env.py
@@ -178,6 +178,40 @@ class TestCredentialProxyEnv:
         assert "ANTHROPIC_UNIX_SOCKET" not in env
 
     @pytest.mark.usefixtures("_enable_proxy")
+    def test_legacy_oauth_credential_detected(self, tmp_path: Path) -> None:
+        """Legacy OAuth rows without 'type' field are detected as OAuth."""
+        from terok_sandbox import CredentialDB
+
+        from terok.lib.orchestration.environment import _credential_proxy_env_and_volumes
+
+        db_path = tmp_path / "proxy" / "credentials.db"
+        db = CredentialDB(db_path)
+        db.store_credential("default", "claude", {"access_token": "tok"})
+        db.close()
+
+        sock_path = tmp_path / "proxy.sock"
+        sock_path.touch()
+        project = MagicMock()
+        project.id = "test-project"
+
+        with (
+            patch("terok_sandbox.credential_proxy_lifecycle.is_daemon_running", return_value=True),
+            patch("terok_sandbox.ensure_proxy_reachable"),
+            patch("terok.lib.orchestration.environment.make_sandbox_config") as mock_cfg_fn,
+            patch("terok.lib.core.config.get_credential_proxy_transport", return_value="direct"),
+        ):
+            mock_cfg = mock_cfg_fn.return_value
+            mock_cfg.proxy_db_path = db_path
+            mock_cfg.proxy_socket_path = sock_path
+            mock_cfg.proxy_port = 18731
+            mock_cfg.ssh_keys_json_path = tmp_path / "ssh-keys.json"
+
+            env, _ = _credential_proxy_env_and_volumes(project, "task-1")
+
+        assert "CLAUDE_CODE_OAUTH_TOKEN" in env
+        assert "ANTHROPIC_API_KEY" not in env
+
+    @pytest.mark.usefixtures("_enable_proxy")
     def test_oauth_socket_transport(self, tmp_path: Path) -> None:
         """OAuth credential with socket transport → CLAUDE_CODE_OAUTH_TOKEN + ANTHROPIC_UNIX_SOCKET."""
         from terok_sandbox import CredentialDB

--- a/tests/unit/lib/test_credential_proxy_env.py
+++ b/tests/unit/lib/test_credential_proxy_env.py
@@ -172,15 +172,15 @@ class TestCredentialProxyEnv:
         assert "ANTHROPIC_UNIX_SOCKET" not in env
 
     @pytest.mark.usefixtures("_enable_proxy")
-    def test_legacy_oauth_credential_detected(self, tmp_path: Path) -> None:
-        """Legacy OAuth rows without 'type' field are detected as OAuth."""
+    def test_oauth_missing_roster_support_raises(self, tmp_path: Path) -> None:
+        """OAuth credential with empty oauth_phantom_env raises SystemExit."""
         from terok_sandbox import CredentialDB
 
         from terok.lib.orchestration.environment import _credential_proxy_env_and_volumes
 
         db_path = tmp_path / "proxy" / "credentials.db"
         db = CredentialDB(db_path)
-        db.store_credential("default", "claude", {"access_token": "tok"})
+        db.store_credential("default", "claude", {"type": "oauth", "access_token": "tok"})
         db.close()
 
         sock_path = tmp_path / "proxy.sock"
@@ -188,11 +188,23 @@ class TestCredentialProxyEnv:
         project = MagicMock()
         project.id = "test-project"
 
+        # Build a stripped roster where Claude has no oauth_phantom_env (old agent)
+        from terok_agent import get_roster
+
+        real_roster = get_roster()
+        real_routes = real_roster.proxy_routes
+        stripped_route = MagicMock(wraps=real_routes["claude"])
+        stripped_route.oauth_phantom_env = {}
+        fake_routes = {**real_routes, "claude": stripped_route}
+        fake_roster = MagicMock(wraps=real_roster, proxy_routes=fake_routes)
+
         with (
             patch("terok_sandbox.credential_proxy_lifecycle.is_daemon_running", return_value=True),
             patch("terok_sandbox.ensure_proxy_reachable"),
             patch("terok.lib.orchestration.environment.make_sandbox_config") as mock_cfg_fn,
             patch("terok.lib.core.config.get_credential_proxy_transport", return_value="direct"),
+            patch("terok_agent.get_roster", return_value=fake_roster),
+            pytest.raises(SystemExit, match="oauth_phantom_env"),
         ):
             mock_cfg = mock_cfg_fn.return_value
             mock_cfg.proxy_db_path = db_path
@@ -200,10 +212,7 @@ class TestCredentialProxyEnv:
             mock_cfg.proxy_port = 18731
             mock_cfg.ssh_keys_json_path = tmp_path / "ssh-keys.json"
 
-            env, _ = _credential_proxy_env_and_volumes(project, "task-1")
-
-        assert "CLAUDE_CODE_OAUTH_TOKEN" in env
-        assert "ANTHROPIC_API_KEY" not in env
+            _credential_proxy_env_and_volumes(project, "task-1")
 
     @pytest.mark.usefixtures("_enable_proxy")
     def test_oauth_socket_transport(self, tmp_path: Path) -> None:

--- a/tests/unit/lib/test_credential_proxy_env.py
+++ b/tests/unit/lib/test_credential_proxy_env.py
@@ -56,7 +56,7 @@ class TestCredentialProxyEnv:
 
     @pytest.mark.usefixtures("_enable_proxy")
     def test_proxy_running_injects_phantom_tokens(self, tmp_path: Path) -> None:
-        """When proxy runs and credentials exist, injects phantom env vars."""
+        """When proxy runs and API key credentials exist, injects phantom env vars."""
         from terok_sandbox import CredentialDB
 
         from terok.lib.orchestration.environment import _credential_proxy_env_and_volumes
@@ -77,6 +77,9 @@ class TestCredentialProxyEnv:
             patch("terok_sandbox.credential_proxy_lifecycle.is_daemon_running", return_value=True),
             patch("terok_sandbox.ensure_proxy_reachable"),
             patch("terok.lib.orchestration.environment.make_sandbox_config") as mock_cfg_fn,
+            patch(
+                "terok.lib.core.config.get_credential_proxy_transport", return_value="direct"
+            ),
         ):
             mock_cfg = mock_cfg_fn.return_value
             mock_cfg.proxy_db_path = db_path
@@ -117,6 +120,9 @@ class TestCredentialProxyEnv:
             patch("terok_sandbox.credential_proxy_lifecycle.is_daemon_running", return_value=True),
             patch("terok_sandbox.ensure_proxy_reachable"),
             patch("terok.lib.orchestration.environment.make_sandbox_config") as mock_cfg_fn,
+            patch(
+                "terok.lib.core.config.get_credential_proxy_transport", return_value="direct"
+            ),
         ):
             mock_cfg = mock_cfg_fn.return_value
             mock_cfg.proxy_db_path = db_path
@@ -130,6 +136,126 @@ class TestCredentialProxyEnv:
         assert "MISTRAL_API_KEY" in env
         # Claude NOT stored → no phantom token
         assert "ANTHROPIC_API_KEY" not in env
+
+    @pytest.mark.usefixtures("_enable_proxy")
+    def test_oauth_direct_transport(self, tmp_path: Path) -> None:
+        """OAuth credential with direct transport → CLAUDE_CODE_OAUTH_TOKEN + ANTHROPIC_BASE_URL."""
+        from terok_sandbox import CredentialDB
+
+        from terok.lib.orchestration.environment import _credential_proxy_env_and_volumes
+
+        db_path = tmp_path / "proxy" / "credentials.db"
+        db = CredentialDB(db_path)
+        db.store_credential("default", "claude", {"type": "oauth", "access_token": "tok"})
+        db.close()
+
+        sock_path = tmp_path / "proxy.sock"
+        sock_path.touch()
+
+        project = MagicMock()
+        project.id = "test-project"
+
+        with (
+            patch("terok_sandbox.credential_proxy_lifecycle.is_daemon_running", return_value=True),
+            patch("terok_sandbox.ensure_proxy_reachable"),
+            patch("terok.lib.orchestration.environment.make_sandbox_config") as mock_cfg_fn,
+            patch(
+                "terok.lib.core.config.get_credential_proxy_transport", return_value="direct"
+            ),
+        ):
+            mock_cfg = mock_cfg_fn.return_value
+            mock_cfg.proxy_db_path = db_path
+            mock_cfg.proxy_socket_path = sock_path
+            mock_cfg.proxy_port = 18731
+            mock_cfg.ssh_keys_json_path = tmp_path / "ssh-keys.json"
+
+            env, _ = _credential_proxy_env_and_volumes(project, "task-1")
+
+        assert "CLAUDE_CODE_OAUTH_TOKEN" in env
+        assert len(env["CLAUDE_CODE_OAUTH_TOKEN"]) == 32
+        assert "ANTHROPIC_BASE_URL" in env
+        assert "ANTHROPIC_API_KEY" not in env
+        assert "ANTHROPIC_UNIX_SOCKET" not in env
+
+    @pytest.mark.usefixtures("_enable_proxy")
+    def test_oauth_socket_transport(self, tmp_path: Path) -> None:
+        """OAuth credential with socket transport → CLAUDE_CODE_OAUTH_TOKEN + ANTHROPIC_UNIX_SOCKET."""
+        from terok_sandbox import CredentialDB
+
+        from terok.lib.orchestration.environment import _credential_proxy_env_and_volumes
+
+        db_path = tmp_path / "proxy" / "credentials.db"
+        db = CredentialDB(db_path)
+        db.store_credential("default", "claude", {"type": "oauth", "access_token": "tok"})
+        db.close()
+
+        sock_path = tmp_path / "proxy.sock"
+        sock_path.touch()
+
+        project = MagicMock()
+        project.id = "test-project"
+
+        with (
+            patch("terok_sandbox.credential_proxy_lifecycle.is_daemon_running", return_value=True),
+            patch("terok_sandbox.ensure_proxy_reachable"),
+            patch("terok.lib.orchestration.environment.make_sandbox_config") as mock_cfg_fn,
+            patch(
+                "terok.lib.core.config.get_credential_proxy_transport", return_value="socket"
+            ),
+        ):
+            mock_cfg = mock_cfg_fn.return_value
+            mock_cfg.proxy_db_path = db_path
+            mock_cfg.proxy_socket_path = sock_path
+            mock_cfg.proxy_port = 18731
+            mock_cfg.ssh_keys_json_path = tmp_path / "ssh-keys.json"
+
+            env, _ = _credential_proxy_env_and_volumes(project, "task-1")
+
+        assert "CLAUDE_CODE_OAUTH_TOKEN" in env
+        assert len(env["CLAUDE_CODE_OAUTH_TOKEN"]) == 32
+        assert env["ANTHROPIC_UNIX_SOCKET"] == "/tmp/terok-claude-proxy.sock"
+        assert "ANTHROPIC_API_KEY" not in env
+        assert "ANTHROPIC_BASE_URL" not in env
+
+    @pytest.mark.usefixtures("_enable_proxy")
+    def test_api_key_socket_transport(self, tmp_path: Path) -> None:
+        """API key credential with socket transport → ANTHROPIC_API_KEY + ANTHROPIC_UNIX_SOCKET."""
+        from terok_sandbox import CredentialDB
+
+        from terok.lib.orchestration.environment import _credential_proxy_env_and_volumes
+
+        db_path = tmp_path / "proxy" / "credentials.db"
+        db = CredentialDB(db_path)
+        db.store_credential("default", "claude", {"type": "api_key", "key": "sk-test"})
+        db.close()
+
+        sock_path = tmp_path / "proxy.sock"
+        sock_path.touch()
+
+        project = MagicMock()
+        project.id = "test-project"
+
+        with (
+            patch("terok_sandbox.credential_proxy_lifecycle.is_daemon_running", return_value=True),
+            patch("terok_sandbox.ensure_proxy_reachable"),
+            patch("terok.lib.orchestration.environment.make_sandbox_config") as mock_cfg_fn,
+            patch(
+                "terok.lib.core.config.get_credential_proxy_transport", return_value="socket"
+            ),
+        ):
+            mock_cfg = mock_cfg_fn.return_value
+            mock_cfg.proxy_db_path = db_path
+            mock_cfg.proxy_socket_path = sock_path
+            mock_cfg.proxy_port = 18731
+            mock_cfg.ssh_keys_json_path = tmp_path / "ssh-keys.json"
+
+            env, _ = _credential_proxy_env_and_volumes(project, "task-1")
+
+        assert "ANTHROPIC_API_KEY" in env
+        assert len(env["ANTHROPIC_API_KEY"]) == 32
+        assert env["ANTHROPIC_UNIX_SOCKET"] == "/tmp/terok-claude-proxy.sock"
+        assert "CLAUDE_CODE_OAUTH_TOKEN" not in env
+        assert "ANTHROPIC_BASE_URL" not in env
 
     @pytest.mark.usefixtures("_enable_proxy")
     def test_leaked_credentials_warning(self, tmp_path: Path, capsys: CaptureFixture[str]) -> None:
@@ -162,6 +288,9 @@ class TestCredentialProxyEnv:
             patch("terok_sandbox.ensure_proxy_reachable"),
             patch("terok.lib.orchestration.environment.make_sandbox_config") as mock_cfg_fn,
             patch("terok_agent.mounts_dir", return_value=mounts_base),
+            patch(
+                "terok.lib.core.config.get_credential_proxy_transport", return_value="direct"
+            ),
         ):
             mock_cfg = mock_cfg_fn.return_value
             mock_cfg.proxy_db_path = db_path

--- a/tests/unit/lib/test_credential_proxy_env.py
+++ b/tests/unit/lib/test_credential_proxy_env.py
@@ -77,9 +77,7 @@ class TestCredentialProxyEnv:
             patch("terok_sandbox.credential_proxy_lifecycle.is_daemon_running", return_value=True),
             patch("terok_sandbox.ensure_proxy_reachable"),
             patch("terok.lib.orchestration.environment.make_sandbox_config") as mock_cfg_fn,
-            patch(
-                "terok.lib.core.config.get_credential_proxy_transport", return_value="direct"
-            ),
+            patch("terok.lib.core.config.get_credential_proxy_transport", return_value="direct"),
         ):
             mock_cfg = mock_cfg_fn.return_value
             mock_cfg.proxy_db_path = db_path
@@ -120,9 +118,7 @@ class TestCredentialProxyEnv:
             patch("terok_sandbox.credential_proxy_lifecycle.is_daemon_running", return_value=True),
             patch("terok_sandbox.ensure_proxy_reachable"),
             patch("terok.lib.orchestration.environment.make_sandbox_config") as mock_cfg_fn,
-            patch(
-                "terok.lib.core.config.get_credential_proxy_transport", return_value="direct"
-            ),
+            patch("terok.lib.core.config.get_credential_proxy_transport", return_value="direct"),
         ):
             mock_cfg = mock_cfg_fn.return_value
             mock_cfg.proxy_db_path = db_path
@@ -159,9 +155,7 @@ class TestCredentialProxyEnv:
             patch("terok_sandbox.credential_proxy_lifecycle.is_daemon_running", return_value=True),
             patch("terok_sandbox.ensure_proxy_reachable"),
             patch("terok.lib.orchestration.environment.make_sandbox_config") as mock_cfg_fn,
-            patch(
-                "terok.lib.core.config.get_credential_proxy_transport", return_value="direct"
-            ),
+            patch("terok.lib.core.config.get_credential_proxy_transport", return_value="direct"),
         ):
             mock_cfg = mock_cfg_fn.return_value
             mock_cfg.proxy_db_path = db_path
@@ -233,9 +227,7 @@ class TestCredentialProxyEnv:
             patch("terok_sandbox.credential_proxy_lifecycle.is_daemon_running", return_value=True),
             patch("terok_sandbox.ensure_proxy_reachable"),
             patch("terok.lib.orchestration.environment.make_sandbox_config") as mock_cfg_fn,
-            patch(
-                "terok.lib.core.config.get_credential_proxy_transport", return_value="socket"
-            ),
+            patch("terok.lib.core.config.get_credential_proxy_transport", return_value="socket"),
         ):
             mock_cfg = mock_cfg_fn.return_value
             mock_cfg.proxy_db_path = db_path
@@ -273,9 +265,7 @@ class TestCredentialProxyEnv:
             patch("terok_sandbox.credential_proxy_lifecycle.is_daemon_running", return_value=True),
             patch("terok_sandbox.ensure_proxy_reachable"),
             patch("terok.lib.orchestration.environment.make_sandbox_config") as mock_cfg_fn,
-            patch(
-                "terok.lib.core.config.get_credential_proxy_transport", return_value="socket"
-            ),
+            patch("terok.lib.core.config.get_credential_proxy_transport", return_value="socket"),
         ):
             mock_cfg = mock_cfg_fn.return_value
             mock_cfg.proxy_db_path = db_path
@@ -322,9 +312,7 @@ class TestCredentialProxyEnv:
             patch("terok_sandbox.ensure_proxy_reachable"),
             patch("terok.lib.orchestration.environment.make_sandbox_config") as mock_cfg_fn,
             patch("terok_agent.mounts_dir", return_value=mounts_base),
-            patch(
-                "terok.lib.core.config.get_credential_proxy_transport", return_value="direct"
-            ),
+            patch("terok.lib.core.config.get_credential_proxy_transport", return_value="direct"),
         ):
             mock_cfg = mock_cfg_fn.return_value
             mock_cfg.proxy_db_path = db_path

--- a/tests/unit/lib/test_credential_proxy_env.py
+++ b/tests/unit/lib/test_credential_proxy_env.py
@@ -172,8 +172,10 @@ class TestCredentialProxyEnv:
         assert "ANTHROPIC_UNIX_SOCKET" not in env
 
     @pytest.mark.usefixtures("_enable_proxy")
-    def test_oauth_missing_roster_support_raises(self, tmp_path: Path) -> None:
-        """OAuth credential with empty oauth_phantom_env raises SystemExit."""
+    def test_oauth_missing_roster_warns_and_falls_back(
+        self, tmp_path: Path, capsys: CaptureFixture[str]
+    ) -> None:
+        """OAuth credential with empty oauth_phantom_env warns and falls back to API-key env."""
         from terok_sandbox import CredentialDB
 
         from terok.lib.orchestration.environment import _credential_proxy_env_and_volumes
@@ -193,8 +195,11 @@ class TestCredentialProxyEnv:
 
         real_roster = get_roster()
         real_routes = real_roster.proxy_routes
-        stripped_route = MagicMock(wraps=real_routes["claude"])
+        real_claude = real_routes["claude"]
+        stripped_route = MagicMock(wraps=real_claude)
         stripped_route.oauth_phantom_env = {}
+        stripped_route.phantom_env = real_claude.phantom_env
+        stripped_route.base_url_env = real_claude.base_url_env
         fake_routes = {**real_routes, "claude": stripped_route}
         fake_roster = MagicMock(wraps=real_roster, proxy_routes=fake_routes)
 
@@ -204,7 +209,6 @@ class TestCredentialProxyEnv:
             patch("terok.lib.orchestration.environment.make_sandbox_config") as mock_cfg_fn,
             patch("terok.lib.core.config.get_credential_proxy_transport", return_value="direct"),
             patch("terok_agent.get_roster", return_value=fake_roster),
-            pytest.raises(SystemExit, match="oauth_phantom_env"),
         ):
             mock_cfg = mock_cfg_fn.return_value
             mock_cfg.proxy_db_path = db_path
@@ -212,7 +216,14 @@ class TestCredentialProxyEnv:
             mock_cfg.proxy_port = 18731
             mock_cfg.ssh_keys_json_path = tmp_path / "ssh-keys.json"
 
-            _credential_proxy_env_and_volumes(project, "task-1")
+            env, _ = _credential_proxy_env_and_volumes(project, "task-1")
+
+        err = capsys.readouterr().err
+        assert "oauth_phantom_env" in err
+        assert "WARNING" in err
+        # Falls back to API-key env var
+        assert "ANTHROPIC_API_KEY" in env
+        assert "CLAUDE_CODE_OAUTH_TOKEN" not in env
 
     @pytest.mark.usefixtures("_enable_proxy")
     def test_oauth_socket_transport(self, tmp_path: Path) -> None:

--- a/tests/unit/lib/test_credential_proxy_env.py
+++ b/tests/unit/lib/test_credential_proxy_env.py
@@ -172,10 +172,10 @@ class TestCredentialProxyEnv:
         assert "ANTHROPIC_UNIX_SOCKET" not in env
 
     @pytest.mark.usefixtures("_enable_proxy")
-    def test_oauth_missing_roster_warns_and_falls_back(
+    def test_oauth_without_roster_support_warns_per_provider(
         self, tmp_path: Path, capsys: CaptureFixture[str]
     ) -> None:
-        """OAuth credential with empty oauth_phantom_env warns and falls back to API-key env."""
+        """OAuth credential + empty oauth_phantom_env warns and falls back per-provider."""
         from terok_sandbox import CredentialDB
 
         from terok.lib.orchestration.environment import _credential_proxy_env_and_volumes
@@ -219,9 +219,10 @@ class TestCredentialProxyEnv:
             env, _ = _credential_proxy_env_and_volumes(project, "task-1")
 
         err = capsys.readouterr().err
-        assert "oauth_phantom_env" in err
-        assert "WARNING" in err
-        # Falls back to API-key env var
+        # Warning is scoped to the specific provider
+        assert "'claude'" in err
+        assert "for 'claude'" in err
+        # Falls back to API-key env var for this provider
         assert "ANTHROPIC_API_KEY" in env
         assert "CLAUDE_CODE_OAUTH_TOKEN" not in env
 

--- a/tests/unit/lib/test_credential_proxy_env.py
+++ b/tests/unit/lib/test_credential_proxy_env.py
@@ -223,7 +223,7 @@ class TestCredentialProxyEnv:
 
     @pytest.mark.usefixtures("_enable_proxy")
     def test_oauth_socket_transport(self, tmp_path: Path) -> None:
-        """OAuth credential with socket transport → CLAUDE_CODE_OAUTH_TOKEN + ANTHROPIC_UNIX_SOCKET."""
+        """OAuth + socket → CLAUDE_CODE_OAUTH_TOKEN + ANTHROPIC_UNIX_SOCKET + ANTHROPIC_BASE_URL."""
         from terok_sandbox import CredentialDB
 
         from terok.lib.orchestration.environment import _credential_proxy_env_and_volumes
@@ -257,11 +257,12 @@ class TestCredentialProxyEnv:
         assert len(env["CLAUDE_CODE_OAUTH_TOKEN"]) == 32
         assert env["ANTHROPIC_UNIX_SOCKET"] == "/tmp/terok-claude-proxy.sock"
         assert "ANTHROPIC_API_KEY" not in env
-        assert "ANTHROPIC_BASE_URL" not in env
+        # Socket flag AND base URL — SDK needs base URL for HTTP, socket is a mode flag
+        assert "ANTHROPIC_BASE_URL" in env
 
     @pytest.mark.usefixtures("_enable_proxy")
     def test_api_key_socket_transport(self, tmp_path: Path) -> None:
-        """API key credential with socket transport → ANTHROPIC_API_KEY + ANTHROPIC_UNIX_SOCKET."""
+        """API key + socket → ANTHROPIC_API_KEY + ANTHROPIC_UNIX_SOCKET + ANTHROPIC_BASE_URL."""
         from terok_sandbox import CredentialDB
 
         from terok.lib.orchestration.environment import _credential_proxy_env_and_volumes
@@ -295,7 +296,8 @@ class TestCredentialProxyEnv:
         assert len(env["ANTHROPIC_API_KEY"]) == 32
         assert env["ANTHROPIC_UNIX_SOCKET"] == "/tmp/terok-claude-proxy.sock"
         assert "CLAUDE_CODE_OAUTH_TOKEN" not in env
-        assert "ANTHROPIC_BASE_URL" not in env
+        # Socket flag AND base URL — SDK needs base URL for HTTP, socket is a mode flag
+        assert "ANTHROPIC_BASE_URL" in env
 
     @pytest.mark.usefixtures("_enable_proxy")
     def test_leaked_credentials_warning(self, tmp_path: Path, capsys: CaptureFixture[str]) -> None:


### PR DESCRIPTION
## Summary
- Select phantom token env vars based on stored credential type (`api_key` → `ANTHROPIC_API_KEY`, `oauth` → `CLAUDE_CODE_OAUTH_TOKEN`)
- Select transport based on global config `credential_proxy.transport` (`direct` → `ANTHROPIC_BASE_URL`, `socket` → `ANTHROPIC_UNIX_SOCKET`)
- Add `transport` field to `RawCredentialProxySection` (default: `socket`)
- Add `get_credential_proxy_transport()` config getter

## Context
Claude Code determines subscription vs API-key mode from the auth env var it sees. With OAuth credentials, injecting `ANTHROPIC_API_KEY` (the old behavior) causes Claude Code to disable subscription features. This PR reads the stored credential type at container launch and injects the correct env vars.

## Dependencies
- Depends on terok-ai/terok-agent#77 (`pyproject.toml` pins the PR commit `c07e22f`)
- After terok-agent#77 is merged and released, update the dep to the release wheel before merging this PR

## Test plan
- [ ] `make check` passes (after terok-agent dep is available)
- [ ] 4 new unit tests: oauth×direct, oauth×socket, apikey×socket, apikey×direct (existing)
- [ ] 2 updated integration tests + 1 new OAuth integration test
- [ ] Manual: OAuth login + `transport: socket` → `CLAUDE_CODE_OAUTH_TOKEN` + `ANTHROPIC_UNIX_SOCKET`, Claude `/status` shows subscription
- [ ] Manual: OAuth login + `transport: direct` → `CLAUDE_CODE_OAUTH_TOKEN` + `ANTHROPIC_BASE_URL`
- [ ] Manual: API key login → `ANTHROPIC_API_KEY` (backward compat)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added credential-proxy transport option ("direct" or "socket"); proxy now injects provider env vars differently for OAuth vs API-key and honors socket vs HTTP transports with per-provider fallbacks and warnings.
  * UI: stored credentials list now shows credential types (e.g., "name (type)").

* **Tests**
  * Added and updated unit and integration tests covering transport modes, OAuth vs API-key env injection, socket vs HTTP behavior, warnings, and failure messages.

* **Chores**
  * Switched terok-agent dependency to a git-based revision.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->