### PR TITLE
fix: add automated-release label to release chain PRs

### DIFF
--- a/tools/terok-release-chain.sh
+++ b/tools/terok-release-chain.sh
@@ -514,7 +514,8 @@ push_and_create_pr() {
         --base master \
         --head "${GH_FORK}:${branch}" \
         --title "$title" \
-        --body "$body")
+        --body "$body" \
+        --label "automated-release")
     log "PR created: ${PR_URL}"
 }
 


### PR DESCRIPTION
## Summary

Add `--label "automated-release"` to `gh pr create` in the release chain script. This was committed on a prior branch but lost in the squash merge.

The label triggers the CodeRabbit `auto_review` skip configured in `.coderabbit.yaml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)