### PR TITLE
deps: synchronize transitive conduit — sandbox 0.0.34, agent 0.0.39

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -2757,55 +2757,55 @@ tomli-w = ">=1.0,<2.0"
 
 [[package]]
 name = "terok-agent"
-version = "0.0.38"
+version = "0.0.39"
 description = "Single-agent task runner for hardened Podman containers"
 optional = false
 python-versions = ">=3.12,<4.0"
 groups = ["main"]
 files = [
-    {file = "terok_agent-0.0.38-py3-none-any.whl", hash = "sha256:d08cbb7bd30d397945717c6a8f4c87863b35764c9e2a2021d47230d7efe156de"},
+    {file = "terok_agent-0.0.39-py3-none-any.whl", hash = "sha256:e476312562f9134ec92cb5b6ca244460d51fd159e7b5a5b7b666e5a6cbbff621"},
 ]
 
 [package.dependencies]
 Jinja2 = ">=3.1"
 "ruamel.yaml" = ">=0.18"
-terok_sandbox = {url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.0.33/terok_sandbox-0.0.33-py3-none-any.whl"}
+terok_sandbox = {url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.0.34/terok_sandbox-0.0.34-py3-none-any.whl"}
 tomli-w = ">=1.0"
 
 [package.source]
 type = "url"
-url = "https://github.com/terok-ai/terok-agent/releases/download/v0.0.38/terok_agent-0.0.38-py3-none-any.whl"
+url = "https://github.com/terok-ai/terok-agent/releases/download/v0.0.39/terok_agent-0.0.39-py3-none-any.whl"
 
 [[package]]
 name = "terok-sandbox"
-version = "0.0.33"
+version = "0.0.34"
 description = "Hardened Podman container runner with gate server and shield integration"
 optional = false
 python-versions = ">=3.12,<4.0"
 groups = ["main"]
 files = [
-    {file = "terok_sandbox-0.0.33-py3-none-any.whl", hash = "sha256:5ad31ac25eb8ef3ca655688696701129c96333de60ba4c95d57b54ff0bc3806b"},
+    {file = "terok_sandbox-0.0.34-py3-none-any.whl", hash = "sha256:be459b36dfe154b7fcfbdbda2ac8f68e6c4278a894b4a1c3b6a43836e8f8d590"},
 ]
 
 [package.dependencies]
 aiohttp = ">=3.9"
 cryptography = ">=43.0"
 platformdirs = ">=4.0"
-terok_shield = {url = "https://github.com/terok-ai/terok-shield/releases/download/v0.6.2/terok_shield-0.6.2-py3-none-any.whl"}
+terok_shield = {url = "https://github.com/terok-ai/terok-shield/releases/download/v0.6.3/terok_shield-0.6.3-py3-none-any.whl"}
 
 [package.source]
 type = "url"
-url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.0.33/terok_sandbox-0.0.33-py3-none-any.whl"
+url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.0.34/terok_sandbox-0.0.34-py3-none-any.whl"
 
 [[package]]
 name = "terok-shield"
-version = "0.6.2"
+version = "0.6.3"
 description = "nftables-based egress firewalling for Podman containers"
 optional = false
 python-versions = ">=3.12,<4.0"
 groups = ["main"]
 files = [
-    {file = "terok_shield-0.6.2-py3-none-any.whl", hash = "sha256:2e33a12a4ac10eb9e237a6c88055f2b681a68f1c83de1a32df7c47f3be4a4e60"},
+    {file = "terok_shield-0.6.3-py3-none-any.whl", hash = "sha256:4ac4ef7a9f690a96883eb1b039b5175d77a657d2574d62f66801044ab0d62084"},
 ]
 
 [package.dependencies]
@@ -2814,7 +2814,7 @@ PyYAML = ">=6.0"
 
 [package.source]
 type = "url"
-url = "https://github.com/terok-ai/terok-shield/releases/download/v0.6.2/terok_shield-0.6.2-py3-none-any.whl"
+url = "https://github.com/terok-ai/terok-shield/releases/download/v0.6.3/terok_shield-0.6.3-py3-none-any.whl"
 
 [[package]]
 name = "textual"
@@ -3285,4 +3285,4 @@ propcache = ">=0.2.1"
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.12,<4.0"
-content-hash = "5f000b25f3478fad5a366b57b3bd07ab03c100833a91de03cc9e91c63a9a9b00"
+content-hash = "9b7a644e6ab83757fb76b90dfa0f26bb6b55ec5e848a766cb75d8b0cbc0d788c"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,8 +44,8 @@ rich = ">=13.0"
 platformdirs = ">=4.5.1"
 unique-namer = ">=1.3"
 textual-serve = ">=1.1.0"
-terok-agent = {url = "https://github.com/terok-ai/terok-agent/releases/download/v0.0.38/terok_agent-0.0.38-py3-none-any.whl"}
-terok-sandbox = {url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.0.33/terok_sandbox-0.0.33-py3-none-any.whl"}
+terok-agent = {url = "https://github.com/terok-ai/terok-agent/releases/download/v0.0.39/terok_agent-0.0.39-py3-none-any.whl"}
+terok-sandbox = {url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.0.34/terok_sandbox-0.0.34-py3-none-any.whl"}
 
 [tool.poetry.group.dev.dependencies]
 pydevd-pycharm = "261.22158.340"

--- a/tests/unit/lib/test_credential_proxy_env.py
+++ b/tests/unit/lib/test_credential_proxy_env.py
@@ -89,7 +89,7 @@ class TestCredentialProxyEnv:
 
         # Phantom token should be injected for Claude
         assert "ANTHROPIC_API_KEY" in env
-        assert len(env["ANTHROPIC_API_KEY"]) == 32  # hex token
+        assert env["ANTHROPIC_API_KEY"].startswith("terok-p-")  # prefixed phantom token
         # Base URL override — TCP via host.containers.internal
         assert "ANTHROPIC_BASE_URL" in env
         assert "host.containers.internal:18731" in env["ANTHROPIC_BASE_URL"]
@@ -206,7 +206,7 @@ class TestCredentialProxyEnv:
 
         # Codex OAuth still gets phantom token env var (static marker is Claude-only)
         assert "OPENAI_API_KEY" in env
-        assert len(env["OPENAI_API_KEY"]) == 32
+        assert env["OPENAI_API_KEY"].startswith("terok-p-")
 
     @pytest.mark.usefixtures("_enable_proxy")
     def test_claude_oauth_socket_transport_still_only_base_url(self, tmp_path: Path) -> None:
@@ -279,7 +279,7 @@ class TestCredentialProxyEnv:
             env, _ = _credential_proxy_env_and_volumes(project, "task-1")
 
         assert "ANTHROPIC_API_KEY" in env
-        assert len(env["ANTHROPIC_API_KEY"]) == 32
+        assert env["ANTHROPIC_API_KEY"].startswith("terok-p-")
         assert env["ANTHROPIC_UNIX_SOCKET"] == "/tmp/terok-claude-proxy.sock"
         assert "CLAUDE_CODE_OAUTH_TOKEN" not in env
         # Socket flag AND base URL — SDK needs base URL for HTTP, socket is a mode flag
@@ -367,7 +367,7 @@ class TestCredentialProxyEnv:
             env, _ = _credential_proxy_env_and_volumes(project, "task-1")
 
         assert "TEROK_SSH_AGENT_TOKEN" in env
-        assert len(env["TEROK_SSH_AGENT_TOKEN"]) == 32
+        assert env["TEROK_SSH_AGENT_TOKEN"].startswith("terok-p-")
         assert env["TEROK_SSH_AGENT_PORT"] == "18732"
 
     @pytest.mark.usefixtures("_enable_proxy")

--- a/tests/unit/lib/test_gate_tokens.py
+++ b/tests/unit/lib/test_gate_tokens.py
@@ -64,12 +64,13 @@ class TestTokenFilePath:
 class TestCreateToken:
     """Tests for create_token."""
 
-    def test_returns_32char_hex(self) -> None:
+    def test_returns_prefixed_token(self) -> None:
         with patched_token_file() as token_path:
             token = create_token("proj-a", "1")
             assert token_path.exists()
-        assert len(token) == 32
-        int(token, 16)
+        assert token.startswith("terok-g-")
+        assert len(token) == 40
+        int(token.removeprefix("terok-g-"), 16)
 
     def test_persists_to_file(self) -> None:
         with patched_token_file() as token_path:


### PR DESCRIPTION
## Summary

- Bump terok-agent from v0.0.38 to v0.0.39
- Bump terok-sandbox from v0.0.33 to v0.0.34
- Transitively brings terok-shield v0.6.3 and terok-dbus v0.3.0
- Fix phantom token test assertions for new prefixed format (`terok-p-`, `terok-g-`)

This completes the release cycle: terok-dbus v0.3.0 (subscribe + COMMANDS registry) → shield v0.6.3 → sandbox v0.0.34 → agent v0.0.39 → terok.

Unblocks #611 (expose `terok dbus` subcommand) and Epic #400 Step 5 (TUI D-Bus notification screen).

## Test plan

- [x] 1450 unit tests pass
- [x] `make check` (lint, tach, docstrings, REUSE) all green
- [ ] Integration tests (CI — need podman)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated `terok-agent` to version 0.0.39
  * Updated `terok-sandbox` to version 0.0.34

* **Tests**
  * Updated token format validations to reflect new token prefix structures in authentication systems

<!-- end of auto-generated comment: release notes by coderabbit.ai -->