### PR TITLE
fix: pass SandboxConfig to gate server sickbay checks

### DIFF
--- a/src/terok/cli/commands/sickbay.py
+++ b/src/terok/cli/commands/sickbay.py
@@ -67,10 +67,11 @@ def dispatch(args: argparse.Namespace) -> bool:
 
 def _check_gate_server() -> _CheckResult:
     """Check gate server status."""
-    status = get_server_status()
+    cfg = make_sandbox_config()
+    status = get_server_status(cfg)
     label = "Gate server"
     if status.running:
-        outdated = check_units_outdated()
+        outdated = check_units_outdated(cfg)
         if outdated:
             return ("warn", label, f"{outdated} Run 'terok gate start' to update.")
         return ("ok", label, f"{status.mode}, port {status.port}")


### PR DESCRIPTION
## Summary
- `_check_gate_server()` now creates a `SandboxConfig` and passes it to `get_server_status(cfg)` and `check_units_outdated(cfg)`, matching the config injection pattern introduced in terok-sandbox v0.0.27

## Context
After terok-sandbox v0.0.27, `get_server_status()` and `check_units_outdated()` accept an optional `cfg` parameter. Without it they fall back to defaults, but explicit injection is the intended pattern (consistent with all other sandbox API calls in sickbay).

## Test plan
- [x] `tests/unit/cli/test_cli_sickbay.py` — all 16 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved server status checking consistency and reliability by standardizing configuration handling across related operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->