### PR TITLE
fix: handle merge race in release chain

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,4 @@
+reviews:
+  auto_review:
+    labels:
+      - "!automated-release"

--- a/tools/terok-release-chain.sh
+++ b/tools/terok-release-chain.sh
@@ -400,8 +400,18 @@ release_repo() {
                 || {
                     # "Merge already in progress" = someone clicked merge moments ago
                     if [[ "$merge_err" == *"already in progress"* || "$merge_err" == *"already been merged"* ]]; then
-                        warn "Merge race detected — waiting for completion..."
-                        sleep 5
+                        warn "Merge race detected — waiting for merge to land..."
+                        local wait=0
+                        while (( wait < 30 )); do
+                            local rs
+                            rs=$(pr_state "$PR_URL" "$gh_repo" 2>/dev/null || true)
+                            if [[ "$rs" == "MERGED" ]]; then
+                                break
+                            fi
+                            sleep 2
+                            wait=$((wait + 2))
+                        done
+                        [[ "$rs" == "MERGED" ]] || die "PR still not merged after 30s — check GitHub"
                         merged_sha=$(gh pr view "$PR_URL" --repo "$gh_repo" --json mergeCommit --jq '.mergeCommit.oid')
                         success "Using concurrent merge (${merged_sha:0:12})."
                     else

--- a/tools/terok-release-chain.sh
+++ b/tools/terok-release-chain.sh
@@ -395,9 +395,23 @@ release_repo() {
             die "PR was closed without merging — aborting."
         else
             log "Merging PR..."
-            gh pr merge "$PR_URL" --squash --delete-branch --admin
-            merged_sha=$(gh pr view "$PR_URL" --repo "$gh_repo" --json mergeCommit --jq '.mergeCommit.oid')
-            success "PR merged (${merged_sha:0:12})."
+            local merge_err=""
+            merge_err=$(gh pr merge "$PR_URL" --squash --delete-branch --admin 2>&1) \
+                || {
+                    # "Merge already in progress" = someone clicked merge moments ago
+                    if [[ "$merge_err" == *"already in progress"* || "$merge_err" == *"already been merged"* ]]; then
+                        warn "Merge race detected — waiting for completion..."
+                        sleep 5
+                        merged_sha=$(gh pr view "$PR_URL" --repo "$gh_repo" --json mergeCommit --jq '.mergeCommit.oid')
+                        success "Using concurrent merge (${merged_sha:0:12})."
+                    else
+                        die "gh pr merge failed: ${merge_err}"
+                    fi
+                }
+            if [[ -z "$merged_sha" ]]; then
+                merged_sha=$(gh pr view "$PR_URL" --repo "$gh_repo" --json mergeCommit --jq '.mergeCommit.oid')
+                success "PR merged (${merged_sha:0:12})."
+            fi
         fi
     fi
 


### PR DESCRIPTION
## Summary

- Catch `"Merge already in progress"` / `"already been merged"` errors from `gh pr merge`
- Wait 5s for the concurrent merge to settle, retrieve the merge SHA, continue
- Any other merge error still dies immediately

Triggered by: operator clicked merge in GitHub UI at the same moment the script ran `gh pr merge`, producing `GraphQL: Merge already in progress (mergePullRequest)`.

## Test plan

- [x] `bash -n` syntax check
- [x] `-p` pretend run works
- [ ] Real race scenario (click merge while script is about to merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enabled automated code reviews for pull requests with automatic labeling
  * Enhanced pull request merge process with improved error handling for concurrent merge scenarios

<!-- end of auto-generated comment: release notes by coderabbit.ai -->