### PR TITLE
docs: update claude ACP adapter name in compat matrix

### DIFF
--- a/docs/agent-compat-matrix.md
+++ b/docs/agent-compat-matrix.md
@@ -14,7 +14,7 @@ local LLM via OpenCode; Tier-3: Copilot.
 
 | Agent | CLI flag | Env var | Config file | ACP adapter | terok uses (per-task) |
 |-------|----------|---------|-------------|-------------|----------------------|
-| Claude | `--dangerously-skip-permissions` | — | `permissions.defaultMode: bypassPermissions` in settings.json | `claude-code-acp` (npm) | `/etc/claude-code/managed-settings.json` |
+| Claude | `--dangerously-skip-permissions` | — | `permissions.defaultMode: bypassPermissions` in settings.json | `claude-agent-acp` (npm) | `/etc/claude-code/managed-settings.json` |
 | Vibe | `--agent auto-approve` | `VIBE_AUTO_APPROVE=true` | `auto_approve = true` in TOML | `vibe-acp` (bundled) | `VIBE_AUTO_APPROVE` env var |
 | Blablador | (inherits OpenCode) | `OPENCODE_PERMISSION='{"*":"allow"}'` | `"permission": {"*":"allow"}` in opencode.json | needs wrapper (#410) | `OPENCODE_PERMISSION` env var |
 | OpenCode | — | `OPENCODE_PERMISSION='{"*":"allow"}'` | `"permission": {"*":"allow"}` in opencode.json | `opencode acp` (native) | `OPENCODE_PERMISSION` env var |


### PR DESCRIPTION
## Summary
- Reflects the package rename from `@zed-industries/claude-code-acp` to `@agentclientprotocol/claude-agent-acp` in the agent compatibility matrix
- Companion to terok-ai/terok-agent#81 which updates the actual install and wrapper scripts

## Test plan
- [ ] Doc-only change, no runtime impact

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the compatibility matrix to reflect the current AI adapter configuration for Claude in unrestricted mode.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->