### PR TITLE
deps: synchronize transitive conduit — sandbox 0.0.29, agent 0.0.34

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -2757,34 +2757,34 @@ tomli-w = ">=1.0,<2.0"
 
 [[package]]
 name = "terok-agent"
-version = "0.0.33"
+version = "0.0.34"
 description = "Single-agent task runner for hardened Podman containers"
 optional = false
 python-versions = ">=3.12,<4.0"
 groups = ["main"]
 files = [
-    {file = "terok_agent-0.0.33-py3-none-any.whl", hash = "sha256:4cead2d30934f956375e986964ef6df95a1d7560ff9366561a09ca09c812b966"},
+    {file = "terok_agent-0.0.34-py3-none-any.whl", hash = "sha256:606051c986fd2e44992766ccc1b22114b8d951fc24fb5587eda234fab5a89c2f"},
 ]
 
 [package.dependencies]
 Jinja2 = ">=3.1"
 "ruamel.yaml" = ">=0.18"
-terok_sandbox = {url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.0.28/terok_sandbox-0.0.28-py3-none-any.whl"}
+terok_sandbox = {url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.0.29/terok_sandbox-0.0.29-py3-none-any.whl"}
 tomli-w = ">=1.0"
 
 [package.source]
 type = "url"
-url = "https://github.com/terok-ai/terok-agent/releases/download/v0.0.33/terok_agent-0.0.33-py3-none-any.whl"
+url = "https://github.com/terok-ai/terok-agent/releases/download/v0.0.34/terok_agent-0.0.34-py3-none-any.whl"
 
 [[package]]
 name = "terok-sandbox"
-version = "0.0.28"
+version = "0.0.29"
 description = "Hardened Podman container runner with gate server and shield integration"
 optional = false
 python-versions = ">=3.12,<4.0"
 groups = ["main"]
 files = [
-    {file = "terok_sandbox-0.0.28-py3-none-any.whl", hash = "sha256:5f003b9f36434495d31f369172337ef11ceee1ab8b954114e354c1f87bcf78f3"},
+    {file = "terok_sandbox-0.0.29-py3-none-any.whl", hash = "sha256:827a28e79a58c39f78a99daba19054b8d3aabcb2a96f1ae7d8e24ddee0506c48"},
 ]
 
 [package.dependencies]
@@ -2795,7 +2795,7 @@ terok_shield = {url = "https://github.com/terok-ai/terok-shield/releases/downloa
 
 [package.source]
 type = "url"
-url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.0.28/terok_sandbox-0.0.28-py3-none-any.whl"
+url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.0.29/terok_sandbox-0.0.29-py3-none-any.whl"
 
 [[package]]
 name = "terok-shield"
@@ -3284,4 +3284,4 @@ propcache = ">=0.2.1"
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.12,<4.0"
-content-hash = "a88dbdcb776a66e91f710db21fb58d90f90a8a845dae673b2c918e0851a0ec54"
+content-hash = "13d883bc4fcbcc5702149adee42e8958e19ff8265f944792ce40a2fdb474970f"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,8 +44,8 @@ rich = ">=13.0"
 platformdirs = ">=4.5.1"
 unique-namer = ">=1.3"
 textual-serve = ">=1.1.0"
-terok-agent = {url = "https://github.com/terok-ai/terok-agent/releases/download/v0.0.33/terok_agent-0.0.33-py3-none-any.whl"}
-terok-sandbox = {url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.0.28/terok_sandbox-0.0.28-py3-none-any.whl"}
+terok-agent = {url = "https://github.com/terok-ai/terok-agent/releases/download/v0.0.34/terok_agent-0.0.34-py3-none-any.whl"}
+terok-sandbox = {url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.0.29/terok_sandbox-0.0.29-py3-none-any.whl"}
 
 [tool.poetry.group.dev.dependencies]
 pydevd-pycharm = "261.22158.340"

--- a/tests/unit/lib/test_gate_server.py
+++ b/tests/unit/lib/test_gate_server.py
@@ -140,7 +140,7 @@ class TestUnitVersion:
     """Tests for _UNIT_VERSION."""
 
     def test_unit_version_is_current(self) -> None:
-        assert _UNIT_VERSION == 4
+        assert _UNIT_VERSION == 5
 
 
 class TestSystemdDetection:


### PR DESCRIPTION
## Summary

- Upgrade terok-sandbox from 0.0.28 to 0.0.29 (gate service stdio fix, terok-ai/terok-sandbox#72)
- Upgrade terok-agent from 0.0.33 to 0.0.34 (relays sandbox 0.0.29, terok-ai/terok-agent#92)
- Update gate unit version assertion (4 → 5)

## Test plan

- [x] All 1431 unit tests pass
- [ ] `terok-sandbox gate start` reinstalls units, `terok task start` clones via gate successfully


🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated core dependencies to latest versions for improved reliability and performance.

* **Tests**
  * Updated internal version validation tests to align with current system baseline.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->