### PR TITLE
fix: sickbay false positives — gate config and SSH key list format

### DIFF
--- a/src/terok/cli/commands/sickbay.py
+++ b/src/terok/cli/commands/sickbay.py
@@ -67,10 +67,11 @@ def dispatch(args: argparse.Namespace) -> bool:
 
 def _check_gate_server() -> _CheckResult:
     """Check gate server status."""
-    status = get_server_status()
+    cfg = make_sandbox_config()
+    status = get_server_status(cfg)
     label = "Gate server"
     if status.running:
-        outdated = check_units_outdated()
+        outdated = check_units_outdated(cfg)
         if outdated:
             return ("warn", label, f"{outdated} Run 'terok gate start' to update.")
         return ("ok", label, f"{status.mode}, port {status.port}")
@@ -231,13 +232,17 @@ def _check_ssh_agent() -> _CheckResult:
     if not mapping:
         return ("warn", label, "no projects registered — run 'terok ssh-init <project>'")
 
-    missing = [
-        pid
-        for pid, entry in mapping.items()
-        if not isinstance(entry, dict)
-        or not Path(entry.get("private_key", "")).is_file()
-        or not Path(entry.get("public_key", "")).is_file()
-    ]
+    def _keys_present(entry: object) -> bool:
+        """Check whether all key files in a project entry exist on disk."""
+        keys = entry if isinstance(entry, list) else [entry]
+        return all(
+            isinstance(k, dict)
+            and Path(k.get("private_key", "")).is_file()
+            and Path(k.get("public_key", "")).is_file()
+            for k in keys
+        )
+
+    missing = [pid for pid, entry in mapping.items() if not _keys_present(entry)]
     total = len(mapping)
     if missing:
         names = ", ".join(missing[:3])


### PR DESCRIPTION
## Summary
- **Gate check**: `_check_gate_server()` called `get_server_status()` and `check_units_outdated()` without passing terok's `SandboxConfig`, causing them to compare against sandbox's default `sandbox/gate` path instead of terok's `core/gate`. The base-path divergence warning was a false positive.
- **SSH check**: `_check_ssh_agent()` assumed each `ssh-keys.json` entry was a single dict (`{"private_key": ..., "public_key": ...}`), but the actual format is a list of key dicts per project (supporting multiple deploy keys). Every project failed the `isinstance(entry, dict)` check.

## Test plan
- [x] `pytest tests/unit/cli/test_sickbay.py` — 25 passed
- [x] Full unit suite — 1409 passed
- [ ] Manual: `terok sickbay` no longer shows false gate divergence or false SSH missing keys

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved SSH agent key validation to correctly handle multiple key configurations
  * Enhanced reliability of server status and configuration checks through better sandbox configuration handling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->