### PR TITLE
refactor: adapt to terok-sandbox scope rename

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -2804,25 +2804,24 @@ tomli-w = ">=1.0,<2.0"
 
 [[package]]
 name = "terok-agent"
-version = "0.0.51"
+version = "0.0.52"
 description = "Single-agent task runner for hardened Podman containers"
 optional = false
 python-versions = ">=3.12,<4.0"
 groups = ["main"]
-files = []
-develop = false
+files = [
+    {file = "terok_agent-0.0.52-py3-none-any.whl", hash = "sha256:2f0fd631855dd71f956be8fba4cec7856278a2f30d57d0913b1f1aab28978cb0"},
+]
 
 [package.dependencies]
 Jinja2 = ">=3.1"
 "ruamel.yaml" = ">=0.18"
-terok-sandbox = {git = "https://github.com/sliwowitz/terok-sandbox.git", rev = "36a108e2d50d69ae79ef7b363f6c775f211b4c87"}
+terok_sandbox = {url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.0.45/terok_sandbox-0.0.45-py3-none-any.whl"}
 tomli-w = ">=1.0"
 
 [package.source]
-type = "git"
-url = "https://github.com/sliwowitz/terok-agent.git"
-reference = "44a32b5b40801d196faaaaa8bedee046f9fa098c"
-resolved_reference = "44a32b5b40801d196faaaaa8bedee046f9fa098c"
+type = "url"
+url = "https://github.com/terok-ai/terok-agent/releases/download/v0.0.52/terok_agent-0.0.52-py3-none-any.whl"
 
 [[package]]
 name = "terok-dbus"
@@ -2844,25 +2843,24 @@ url = "https://github.com/terok-ai/terok-dbus/releases/download/v0.5.6/terok_dbu
 
 [[package]]
 name = "terok-sandbox"
-version = "0.0.44"
+version = "0.0.45"
 description = "Hardened Podman container runner with gate server and shield integration"
 optional = false
 python-versions = ">=3.12,<4.0"
 groups = ["main"]
-files = []
-develop = false
+files = [
+    {file = "terok_sandbox-0.0.45-py3-none-any.whl", hash = "sha256:cb56b19fb2a20eb9cff16fdd8cc8d894217ccd490092b0036aecbc8ad2c70f55"},
+]
 
 [package.dependencies]
 aiohttp = ">=3.9"
 cryptography = ">=43.0"
 platformdirs = ">=4.0"
-terok-shield = {url = "https://github.com/terok-ai/terok-shield/releases/download/v0.6.13/terok_shield-0.6.13-py3-none-any.whl"}
+terok_shield = {url = "https://github.com/terok-ai/terok-shield/releases/download/v0.6.13/terok_shield-0.6.13-py3-none-any.whl"}
 
 [package.source]
-type = "git"
-url = "https://github.com/sliwowitz/terok-sandbox.git"
-reference = "36a108e2d50d69ae79ef7b363f6c775f211b4c87"
-resolved_reference = "36a108e2d50d69ae79ef7b363f6c775f211b4c87"
+type = "url"
+url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.0.45/terok_sandbox-0.0.45-py3-none-any.whl"
 
 [[package]]
 name = "terok-shield"
@@ -3352,4 +3350,4 @@ propcache = ">=0.2.1"
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.12,<4.0"
-content-hash = "4a3e82bd4bbf2a75ce9ec6741c76a3ec08e7295fa1be1a5c7aceb0e5ec9f4aac"
+content-hash = "bfa0f40c5c40b981187bd299d7736119a7928d223fe5dc515d51dddbcce42524"

--- a/poetry.lock
+++ b/poetry.lock
@@ -2809,19 +2809,20 @@ description = "Single-agent task runner for hardened Podman containers"
 optional = false
 python-versions = ">=3.12,<4.0"
 groups = ["main"]
-files = [
-    {file = "terok_agent-0.0.51-py3-none-any.whl", hash = "sha256:f4008c36c3c13d500ab4260b14e1d3b87dc9beff821cb3a41a1f4af755de9116"},
-]
+files = []
+develop = false
 
 [package.dependencies]
 Jinja2 = ">=3.1"
 "ruamel.yaml" = ">=0.18"
-terok_sandbox = {url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.0.44/terok_sandbox-0.0.44-py3-none-any.whl"}
+terok-sandbox = {git = "https://github.com/sliwowitz/terok-sandbox.git", rev = "36a108e2d50d69ae79ef7b363f6c775f211b4c87"}
 tomli-w = ">=1.0"
 
 [package.source]
-type = "url"
-url = "https://github.com/terok-ai/terok-agent/releases/download/v0.0.51/terok_agent-0.0.51-py3-none-any.whl"
+type = "git"
+url = "https://github.com/sliwowitz/terok-agent.git"
+reference = "44a32b5b40801d196faaaaa8bedee046f9fa098c"
+resolved_reference = "44a32b5b40801d196faaaaa8bedee046f9fa098c"
 
 [[package]]
 name = "terok-dbus"
@@ -2848,19 +2849,20 @@ description = "Hardened Podman container runner with gate server and shield inte
 optional = false
 python-versions = ">=3.12,<4.0"
 groups = ["main"]
-files = [
-    {file = "terok_sandbox-0.0.44-py3-none-any.whl", hash = "sha256:34eebc1d2769f409d44fcd3a0ceafa0e5e28becb03145eb3426b5b62a500c05a"},
-]
+files = []
+develop = false
 
 [package.dependencies]
 aiohttp = ">=3.9"
 cryptography = ">=43.0"
 platformdirs = ">=4.0"
-terok_shield = {url = "https://github.com/terok-ai/terok-shield/releases/download/v0.6.13/terok_shield-0.6.13-py3-none-any.whl"}
+terok-shield = {url = "https://github.com/terok-ai/terok-shield/releases/download/v0.6.13/terok_shield-0.6.13-py3-none-any.whl"}
 
 [package.source]
-type = "url"
-url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.0.44/terok_sandbox-0.0.44-py3-none-any.whl"
+type = "git"
+url = "https://github.com/sliwowitz/terok-sandbox.git"
+reference = "36a108e2d50d69ae79ef7b363f6c775f211b4c87"
+resolved_reference = "36a108e2d50d69ae79ef7b363f6c775f211b4c87"
 
 [[package]]
 name = "terok-shield"
@@ -3350,4 +3352,4 @@ propcache = ">=0.2.1"
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.12,<4.0"
-content-hash = "6b99c34ddf4818f0d5f1c15758c323abe5a7a78f0faab7a7101e04215513b395"
+content-hash = "4a3e82bd4bbf2a75ce9ec6741c76a3ec08e7295fa1be1a5c7aceb0e5ec9f4aac"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,8 +44,8 @@ rich = ">=13.0"
 platformdirs = ">=4.5.1"
 unique-namer = ">=1.3"
 textual-serve = ">=1.1.0"
-terok-agent = {git = "https://github.com/sliwowitz/terok-agent.git", rev = "44a32b5b40801d196faaaaa8bedee046f9fa098c"}
-terok-sandbox = {git = "https://github.com/sliwowitz/terok-sandbox.git", rev = "36a108e2d50d69ae79ef7b363f6c775f211b4c87"}
+terok-agent = {url = "https://github.com/terok-ai/terok-agent/releases/download/v0.0.52/terok_agent-0.0.52-py3-none-any.whl"}
+terok-sandbox = {url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.0.45/terok_sandbox-0.0.45-py3-none-any.whl"}
 terok-dbus = {url = "https://github.com/terok-ai/terok-dbus/releases/download/v0.5.6/terok_dbus-0.5.6-py3-none-any.whl"}
 
 [tool.poetry.group.dev.dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,8 +44,8 @@ rich = ">=13.0"
 platformdirs = ">=4.5.1"
 unique-namer = ">=1.3"
 textual-serve = ">=1.1.0"
-terok-agent = {url = "https://github.com/terok-ai/terok-agent/releases/download/v0.0.51/terok_agent-0.0.51-py3-none-any.whl"}
-terok-sandbox = {url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.0.44/terok_sandbox-0.0.44-py3-none-any.whl"}
+terok-agent = {git = "https://github.com/sliwowitz/terok-agent.git", rev = "44a32b5b40801d196faaaaa8bedee046f9fa098c"}
+terok-sandbox = {git = "https://github.com/sliwowitz/terok-sandbox.git", rev = "36a108e2d50d69ae79ef7b363f6c775f211b4c87"}
 terok-dbus = {url = "https://github.com/terok-ai/terok-dbus/releases/download/v0.5.6/terok_dbus-0.5.6-py3-none-any.whl"}
 
 [tool.poetry.group.dev.dependencies]

--- a/src/terok/lib/domain/project.py
+++ b/src/terok/lib/domain/project.py
@@ -176,7 +176,7 @@ def make_git_gate(config: ProjectConfig) -> GitGate:
     Injects ``validate_gate_upstream_match`` as the gate validation callback.
     """
     return GitGate(
-        project_id=config.id,
+        scope=config.id,
         gate_path=config.gate_path,
         upstream_url=config.upstream_url,
         default_branch=config.default_branch,
@@ -190,7 +190,7 @@ def make_ssh_manager(config: ProjectConfig) -> SSHManager:
     """Construct an :class:`SSHManager` from a :class:`ProjectConfig` (adapter factory)."""
     ssh_dir = config.ssh_host_dir or (make_sandbox_config().ssh_keys_dir / config.id)
     return SSHManager(
-        project_id=config.id,
+        scope=config.id,
         ssh_host_dir=ssh_dir,
         ssh_key_name=config.ssh_key_name,
         ssh_config_template=config.ssh_config_template,

--- a/src/terok/lib/orchestration/tasks.py
+++ b/src/terok/lib/orchestration/tasks.py
@@ -21,7 +21,7 @@ from pathlib import Path
 
 from terok_sandbox import (
     get_container_state,
-    get_project_container_states,
+    get_container_states,
     stop_task_containers,
 )
 
@@ -507,7 +507,7 @@ def get_all_task_states(
     Returns:
         ``{task_id: container_state_or_None}`` dict.
     """
-    container_states = get_project_container_states(project_id)
+    container_states = get_container_states(project_id)
     result: dict[str, str | None] = {}
     for t in tasks:
         if t.mode:

--- a/tests/integration/test_container_e2e.py
+++ b/tests/integration/test_container_e2e.py
@@ -127,7 +127,7 @@ def gate_env(tmp_path: Path) -> dict:
     token = uuid.uuid4().hex
     token_file = tmp_path / "tokens.json"
     token_file.write_text(
-        json.dumps({token: {"project": project_id, "task": "1"}}),
+        json.dumps({token: {"scope": project_id, "task": "1"}}),
         encoding="utf-8",
     )
 

--- a/tests/unit/gate/test_server.py
+++ b/tests/unit/gate/test_server.py
@@ -31,7 +31,7 @@ from terok_sandbox.gate.server import (
 from tests.testfs import NONEXISTENT_TOKENS_PATH
 from tests.testnet import GATE_PORT, LOCALHOST_PEER
 
-VALID_TOKEN_DATA = {"validtoken": {"project": "proj-a", "task": "1"}}
+VALID_TOKEN_DATA = {"validtoken": {"scope": "proj-a", "task": "1"}}
 SUCCESS_CGI_RESPONSE = b"Status: 200 OK\r\nContent-Type: text/plain\r\n\r\nok"
 
 
@@ -139,12 +139,12 @@ class TestTokenStore:
 
     def test_mtime_reload(self) -> None:
         """Token store reloads when file mtime changes."""
-        with token_store_file({"t1": {"project": "p1", "task": "1"}}) as token_file:
+        with token_store_file({"t1": {"scope": "p1", "task": "1"}}) as token_file:
             store = TokenStore(token_file)
             assert store.validate("t1") == "p1"
 
             time.sleep(0.05)
-            token_file.write_text(json.dumps({"t2": {"project": "p2", "task": "2"}}))
+            token_file.write_text(json.dumps({"t2": {"scope": "p2", "task": "2"}}))
             stat_result = token_file.stat()
             os.utime(token_file, (stat_result.st_atime, stat_result.st_mtime + 1))
 
@@ -154,7 +154,7 @@ class TestTokenStore:
     def test_malformed_token_entry_skipped(self) -> None:
         """Token entries with wrong structure are ignored."""
         with token_store_file(
-            {"bad": "not-a-dict", "ok": {"project": "p", "task": "1"}}
+            {"bad": "not-a-dict", "ok": {"scope": "p", "task": "1"}}
         ) as token_file:
             store = TokenStore(token_file)
             assert store.validate("bad") is None
@@ -165,7 +165,7 @@ class TestValidateTokenData:
     """Tests for _validate_token_data."""
 
     def test_valid_data(self) -> None:
-        data = {"t1": {"project": "p", "task": "1"}}
+        data = {"t1": {"scope": "p", "task": "1"}}
         assert _validate_token_data(data) == data
 
     @pytest.mark.parametrize(
@@ -174,10 +174,10 @@ class TestValidateTokenData:
             ([1, 2], {}),
             ("string", {}),
             (
-                {"good": {"project": "p", "task": "1"}, "bad": "string"},
-                {"good": {"project": "p", "task": "1"}},
+                {"good": {"scope": "p", "task": "1"}, "bad": "string"},
+                {"good": {"scope": "p", "task": "1"}},
             ),
-            ({"no_task": {"project": "p"}, "no_proj": {"task": "1"}}, {}),
+            ({"no_task": {"scope": "p"}, "no_scope": {"task": "1"}}, {}),
         ],
         ids=["non-dict-list", "non-dict-string", "skip-non-dict-values", "skip-missing-fields"],
     )
@@ -322,7 +322,7 @@ class TestAuth:
             ("/proj-b.git/info/refs", "validtoken", 403),
             ("/invalid/path", "validtoken", 404),
         ],
-        ids=["no-auth", "wrong-token", "wrong-project", "invalid-path"],
+        ids=["no-auth", "wrong-token", "wrong-scope", "invalid-path"],
     )
     def test_auth_failures(self, path: str, token: str | None, expected: int) -> None:
         code, _handler = make_request(path, token=token)
@@ -330,7 +330,7 @@ class TestAuth:
 
     @unittest.mock.patch("subprocess.Popen")
     def test_valid_auth_delegates_to_cgi(self, mock_popen: unittest.mock.Mock) -> None:
-        """Valid token + matching project delegates to git http-backend."""
+        """Valid token + matching scope delegates to git http-backend."""
         mock_popen.return_value = make_cgi_process()
         code, _handler = make_request(
             "/proj-a.git/info/refs?service=git-upload-pack",

--- a/tests/unit/lib/test_effective_status.py
+++ b/tests/unit/lib/test_effective_status.py
@@ -9,7 +9,7 @@ import subprocess
 from unittest.mock import patch
 
 import pytest
-from terok_sandbox import get_project_container_states
+from terok_sandbox import get_container_states
 
 from terok.lib.core.task_display import (
     STATUS_DISPLAY,
@@ -172,7 +172,7 @@ class TestTaskStateInheritance:
         ),
     ],
 )
-def test_get_project_container_states_handles_output_and_errors(
+def test_get_container_states_handles_output_and_errors(
     output: str | None,
     error: Exception | None,
     expected: dict[str, str],
@@ -180,7 +180,7 @@ def test_get_project_container_states_handles_output_and_errors(
     """Project-wide state lookup parses output and degrades cleanly on errors."""
     patch_kwargs = {"side_effect": error} if error else {"return_value": output}
     with patch("terok_sandbox.runtime.subprocess.check_output", **patch_kwargs):
-        assert get_project_container_states("proj") == expected
+        assert get_container_states("proj") == expected
 
 
 @pytest.mark.parametrize(
@@ -211,7 +211,7 @@ def test_get_all_task_states_maps_project_container_lookup(
 ) -> None:
     """Task-state lookup maps batch project container states back to task IDs."""
     with patch(
-        "terok.lib.orchestration.tasks.get_project_container_states",
+        "terok.lib.orchestration.tasks.get_container_states",
         return_value=container_states,
     ) as mocked_get_states:
         assert get_all_task_states("proj", tasks) == expected

--- a/tests/unit/lib/test_gate_tokens.py
+++ b/tests/unit/lib/test_gate_tokens.py
@@ -76,7 +76,7 @@ class TestCreateToken:
         with patched_token_file() as token_path:
             token = create_token("proj-a", "1")
             data = read_token_json(token_path)
-        assert data[token] == {"project": "proj-a", "task": "1"}
+        assert data[token] == {"scope": "proj-a", "task": "1"}
 
     def test_multiple_tokens_coexist(self) -> None:
         with patched_token_file() as token_path:
@@ -116,8 +116,8 @@ class TestAtomicWrite:
     def test_write_creates_parent_dirs(self) -> None:
         with tempfile.TemporaryDirectory() as td:
             token_path = Path(td) / "sub" / "dir" / "tokens.json"
-            _write_tokens(token_path, {"abc": {"project": "p", "task": "1"}})
-            assert read_token_json(token_path) == {"abc": {"project": "p", "task": "1"}}
+            _write_tokens(token_path, {"abc": {"scope": "p", "task": "1"}})
+            assert read_token_json(token_path) == {"abc": {"scope": "p", "task": "1"}}
 
     @pytest.mark.parametrize(
         ("path", "content", "expected"),
@@ -129,13 +129,13 @@ class TestAtomicWrite:
                 Path("tokens.json"),
                 json.dumps(
                     {
-                        "good": {"project": "p", "task": "1"},
+                        "good": {"scope": "p", "task": "1"},
                         "bad_info": "not a dict",
-                        "missing_task": {"project": "p"},
-                        "int_project": {"project": 123, "task": "1"},
+                        "missing_task": {"scope": "p"},
+                        "int_scope": {"scope": 123, "task": "1"},
                     }
                 ),
-                {"good": {"project": "p", "task": "1"}},
+                {"good": {"scope": "p", "task": "1"}},
             ),
         ],
         ids=["missing", "corrupt-json", "non-dict-json", "malformed-entries"],
@@ -158,8 +158,8 @@ class TestAtomicWrite:
         """Verify that _write_tokens uses atomic replacement semantics."""
         with tempfile.TemporaryDirectory() as td:
             token_path = Path(td) / "tokens.json"
-            _write_tokens(token_path, {"t1": {"project": "p", "task": "1"}})
-            _write_tokens(token_path, {"t2": {"project": "p", "task": "2"}})
+            _write_tokens(token_path, {"t1": {"scope": "p", "task": "1"}})
+            _write_tokens(token_path, {"t2": {"scope": "p", "task": "2"}})
             data = read_token_json(token_path)
-            assert data == {"t2": {"project": "p", "task": "2"}}
+            assert data == {"t2": {"scope": "p", "task": "2"}}
             assert list(Path(td).glob("*.tmp")) == []


### PR DESCRIPTION
## Summary

Companion to terok-ai/terok-sandbox#102 — the sandbox credential subsystem renamed "project" to "scope" in its Python API.

- `GitGate(project_id=)` -> `GitGate(scope=)`
- `SSHManager(project_id=)` -> `SSHManager(scope=)`
- `get_project_container_states` -> `get_container_states`

Only keyword arguments passed to sandbox APIs are renamed. The orchestrator's own `project_id` concept is unchanged — it passes `config.id` / `project.id` as the `scope` value.

## Test plan

- [ ] Verify terok-sandbox#102 is merged first
- [ ] Run terok test suite with updated sandbox
- [ ] Manual smoke test: project init, ssh-init, gate-sync, task launch

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Unified internal handling to use "scope" for gate/auth and container-state lookups.

* **Chores**
  * Updated core runtime component versions to newer releases.

* **Tests**
  * Tests and fixtures adjusted to expect "scope" in token metadata and to follow the updated container-state lookup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->