### PR TITLE
chore: rename umbrella→namespace and fix terokctl references

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -50,7 +50,7 @@ RUN mkdir -p \
     && printf '%s\n' \
         'unqualified-search-registries = ["docker.io"]' \
         > ~/.config/containers/registries.conf \
-    && terokctl completions install --shell bash
+    && terok completions install --shell bash
 USER root
 
 # ── 4. Inline entrypoint ──────────────────────────────────────────
@@ -72,7 +72,7 @@ RUN printf '%s\n' '#!/bin/sh' \
         'echo "  git clone http://$TEROK_GATE_ADMIN_TOKEN@localhost:9418/<project>.git"' \
         'echo "══════════════════════════════════════════════════"' \
         'echo ""' \
-        'su -m podman -s /bin/sh -c "terokctl gate-server start"' \
+        'su -m podman -s /bin/sh -c "terok gate start"' \
         'exec su -m podman -s /bin/sh -c "exec terok-web --host 0.0.0.0 --port 8566 ${TEROK_PUBLIC_URL:+--public-url \"$TEROK_PUBLIC_URL\"}"' \
         > /usr/local/bin/docker-entrypoint.sh \
     && chmod +x /usr/local/bin/docker-entrypoint.sh

--- a/docs/gen_config_reference.py
+++ b/docs/gen_config_reference.py
@@ -84,7 +84,7 @@ _FIELD_DOCS: dict[str, str] = {
     # credentials
     "credentials.dir": "Shared credentials directory (proxy DB, agent config mounts)",
     # paths
-    "paths.root": "Umbrella state root shared by all ecosystem packages "
+    "paths.root": "Namespace state root shared by all ecosystem packages "
     "(Podman model — one config, multiple readers)",
     "paths.sandbox_live_dir": "Container-writable runtime data (tasks, agent mounts). "
     "For hardened installs, mount the target with ``noexec,nosuid,nodev``",

--- a/docs/kernel-keyring.md
+++ b/docs/kernel-keyring.md
@@ -62,7 +62,7 @@ keyring = false
 ```
 
 !!! tip "Sickbay detection"
-    `terokctl sickbay` warns when keyring creation is not disabled.
+    `terok sickbay` warns when keyring creation is not disabled.
     Run it after installation to verify your setup.
 
 ## References

--- a/poetry.lock
+++ b/poetry.lock
@@ -2906,24 +2906,24 @@ tomli-w = ">=1.0,<2.0"
 
 [[package]]
 name = "terok-agent"
-version = "0.0.56"
+version = "0.0.57"
 description = "Single-agent task runner for hardened Podman containers"
 optional = false
 python-versions = ">=3.12,<4.0"
 groups = ["main"]
 files = [
-    {file = "terok_agent-0.0.56-py3-none-any.whl", hash = "sha256:2fc965e916aad6106801d24542c4981d5ab2508ebb3cba66d3fab5b8b264ce46"},
+    {file = "terok_agent-0.0.57-py3-none-any.whl", hash = "sha256:678d8e276016b04b2ed2aed933836dec9a38d03c20e866b8a25b4edfb560b377"},
 ]
 
 [package.dependencies]
 Jinja2 = ">=3.1"
 "ruamel.yaml" = ">=0.18"
-terok_sandbox = {url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.0.50/terok_sandbox-0.0.50-py3-none-any.whl"}
+terok_sandbox = {url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.0.51/terok_sandbox-0.0.51-py3-none-any.whl"}
 tomli-w = ">=1.0"
 
 [package.source]
 type = "url"
-url = "https://github.com/terok-ai/terok-agent/releases/download/v0.0.56/terok_agent-0.0.56-py3-none-any.whl"
+url = "https://github.com/terok-ai/terok-agent/releases/download/v0.0.57/terok_agent-0.0.57-py3-none-any.whl"
 
 [[package]]
 name = "terok-dbus"
@@ -2945,13 +2945,13 @@ url = "https://github.com/terok-ai/terok-dbus/releases/download/v0.5.6/terok_dbu
 
 [[package]]
 name = "terok-sandbox"
-version = "0.0.50"
+version = "0.0.51"
 description = "Hardened Podman container runner with gate server and shield integration"
 optional = false
 python-versions = ">=3.12,<4.0"
 groups = ["main"]
 files = [
-    {file = "terok_sandbox-0.0.50-py3-none-any.whl", hash = "sha256:2d45f9c16b910a4edd9e5f31e0aca94d2907481fefdbea6977a1b06f233a13c6"},
+    {file = "terok_sandbox-0.0.51-py3-none-any.whl", hash = "sha256:26843efa8efd232d2b1768ea83c545c7889b7fd2117d27b66997a8360b15b5af"},
 ]
 
 [package.dependencies]
@@ -2962,7 +2962,7 @@ terok_shield = {url = "https://github.com/terok-ai/terok-shield/releases/downloa
 
 [package.source]
 type = "url"
-url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.0.50/terok_sandbox-0.0.50-py3-none-any.whl"
+url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.0.51/terok_sandbox-0.0.51-py3-none-any.whl"
 
 [[package]]
 name = "terok-shield"
@@ -3470,4 +3470,4 @@ propcache = ">=0.2.1"
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.12,<4.0"
-content-hash = "633429504751f9e70ba11681ea95cafb97ffc56172a469515ea47d4d29382eac"
+content-hash = "e8fb46baacb297de4fc1fd29a2dfe209659e2734b22e52f6252e7deb28d4e357"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,8 +44,8 @@ rich = ">=13.0"
 platformdirs = ">=4.5.1"
 unique-namer = ">=1.3"
 textual-serve = ">=1.1.0"
-terok-agent = {url = "https://github.com/terok-ai/terok-agent/releases/download/v0.0.56/terok_agent-0.0.56-py3-none-any.whl"}
-terok-sandbox = {url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.0.50/terok_sandbox-0.0.50-py3-none-any.whl"}
+terok-agent = {url = "https://github.com/terok-ai/terok-agent/releases/download/v0.0.57/terok_agent-0.0.57-py3-none-any.whl"}
+terok-sandbox = {url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.0.51/terok_sandbox-0.0.51-py3-none-any.whl"}
 terok-dbus = {url = "https://github.com/terok-ai/terok-dbus/releases/download/v0.5.6/terok_dbus-0.5.6-py3-none-any.whl"}
 
 [tool.poetry.group.dev.dependencies]

--- a/src/terok/lib/core/config.py
+++ b/src/terok/lib/core/config.py
@@ -191,12 +191,12 @@ def state_dir() -> Path:
 
     Precedence:
     - ``TEROK_STATE_DIR`` environment variable (per-package escape hatch).
-    - Umbrella root (``TEROK_ROOT`` / ``config.yml`` ``paths.root``) + ``core/``.
+    - Namespace root (``TEROK_ROOT`` / ``config.yml`` ``paths.root``) + ``core/``.
     - Platform default (``~/.local/share/terok/core``).
     """
-    from terok_sandbox.paths import umbrella_state_dir
+    from terok_sandbox.paths import namespace_state_dir
 
-    return umbrella_state_dir("core", "TEROK_STATE_DIR").resolve()
+    return namespace_state_dir("core", "TEROK_STATE_DIR").resolve()
 
 
 def sandbox_live_dir() -> Path:
@@ -209,14 +209,14 @@ def sandbox_live_dir() -> Path:
     Precedence:
     - ``TEROK_SANDBOX_LIVE_DIR`` environment variable.
     - Global config ``paths.sandbox_live_dir``.
-    - Umbrella root + ``sandbox-live/``.
+    - Namespace root + ``sandbox-live/``.
     """
-    from terok_sandbox.paths import umbrella_state_dir
+    from terok_sandbox.paths import namespace_state_dir
 
     return _resolve_path(
         "TEROK_SANDBOX_LIVE_DIR",
         ("paths", "sandbox_live_dir"),
-        lambda: umbrella_state_dir("sandbox-live"),
+        lambda: namespace_state_dir("sandbox-live"),
     )
 
 
@@ -296,7 +296,7 @@ def build_dir() -> Path:
 
 
 def archive_dir() -> Path:
-    """Umbrella archive tree for project and task archives.
+    """Namespace archive tree for project and task archives.
 
     All archived data lives under one discoverable location::
 
@@ -307,9 +307,9 @@ def archive_dir() -> Path:
     The ``<project>/`` subdirectory is bundled into the project tar and
     removed on project deletion — freeing the name for reuse.
     """
-    from terok_sandbox.paths import umbrella_state_dir
+    from terok_sandbox.paths import namespace_state_dir
 
-    return umbrella_state_dir("archive").resolve()
+    return namespace_state_dir("archive").resolve()
 
 
 def get_ui_base_port() -> int:
@@ -323,14 +323,14 @@ def credentials_dir() -> Path:
     Precedence:
     - ``TEROK_CREDENTIALS_DIR`` environment variable.
     - Global config ``credentials.dir``.
-    - Umbrella root + ``credentials/`` (honors ``paths.root``).
+    - Namespace root + ``credentials/`` (honors ``paths.root``).
     """
-    from terok_sandbox.paths import umbrella_state_dir
+    from terok_sandbox.paths import namespace_state_dir
 
     return _resolve_path(
         "TEROK_CREDENTIALS_DIR",
         ("credentials", "dir"),
-        lambda: umbrella_state_dir("credentials"),
+        lambda: namespace_state_dir("credentials"),
     )
 
 

--- a/src/terok/lib/core/paths.py
+++ b/src/terok/lib/core/paths.py
@@ -97,7 +97,7 @@ def runtime_root() -> Path:
 def credentials_root() -> Path:
     """Shared credentials directory used by all terok ecosystem packages.
 
-    Lives under the ``terok/`` umbrella so a single ``rm -rf`` or backup
+    Lives under the ``terok/`` namespace so a single ``rm -rf`` or backup
     captures everything.
 
     Priority: ``TEROK_CREDENTIALS_DIR`` → ``/var/lib/terok/credentials`` (root)

--- a/src/terok/lib/core/yaml_schema.py
+++ b/src/terok/lib/core/yaml_schema.py
@@ -309,7 +309,7 @@ class RawCredentialsSection(BaseModel):
 class RawPathsSection(BaseModel):
     """Global ``paths:`` section.
 
-    ``root`` is the umbrella state root read by all ecosystem packages
+    ``root`` is the namespace state root read by all ecosystem packages
     (Podman model).
     """
 

--- a/src/terok/lib/domain/project.py
+++ b/src/terok/lib/domain/project.py
@@ -251,7 +251,7 @@ def _archive_project(project_id: str) -> str | None:
         if project_state.is_dir():
             sources.append(("state", project_state))
 
-        # Task archives (umbrella archive tree)
+        # Task archives (namespace archive tree)
         task_archive_path = archive_root / pid
         if task_archive_path.is_dir():
             sources.append(("task-archives", task_archive_path))

--- a/src/terok/lib/orchestration/environment.py
+++ b/src/terok/lib/orchestration/environment.py
@@ -212,9 +212,17 @@ def ensure_credential_proxy() -> None:
     if get_credential_proxy_bypass():
         return
 
-    from terok_sandbox import ensure_proxy_reachable
+    from terok_sandbox import ProxyUnreachableError, ensure_proxy_reachable
 
-    ensure_proxy_reachable(make_sandbox_config())
+    try:
+        ensure_proxy_reachable(make_sandbox_config())
+    except ProxyUnreachableError as exc:
+        raise SystemExit(
+            f"{exc}\n\n"
+            "Start it with:\n"
+            "  terok credential-proxy install   (systemd socket activation)\n"
+            "  terok credential-proxy start     (manual daemon)"
+        ) from exc
 
 
 def _credential_proxy_env_and_volumes(
@@ -243,13 +251,22 @@ def _credential_proxy_env_and_volumes(
     from terok_agent import get_roster
     from terok_sandbox import (
         CredentialDB,
+        ProxyUnreachableError,
         ensure_proxy_reachable,
         get_proxy_port,
         get_ssh_agent_port,
     )
 
     cfg = make_sandbox_config()
-    ensure_proxy_reachable(cfg)
+    try:
+        ensure_proxy_reachable(cfg)
+    except ProxyUnreachableError as exc:
+        raise SystemExit(
+            f"{exc}\n\n"
+            "Start it with:\n"
+            "  terok credential-proxy install   (systemd socket activation)\n"
+            "  terok credential-proxy start     (manual daemon)"
+        ) from exc
 
     roster = get_roster()
     proxy_routes = roster.proxy_routes

--- a/src/terok/lib/orchestration/tasks.py
+++ b/src/terok/lib/orchestration/tasks.py
@@ -279,7 +279,7 @@ def tasks_meta_dir(project_id: str) -> Path:
 def tasks_archive_dir(project_id: str) -> Path:
     """Return the directory containing archived task data for *project_id*.
 
-    Lives under the umbrella archive tree (``archive/<pid>/tasks/``) so
+    Lives under the namespace archive tree (``archive/<pid>/tasks/``) so
     operators can find all archived data in one location.  On project
     deletion the entire ``archive/<pid>/`` subtree is bundled into the
     project snapshot and removed.

--- a/src/terok/resources/templates/l2.project.Dockerfile.template
+++ b/src/terok/resources/templates/l2.project.Dockerfile.template
@@ -1,4 +1,5 @@
 # syntax=docker/dockerfile:1
+
 ARG BASE_IMAGE
 FROM ${BASE_IMAGE}
 

--- a/src/terok/resources/templates/ssh_config.template
+++ b/src/terok/resources/templates/ssh_config.template
@@ -1,3 +1,5 @@
+# terok:container — this file is deployed into task containers, not used on the host.
+
 # Default SSH config template used by `terok ssh-init` when no project-specific
 # template is provided. You can copy this file and point project.yml → ssh.config_template
 # to your customized version. Supported tokens:
@@ -9,12 +11,4 @@ Host *
   # Use only the key filename so this config works both on the host (when
   # combined with an explicit IdentityFile override) and inside containers,
   # where the key lives in ~/.ssh/{{KEY_NAME}}.
-  IdentityFile ~/.ssh/{{KEY_NAME}}
-
-# Common Git host (kept explicit; inherits Host * defaults)
-Host github.com
-  HostName github.com
-  User git
-  IdentitiesOnly yes
-  StrictHostKeyChecking no
   IdentityFile ~/.ssh/{{KEY_NAME}}

--- a/tests/unit/lib/test_config.py
+++ b/tests/unit/lib/test_config.py
@@ -194,7 +194,7 @@ def test_state_dir_via_env(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> N
 
 
 def test_state_dir_via_config(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
-    """``state_dir()`` honors ``paths.root`` from config as umbrella root."""
+    """``state_dir()`` honors ``paths.root`` from config as namespace root."""
     target = tmp_path / "custom-root"
     monkeypatch.delenv("TEROK_STATE_DIR", raising=False)
     monkeypatch.setenv(
@@ -221,8 +221,8 @@ def test_build_dir_defaults_under_state(monkeypatch: pytest.MonkeyPatch, tmp_pat
     assert cfg.build_dir() == (tmp_path / "build").resolve()
 
 
-def test_archive_dir_at_umbrella_root(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
-    """``archive_dir()`` lives at the umbrella state root."""
+def test_archive_dir_at_namespace_root(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """``archive_dir()`` lives at the namespace state root."""
     monkeypatch.setenv("TEROK_ROOT", str(tmp_path))
     assert cfg.archive_dir() == (tmp_path / "archive").resolve()
 
@@ -245,10 +245,10 @@ def test_sandbox_live_dir_via_config(monkeypatch: pytest.MonkeyPatch, tmp_path: 
     assert cfg.sandbox_live_dir() == target.resolve()
 
 
-def test_sandbox_live_dir_defaults_under_umbrella(
+def test_sandbox_live_dir_defaults_under_namespace(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
-    """``sandbox_live_dir()`` defaults to ``umbrella_root/sandbox-live``."""
+    """``sandbox_live_dir()`` defaults to ``namespace_root/sandbox-live``."""
     monkeypatch.delenv("TEROK_SANDBOX_LIVE_DIR", raising=False)
     monkeypatch.setenv("TEROK_ROOT", str(tmp_path))
     monkeypatch.setenv("TEROK_CONFIG_FILE", str(write_config(tmp_path, "")))

--- a/tests/unit/lib/test_paths.py
+++ b/tests/unit/lib/test_paths.py
@@ -61,11 +61,11 @@ class TestCredentialsRoot:
         )
 
 
-class TestCredentialsUmbrella:
-    """Verify credentials live under the terok/ umbrella."""
+class TestCredentialsNamespace:
+    """Verify credentials live under the terok/ namespace."""
 
-    def test_default_is_under_umbrella(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        """Default credentials_root() nests under the terok/ umbrella, not a sibling."""
+    def test_default_is_under_namespace(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Default credentials_root() nests under the terok/ namespace, not a sibling."""
         monkeypatch.delenv("TEROK_CREDENTIALS_DIR", raising=False)
         monkeypatch.delenv("XDG_DATA_HOME", raising=False)
         monkeypatch.setattr(paths, "_is_root", lambda: False)

--- a/tests/unit/lib/test_project_delete.py
+++ b/tests/unit/lib/test_project_delete.py
@@ -63,7 +63,7 @@ def gate_dir(env: SimpleNamespace, _project_id: str) -> Path:
 
 
 def task_archive_subdir(_env: SimpleNamespace, project_id: str) -> Path:
-    """Create and return the project's task archive dir (under umbrella archive)."""
+    """Create and return the project's task archive dir (under namespace archive)."""
     from terok.lib.core.config import archive_dir as cfg_archive_dir
 
     target = cfg_archive_dir() / project_id / "tasks"

--- a/tests/unit/lib/test_shield.py
+++ b/tests/unit/lib/test_shield.py
@@ -87,7 +87,7 @@ def test_make_shield_maps_config_to_shield_config(
     cfg = SandboxConfig(config_dir=MOCK_CONFIG_ROOT, **cfg_kwargs)
     with (
         patch("terok_shield.run.SubprocessRunner", autospec=True),
-        patch("terok_sandbox.paths.umbrella_config_root", return_value=MOCK_CONFIG_ROOT),
+        patch("terok_sandbox.paths.namespace_config_root", return_value=MOCK_CONFIG_ROOT),
     ):
         shield = make_shield(MOCK_TASK_DIR, cfg=cfg)
 

--- a/tests/unit/lib/test_tasks.py
+++ b/tests/unit/lib/test_tasks.py
@@ -1285,7 +1285,7 @@ class TestTaskArchive:
                 # Task should be deleted
                 assert not meta_path.exists()
 
-                # Archive should exist under umbrella archive tree
+                # Archive should exist under namespace archive tree
                 from terok.lib.orchestration.tasks import tasks_archive_dir
 
                 archive_root = tasks_archive_dir(project_id)


### PR DESCRIPTION
## Summary
- Rename all `umbrella_state_dir` imports/calls to `namespace_state_dir`
- Fix `terokctl` → `terok` in Dockerfile and docs/kernel-keyring.md
- Update docstrings, comments, and test names across config, paths, project, tasks, and gen_config_reference

Depends on terok-ai/terok-sandbox#116 and terok-ai/terok-agent release with namespace API.

## Test plan
- [x] `make lint` passes
- [x] Zero remaining `terokctl` or `umbrella` references (except negative assertion in test_cli_main.py)
- [ ] Tests pass once sandbox+agent with namespace API are released

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated CLI references from `terokctl` to `terok` in build/runtime config and docs.
  * Standardized terminology from "umbrella" to "namespace" across docs, config descriptions, and tests.
  * Bumped packaged dependency versions for agent and sandbox.
  * Removed embedded GitHub host block from the SSH template and minor Dockerfile template formatting tweak.

* **Bug Fixes**
  * Improved credential-proxy error handling to emit a clear message instructing how to install/start the proxy.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->