### PR TITLE
fix: correct misleading gate fallback warning in online mode

### DIFF
--- a/src/terok/lib/orchestration/environment.py
+++ b/src/terok/lib/orchestration/environment.py
@@ -85,8 +85,8 @@ def _security_mode_env_and_volumes(
 
                 warn_user(
                     "gate",
-                    "Gate server unreachable; falling back to upstream clone. "
-                    "Gatekeeping is bypassed for this task.",
+                    "Gate server unreachable; cloning directly from upstream. "
+                    "This is safe — online mode does not require the gate.",
                 )
             else:
                 port = get_gate_server_port(cfg)

--- a/tests/unit/test_error_surfacing.py
+++ b/tests/unit/test_error_surfacing.py
@@ -486,7 +486,7 @@ class TestEnvironmentWarnings:
         assert capsys.readouterr().err == ""
 
     def test_gate_fallback_warns(self, capsys: pytest.CaptureFixture[str]) -> None:
-        """Gate server unreachable triggers a bypass warning on stderr."""
+        """Gate server unreachable triggers an informational warning on stderr."""
         from terok.lib.orchestration.environment import _security_mode_env_and_volumes
 
         mock_project = MagicMock()
@@ -518,4 +518,4 @@ class TestEnvironmentWarnings:
 
         err = capsys.readouterr().err
         assert "Gate server unreachable" in err
-        assert "bypassed" in err.lower()
+        assert "online mode" in err.lower()


### PR DESCRIPTION
## Summary
- The gate-unreachable warning in online mode said "Gatekeeping is bypassed" — implying a security boundary was breached when it wasn't
- Online mode uses the gate only as a clone accelerator; falling back to direct upstream clone is safe by design
- Reworded to: "cloning directly from upstream. This is safe — online mode does not require the gate."

## Test plan
- [x] Existing `test_gate_fallback_warns` updated and passing
- [x] Lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improved Messaging**
  * Updated the warning message displayed when the gate server is unreachable to clarify that online mode does not require the gate server and cloning occurs directly from upstream.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->