### PR TITLE
fix: detect externally merged/closed PRs during check wait

### DIFF
--- a/tools/terok-release-chain.sh
+++ b/tools/terok-release-chain.sh
@@ -313,7 +313,9 @@ execute_chain() {
 
 print_summary() {
     local -n _chain=$1 _versions=$2
-    printf "\n${GREEN}${BOLD}All releases complete!${RESET}\n\n"
+    local prefix=""
+    $DRY_RUN && prefix="${YELLOW}[pretend]${RESET} "
+    printf "\n${prefix}${GREEN}${BOLD}All releases complete!${RESET}\n\n"
     for i in "${!_chain[@]}"; do
         local repo="${_chain[$i]}"
         if [[ "$repo" == "$STOP_AT" ]]; then


### PR DESCRIPTION
## Summary

- Poll PR state (OPEN/MERGED/CLOSED) every 10s during check wait
- If someone merges the PR externally (e.g. stalled codecov), the script picks up the merge SHA and continues with tag + release
- If someone closes without merging, the script aborts immediately
- Safe with `set -e` via `|| check_rc=$?` pattern

## Test plan

- [x] `bash -n` syntax check passes
- [x] `-p` pretend run works
- [ ] Real run with manual merge during stalled check

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Enhanced release automation to detect and handle pull requests merged externally and skip redundant merge steps.
  * Improved CI check polling to periodically verify PR state while waiting, aborting if the PR is closed.
  * Refined release messaging to clearly indicate when an external merge is used and to communicate merge/check outcomes.
  * Updated dry-run output to visibly mark simulated runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->