### PR TITLE
fix: sickbay shield status check passes wrong argument

### DIFF
--- a/src/terok/lib/orchestration/container_doctor.py
+++ b/src/terok/lib/orchestration/container_doctor.py
@@ -178,7 +178,7 @@ def _check_shield_state(task_dir: Path, cname: str) -> _CheckResult:
 
     try:
         shield = make_shield(task_dir)
-        actual_status = shield.status(cname)
+        actual_status = shield.status()
         actual = "up" if actual_status.get("active", False) else "down"
     except Exception as exc:  # noqa: BLE001
         return ("warn", _SHIELD_STATE_LABEL, f"status check failed: {exc}")


### PR DESCRIPTION
## Summary

- `Shield.status()` no longer accepts a container name parameter (changed in terok-shield v0.6.0)
- `container_doctor._check_shield_state()` was calling `shield.status(cname)`, causing `TypeError: Shield.status() takes 1 positional argument but 2 were given`
- Removed the stale `cname` argument

## Test plan

- [x] `make lint` passes
- [x] `tests/unit/lib/test_container_doctor.py` — 22 tests pass
- [ ] Manual: `terok sickbay` no longer shows "status check failed" WARN for shield state

🤖 Generated with [Claude Code](https://claude.com/claude-code)