### PR TITLE
deps: synchronize transitive conduit — sandbox 0.0.32, agent 0.0.37

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -2757,55 +2757,55 @@ tomli-w = ">=1.0,<2.0"
 
 [[package]]
 name = "terok-agent"
-version = "0.0.36"
+version = "0.0.37"
 description = "Single-agent task runner for hardened Podman containers"
 optional = false
 python-versions = ">=3.12,<4.0"
 groups = ["main"]
 files = [
-    {file = "terok_agent-0.0.36-py3-none-any.whl", hash = "sha256:f26d2a8183f47c6493cdcfe80e2acade94b2a80240d3a24131c2748b38683c7c"},
+    {file = "terok_agent-0.0.37-py3-none-any.whl", hash = "sha256:7c1317cd0a39ba827a24884a65da50af6ea3288cd8b3302a987ab24442bbd8b9"},
 ]
 
 [package.dependencies]
 Jinja2 = ">=3.1"
 "ruamel.yaml" = ">=0.18"
-terok_sandbox = {url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.0.31/terok_sandbox-0.0.31-py3-none-any.whl"}
+terok_sandbox = {url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.0.32/terok_sandbox-0.0.32-py3-none-any.whl"}
 tomli-w = ">=1.0"
 
 [package.source]
 type = "url"
-url = "https://github.com/terok-ai/terok-agent/releases/download/v0.0.36/terok_agent-0.0.36-py3-none-any.whl"
+url = "https://github.com/terok-ai/terok-agent/releases/download/v0.0.37/terok_agent-0.0.37-py3-none-any.whl"
 
 [[package]]
 name = "terok-sandbox"
-version = "0.0.31"
+version = "0.0.32"
 description = "Hardened Podman container runner with gate server and shield integration"
 optional = false
 python-versions = ">=3.12,<4.0"
 groups = ["main"]
 files = [
-    {file = "terok_sandbox-0.0.31-py3-none-any.whl", hash = "sha256:34cf61842928530abec330fc7049609245050d515abf094e3387b3bb5d8094b7"},
+    {file = "terok_sandbox-0.0.32-py3-none-any.whl", hash = "sha256:42710e63737092efad3e7c084fe2b0e9e432690a035a9c927070e273a0680631"},
 ]
 
 [package.dependencies]
 aiohttp = ">=3.9"
 cryptography = ">=43.0"
 platformdirs = ">=4.0"
-terok_shield = {url = "https://github.com/terok-ai/terok-shield/releases/download/v0.6.0/terok_shield-0.6.0-py3-none-any.whl"}
+terok_shield = {url = "https://github.com/terok-ai/terok-shield/releases/download/v0.6.1/terok_shield-0.6.1-py3-none-any.whl"}
 
 [package.source]
 type = "url"
-url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.0.31/terok_sandbox-0.0.31-py3-none-any.whl"
+url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.0.32/terok_sandbox-0.0.32-py3-none-any.whl"
 
 [[package]]
 name = "terok-shield"
-version = "0.6.0"
+version = "0.6.1"
 description = "nftables-based egress firewalling for Podman containers"
 optional = false
 python-versions = ">=3.12,<4.0"
 groups = ["main"]
 files = [
-    {file = "terok_shield-0.6.0-py3-none-any.whl", hash = "sha256:5db279f029ae591043587ff9fb5a4e7725ffe74df4c87fa928be28953aa31b55"},
+    {file = "terok_shield-0.6.1-py3-none-any.whl", hash = "sha256:8c30eaa02c28b8c892b4a5506d474dbd199defa583789dbacc7396faa30d9999"},
 ]
 
 [package.dependencies]
@@ -2814,7 +2814,7 @@ PyYAML = ">=6.0"
 
 [package.source]
 type = "url"
-url = "https://github.com/terok-ai/terok-shield/releases/download/v0.6.0/terok_shield-0.6.0-py3-none-any.whl"
+url = "https://github.com/terok-ai/terok-shield/releases/download/v0.6.1/terok_shield-0.6.1-py3-none-any.whl"
 
 [[package]]
 name = "textual"
@@ -3285,4 +3285,4 @@ propcache = ">=0.2.1"
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.12,<4.0"
-content-hash = "58b0ae2757001fef89d12e1fcd4dd98e0a5f79bb62d890a48537a0bf96c84954"
+content-hash = "baf5e4df064207417c7e24cf79dde9f8e02f3fa7e36a2a25021d5f09b14c075f"

--- a/poetry.lock
+++ b/poetry.lock
@@ -2757,63 +2757,64 @@ tomli-w = ">=1.0,<2.0"
 
 [[package]]
 name = "terok-agent"
-version = "0.0.35"
+version = "0.0.36"
 description = "Single-agent task runner for hardened Podman containers"
 optional = false
 python-versions = ">=3.12,<4.0"
 groups = ["main"]
 files = [
-    {file = "terok_agent-0.0.35-py3-none-any.whl", hash = "sha256:b02663d981559e6344bfd014770d7dd1ddb1c695ae94b937bd5270a98bc46baf"},
+    {file = "terok_agent-0.0.36-py3-none-any.whl", hash = "sha256:f26d2a8183f47c6493cdcfe80e2acade94b2a80240d3a24131c2748b38683c7c"},
 ]
 
 [package.dependencies]
 Jinja2 = ">=3.1"
 "ruamel.yaml" = ">=0.18"
-terok_sandbox = {url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.0.30/terok_sandbox-0.0.30-py3-none-any.whl"}
+terok_sandbox = {url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.0.31/terok_sandbox-0.0.31-py3-none-any.whl"}
 tomli-w = ">=1.0"
 
 [package.source]
 type = "url"
-url = "https://github.com/terok-ai/terok-agent/releases/download/v0.0.35/terok_agent-0.0.35-py3-none-any.whl"
+url = "https://github.com/terok-ai/terok-agent/releases/download/v0.0.36/terok_agent-0.0.36-py3-none-any.whl"
 
 [[package]]
 name = "terok-sandbox"
-version = "0.0.30"
+version = "0.0.31"
 description = "Hardened Podman container runner with gate server and shield integration"
 optional = false
 python-versions = ">=3.12,<4.0"
 groups = ["main"]
 files = [
-    {file = "terok_sandbox-0.0.30-py3-none-any.whl", hash = "sha256:1b255d222f166940718bf16caf86fc7dac26a4286180cb5f09ab22d2c99a4045"},
+    {file = "terok_sandbox-0.0.31-py3-none-any.whl", hash = "sha256:34cf61842928530abec330fc7049609245050d515abf094e3387b3bb5d8094b7"},
 ]
 
 [package.dependencies]
 aiohttp = ">=3.9"
 cryptography = ">=43.0"
 platformdirs = ">=4.0"
-terok_shield = {url = "https://github.com/terok-ai/terok-shield/releases/download/v0.5.4/terok_shield-0.5.4-py3-none-any.whl"}
+terok_shield = {url = "https://github.com/terok-ai/terok-shield/releases/download/v0.6.0/terok_shield-0.6.0-py3-none-any.whl"}
 
 [package.source]
 type = "url"
-url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.0.30/terok_sandbox-0.0.30-py3-none-any.whl"
+url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.0.31/terok_sandbox-0.0.31-py3-none-any.whl"
 
 [[package]]
 name = "terok-shield"
-version = "0.5.4"
+version = "0.6.0"
 description = "nftables-based egress firewalling for Podman containers"
 optional = false
 python-versions = ">=3.12,<4.0"
 groups = ["main"]
 files = [
-    {file = "terok_shield-0.5.4-py3-none-any.whl", hash = "sha256:11d13cd9631a4308d0cfffb547e102258bf33916f3efb3d9440a5be705517ec7"},
+    {file = "terok_shield-0.6.0-py3-none-any.whl", hash = "sha256:5db279f029ae591043587ff9fb5a4e7725ffe74df4c87fa928be28953aa31b55"},
 ]
 
 [package.dependencies]
+pydantic = ">=2.0"
 PyYAML = ">=6.0"
 
 [package.source]
 type = "url"
-url = "https://github.com/terok-ai/terok-shield/releases/download/v0.5.4/terok_shield-0.5.4-py3-none-any.whl"
+url = "https://github.com/terok-ai/terok-shield/releases/download/v0.6.0/terok_shield-0.6.0-py3-none-any.whl"
 
 [[package]]
 name = "textual"
@@ -3284,4 +3285,4 @@ propcache = ">=0.2.1"
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.12,<4.0"
-content-hash = "13eeb0b5457956b84c80ea90084fd4b95361f53ce0e23993a3b24d7a01e6bb6f"
+content-hash = "58b0ae2757001fef89d12e1fcd4dd98e0a5f79bb62d890a48537a0bf96c84954"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,8 +44,8 @@ rich = ">=13.0"
 platformdirs = ">=4.5.1"
 unique-namer = ">=1.3"
 textual-serve = ">=1.1.0"
-terok-agent = {url = "https://github.com/terok-ai/terok-agent/releases/download/v0.0.35/terok_agent-0.0.35-py3-none-any.whl"}
-terok-sandbox = {url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.0.30/terok_sandbox-0.0.30-py3-none-any.whl"}
+terok-agent = {url = "https://github.com/terok-ai/terok-agent/releases/download/v0.0.36/terok_agent-0.0.36-py3-none-any.whl"}
+terok-sandbox = {url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.0.31/terok_sandbox-0.0.31-py3-none-any.whl"}
 
 [tool.poetry.group.dev.dependencies]
 pydevd-pycharm = "261.22158.340"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,8 +44,8 @@ rich = ">=13.0"
 platformdirs = ">=4.5.1"
 unique-namer = ">=1.3"
 textual-serve = ">=1.1.0"
-terok-agent = {url = "https://github.com/terok-ai/terok-agent/releases/download/v0.0.36/terok_agent-0.0.36-py3-none-any.whl"}
-terok-sandbox = {url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.0.31/terok_sandbox-0.0.31-py3-none-any.whl"}
+terok-agent = {url = "https://github.com/terok-ai/terok-agent/releases/download/v0.0.37/terok_agent-0.0.37-py3-none-any.whl"}
+terok-sandbox = {url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.0.32/terok_sandbox-0.0.32-py3-none-any.whl"}
 
 [tool.poetry.group.dev.dependencies]
 pydevd-pycharm = "261.22158.340"

--- a/tests/integration/test_shield_no_podman.py
+++ b/tests/integration/test_shield_no_podman.py
@@ -59,7 +59,7 @@ def _pre_start_with_mocks(
     shield = _make_shield(config, rootless_mode=rootless_mode)
     with (
         patch("os.geteuid", return_value=euid),
-        patch("terok_shield.mode_hook.has_global_hooks", return_value=True),
+        patch("terok_shield.core.mode_hook.has_global_hooks", return_value=True),
     ):
         return shield.pre_start(container)
 
@@ -228,7 +228,7 @@ class TestSandboxRunShieldIntegration:
                     runner=MockRunner(),
                 ),
             ),
-            patch("terok_shield.mode_hook.has_global_hooks", return_value=True),
+            patch("terok_shield.core.mode_hook.has_global_hooks", return_value=True),
         ):
             sandbox = Sandbox()
             sandbox.run(spec)


### PR DESCRIPTION
## Summary

- Bump `terok-agent` from 0.0.35 to 0.0.37
- Bump `terok-sandbox` from 0.0.30 to 0.0.32
- Fix integration test mock targets for shield tach layer module paths

### Full dependency chain

```
terok-dbus 0.2.0
  └─ terok-shield 0.6.1 — D-Bus bridge, container ID persistence, restored registry re-exports
      └─ terok-sandbox 0.0.32
          └─ terok-agent 0.0.37
              └─ terok (this PR)
```

### Why two version bumps per package

The first bump (sandbox 0.0.31, agent 0.0.36) picked up shield 0.6.0 with the D-Bus bridge feature. The second bump (sandbox 0.0.32, agent 0.0.37) picks up shield 0.6.1 which restores `COMMANDS`, `ArgDef`, `CommandDef` re-exports that were dropped during the tach layer refactoring — fixing the `from terok_shield import COMMANDS` import used by `terok.cli.commands.shield`.

## Test plan

- [x] `poetry lock` resolves cleanly
- [x] `from terok_shield import COMMANDS, ArgDef, CommandDef, ExecError` works
- [ ] Existing terok test suite passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated two internal dependency packages to newer patch releases for improved stability and compatibility.
  * No user-facing features or behavioral changes; existing functionality remains unchanged.

* **Tests**
  * Adjusted integration test mocks to reflect internal test structure changes; test behavior unchanged for end users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->