### PR TITLE
fix: always fetch upstream before tagging in release chain

### DIFF
--- a/tools/terok-release-chain.sh
+++ b/tools/terok-release-chain.sh
@@ -474,9 +474,10 @@ push_and_create_pr() {
 
 tag_and_release() {
     local repo_dir="$1" gh_repo="$2" tag="$3" title="$4" target="${5:-}"
+    # Always fetch — the squash-merge commit only exists on the remote
+    # until we pull it into the local clone.
+    run git -C "$repo_dir" fetch upstream
     if [[ -z "$target" ]]; then
-        # Fallback for pretend mode — no merge SHA available
-        run git -C "$repo_dir" fetch upstream
         target="upstream/master"
     fi
     log "Tagging ${tag} on ${target:0:12}..."


### PR DESCRIPTION
## Summary

- Fix `tools/terok-release-chain.sh` crash: `git tag` fails with "nonexistent object" after squash-merge
- Root cause: the squash-merge commit only exists on the remote, but `git fetch upstream` was skipped when a merge SHA was available
- Move the fetch outside the conditional so the local clone always has the commit before tagging

## Test plan

- [x] Run with `-p` (pretend) — fetch still appears in output
- [ ] Run a real release chain — tagging succeeds after squash-merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved release process reliability by ensuring git repository data is consistently fetched before determining release targets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->