### PR TITLE
deps: synchronize transitive conduit — sandbox 0.0.33, agent 0.0.38

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -2757,55 +2757,55 @@ tomli-w = ">=1.0,<2.0"
 
 [[package]]
 name = "terok-agent"
-version = "0.0.37"
+version = "0.0.38"
 description = "Single-agent task runner for hardened Podman containers"
 optional = false
 python-versions = ">=3.12,<4.0"
 groups = ["main"]
 files = [
-    {file = "terok_agent-0.0.37-py3-none-any.whl", hash = "sha256:7c1317cd0a39ba827a24884a65da50af6ea3288cd8b3302a987ab24442bbd8b9"},
+    {file = "terok_agent-0.0.38-py3-none-any.whl", hash = "sha256:d08cbb7bd30d397945717c6a8f4c87863b35764c9e2a2021d47230d7efe156de"},
 ]
 
 [package.dependencies]
 Jinja2 = ">=3.1"
 "ruamel.yaml" = ">=0.18"
-terok_sandbox = {url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.0.32/terok_sandbox-0.0.32-py3-none-any.whl"}
+terok_sandbox = {url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.0.33/terok_sandbox-0.0.33-py3-none-any.whl"}
 tomli-w = ">=1.0"
 
 [package.source]
 type = "url"
-url = "https://github.com/terok-ai/terok-agent/releases/download/v0.0.37/terok_agent-0.0.37-py3-none-any.whl"
+url = "https://github.com/terok-ai/terok-agent/releases/download/v0.0.38/terok_agent-0.0.38-py3-none-any.whl"
 
 [[package]]
 name = "terok-sandbox"
-version = "0.0.32"
+version = "0.0.33"
 description = "Hardened Podman container runner with gate server and shield integration"
 optional = false
 python-versions = ">=3.12,<4.0"
 groups = ["main"]
 files = [
-    {file = "terok_sandbox-0.0.32-py3-none-any.whl", hash = "sha256:42710e63737092efad3e7c084fe2b0e9e432690a035a9c927070e273a0680631"},
+    {file = "terok_sandbox-0.0.33-py3-none-any.whl", hash = "sha256:5ad31ac25eb8ef3ca655688696701129c96333de60ba4c95d57b54ff0bc3806b"},
 ]
 
 [package.dependencies]
 aiohttp = ">=3.9"
 cryptography = ">=43.0"
 platformdirs = ">=4.0"
-terok_shield = {url = "https://github.com/terok-ai/terok-shield/releases/download/v0.6.1/terok_shield-0.6.1-py3-none-any.whl"}
+terok_shield = {url = "https://github.com/terok-ai/terok-shield/releases/download/v0.6.2/terok_shield-0.6.2-py3-none-any.whl"}
 
 [package.source]
 type = "url"
-url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.0.32/terok_sandbox-0.0.32-py3-none-any.whl"
+url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.0.33/terok_sandbox-0.0.33-py3-none-any.whl"
 
 [[package]]
 name = "terok-shield"
-version = "0.6.1"
+version = "0.6.2"
 description = "nftables-based egress firewalling for Podman containers"
 optional = false
 python-versions = ">=3.12,<4.0"
 groups = ["main"]
 files = [
-    {file = "terok_shield-0.6.1-py3-none-any.whl", hash = "sha256:8c30eaa02c28b8c892b4a5506d474dbd199defa583789dbacc7396faa30d9999"},
+    {file = "terok_shield-0.6.2-py3-none-any.whl", hash = "sha256:2e33a12a4ac10eb9e237a6c88055f2b681a68f1c83de1a32df7c47f3be4a4e60"},
 ]
 
 [package.dependencies]
@@ -2814,7 +2814,7 @@ PyYAML = ">=6.0"
 
 [package.source]
 type = "url"
-url = "https://github.com/terok-ai/terok-shield/releases/download/v0.6.1/terok_shield-0.6.1-py3-none-any.whl"
+url = "https://github.com/terok-ai/terok-shield/releases/download/v0.6.2/terok_shield-0.6.2-py3-none-any.whl"
 
 [[package]]
 name = "textual"
@@ -3285,4 +3285,4 @@ propcache = ">=0.2.1"
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.12,<4.0"
-content-hash = "baf5e4df064207417c7e24cf79dde9f8e02f3fa7e36a2a25021d5f09b14c075f"
+content-hash = "5f000b25f3478fad5a366b57b3bd07ab03c100833a91de03cc9e91c63a9a9b00"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,8 +44,8 @@ rich = ">=13.0"
 platformdirs = ">=4.5.1"
 unique-namer = ">=1.3"
 textual-serve = ">=1.1.0"
-terok-agent = {url = "https://github.com/terok-ai/terok-agent/releases/download/v0.0.37/terok_agent-0.0.37-py3-none-any.whl"}
-terok-sandbox = {url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.0.32/terok_sandbox-0.0.32-py3-none-any.whl"}
+terok-agent = {url = "https://github.com/terok-ai/terok-agent/releases/download/v0.0.38/terok_agent-0.0.38-py3-none-any.whl"}
+terok-sandbox = {url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.0.33/terok_sandbox-0.0.33-py3-none-any.whl"}
 
 [tool.poetry.group.dev.dependencies]
 pydevd-pycharm = "261.22158.340"


### PR DESCRIPTION
## Summary

- Bump terok-agent 0.0.37 -> 0.0.38
- Bump terok-sandbox 0.0.32 -> 0.0.33

Picks up terok-shield v0.6.2 (fix: container ID persistence moved from pre_start to OCI hook).

## Test plan

- [ ] `terok task start` no longer crashes on shield pre_start

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependencies: `terok-agent` to v0.0.38 and `terok-sandbox` to v0.0.33.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->