### PR TITLE
fix: add keyring warning with proper TOML format in run-matrix.sh

### DIFF
--- a/docs/kernel-keyring.md
+++ b/docs/kernel-keyring.md
@@ -23,13 +23,13 @@ Linux defaults to **200 keys** and **20 000 bytes** per non-root user
 (`/proc/sys/kernel/keys/maxkeys` and `maxbytes`).  A busy terok host that
 cycles many agent containers will hit this limit.
 
-## Why disabling is safe
+## Impact on terok containers
 
-The per-container kernel keyring is used by subsystems that terok containers
-never touch:
+The per-container kernel keyring is used by subsystems that terok agent
+containers never touch:
 
-| Subsystem | Used by agents? |
-|-----------|-----------------|
+| Subsystem | Used by terok agents? |
+|-----------|----------------------|
 | Kerberos ticket cache | No |
 | dm-crypt / LUKS | No |
 | eCryptfs | No |
@@ -41,21 +41,25 @@ Kernel keyrings are also
 they are separated by UID only, not by container.  Rootless user namespaces
 and seccomp (both active in terok) provide the real isolation.
 
-## Fix
+Disabling keyring creation has no effect on terok's functionality.
 
-Add `keyring = false` to your `containers.conf`:
+## Workaround
 
-```bash
-mkdir -p ~/.config/containers
-cat >> ~/.config/containers/containers.conf << 'EOF'
+Podman does not support disabling keyring creation per container — the
+setting is global in `containers.conf`.  This means the workaround
+affects **all** containers on the host, not just terok's.  If you run
+other workloads that depend on kernel keyrings (Kerberos, dm-crypt, etc.),
+evaluate the trade-off before applying.
 
+Set `keyring = false` in the `[containers]` section of
+`~/.config/containers/containers.conf` (create the file if it does not
+exist).  This tells `crun` to skip the
+`keyctl(KEYCTL_JOIN_SESSION_KEYRING)` call entirely, eliminating the leak:
+
+```toml
 [containers]
 keyring = false
-EOF
 ```
-
-This tells `crun` to skip the `keyctl(KEYCTL_JOIN_SESSION_KEYRING)` call
-entirely, eliminating the leak.
 
 !!! tip "Sickbay detection"
     `terokctl sickbay` warns when keyring creation is not disabled.

--- a/tests/containers/run-matrix.sh
+++ b/tests/containers/run-matrix.sh
@@ -83,6 +83,33 @@ usage() {
     return 0
 }
 
+warn_keyring() {
+    # Warn when the host's containers.conf does not disable kernel keyrings.
+    # Matrix runs cycle many containers and can exhaust the per-user 200-key
+    # quota, causing misleading "Disk quota exceeded" (EDQUOT) from crun.
+    local conf="${CONTAINERS_CONF:-}"
+    if [[ -z "$conf" ]]; then
+        for candidate in "$HOME/.config/containers/containers.conf" \
+                         /etc/containers/containers.conf; do
+            [[ -f "$candidate" ]] && conf="$candidate" && break
+        done
+    fi
+    if [[ -z "$conf" ]] || ! grep -qE '^\s*keyring\s*=\s*false' "$conf" 2>/dev/null; then
+        echo -e "${C_YELLOW}WARNING: kernel keyring is not disabled in containers.conf"
+        echo -e ""
+        echo -e "  Matrix tests create many containers and may exhaust the per-user"
+        echo -e "  keyring quota (200 keys), causing spurious EDQUOT errors."
+        echo -e ""
+        echo -e "  Add to ${C_BOLD}~/.config/containers/containers.conf${C_YELLOW}:"
+        echo -e ""
+        echo -e "    ${C_BOLD}[containers]${C_YELLOW}"
+        echo -e "    ${C_BOLD}keyring = false${C_YELLOW}"
+        echo -e ""
+        echo -e "  See: https://terok-ai.github.io/terok/kernel-keyring/${C_RESET}"
+        echo ""
+    fi
+}
+
 build_image() {
     local name="$1"
     local file="$SCRIPT_DIR/Containerfile.${DISTROS[$name]}"
@@ -237,6 +264,8 @@ for target in "${TARGETS[@]}"; do
         exit 1
     fi
 done
+
+warn_keyring
 
 for target in "${TARGETS[@]}"; do
     build_image "$target"


### PR DESCRIPTION
## Summary

- Add `warn_keyring()` pre-flight check to `run-matrix.sh`
- Show the TOML fix as a proper multi-line block instead of the ambiguous single-line `[containers] keyring = false` which users might paste literally

Companion PRs across all repos with the same change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added an automatic configuration validation for matrix test runs. A warning is shown early if kernel keyring creation isn't disabled in the host containers configuration, giving visibility before any test images are built.

* **Documentation**
  * Updated guidance about kernel keyring: clarifies its impact on the targeted containers, explains the global scope of the setting, presents a concise config example and a clear workaround, and states that disabling keyring does not affect container functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->