### PR TITLE
feat: skip env var injection for Claude OAuth subscription mode

### DIFF
--- a/docs/shared-dirs.md
+++ b/docs/shared-dirs.md
@@ -74,6 +74,37 @@ ssh:
 
 Supported tokens: `{{IDENTITY_FILE}}`, `{{KEY_NAME}}`, `{{PROJECT_ID}}`
 
+## Credential Proxy
+
+The credential proxy holds real API keys and OAuth tokens on the host
+and injects **phantom tokens** into containers.  When a container makes
+an API call, the proxy intercepts the phantom token and swaps it for the
+real credential — the actual secret never enters any container.
+
+### Per-task vs shared tokens
+
+| Auth method | Token scope | Notes |
+|-------------|------------|-------|
+| API key (all providers) | Per-task | Each task gets a unique phantom token that is revoked when the task ends. |
+| OAuth (Codex, etc.) | Per-task | Same per-task lifecycle as API keys. |
+| **Claude OAuth** | **Shared** | Uses a static marker token in `.credentials.json` instead of a per-task phantom. All tasks share the same lookup key. |
+
+Claude OAuth is shared because Claude Code determines the subscription
+plan display ("Claude Max", "Claude Pro", etc.) by reading `accessToken`
+from `~/.claude/.credentials.json`.  If the token comes from the
+`CLAUDE_CODE_OAUTH_TOKEN` environment variable instead, Claude Code
+always shows "Claude API" regardless of subscription metadata.  The
+static marker in the file works around this limitation.
+
+**Implications of shared Claude OAuth:**
+
+- The credential applies to **all tasks** in the default credential set
+  — you cannot have per-project or per-task Claude OAuth credentials.
+- The static marker token is not revoked between tasks.  The real OAuth
+  token is still protected by the proxy and refreshed automatically.
+- API key auth for Claude (`terok auth claude` → option 2) remains
+  per-task and is unaffected.
+
 ## Git Identity
 
 terok configures git author/committer identities to distinguish AI-generated commits. The mapping is controlled by `git.authorship` in `project.yml` or global `config.yml`:

--- a/poetry.lock
+++ b/poetry.lock
@@ -2757,13 +2757,14 @@ tomli-w = ">=1.0,<2.0"
 
 [[package]]
 name = "terok-agent"
-version = "0.0.27"
+version = "0.0.28"
 description = "Single-agent task runner for hardened Podman containers"
 optional = false
 python-versions = ">=3.12,<4.0"
 groups = ["main"]
-files = []
-develop = false
+files = [
+    {file = "terok_agent-0.0.28-py3-none-any.whl", hash = "sha256:753dcff5fcd135632b23d885c3634423d5c00a69ce2b3dd3ca6304a55997d6f4"},
+]
 
 [package.dependencies]
 Jinja2 = ">=3.1"
@@ -2772,10 +2773,8 @@ terok-sandbox = {git = "https://github.com/sliwowitz/terok-sandbox.git", rev = "
 tomli-w = ">=1.0"
 
 [package.source]
-type = "git"
-url = "https://github.com/sliwowitz/terok-agent.git"
-reference = "b7d12312e34e4a04eed9ca84ae587746e3dc449b"
-resolved_reference = "b7d12312e34e4a04eed9ca84ae587746e3dc449b"
+type = "url"
+url = "https://github.com/terok-ai/terok-agent/releases/download/v0.0.28/terok_agent-0.0.28-py3-none-any.whl"
 
 [[package]]
 name = "terok-sandbox"
@@ -3286,4 +3285,4 @@ propcache = ">=0.2.1"
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.12,<4.0"
-content-hash = "37c971c2cf8541475a654e8cbe70e0a0ce31e6c712197c7baa2b54d47b6c300f"
+content-hash = "a39448e24e41bef6aa138f375fb21c7f0ba14c531f8b5d5cf2af9ee0697ac9ee"

--- a/poetry.lock
+++ b/poetry.lock
@@ -2762,19 +2762,20 @@ description = "Single-agent task runner for hardened Podman containers"
 optional = false
 python-versions = ">=3.12,<4.0"
 groups = ["main"]
-files = [
-    {file = "terok_agent-0.0.27-py3-none-any.whl", hash = "sha256:d1c5f0a45067ae9d6f0850614e700640bbf9366d08417d5f19040faa4d5ad301"},
-]
+files = []
+develop = false
 
 [package.dependencies]
 Jinja2 = ">=3.1"
 "ruamel.yaml" = ">=0.18"
-terok_sandbox = {url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.0.23/terok_sandbox-0.0.23-py3-none-any.whl"}
+terok-sandbox = {git = "https://github.com/sliwowitz/terok-sandbox.git", rev = "20533d29b1b699c6aa04e3dd1046a390049d60da"}
 tomli-w = ">=1.0"
 
 [package.source]
-type = "url"
-url = "https://github.com/terok-ai/terok-agent/releases/download/v0.0.27/terok_agent-0.0.27-py3-none-any.whl"
+type = "git"
+url = "https://github.com/sliwowitz/terok-agent.git"
+reference = "bc6de0330efb35e72e879ef79086424280590131"
+resolved_reference = "bc6de0330efb35e72e879ef79086424280590131"
 
 [[package]]
 name = "terok-sandbox"
@@ -2783,19 +2784,20 @@ description = "Hardened Podman container runner with gate server and shield inte
 optional = false
 python-versions = ">=3.12,<4.0"
 groups = ["main"]
-files = [
-    {file = "terok_sandbox-0.0.23-py3-none-any.whl", hash = "sha256:144aeb72518b476bf05b5c9b8abfce881351b4f85d64643d0483450307ce3e19"},
-]
+files = []
+develop = false
 
 [package.dependencies]
 aiohttp = ">=3.9"
 cryptography = ">=43.0"
 platformdirs = ">=4.0"
-terok_shield = {url = "https://github.com/terok-ai/terok-shield/releases/download/v0.5.3/terok_shield-0.5.3-py3-none-any.whl"}
+terok-shield = {url = "https://github.com/terok-ai/terok-shield/releases/download/v0.5.3/terok_shield-0.5.3-py3-none-any.whl"}
 
 [package.source]
-type = "url"
-url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.0.23/terok_sandbox-0.0.23-py3-none-any.whl"
+type = "git"
+url = "https://github.com/sliwowitz/terok-sandbox.git"
+reference = "20533d29b1b699c6aa04e3dd1046a390049d60da"
+resolved_reference = "20533d29b1b699c6aa04e3dd1046a390049d60da"
 
 [[package]]
 name = "terok-shield"
@@ -3284,4 +3286,4 @@ propcache = ">=0.2.1"
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.12,<4.0"
-content-hash = "24c231ddfdb8e911cf6ee657dacc328123e813f1d346730aec8cea08a8712d64"
+content-hash = "e65d7615526e6b2033f11a3b88a1f69d34112b8fddd766a00dbd6105fac0ccbb"

--- a/poetry.lock
+++ b/poetry.lock
@@ -2774,8 +2774,8 @@ tomli-w = ">=1.0"
 [package.source]
 type = "git"
 url = "https://github.com/sliwowitz/terok-agent.git"
-reference = "468e1d0c0563b2f0f28febfe046bd1a193e032a2"
-resolved_reference = "468e1d0c0563b2f0f28febfe046bd1a193e032a2"
+reference = "b7d12312e34e4a04eed9ca84ae587746e3dc449b"
+resolved_reference = "b7d12312e34e4a04eed9ca84ae587746e3dc449b"
 
 [[package]]
 name = "terok-sandbox"
@@ -3286,4 +3286,4 @@ propcache = ">=0.2.1"
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.12,<4.0"
-content-hash = "9c88388a545c209e91ade159345a16faeb8d916f258aa68c74a47084d6ff5237"
+content-hash = "37c971c2cf8541475a654e8cbe70e0a0ce31e6c712197c7baa2b54d47b6c300f"

--- a/poetry.lock
+++ b/poetry.lock
@@ -2774,8 +2774,8 @@ tomli-w = ">=1.0"
 [package.source]
 type = "git"
 url = "https://github.com/sliwowitz/terok-agent.git"
-reference = "bc6de0330efb35e72e879ef79086424280590131"
-resolved_reference = "bc6de0330efb35e72e879ef79086424280590131"
+reference = "468e1d0c0563b2f0f28febfe046bd1a193e032a2"
+resolved_reference = "468e1d0c0563b2f0f28febfe046bd1a193e032a2"
 
 [[package]]
 name = "terok-sandbox"
@@ -3286,4 +3286,4 @@ propcache = ">=0.2.1"
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.12,<4.0"
-content-hash = "e65d7615526e6b2033f11a3b88a1f69d34112b8fddd766a00dbd6105fac0ccbb"
+content-hash = "9c88388a545c209e91ade159345a16faeb8d916f258aa68c74a47084d6ff5237"

--- a/poetry.lock
+++ b/poetry.lock
@@ -2757,46 +2757,45 @@ tomli-w = ">=1.0,<2.0"
 
 [[package]]
 name = "terok-agent"
-version = "0.0.28"
+version = "0.0.29"
 description = "Single-agent task runner for hardened Podman containers"
 optional = false
 python-versions = ">=3.12,<4.0"
 groups = ["main"]
 files = [
-    {file = "terok_agent-0.0.28-py3-none-any.whl", hash = "sha256:753dcff5fcd135632b23d885c3634423d5c00a69ce2b3dd3ca6304a55997d6f4"},
+    {file = "terok_agent-0.0.29-py3-none-any.whl", hash = "sha256:8d17cc040cd9ce72fe0ca57bfdb0796b28930509d9c320f790b9397f7ce602ca"},
 ]
 
 [package.dependencies]
 Jinja2 = ">=3.1"
 "ruamel.yaml" = ">=0.18"
-terok-sandbox = {git = "https://github.com/sliwowitz/terok-sandbox.git", rev = "20533d29b1b699c6aa04e3dd1046a390049d60da"}
+terok_sandbox = {url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.0.24/terok_sandbox-0.0.24-py3-none-any.whl"}
 tomli-w = ">=1.0"
 
 [package.source]
 type = "url"
-url = "https://github.com/terok-ai/terok-agent/releases/download/v0.0.28/terok_agent-0.0.28-py3-none-any.whl"
+url = "https://github.com/terok-ai/terok-agent/releases/download/v0.0.29/terok_agent-0.0.29-py3-none-any.whl"
 
 [[package]]
 name = "terok-sandbox"
-version = "0.0.23"
+version = "0.0.24"
 description = "Hardened Podman container runner with gate server and shield integration"
 optional = false
 python-versions = ">=3.12,<4.0"
 groups = ["main"]
-files = []
-develop = false
+files = [
+    {file = "terok_sandbox-0.0.24-py3-none-any.whl", hash = "sha256:1910e07f6f2c19ae4761003e680dce840add47a459c1177f0d1a9c452f30236b"},
+]
 
 [package.dependencies]
 aiohttp = ">=3.9"
 cryptography = ">=43.0"
 platformdirs = ">=4.0"
-terok-shield = {url = "https://github.com/terok-ai/terok-shield/releases/download/v0.5.3/terok_shield-0.5.3-py3-none-any.whl"}
+terok_shield = {url = "https://github.com/terok-ai/terok-shield/releases/download/v0.5.3/terok_shield-0.5.3-py3-none-any.whl"}
 
 [package.source]
-type = "git"
-url = "https://github.com/sliwowitz/terok-sandbox.git"
-reference = "20533d29b1b699c6aa04e3dd1046a390049d60da"
-resolved_reference = "20533d29b1b699c6aa04e3dd1046a390049d60da"
+type = "url"
+url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.0.24/terok_sandbox-0.0.24-py3-none-any.whl"
 
 [[package]]
 name = "terok-shield"
@@ -3285,4 +3284,4 @@ propcache = ">=0.2.1"
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.12,<4.0"
-content-hash = "a39448e24e41bef6aa138f375fb21c7f0ba14c531f8b5d5cf2af9ee0697ac9ee"
+content-hash = "fab733e193d07c8c5db8c06711f315ff9dd1ff667382c3bfc835e8b66d60b319"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,8 +44,8 @@ rich = ">=13.0"
 platformdirs = ">=4.5.1"
 unique-namer = ">=1.3"
 textual-serve = ">=1.1.0"
-terok-agent = {url = "https://github.com/terok-ai/terok-agent/releases/download/v0.0.27/terok_agent-0.0.27-py3-none-any.whl"}
-terok-sandbox = {url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.0.23/terok_sandbox-0.0.23-py3-none-any.whl"}
+terok-agent = {git = "https://github.com/sliwowitz/terok-agent.git", rev = "bc6de0330efb35e72e879ef79086424280590131"}
+terok-sandbox = {git = "https://github.com/sliwowitz/terok-sandbox.git", rev = "20533d29b1b699c6aa04e3dd1046a390049d60da"}
 
 [tool.poetry.group.dev.dependencies]
 pydevd-pycharm = "261.22158.340"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ rich = ">=13.0"
 platformdirs = ">=4.5.1"
 unique-namer = ">=1.3"
 textual-serve = ">=1.1.0"
-terok-agent = {git = "https://github.com/sliwowitz/terok-agent.git", rev = "468e1d0c0563b2f0f28febfe046bd1a193e032a2"}
+terok-agent = {git = "https://github.com/sliwowitz/terok-agent.git", rev = "b7d12312e34e4a04eed9ca84ae587746e3dc449b"}
 terok-sandbox = {git = "https://github.com/sliwowitz/terok-sandbox.git", rev = "20533d29b1b699c6aa04e3dd1046a390049d60da"}
 
 [tool.poetry.group.dev.dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ rich = ">=13.0"
 platformdirs = ">=4.5.1"
 unique-namer = ">=1.3"
 textual-serve = ">=1.1.0"
-terok-agent = {git = "https://github.com/sliwowitz/terok-agent.git", rev = "b7d12312e34e4a04eed9ca84ae587746e3dc449b"}
+terok-agent = {url = "https://github.com/terok-ai/terok-agent/releases/download/v0.0.28/terok_agent-0.0.28-py3-none-any.whl"}
 terok-sandbox = {git = "https://github.com/sliwowitz/terok-sandbox.git", rev = "20533d29b1b699c6aa04e3dd1046a390049d60da"}
 
 [tool.poetry.group.dev.dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ rich = ">=13.0"
 platformdirs = ">=4.5.1"
 unique-namer = ">=1.3"
 textual-serve = ">=1.1.0"
-terok-agent = {git = "https://github.com/sliwowitz/terok-agent.git", rev = "bc6de0330efb35e72e879ef79086424280590131"}
+terok-agent = {git = "https://github.com/sliwowitz/terok-agent.git", rev = "468e1d0c0563b2f0f28febfe046bd1a193e032a2"}
 terok-sandbox = {git = "https://github.com/sliwowitz/terok-sandbox.git", rev = "20533d29b1b699c6aa04e3dd1046a390049d60da"}
 
 [tool.poetry.group.dev.dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,8 +44,8 @@ rich = ">=13.0"
 platformdirs = ">=4.5.1"
 unique-namer = ">=1.3"
 textual-serve = ">=1.1.0"
-terok-agent = {url = "https://github.com/terok-ai/terok-agent/releases/download/v0.0.28/terok_agent-0.0.28-py3-none-any.whl"}
-terok-sandbox = {git = "https://github.com/sliwowitz/terok-sandbox.git", rev = "20533d29b1b699c6aa04e3dd1046a390049d60da"}
+terok-agent = {url = "https://github.com/terok-ai/terok-agent/releases/download/v0.0.29/terok_agent-0.0.29-py3-none-any.whl"}
+terok-sandbox = {url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.0.24/terok_sandbox-0.0.24-py3-none-any.whl"}
 
 [tool.poetry.group.dev.dependencies]
 pydevd-pycharm = "261.22158.340"

--- a/src/terok/lib/orchestration/environment.py
+++ b/src/terok/lib/orchestration/environment.py
@@ -304,9 +304,15 @@ def _credential_proxy_env_and_volumes(
         tokens: dict[str, str] = {}
         credential_types: dict[str, str] = {}
         for name in routed:
-            tokens[name] = db.create_proxy_token(project.id, task_id, credential_set, name)
             cred = db.load_credential(credential_set, name)
-            credential_types[name] = _credential_type(cred) if cred else "api_key"
+            ctype = _credential_type(cred) if cred else "api_key"
+            credential_types[name] = ctype
+            # Claude OAuth: the static marker in .credentials.json serves as
+            # the access token — no per-task phantom token needed.  The proxy
+            # accepts that marker directly (see credential_proxy.constants).
+            if name == "claude" and ctype == "oauth":
+                continue
+            tokens[name] = db.create_proxy_token(project.id, task_id, credential_set, name)
 
         # SSH agent: create phantom token if project has at least one valid key registered
         ssh_keys = _load_ssh_keys_json(cfg.ssh_keys_json_path)
@@ -328,10 +334,20 @@ def _credential_proxy_env_and_volumes(
         if name not in routed:
             continue
 
+        is_oauth = credential_types[name] == "oauth"
+
+        # Claude OAuth: don't inject CLAUDE_CODE_OAUTH_TOKEN or ANTHROPIC_UNIX_SOCKET.
+        # Claude Code shows "Claude API" when the token source is the env var;
+        # subscription mode requires the token to come from .credentials.json.
+        # The static marker in that file is accepted by the proxy directly.
+        if name == "claude" and is_oauth:
+            if route.base_url_env:
+                env[route.base_url_env] = proxy_base
+            continue
+
         # Auth dimension: select phantom env vars by credential type.
         # Providers with oauth_phantom_env get OAuth-specific env vars;
         # others fall back to phantom_env (same env var for both auth types).
-        is_oauth = credential_types[name] == "oauth"
         token_vars = (
             route.oauth_phantom_env if (is_oauth and route.oauth_phantom_env) else route.phantom_env
         )
@@ -339,9 +355,6 @@ def _credential_proxy_env_and_volumes(
             env[env_var] = tokens[name]
 
         # Transport dimension: socket flag + HTTP base URL.
-        # ANTHROPIC_UNIX_SOCKET is a subscription-mode flag for Claude Code
-        # (its UD() function checks it), but actual HTTP traffic still routes
-        # through ANTHROPIC_BASE_URL — the SDK only uses unix sockets on Bun.
         if use_socket and route.socket_path and route.socket_env:
             env[route.socket_env] = route.socket_path
         if route.base_url_env:

--- a/tests/unit/lib/test_credential_proxy_env.py
+++ b/tests/unit/lib/test_credential_proxy_env.py
@@ -134,8 +134,8 @@ class TestCredentialProxyEnv:
         assert "ANTHROPIC_API_KEY" not in env
 
     @pytest.mark.usefixtures("_enable_proxy")
-    def test_oauth_direct_transport(self, tmp_path: Path) -> None:
-        """OAuth credential with direct transport → CLAUDE_CODE_OAUTH_TOKEN + ANTHROPIC_BASE_URL."""
+    def test_claude_oauth_only_base_url(self, tmp_path: Path) -> None:
+        """Claude OAuth → only ANTHROPIC_BASE_URL (no token env vars, no socket flag)."""
         from terok_sandbox import CredentialDB
 
         from terok.lib.orchestration.environment import _credential_proxy_env_and_volumes
@@ -165,22 +165,24 @@ class TestCredentialProxyEnv:
 
             env, _ = _credential_proxy_env_and_volumes(project, "task-1")
 
-        assert "CLAUDE_CODE_OAUTH_TOKEN" in env
-        assert len(env["CLAUDE_CODE_OAUTH_TOKEN"]) == 32
-        assert "ANTHROPIC_BASE_URL" in env
+        # Claude OAuth uses the static marker in .credentials.json — no env var token
+        assert "CLAUDE_CODE_OAUTH_TOKEN" not in env
         assert "ANTHROPIC_API_KEY" not in env
         assert "ANTHROPIC_UNIX_SOCKET" not in env
+        # Only base URL for HTTP routing to the proxy
+        assert "ANTHROPIC_BASE_URL" in env
+        assert "host.containers.internal:18731" in env["ANTHROPIC_BASE_URL"]
 
     @pytest.mark.usefixtures("_enable_proxy")
-    def test_oauth_without_roster_support_falls_back(self, tmp_path: Path) -> None:
-        """OAuth credential + empty oauth_phantom_env silently uses phantom_env."""
+    def test_non_claude_oauth_still_uses_phantom_env(self, tmp_path: Path) -> None:
+        """Non-Claude OAuth provider still gets phantom token env vars."""
         from terok_sandbox import CredentialDB
 
         from terok.lib.orchestration.environment import _credential_proxy_env_and_volumes
 
         db_path = tmp_path / "proxy" / "credentials.db"
         db = CredentialDB(db_path)
-        db.store_credential("default", "claude", {"type": "oauth", "access_token": "tok"})
+        db.store_credential("default", "codex", {"type": "oauth", "access_token": "tok"})
         db.close()
 
         sock_path = tmp_path / "proxy.sock"
@@ -188,25 +190,11 @@ class TestCredentialProxyEnv:
         project = MagicMock()
         project.id = "test-project"
 
-        # Build a stripped roster where Claude has no oauth_phantom_env (old agent)
-        from terok_agent import get_roster
-
-        real_roster = get_roster()
-        real_routes = real_roster.proxy_routes
-        real_claude = real_routes["claude"]
-        stripped_route = MagicMock(wraps=real_claude)
-        stripped_route.oauth_phantom_env = {}
-        stripped_route.phantom_env = real_claude.phantom_env
-        stripped_route.base_url_env = real_claude.base_url_env
-        fake_routes = {**real_routes, "claude": stripped_route}
-        fake_roster = MagicMock(wraps=real_roster, proxy_routes=fake_routes)
-
         with (
             patch("terok_sandbox.credential_proxy_lifecycle.is_daemon_running", return_value=True),
             patch("terok_sandbox.ensure_proxy_reachable"),
             patch("terok.lib.orchestration.environment.make_sandbox_config") as mock_cfg_fn,
             patch("terok.lib.core.config.get_credential_proxy_transport", return_value="direct"),
-            patch("terok_agent.get_roster", return_value=fake_roster),
         ):
             mock_cfg = mock_cfg_fn.return_value
             mock_cfg.proxy_db_path = db_path
@@ -216,14 +204,13 @@ class TestCredentialProxyEnv:
 
             env, _ = _credential_proxy_env_and_volumes(project, "task-1")
 
-        # Falls back to API-key env var silently (valid path for providers
-        # that use the same env var for both auth types)
-        assert "ANTHROPIC_API_KEY" in env
-        assert "CLAUDE_CODE_OAUTH_TOKEN" not in env
+        # Codex OAuth still gets phantom token env var (static marker is Claude-only)
+        assert "OPENAI_API_KEY" in env
+        assert len(env["OPENAI_API_KEY"]) == 32
 
     @pytest.mark.usefixtures("_enable_proxy")
-    def test_oauth_socket_transport(self, tmp_path: Path) -> None:
-        """OAuth + socket → CLAUDE_CODE_OAUTH_TOKEN + ANTHROPIC_UNIX_SOCKET + ANTHROPIC_BASE_URL."""
+    def test_claude_oauth_socket_transport_still_only_base_url(self, tmp_path: Path) -> None:
+        """Claude OAuth + socket transport → still only ANTHROPIC_BASE_URL (no socket flag)."""
         from terok_sandbox import CredentialDB
 
         from terok.lib.orchestration.environment import _credential_proxy_env_and_volumes
@@ -253,11 +240,10 @@ class TestCredentialProxyEnv:
 
             env, _ = _credential_proxy_env_and_volumes(project, "task-1")
 
-        assert "CLAUDE_CODE_OAUTH_TOKEN" in env
-        assert len(env["CLAUDE_CODE_OAUTH_TOKEN"]) == 32
-        assert env["ANTHROPIC_UNIX_SOCKET"] == "/tmp/terok-claude-proxy.sock"
+        # Claude OAuth bypasses socket/token env vars even with socket transport
+        assert "CLAUDE_CODE_OAUTH_TOKEN" not in env
+        assert "ANTHROPIC_UNIX_SOCKET" not in env
         assert "ANTHROPIC_API_KEY" not in env
-        # Socket flag AND base URL — SDK needs base URL for HTTP, socket is a mode flag
         assert "ANTHROPIC_BASE_URL" in env
 
     @pytest.mark.usefixtures("_enable_proxy")


### PR DESCRIPTION
## Summary

- Skip `CLAUDE_CODE_OAUTH_TOKEN` and `ANTHROPIC_UNIX_SOCKET` env var injection for Claude OAuth setups
- Only inject `ANTHROPIC_BASE_URL` for HTTP routing to the credential proxy
- Skip per-task phantom token creation for Claude OAuth (static marker in `.credentials.json` handles auth)

## Context

Claude Code's JS binary shows "Claude API" when `CLAUDE_CODE_OAUTH_TOKEN` env var is the detected token source, regardless of `.credentials.json` subscription metadata. For subscription display ("Claude Max", etc.) to work, the token must come from the credentials file.

The static `PHANTOM_CREDENTIALS_MARKER` written to `.credentials.json` at auth time serves as the access token. The credential proxy (terok-ai/terok-sandbox#65) accepts this marker and swaps it for the real OAuth token. No per-task phantom token or socket flag needed.

Claude API-key setups and all other providers are unchanged.

**Depends on:**
- terok-ai/terok-sandbox#65 (static marker acceptance)
- terok-ai/terok-agent#82 (`.credentials.json` injection + constant import)

Dependencies are pinned to branch commit hashes for cross-package testing.

## Test plan

- [x] All 1369 unit tests pass
- [x] Ruff lint/format clean
- [ ] Manual: `terok auth claude` (OAuth) → container shows "Claude Max" in status
- [ ] Manual: Claude Code `/usage` works
- [ ] Manual: Claude API-key auth still works as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Dependencies**
  * Bumped two packaged dependencies to newer released wheel versions.

* **Bug Fixes**
  * OAuth handling updated so a specific provider no longer receives phantom token environment variables while its base URL routing remains intact.

* **Tests**
  * Updated unit tests to reflect revised OAuth environment-variable and transport expectations.

* **Documentation**
  * Added Credential Proxy docs clarifying per-task vs shared token behaviors and implications for OAuth.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->