### PR TITLE
feat: PanicButton widget with arm-then-fire activation

### DIFF
--- a/src/terok/tui/app.py
+++ b/src/terok/tui/app.py
@@ -976,7 +976,7 @@ if _HAS_TEXTUAL:
             try:
                 btn = self.query_one("#panic-button", PanicButton)
             except Exception:
-                await self._execute_panic_phase1()
+                self.notify("Panic button not found — resize terminal?")
                 return
             if btn._armed:
                 btn.fire()

--- a/src/terok/tui/app.py
+++ b/src/terok/tui/app.py
@@ -90,7 +90,7 @@ if _HAS_TEXTUAL:
     from .polling import PollingMixin
     from .project_actions import ProjectActionsMixin
     from .screens import (
-        ConfirmDeleteScreen,
+        ConfirmDestructiveScreen,
         CredentialProxyScreen,
         GateServerScreen,
         ProjectDetailsScreen,
@@ -99,6 +99,7 @@ if _HAS_TEXTUAL:
     )
     from .task_actions import TaskActionsMixin
     from .widgets import (
+        PanicButton,
         ProjectList,
         ProjectState,
         TaskDetails,
@@ -304,6 +305,7 @@ if _HAS_TEXTUAL:
                     project_state = ProjectState(id="project-state")
                     project_state.border_title = "Project Details"
                     yield project_state
+                    yield PanicButton(id="panic-button")
                 # Right pane: tasks + task details
                 with Vertical(id="right-pane"):
                     task_list = TaskList(id="task-list")
@@ -933,7 +935,7 @@ if _HAS_TEXTUAL:
                 self._refresh_project_state()
                 if panic_result.total_running > 0:
                     await self.push_screen(
-                        ConfirmDeleteScreen(
+                        ConfirmDestructiveScreen(
                             "Resource access has been cut.\n\n"
                             "Also stop all containers?\n"
                             "(This may be slow on some platforms.)",
@@ -970,25 +972,23 @@ if _HAS_TEXTUAL:
             await self._action_show_default_instructions()
 
         async def action_panic(self) -> None:
-            """Emergency panic: cut all resource access immediately."""
-            await self.push_screen(
-                ConfirmDeleteScreen(
-                    "Cut ALL resource access for ALL running containers?\n\n"
-                    "This will:\n"
-                    "  - Raise shields (deny all network)\n"
-                    "  - Stop credential proxy\n"
-                    "  - Stop gate server\n\n"
-                    "Tokens are preserved for easy resume after investigation.",
-                    title="EMERGENCY PANIC",
-                    confirm_label="PANIC",
-                ),
-                self._on_panic_confirmed,
-            )
-
-        async def _on_panic_confirmed(self, confirmed: bool) -> None:
-            """Handle the panic confirmation result."""
-            if not confirmed:
+            """Emergency panic: arm the button (or fire if already armed)."""
+            try:
+                btn = self.query_one("#panic-button", PanicButton)
+            except Exception:
+                await self._execute_panic_phase1()
                 return
+            if btn._armed:
+                btn.fire()
+            else:
+                btn.arm()
+
+        async def on_panic_button_fired(self, _event: PanicButton.Fired) -> None:
+            """Handle the panic button completing its arm-then-fire sequence."""
+            await self._execute_panic_phase1()
+
+        async def _execute_panic_phase1(self) -> None:
+            """Launch Phase 1 panic: shields up, stop proxy and gate."""
             from ..lib.domain.panic import execute_panic
 
             self.run_worker(

--- a/src/terok/tui/project_actions.py
+++ b/src/terok/tui/project_actions.py
@@ -487,10 +487,10 @@ class ProjectActionsMixin:
         lines.append("Project config, task data, and build artifacts will be archived at:")
         lines.append(f"{archive_path}")
 
-        from .screens import ConfirmDeleteScreen
+        from .screens import ConfirmDestructiveScreen
 
         await self.push_screen(
-            ConfirmDeleteScreen(
+            ConfirmDestructiveScreen(
                 message="\n".join(lines),
                 title=f"Delete Project: {pid}",
             ),

--- a/src/terok/tui/screens.py
+++ b/src/terok/tui/screens.py
@@ -1349,7 +1349,7 @@ class TaskLaunchScreen(screen.ModalScreen["tuple[str, str, str, str, str, str | 
 # ---------------------------------------------------------------------------
 
 
-class ConfirmDeleteScreen(screen.ModalScreen[bool]):
+class ConfirmDestructiveScreen(screen.ModalScreen[bool]):
     """Modal confirmation dialog for destructive operations.
 
     Dismisses with ``True`` if the user confirms, ``False`` otherwise.
@@ -1360,7 +1360,7 @@ class ConfirmDeleteScreen(screen.ModalScreen[bool]):
     ]
 
     CSS = """
-    ConfirmDeleteScreen {
+    ConfirmDestructiveScreen {
         align: center middle;
     }
 

--- a/src/terok/tui/widgets/__init__.py
+++ b/src/terok/tui/widgets/__init__.py
@@ -7,6 +7,7 @@ Re-exports widget classes and render helpers from focused submodules.
 """
 
 from ...lib.orchestration.tasks import TaskMeta  # noqa: F401 — re-exported public API
+from .panic_button import PanicButton  # noqa: F401
 from .project_list import ProjectActions, ProjectList, ProjectListItem  # noqa: F401
 from .project_state import (  # noqa: F401
     ProjectState,
@@ -18,6 +19,8 @@ from .task_detail import TaskDetails, render_task_details  # noqa: F401
 from .task_list import TaskList, TaskListItem, get_backend_name  # noqa: F401
 
 __all__ = [
+    # Emergency
+    "PanicButton",
     # Project widgets
     "ProjectActions",
     "ProjectList",

--- a/src/terok/tui/widgets/panic_button.py
+++ b/src/terok/tui/widgets/panic_button.py
@@ -1,0 +1,84 @@
+# SPDX-FileCopyrightText: 2026 Jiri Vyskocil
+# SPDX-License-Identifier: Apache-2.0
+
+"""Panic button widget with arm-then-fire safety mechanism.
+
+The button sits in the main layout but is excluded from the Tab focus chain
+(``can_focus = False``).  A single click arms it (visual change + 5-second
+auto-disarm timer); a second click fires the emergency panic sequence.
+"""
+
+from textual.message import Message
+from textual.widgets import Static
+
+_LABEL_IDLE = "PANIC"
+_LABEL_ARMED = "!! CONFIRM PANIC !!"
+_DISARM_SECONDS = 5.0
+
+
+class PanicButton(Static):
+    """Clickable emergency button with arm-then-fire two-phase activation."""
+
+    can_focus = False
+
+    DEFAULT_CSS = """
+    PanicButton {
+        height: 3;
+        margin-top: 1;
+        content-align: center middle;
+        text-align: center;
+        background: $error;
+        color: white;
+        text-style: bold;
+    }
+
+    PanicButton.armed {
+        background: darkred;
+        text-style: bold reverse;
+    }
+    """
+
+    class Fired(Message):
+        """Posted when the arm-then-fire sequence completes."""
+
+    def __init__(self, **kwargs: object) -> None:
+        """Initialize in idle (disarmed) state."""
+        super().__init__(**kwargs)
+        self._armed = False
+        self._disarm_timer = None
+
+    def on_mount(self) -> None:
+        """Set the idle label once the widget is mounted."""
+        self.update(_LABEL_IDLE)
+
+    def arm(self) -> None:
+        """Transition from idle to armed state with auto-disarm timer."""
+        if self._armed:
+            return
+        self._armed = True
+        self.add_class("armed")
+        self.update(_LABEL_ARMED)
+        self._disarm_timer = self.set_timer(_DISARM_SECONDS, self.disarm)
+
+    def disarm(self) -> None:
+        """Return to idle state, cancelling any pending timer."""
+        if not self._armed:
+            return
+        self._armed = False
+        self.remove_class("armed")
+        self.update(_LABEL_IDLE)
+        if self._disarm_timer is not None:
+            self._disarm_timer.stop()
+            self._disarm_timer = None
+
+    def fire(self) -> None:
+        """Complete the arm-then-fire sequence: disarm and emit :class:`Fired`."""
+        self.disarm()
+        self.post_message(self.Fired())
+
+    def on_click(self) -> None:
+        """Handle mouse clicks: arm on first click, fire on second."""
+        if self._armed:
+            self.fire()
+        else:
+            self.arm()

--- a/tests/unit/tui/test_panic_button.py
+++ b/tests/unit/tui/test_panic_button.py
@@ -1,0 +1,175 @@
+# SPDX-FileCopyrightText: 2026 Jiri Vyskocil
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the PanicButton widget and panic flow integration."""
+
+from unittest import mock
+
+import pytest
+
+from tests.unit.tui.tui_test_helpers import build_textual_stubs, import_fresh
+
+
+@pytest.fixture()
+def modules():
+    """Import TUI modules with Textual stubs."""
+    stubs = build_textual_stubs()
+    # The stub Message needs post_message/set_timer/add_class/remove_class
+    # to support PanicButton's runtime calls.  These are provided by Textual's
+    # Widget at runtime; we patch them onto instances in each test instead of
+    # modifying the shared stubs.
+    return import_fresh(stubs)
+
+
+@pytest.fixture()
+def button(modules):
+    """Create a PanicButton instance with mocked Textual methods."""
+    _, widgets, _ = modules
+    btn = widgets.PanicButton(id="panic-button")
+    btn.add_class = mock.Mock()
+    btn.remove_class = mock.Mock()
+    btn.update = mock.Mock()
+    btn.post_message = mock.Mock()
+
+    timer = mock.Mock()
+    timer.stop = mock.Mock()
+    btn.set_timer = mock.Mock(return_value=timer)
+
+    return btn
+
+
+class TestPanicButtonInitialState:
+    """Verify the button starts in a safe idle state."""
+
+    def test_not_armed(self, button):
+        """Button is not armed after construction."""
+        assert button._armed is False
+
+    def test_can_focus_disabled(self, modules):
+        """Button is excluded from the Tab focus chain."""
+        _, widgets, _ = modules
+        assert widgets.PanicButton.can_focus is False
+
+    def test_no_timer(self, button):
+        """No disarm timer is set initially."""
+        assert button._disarm_timer is None
+
+
+class TestArm:
+    """Verify arming transitions and side effects."""
+
+    def test_sets_armed_flag(self, button):
+        """arm() transitions to armed state."""
+        button.arm()
+        assert button._armed is True
+
+    def test_adds_css_class(self, button):
+        """arm() adds the 'armed' CSS class for visual feedback."""
+        button.arm()
+        button.add_class.assert_called_once_with("armed")
+
+    def test_updates_label(self, button):
+        """arm() changes the label to the armed prompt."""
+        button.arm()
+        button.update.assert_called_with("!! CONFIRM PANIC !!")
+
+    def test_starts_disarm_timer(self, button):
+        """arm() starts a 5-second auto-disarm timer."""
+        button.arm()
+        button.set_timer.assert_called_once()
+        delay, callback = button.set_timer.call_args[0]
+        assert delay == 5.0
+        assert callback == button.disarm
+
+    def test_idempotent(self, button):
+        """Calling arm() twice does not reset the timer."""
+        button.arm()
+        button.arm()
+        button.set_timer.assert_called_once()
+
+
+class TestDisarm:
+    """Verify disarming transitions and cleanup."""
+
+    def test_clears_armed_flag(self, button):
+        """disarm() returns to idle state."""
+        button.arm()
+        button.disarm()
+        assert button._armed is False
+
+    def test_removes_css_class(self, button):
+        """disarm() removes the 'armed' CSS class."""
+        button.arm()
+        button.disarm()
+        button.remove_class.assert_called_once_with("armed")
+
+    def test_restores_label(self, button):
+        """disarm() restores the idle label."""
+        button.arm()
+        button.disarm()
+        assert button.update.call_args[0][0] == "PANIC"
+
+    def test_stops_timer(self, button):
+        """disarm() stops the pending auto-disarm timer."""
+        button.arm()
+        timer = button._disarm_timer
+        button.disarm()
+        timer.stop.assert_called_once()
+        assert button._disarm_timer is None
+
+    def test_noop_when_idle(self, button):
+        """disarm() is safe to call when already idle."""
+        button.disarm()
+        button.remove_class.assert_not_called()
+
+
+class TestFire:
+    """Verify firing posts the message and disarms."""
+
+    def test_posts_fired_message(self, button, modules):
+        """fire() posts a PanicButton.Fired message."""
+        _, widgets, _ = modules
+        button.arm()
+        button.fire()
+        button.post_message.assert_called_once()
+        msg = button.post_message.call_args[0][0]
+        assert isinstance(msg, widgets.PanicButton.Fired)
+
+    def test_disarms_after_firing(self, button):
+        """fire() returns the button to idle state."""
+        button.arm()
+        button.fire()
+        assert button._armed is False
+
+
+class TestOnClick:
+    """Verify mouse click dispatches to arm or fire."""
+
+    def test_arms_when_idle(self, button):
+        """Click on idle button arms it."""
+        button.on_click()
+        assert button._armed is True
+
+    def test_fires_when_armed(self, button, modules):
+        """Click on armed button fires."""
+        _, widgets, _ = modules
+        button.arm()
+        button.on_click()
+        button.post_message.assert_called_once()
+        msg = button.post_message.call_args[0][0]
+        assert isinstance(msg, widgets.PanicButton.Fired)
+        assert button._armed is False
+
+
+class TestConfirmDestructiveScreenRename:
+    """Regression guard: the old name is gone, the new name exists."""
+
+    def test_new_name_exists(self, modules):
+        """ConfirmDestructiveScreen is importable from screens."""
+        screens, _, _ = modules
+        assert hasattr(screens, "ConfirmDestructiveScreen")
+
+    def test_old_name_gone(self, modules):
+        """ConfirmDeleteScreen no longer exists."""
+        screens, _, _ = modules
+        assert not hasattr(screens, "ConfirmDeleteScreen")


### PR DESCRIPTION
## Summary

- Rename `ConfirmDeleteScreen` → `ConfirmDestructiveScreen` (it's a generic destructive-action confirmation modal, not delete-specific)
- Add a visible red **PanicButton** widget to the TUI main screen (bottom of left pane)
- Two-phase arm-then-fire: click once to arm (5s auto-disarm), click again to execute Phase 1 (shields up, stop proxy/gate)
- `can_focus = False` — excluded from Tab focus chain, unreachable by accident
- Phase 2 (container stop) still requires a modal confirmation — it's the truly destructive part
- Shift+P and command palette route through the same arm/fire state machine

## Test plan

- [ ] `make check` passes (lint, test, tach, docstrings, reuse)
- [ ] TUI renders the red button below Project Details
- [ ] Tab never lands on the button
- [ ] Click arms → visual change → 5s timeout disarms
- [ ] Double-click fires Phase 1 → shields raised, proxy/gate stopped
- [ ] Phase 2 modal still appears for container stop
- [ ] Shift+P arms on first press, fires on second

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a two-phase "Panic" button in the UI: first click arms, second click fires; auto-disarms after 5 seconds if not confirmed. Follow-up "stop all containers?" confirmation still appears when needed.

* **Refactor**
  * Renamed and standardized the destructive confirmation modal used across destructive actions.

* **Tests**
  * Added unit tests validating the new emergency button behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->