### PR TITLE
fix: make sickbay SSH agent check project-aware

### DIFF
--- a/src/terok/cli/commands/sickbay.py
+++ b/src/terok/cli/commands/sickbay.py
@@ -239,7 +239,7 @@ def _check_ssh_agent() -> _CheckResult:
     def _keys_healthy(entry: object) -> bool:
         """Check whether all key files in a scope entry exist on disk."""
         keys = entry if isinstance(entry, list) else [entry]
-        return all(
+        return bool(keys) and all(
             isinstance(k, dict)
             and Path(k.get("private_key", "")).is_file()
             and Path(k.get("public_key", "")).is_file()

--- a/src/terok/cli/commands/sickbay.py
+++ b/src/terok/cli/commands/sickbay.py
@@ -213,6 +213,28 @@ def _check_unfired_hooks(
     return results
 
 
+def _is_key_path(value: object) -> bool:
+    """Check whether a value is a non-empty string pointing to an existing file."""
+    return isinstance(value, str) and bool(value) and Path(value).is_file()
+
+
+def _keys_healthy(entry: object) -> bool:
+    """Check whether all key files in a scope entry exist on disk."""
+    keys = entry if isinstance(entry, list) else [entry]
+    return bool(keys) and all(
+        isinstance(k, dict)
+        and _is_key_path(k.get("private_key"))
+        and _is_key_path(k.get("public_key"))
+        for k in keys
+    )
+
+
+def _abbreviate(ids: list[str], limit: int = 3) -> str:
+    """Join project IDs with a '+N more' suffix when the list is long."""
+    suffix = f" (+{len(ids) - limit} more)" if len(ids) > limit else ""
+    return ", ".join(ids[:limit]) + suffix
+
+
 def _check_ssh_agent() -> _CheckResult:
     """Check SSH agent proxy key registration against known projects."""
     import json
@@ -236,41 +258,24 @@ def _check_ssh_agent() -> _CheckResult:
     if not projects:
         return ("ok", label, "no projects configured")
 
-    def _is_key_path(value: object) -> bool:
-        return isinstance(value, str) and bool(value) and Path(value).is_file()
-
-    def _keys_healthy(entry: object) -> bool:
-        """Check whether all key files in a scope entry exist on disk."""
-        keys = entry if isinstance(entry, list) else [entry]
-        return bool(keys) and all(
-            isinstance(k, dict)
-            and _is_key_path(k.get("private_key"))
-            and _is_key_path(k.get("public_key"))
-            for k in keys
-        )
-
     broken = [p.id for p in projects if p.id in mapping and not _keys_healthy(mapping[p.id])]
     unregistered = [p.id for p in projects if p.id not in mapping]
     registered = len(projects) - len(broken) - len(unregistered)
     total = len(projects)
 
     if broken:
-        names = ", ".join(broken[:3])
-        suffix = f" (+{len(broken) - 3} more)" if len(broken) > 3 else ""
         return (
             "error",
             label,
             f"{len(broken)}/{total} project(s) have missing key files: "
-            f"{names}{suffix} — re-run 'terok ssh-init'",
+            f"{_abbreviate(broken)} — re-run 'terok ssh-init'",
         )
     if unregistered:
-        names = ", ".join(unregistered[:3])
-        suffix = f" (+{len(unregistered) - 3} more)" if len(unregistered) > 3 else ""
         return (
             "warn",
             label,
             f"{registered}/{total} project(s) have SSH keys — missing: "
-            f"{names}{suffix}. Run 'terok ssh-init <project>'",
+            f"{_abbreviate(unregistered)}. Run 'terok ssh-init <project>'",
         )
     return ("ok", label, f"{total}/{total} project(s) have SSH keys")
 

--- a/src/terok/cli/commands/sickbay.py
+++ b/src/terok/cli/commands/sickbay.py
@@ -236,13 +236,16 @@ def _check_ssh_agent() -> _CheckResult:
     if not projects:
         return ("ok", label, "no projects configured")
 
+    def _is_key_path(value: object) -> bool:
+        return isinstance(value, str) and bool(value) and Path(value).is_file()
+
     def _keys_healthy(entry: object) -> bool:
         """Check whether all key files in a scope entry exist on disk."""
         keys = entry if isinstance(entry, list) else [entry]
         return bool(keys) and all(
             isinstance(k, dict)
-            and Path(k.get("private_key", "")).is_file()
-            and Path(k.get("public_key", "")).is_file()
+            and _is_key_path(k.get("private_key"))
+            and _is_key_path(k.get("public_key"))
             for k in keys
         )
 

--- a/src/terok/cli/commands/sickbay.py
+++ b/src/terok/cli/commands/sickbay.py
@@ -229,10 +229,20 @@ def _keys_healthy(entry: object) -> bool:
     )
 
 
+def _sanitize_id(value: str) -> str:
+    """Strip C0/C1 control characters from a project ID for safe terminal output."""
+    import unicodedata
+
+    return "".join(
+        " " if ch in "\n\r\t" else f"\\x{ord(ch):02x}" if unicodedata.category(ch)[0] == "C" else ch
+        for ch in value
+    )
+
+
 def _abbreviate(ids: list[str], limit: int = 3) -> str:
     """Join project IDs with a '+N more' suffix when the list is long."""
     suffix = f" (+{len(ids) - limit} more)" if len(ids) > limit else ""
-    return ", ".join(ids[:limit]) + suffix
+    return ", ".join(_sanitize_id(i) for i in ids[:limit]) + suffix
 
 
 def _check_ssh_agent() -> _CheckResult:

--- a/src/terok/cli/commands/sickbay.py
+++ b/src/terok/cli/commands/sickbay.py
@@ -214,7 +214,7 @@ def _check_unfired_hooks(
 
 
 def _check_ssh_agent() -> _CheckResult:
-    """Check SSH agent proxy key registration and file health."""
+    """Check SSH agent proxy key registration against known projects."""
     import json
 
     label = "SSH agent"
@@ -232,11 +232,12 @@ def _check_ssh_agent() -> _CheckResult:
     if not isinstance(mapping, dict):
         return ("error", label, "ssh-keys.json has invalid schema (expected object)")
 
-    if not mapping:
-        return ("warn", label, "no projects registered — run 'terok ssh-init <project>'")
+    projects = list_projects()
+    if not projects:
+        return ("ok", label, "no projects configured")
 
-    def _keys_present(entry: object) -> bool:
-        """Check whether all key files in a project entry exist on disk."""
+    def _keys_healthy(entry: object) -> bool:
+        """Check whether all key files in a scope entry exist on disk."""
         keys = entry if isinstance(entry, list) else [entry]
         return all(
             isinstance(k, dict)
@@ -245,18 +246,30 @@ def _check_ssh_agent() -> _CheckResult:
             for k in keys
         )
 
-    missing = [pid for pid, entry in mapping.items() if not _keys_present(entry)]
-    total = len(mapping)
-    if missing:
-        names = ", ".join(missing[:3])
-        suffix = f" (+{len(missing) - 3} more)" if len(missing) > 3 else ""
+    broken = [p.id for p in projects if p.id in mapping and not _keys_healthy(mapping[p.id])]
+    unregistered = [p.id for p in projects if p.id not in mapping]
+    registered = len(projects) - len(broken) - len(unregistered)
+    total = len(projects)
+
+    if broken:
+        names = ", ".join(broken[:3])
+        suffix = f" (+{len(broken) - 3} more)" if len(broken) > 3 else ""
         return (
             "error",
             label,
-            f"{len(missing)}/{total} project(s) have missing key files: "
+            f"{len(broken)}/{total} project(s) have missing key files: "
             f"{names}{suffix} — re-run 'terok ssh-init'",
         )
-    return ("ok", label, f"{total} project(s) registered, all keys present")
+    if unregistered:
+        names = ", ".join(unregistered[:3])
+        suffix = f" (+{len(unregistered) - 3} more)" if len(unregistered) > 3 else ""
+        return (
+            "warn",
+            label,
+            f"{registered}/{total} project(s) have SSH keys — missing: "
+            f"{names}{suffix}. Run 'terok ssh-init <project>'",
+        )
+    return ("ok", label, f"{total}/{total} project(s) have SSH keys")
 
 
 _KEYRING_DOC_URL = "https://terok-ai.github.io/terok/kernel-keyring/"

--- a/src/terok/lib/core/project_model.py
+++ b/src/terok/lib/core/project_model.py
@@ -104,6 +104,14 @@ def effective_ssh_key_name(project: ProjectConfig, key_type: str = "ed25519") ->
     return f"id_{algo}_{project.id}"
 
 
+_PROJECT_ID_RE = re.compile(r"[a-z0-9][a-z0-9_-]*")
+
+
+def is_valid_project_id(project_id: str) -> bool:
+    """Return whether *project_id* matches the ``[a-z0-9][a-z0-9_-]*`` contract."""
+    return bool(project_id) and _PROJECT_ID_RE.fullmatch(project_id) is not None
+
+
 def validate_project_id(project_id: str) -> None:
     """Ensure a project ID is safe for use as a directory and OCI image name.
 
@@ -111,9 +119,7 @@ def validate_project_id(project_id: str) -> None:
     separators or traversal sequences, or uses characters outside
     ``[a-z0-9_-]``.
     """
-    if not project_id:
-        raise SystemExit("Project ID must not be empty")
-    if not re.fullmatch(r"[a-z0-9][a-z0-9_-]*", project_id):
+    if not is_valid_project_id(project_id):
         raise SystemExit(
             f"Invalid project ID '{project_id}': "
             "must start with a lowercase letter or digit, followed by lowercase letters, "

--- a/src/terok/lib/core/projects.py
+++ b/src/terok/lib/core/projects.py
@@ -32,6 +32,7 @@ from .project_model import (  # noqa: F401 — re-exported public API
     PresetInfo,
     ProjectConfig,
     effective_ssh_key_name,
+    is_valid_project_id,
     validate_project_id,
 )
 from .yaml_schema import RawGlobalGitSection, RawProjectYaml
@@ -145,6 +146,7 @@ def _build_project_config(
 ) -> ProjectConfig:
     """Transform a validated raw YAML model + resolved identity into a flat ProjectConfig."""
     pid = raw.project.id or project_id
+    validate_project_id(pid)
     sec = raw.project.security_class
     sr = state_dir()
 
@@ -340,7 +342,7 @@ def list_projects() -> list[ProjectConfig]:
         for d in root.iterdir():
             if not d.is_dir():
                 continue
-            if (d / _PROJECT_YML).is_file():
+            if (d / _PROJECT_YML).is_file() and is_valid_project_id(d.name):
                 ids.add(d.name)
 
     projects: list[ProjectConfig] = []

--- a/tach.toml
+++ b/tach.toml
@@ -449,6 +449,7 @@ expose = [
     "ProjectConfig",
     "PresetInfo",
     "effective_ssh_key_name",
+    "is_valid_project_id",
     "validate_project_id",
 ]
 from = ["terok.lib.core.project_model"]

--- a/tests/unit/cli/test_sickbay.py
+++ b/tests/unit/cli/test_sickbay.py
@@ -55,7 +55,13 @@ class TestUpdateWorst:
 
 
 class TestCheckSshAgent:
-    """Verify _check_ssh_agent diagnostics."""
+    """Verify _check_ssh_agent diagnostics (project-aware)."""
+
+    @staticmethod
+    def _mock_project(pid: str) -> unittest.mock.MagicMock:
+        p = unittest.mock.MagicMock()
+        p.id = pid
+        return p
 
     def test_missing_keys_file(self, tmp_path: Path) -> None:
         """No ssh-keys.json → warn with ssh-init hint."""
@@ -65,18 +71,21 @@ class TestCheckSshAgent:
         assert sev == "warn"
         assert "ssh-init" in detail
 
-    def test_empty_keys_file(self, tmp_path: Path) -> None:
-        """Empty mapping → warn with ssh-init hint."""
+    def test_no_projects(self, tmp_path: Path) -> None:
+        """No projects configured → ok (nothing to check)."""
         kf = tmp_path / "ssh-keys.json"
         kf.write_text("{}")
-        with unittest.mock.patch("terok.cli.commands.sickbay.make_sandbox_config") as mock_cfg:
+        with (
+            unittest.mock.patch("terok.cli.commands.sickbay.make_sandbox_config") as mock_cfg,
+            unittest.mock.patch("terok.cli.commands.sickbay.list_projects", return_value=[]),
+        ):
             mock_cfg.return_value.ssh_keys_json_path = kf
             sev, _, detail = _check_ssh_agent()
-        assert sev == "warn"
+        assert sev == "ok"
         assert "no projects" in detail
 
     def test_all_keys_present(self, tmp_path: Path) -> None:
-        """All registered keys exist → ok."""
+        """All projects have healthy keys → ok."""
         import json
 
         priv = tmp_path / "id"
@@ -85,26 +94,84 @@ class TestCheckSshAgent:
         pub.write_text("pubkey")
         kf = tmp_path / "ssh-keys.json"
         kf.write_text(json.dumps({"proj": {"private_key": str(priv), "public_key": str(pub)}}))
-        with unittest.mock.patch("terok.cli.commands.sickbay.make_sandbox_config") as mock_cfg:
+        with (
+            unittest.mock.patch("terok.cli.commands.sickbay.make_sandbox_config") as mock_cfg,
+            unittest.mock.patch(
+                "terok.cli.commands.sickbay.list_projects",
+                return_value=[self._mock_project("proj")],
+            ),
+        ):
             mock_cfg.return_value.ssh_keys_json_path = kf
             sev, _, detail = _check_ssh_agent()
         assert sev == "ok"
-        assert "1 project(s)" in detail
+        assert "1/1" in detail
 
     def test_missing_key_files(self, tmp_path: Path) -> None:
-        """Registered keys with missing files → error."""
+        """Project keys with missing files → error."""
         import json
 
         kf = tmp_path / "ssh-keys.json"
         kf.write_text(
             json.dumps({"bad": {"private_key": "/gone/id", "public_key": "/gone/id.pub"}})
         )
-        with unittest.mock.patch("terok.cli.commands.sickbay.make_sandbox_config") as mock_cfg:
+        with (
+            unittest.mock.patch("terok.cli.commands.sickbay.make_sandbox_config") as mock_cfg,
+            unittest.mock.patch(
+                "terok.cli.commands.sickbay.list_projects",
+                return_value=[self._mock_project("bad")],
+            ),
+        ):
             mock_cfg.return_value.ssh_keys_json_path = kf
             sev, _, detail = _check_ssh_agent()
         assert sev == "error"
         assert "bad" in detail
         assert "ssh-init" in detail
+
+    def test_unregistered_project(self, tmp_path: Path) -> None:
+        """Project exists but has no keys → warn with name."""
+        kf = tmp_path / "ssh-keys.json"
+        kf.write_text("{}")
+        with (
+            unittest.mock.patch("terok.cli.commands.sickbay.make_sandbox_config") as mock_cfg,
+            unittest.mock.patch(
+                "terok.cli.commands.sickbay.list_projects",
+                return_value=[self._mock_project("myproj")],
+            ),
+        ):
+            mock_cfg.return_value.ssh_keys_json_path = kf
+            sev, _, detail = _check_ssh_agent()
+        assert sev == "warn"
+        assert "myproj" in detail
+        assert "0/1" in detail
+
+    def test_custom_scopes_ignored(self, tmp_path: Path) -> None:
+        """Non-project scopes in ssh-keys.json don't affect project check."""
+        import json
+
+        priv = tmp_path / "id"
+        pub = tmp_path / "id.pub"
+        priv.write_text("key")
+        pub.write_text("pubkey")
+        kf = tmp_path / "ssh-keys.json"
+        kf.write_text(
+            json.dumps(
+                {
+                    "proj": {"private_key": str(priv), "public_key": str(pub)},
+                    "custom-scope": {"private_key": "/gone", "public_key": "/gone"},
+                }
+            )
+        )
+        with (
+            unittest.mock.patch("terok.cli.commands.sickbay.make_sandbox_config") as mock_cfg,
+            unittest.mock.patch(
+                "terok.cli.commands.sickbay.list_projects",
+                return_value=[self._mock_project("proj")],
+            ),
+        ):
+            mock_cfg.return_value.ssh_keys_json_path = kf
+            sev, _, detail = _check_ssh_agent()
+        assert sev == "ok"
+        assert "1/1" in detail
 
     def test_corrupt_json(self, tmp_path: Path) -> None:
         """Corrupt JSON → error."""

--- a/tests/unit/cli/test_sickbay.py
+++ b/tests/unit/cli/test_sickbay.py
@@ -173,6 +173,25 @@ class TestCheckSshAgent:
         assert sev == "ok"
         assert "1/1" in detail
 
+    def test_empty_key_list_not_healthy(self, tmp_path: Path) -> None:
+        """Project with an empty key list is not treated as healthy."""
+        import json
+
+        kf = tmp_path / "ssh-keys.json"
+        kf.write_text(json.dumps({"proj": []}))
+        with (
+            unittest.mock.patch("terok.cli.commands.sickbay.make_sandbox_config") as mock_cfg,
+            unittest.mock.patch(
+                "terok.cli.commands.sickbay.list_projects",
+                return_value=[self._mock_project("proj")],
+            ),
+        ):
+            mock_cfg.return_value.ssh_keys_json_path = kf
+            sev, _, detail = _check_ssh_agent()
+        assert sev == "error"
+        assert "proj" in detail
+        assert "missing key files" in detail
+
     def test_corrupt_json(self, tmp_path: Path) -> None:
         """Corrupt JSON → error."""
         kf = tmp_path / "ssh-keys.json"


### PR DESCRIPTION
## Summary
- `_check_ssh_agent()` now cross-references `ssh-keys.json` scopes against actual projects from `list_projects()` instead of just checking if the file is non-empty
- Custom credential scopes (from `ssh add-key`) no longer cause false positives — only project IDs matter
- Reports "N/M project(s) have SSH keys" with specific names of unregistered projects

## Context
Found during fresh-install testing: user added keys via `terok ssh add-key` (custom scopes), sickbay reported "all good" even though no actual projects had SSH keys registered via `ssh-init`.

## Test plan
- [x] `make lint` passes
- [x] Tests pass: `test_no_projects`, `test_all_keys_present`, `test_unregistered_project`, `test_custom_scopes_ignored`, `test_missing_key_files`, `test_corrupt_json`
- [ ] Manual: add custom-scope key via `ssh add-key`, run `sickbay`, verify it doesn't count toward project coverage

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * SSH-key health now evaluates only configured projects: no configured projects → OK; distinguishes broken (error) vs unregistered (warn) projects, reports X/Y project key status, and gives per-project remediation hints. IDs in messages are sanitized/abbreviated; empty key lists are treated as unhealthy and unrelated entries are ignored.

* **Tests**
  * Expanded coverage for project-aware behaviors: unregistered projects, empty-key scenarios, non-project entries ignored, and updated status/message formats.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->