### PR TITLE
fix: credential proxy autostart on reattach + accurate status display

### DIFF
--- a/docs/developer.md
+++ b/docs/developer.md
@@ -180,6 +180,76 @@ See [git-gate-and-security-modes.md](git-gate-and-security-modes.md) for detaile
 
 ---
 
+## Host-Side Service Activation Patterns
+
+terok runs several host-side services that containers reach over TCP
+(Podman cannot securely share Unix sockets into rootless containers).
+These services use **systemd socket activation** so they start on demand
+rather than requiring manual launch, but they follow two distinct
+patterns dictated by their architectures:
+
+### Inetd-style (`Accept=yes`) — Git Gate
+
+The gate handles the git smart-HTTP protocol: each request is
+short-lived, stateless, and independent.  The systemd socket unit
+uses `Accept=yes`, so systemd itself accepts each TCP connection and
+spawns a fresh `terok-gate --inetd` process with the connection on
+stdin.  No persistent daemon, no shared state, no concurrency
+concerns.  "Socket active" genuinely means "serving" — every
+connection is handled immediately.
+
+- **Unit:** `terok-gate.socket` (TCP) + `terok-gate@.service` (instantiated per connection)
+- **When it fits:** stateless, short-lived request handlers with no shared state
+
+### Persistent daemon (`Accept=no`) — Credential Proxy
+
+The credential proxy is a long-running aiohttp reverse-proxy that
+holds an open SQLite credential database, a route table, and an SSH
+agent server on a separate port.  It serves multiple concurrent
+containers simultaneously.  The systemd socket unit uses the default
+`Accept=no`: systemd listens on both the Unix socket and the TCP port,
+and on the **first** connection starts the daemon process, handing it the
+inherited file descriptors.  The daemon then stays running and handles
+all subsequent connections itself.
+
+This means there is a brief startup delay (~1–2 s) on the very first
+container request after a host reboot, after which the proxy is fully
+warm.  The status display reflects this as **standby** (socket active,
+service not yet started) vs **running** (daemon active, TCP ports bound).
+
+- **Unit:** `terok-credential-proxy.socket` (Unix + TCP) + `terok-credential-proxy.service`
+- **When it fits:** stateful daemons with shared resources, concurrent connections, or multiple ports
+
+### Why not unify them?
+
+Forcing the credential proxy into `Accept=yes` would spawn a full
+Python/aiohttp process per HTTP request, cause SQLite contention across
+instances, and orphan the SSH agent port.  Forcing the gate into a
+persistent daemon would add unnecessary complexity for a service whose
+entire protocol is "handle one connection, exit".  Each pattern is the
+natural fit for its workload.
+
+### Why TCP instead of Unix sockets?
+
+Podman cannot securely share a Unix socket from the host into a rootless
+container.  TCP ports on `127.0.0.1` are the pragmatic workaround —
+containers reach the host via `host.containers.internal:<port>`.
+
+This has a real downside: if a port is already occupied, terok would need
+to pick a different one and propagate the new port to every running
+container.  Unix sockets avoid this entirely (a filesystem path has no
+collision risk).  If Podman (or an alternative) ever gains secure socket
+sharing, the transport layer should be swapped — the current TCP binding
+is a bridge, not the target architecture.
+
+### Shield (no socket service)
+
+`terok-shield` does not run a host-side service.  It operates entirely
+via OCI hooks (`prestart`/`poststop`) that configure firewall rules when
+containers start and stop.  No socket activation, no daemon, no TCP port.
+
+---
+
 ## Agent Permission Mode Architecture
 
 > **See also:** [Agent Configuration Compatibility Matrix](agent-compat-matrix.md)

--- a/src/terok/cli/commands/sickbay.py
+++ b/src/terok/cli/commands/sickbay.py
@@ -29,6 +29,7 @@ from terok_sandbox import (
     get_container_state,
     get_proxy_status,
     get_server_status,
+    is_proxy_socket_active,
     is_proxy_systemd_available,
     is_systemd_available,
 )
@@ -111,6 +112,8 @@ def _check_credential_proxy() -> _CheckResult:
         creds = len(status.credentials_stored) if status.credentials_stored else 0
         return ("ok", label, f"{status.mode}, {creds} credential(s) stored")
     if status.mode == "systemd":
+        if is_proxy_socket_active():
+            return ("ok", label, "systemd, socket active — service starts on first connection")
         return (
             "error",
             label,

--- a/src/terok/lib/orchestration/environment.py
+++ b/src/terok/lib/orchestration/environment.py
@@ -238,6 +238,26 @@ def _credential_type(cred: dict) -> str:
     return cred.get("type") or "api_key"
 
 
+def ensure_credential_proxy() -> None:
+    """Ensure the credential proxy is reachable (respecting the bypass flag).
+
+    Call this before (re)starting a container that was created with proxy
+    phantom tokens.  After a host reboot the systemd socket may be active
+    but the service idle — this function brings the TCP ports up so
+    containers can connect.
+
+    No-op when the ``bypass_no_secret_protection`` flag is set.
+    """
+    from ..core.config import get_credential_proxy_bypass
+
+    if get_credential_proxy_bypass():
+        return
+
+    from terok_sandbox import ensure_proxy_reachable
+
+    ensure_proxy_reachable(make_sandbox_config())
+
+
 def _credential_proxy_env_and_volumes(
     project: ProjectConfig, task_id: str
 ) -> tuple[dict[str, str], list[str]]:

--- a/src/terok/lib/orchestration/task_runners.py
+++ b/src/terok/lib/orchestration/task_runners.py
@@ -49,7 +49,7 @@ from ..util.ansi import (
 )
 from ..util.yaml import dump as _yaml_dump, load as _yaml_load
 from .container_exec import container_git_diff
-from .environment import build_task_env_and_volumes
+from .environment import build_task_env_and_volumes, ensure_credential_proxy
 from .hooks import run_hook
 from .ports import assign_web_port
 from .tasks import (
@@ -358,6 +358,7 @@ def task_run_cli(
 
     # If container already exists, handle it
     if container_state is not None:
+        ensure_credential_proxy()
         color_enabled = _supports_color()
         if container_state == "running":
             print(f"Container {_green(cname, color_enabled)} is already running.")
@@ -505,6 +506,7 @@ def task_run_toad(
     pub_host = get_public_host()
 
     if container_state is not None:
+        ensure_credential_proxy()
         color_enabled = _supports_color()
         url = f"http://{pub_host}:{port}/"
         if container_state == "running":
@@ -926,6 +928,10 @@ def task_followup_headless(
             hf.write(f"{existing}\n\n---\n\n")
     prompt_path.write_text(prompt, encoding="utf-8")
 
+    # Ensure the credential proxy is reachable before restarting — after a
+    # host reboot the systemd socket may be active but the service idle.
+    ensure_credential_proxy()
+
     # Restart the existing container (re-runs the original bash command,
     # which reads prompt.txt and session files from the volume)
     _podman_start(cname)
@@ -995,6 +1001,7 @@ def task_restart(project_id: str, task_id: str) -> None:
     container_state = get_container_state(cname)
 
     print(f"Restarting task {project_id}/{task_id} ({mode})...")
+    ensure_credential_proxy()
 
     if container_state == "running":
         # Container is running - stop it first, then start it again

--- a/src/terok/tui/screens.py
+++ b/src/terok/tui/screens.py
@@ -1902,11 +1902,24 @@ def render_proxy_status(status: CredentialProxyStatus | None) -> Text:
         return Text("Credential proxy status unknown.")
 
     ok = Style(color="green")
+    warn = Style(color="yellow")
     err = Style(color="red")
     dim = Style(dim=True)
 
     mode_s = Text(status.mode)
-    running_s = Text("running", style=ok) if status.running else Text("stopped", style=err)
+    standby = False
+    if status.running:
+        running_s = Text("running", style=ok)
+    elif status.mode == "systemd":
+        from terok_sandbox import is_proxy_socket_active
+
+        if is_proxy_socket_active():
+            running_s = Text("standby (starts on first connection)", style=warn)
+            standby = True
+        else:
+            running_s = Text("stopped", style=err)
+    else:
+        running_s = Text("stopped", style=err)
 
     lines: list[Text] = [
         Text.assemble("Mode:        ", mode_s),
@@ -1921,7 +1934,7 @@ def render_proxy_status(status: CredentialProxyStatus | None) -> Text:
     else:
         lines.append(Text.assemble("Credentials: ", Text("none stored", style=dim)))
 
-    if not status.running:
+    if not status.running and not standby:
         lines.append(Text(""))
         lines.append(
             Text(

--- a/tach.toml
+++ b/tach.toml
@@ -604,6 +604,7 @@ expose = [
     "SharedMount",
     "apply_git_identity_env",
     "build_task_env_and_volumes",
+    "ensure_credential_proxy",
 ]
 from = ["terok.lib.orchestration.environment"]
 

--- a/tests/unit/cli/test_sickbay.py
+++ b/tests/unit/cli/test_sickbay.py
@@ -11,6 +11,7 @@ from pathlib import Path
 import pytest
 
 from terok.cli.commands.sickbay import (
+    _check_credential_proxy,
     _check_ssh_agent,
     _check_task_hook,
     _reconcile_post_stop,
@@ -229,3 +230,90 @@ class TestReconcilePostStop:
             result = _reconcile_post_stop("p", "1", "cli", "c", project, meta_path, "Task p/1")
             assert result[0] == "error"
             assert "boom" in result[2]
+
+
+class TestCheckCredentialProxy:
+    """Verify _check_credential_proxy three-state display."""
+
+    def _make_status(self, **overrides: object) -> unittest.mock.MagicMock:
+        """Build a mock CredentialProxyStatus with defaults."""
+        defaults = {
+            "mode": "none",
+            "running": False,
+            "healthy": False,
+            "credentials_stored": (),
+        }
+        defaults.update(overrides)
+        return unittest.mock.MagicMock(**defaults)
+
+    def test_running_shows_ok(self) -> None:
+        """Service active → ok with credential count."""
+        status = self._make_status(mode="systemd", running=True, credentials_stored=("claude",))
+        with unittest.mock.patch(
+            "terok.cli.commands.sickbay.get_proxy_status", return_value=status
+        ):
+            sev, _, detail = _check_credential_proxy()
+        assert sev == "ok"
+        assert "1 credential(s)" in detail
+
+    def test_systemd_socket_active_service_idle(self) -> None:
+        """Socket active but service idle → ok with standby message."""
+        status = self._make_status(mode="systemd", running=False)
+        with (
+            unittest.mock.patch("terok.cli.commands.sickbay.get_proxy_status", return_value=status),
+            unittest.mock.patch(
+                "terok.cli.commands.sickbay.is_proxy_socket_active", return_value=True
+            ),
+        ):
+            sev, _, detail = _check_credential_proxy()
+        assert sev == "ok"
+        assert "starts on first connection" in detail
+
+    def test_systemd_socket_inactive(self) -> None:
+        """Socket installed but inactive → error."""
+        status = self._make_status(mode="systemd", running=False)
+        with (
+            unittest.mock.patch("terok.cli.commands.sickbay.get_proxy_status", return_value=status),
+            unittest.mock.patch(
+                "terok.cli.commands.sickbay.is_proxy_socket_active", return_value=False
+            ),
+        ):
+            sev, _, detail = _check_credential_proxy()
+        assert sev == "error"
+        assert "not active" in detail
+
+    def test_not_installed_systemd_available(self) -> None:
+        """No proxy, systemd available → warn with install hint."""
+        status = self._make_status(mode="none", running=False)
+        with (
+            unittest.mock.patch("terok.cli.commands.sickbay.get_proxy_status", return_value=status),
+            unittest.mock.patch(
+                "terok.cli.commands.sickbay.is_proxy_systemd_available", return_value=True
+            ),
+        ):
+            sev, _, detail = _check_credential_proxy()
+        assert sev == "warn"
+        assert "install" in detail
+
+    def test_not_installed_no_systemd(self) -> None:
+        """No proxy, no systemd → warn with start hint."""
+        status = self._make_status(mode="none", running=False)
+        with (
+            unittest.mock.patch("terok.cli.commands.sickbay.get_proxy_status", return_value=status),
+            unittest.mock.patch(
+                "terok.cli.commands.sickbay.is_proxy_systemd_available", return_value=False
+            ),
+        ):
+            sev, _, detail = _check_credential_proxy()
+        assert sev == "warn"
+        assert "start" in detail
+
+    def test_exception_returns_warn(self) -> None:
+        """Exception during status check → warn."""
+        with unittest.mock.patch(
+            "terok.cli.commands.sickbay.get_proxy_status",
+            side_effect=RuntimeError("oops"),
+        ):
+            sev, _, detail = _check_credential_proxy()
+        assert sev == "warn"
+        assert "oops" in detail

--- a/tests/unit/lib/test_ensure_credential_proxy.py
+++ b/tests/unit/lib/test_ensure_credential_proxy.py
@@ -1,0 +1,52 @@
+# SPDX-FileCopyrightText: 2026 Jiri Vyskocil
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for ensure_credential_proxy() — the reattach-path proxy startup."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from terok.lib.orchestration.environment import ensure_credential_proxy
+
+_CFG = "terok.lib.core.config"
+_ENV = "terok.lib.orchestration.environment"
+
+
+class TestEnsureCredentialProxy:
+    """Verify ensure_credential_proxy respects bypass and delegates correctly."""
+
+    def test_noop_when_bypass_enabled(self) -> None:
+        """Does nothing when bypass_no_secret_protection is set."""
+        with (
+            patch(f"{_CFG}.get_credential_proxy_bypass", return_value=True),
+            patch("terok_sandbox.ensure_proxy_reachable") as mock_reach,
+        ):
+            ensure_credential_proxy()
+        mock_reach.assert_not_called()
+
+    def test_calls_ensure_proxy_reachable(self) -> None:
+        """Delegates to sandbox ensure_proxy_reachable with correct config."""
+        mock_cfg = MagicMock()
+        with (
+            patch(f"{_CFG}.get_credential_proxy_bypass", return_value=False),
+            patch(f"{_ENV}.make_sandbox_config", return_value=mock_cfg),
+            patch("terok_sandbox.ensure_proxy_reachable") as mock_reach,
+        ):
+            ensure_credential_proxy()
+        mock_reach.assert_called_once_with(mock_cfg)
+
+    def test_propagates_system_exit(self) -> None:
+        """SystemExit from ensure_proxy_reachable propagates to caller."""
+        with (
+            patch(f"{_CFG}.get_credential_proxy_bypass", return_value=False),
+            patch(f"{_ENV}.make_sandbox_config"),
+            patch(
+                "terok_sandbox.ensure_proxy_reachable",
+                side_effect=SystemExit("proxy down"),
+            ),
+        ):
+            with pytest.raises(SystemExit, match="proxy down"):
+                ensure_credential_proxy()

--- a/tests/unit/tui/test_detail_screens.py
+++ b/tests/unit/tui/test_detail_screens.py
@@ -1118,6 +1118,28 @@ class TestRenderProxyStatus:
         assert "stopped" in text_str
         assert "actions below" in text_str
 
+    def test_render_proxy_status_standby(self) -> None:
+        """Systemd socket active but service idle shows standby."""
+        screens, _ = import_screens()
+        status = make_proxy_status(mode="systemd", running=False)
+        with mock.patch("terok_sandbox.is_proxy_socket_active", return_value=True):
+            result = screens.render_proxy_status(status)
+        text_str = str(result)
+        assert "standby" in text_str
+        assert "first connection" in text_str
+        # Standby should not show the "actions below" help text
+        assert "actions below" not in text_str
+
+    def test_render_proxy_status_systemd_stopped(self) -> None:
+        """Systemd socket inactive shows stopped with help text."""
+        screens, _ = import_screens()
+        status = make_proxy_status(mode="systemd", running=False)
+        with mock.patch("terok_sandbox.is_proxy_socket_active", return_value=False):
+            result = screens.render_proxy_status(status)
+        text_str = str(result)
+        assert "stopped" in text_str
+        assert "actions below" in text_str
+
     def test_render_proxy_status_no_credentials(self) -> None:
         """Empty credentials tuple renders 'none stored'."""
         screens, _ = import_screens()


### PR DESCRIPTION
## Summary

- Credential proxy was not reachable after host reboot when reattaching to existing containers — `ensure_proxy_reachable()` was only called during new container creation
- Status display (sickbay + TUI) reported "running" when only the systemd socket was active, even though the service daemon was idle and TCP ports unreachable

## Changes

- **`environment.py`**: New `ensure_credential_proxy()` helper — checks bypass flag, then triggers proxy startup
- **`task_runners.py`**: Call `ensure_credential_proxy()` in all reattach/restart paths: `task_run_cli`, `task_run_toad`, `task_followup_headless`, `task_restart`
- **`sickbay.py`**: Three-state display — running / standby (socket active, service idle) / stopped
- **`screens.py`** (TUI): Same three-state display with yellow "standby" indicator
- **`developer.md`**: New section documenting inetd vs persistent daemon socket activation patterns, TCP-vs-socket rationale

## Companion PR

Requires terok-ai/terok-sandbox#63 (TCP ListenStream + accurate `get_proxy_status()`)

## Test plan

- [ ] `make lint` passes
- [ ] `make test` passes
- [ ] After `terok credentials install` + host reboot, `terok sickbay` shows "standby" (not "running")
- [ ] Starting a task triggers proxy auto-start; `terok sickbay` then shows "running"
- [ ] Reattaching to existing container after reboot works without manual `terok credentials start`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Ensure the credential proxy is prepared/reachable before container start/restart; UI shows a yellow “standby (starts on first connection)” state for socket-activated services.

* **Bug Fixes**
  * Health/status checks now report socket-activated credential proxy as standby instead of erroneously inactive.

* **Documentation**
  * Added "Host-Side Service Activation Patterns" explaining socket-activation modes, status semantics, and rationale.

* **Tests**
  * Added unit tests covering proxy readiness and health-check outcomes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->