### PR TITLE
feat: multi-user port-file discovery prerequisites

### DIFF
--- a/docs/developer.md
+++ b/docs/developer.md
@@ -542,6 +542,54 @@ This pattern (config key for inheritance control + file for additive content) is
 
 ---
 
+## Multi-User Port Allocation
+
+### Problem
+
+terok's host-side services (gate server, credential proxy, Toad web UI) bind to fixed TCP ports.
+On a shared Linux host with multiple users, only one user can run terok at a time because port
+conflicts prevent the second user's services from starting.
+
+### Solution: port-file discovery
+
+Each service binds to an OS-assigned port (port 0) and writes the actual bound port to a file
+under `$XDG_RUNTIME_DIR/terok/` (typically `/run/user/{uid}/terok/`).  Clients read the file to
+discover the port.  On restart, the service attempts to reuse its previous port (SO_REUSEADDR),
+so running containers are unaffected.
+
+This is the same pattern used by JupyterHub (per-user notebook servers) and Xvfb (display
+servers).
+
+### Port file locations
+
+| Service          | Port file                                 | Preferred port config          |
+|------------------|-------------------------------------------|--------------------------------|
+| Gate server      | `runtime_root()/gate.port`                | `gate_server.port` (9418)      |
+| Credential proxy | `runtime_root()/proxy.port`               | `credential_proxy.port` (18731)|
+| Toad web UI      | Per-task in `tasks/{id}.yml` → `web_port` | `ui.base_port` (7860)          |
+
+`runtime_root()` resolves to `$XDG_RUNTIME_DIR/terok` on systemd-based Linux — per-user,
+permission-protected (mode 0700), cleaned on logout.
+
+### Package boundary
+
+Port-file writing and reading is implemented in **terok-sandbox** (gate server, credential
+proxy).  The **terok** package consumes ports via sandbox APIs (`get_gate_server_port()`,
+`get_proxy_port()`), which transparently read from port files.  Toad ports are managed directly
+in terok's task metadata.
+
+The `config.yml` port fields (`gate_server.port`, `credential_proxy.port`) specify the
+*preferred* port — what the service will try to bind first.  The actual bound port may differ
+in multi-user environments.
+
+### Future: bridge mode networking
+
+Port-file discovery is a pragmatic near-term solution.  The long-term architecture is Podman
+bridge-mode networking with per-user networks and DNS-based service discovery, eliminating host
+port exposure entirely.
+
+---
+
 ## Making a Release
 
 ### Steps

--- a/src/terok/lib/core/config.py
+++ b/src/terok/lib/core/config.py
@@ -348,7 +348,7 @@ def make_sandbox_config() -> "SandboxConfig":  # noqa: F821 — forward ref
 
     return SandboxConfig(
         credentials_dir=credentials_dir(),
-        gate_port=get_gate_server_port(),
+        gate_port=get_configured_gate_port(),
         shield_bypass=get_shield_bypass_firewall_no_protection(),
         shield_audit=get_shield_audit(),
     )
@@ -401,6 +401,21 @@ def get_task_name_categories() -> list[str] | None:
 
 # Presentation-layer hint appended to CLI/TUI messages when the shield is weakened.
 SHIELD_SECURITY_HINT = "See: https://terok-ai.github.io/terok/shield-security/"
+
+
+def get_configured_proxy_port() -> int:
+    """Return the preferred credential proxy port from global config (default 18731).
+
+    This is the port the proxy will *try* to bind.  In multi-user setups the
+    actual bound port may differ — use ``terok_sandbox.get_proxy_port()`` for
+    the live value.
+
+    Global config (config.yml)::
+
+        credential_proxy:
+          port: 18731
+    """
+    return _load_validated().credential_proxy.port
 
 
 def get_credential_proxy_bypass() -> bool:
@@ -470,8 +485,18 @@ def get_public_host() -> str:
     return os.environ.get("TEROK_PUBLIC_HOST", "").strip() or "127.0.0.1"
 
 
-def get_gate_server_port() -> int:
-    """Return the gate server port from global config (default 9418)."""
+def get_configured_gate_port() -> int:
+    """Return the preferred gate server port from global config (default 9418).
+
+    This is the port the server will *try* to bind.  In multi-user setups the
+    actual bound port may differ — use ``terok_sandbox.get_gate_server_port()``
+    for the live value.
+
+    Global config (config.yml)::
+
+        gate_server:
+          port: 9418
+    """
     return _load_validated().gate_server.port
 
 

--- a/src/terok/lib/core/paths.py
+++ b/src/terok/lib/core/paths.py
@@ -11,9 +11,10 @@ try:
     from platformdirs import (
         user_config_dir as _user_config_dir,
         user_data_dir as _user_data_dir,
+        user_runtime_dir as _user_runtime_dir,
     )
 except ImportError:  # optional dependency
-    _user_config_dir = _user_data_dir = None  # type: ignore[assignment]
+    _user_config_dir = _user_data_dir = _user_runtime_dir = None  # type: ignore[assignment]
 
 
 APP_NAME = "terok"
@@ -76,13 +77,15 @@ def state_root() -> Path:
 
 
 def runtime_root() -> Path:
-    """
-    Transient runtime bits.
+    """Transient runtime files (port files, PID files).
+
+    Port files for host-side services live here so each user on a shared host
+    gets an isolated, session-scoped directory (cleaned on logout).
 
     Priority:
       1. TEROK_RUNTIME_DIR
       2. if root   → /run/terok
-         else      → ~/.cache/terok
+         else      → platformdirs → $XDG_RUNTIME_DIR/terok → ~/.cache/terok
     """
     env = os.getenv("TEROK_RUNTIME_DIR")
     if env:
@@ -91,6 +94,12 @@ def runtime_root() -> Path:
     if _is_root():
         return Path("/run") / APP_NAME
 
+    if _user_runtime_dir is not None:
+        return Path(_user_runtime_dir(APP_NAME))
+
+    xdg = os.getenv("XDG_RUNTIME_DIR")
+    if xdg:
+        return Path(xdg) / APP_NAME
     return Path.home() / ".cache" / APP_NAME
 
 

--- a/src/terok/lib/core/yaml_schema.py
+++ b/src/terok/lib/core/yaml_schema.py
@@ -363,10 +363,16 @@ class RawShieldGlobalSection(BaseModel):
 
 
 class RawCredentialProxySection(BaseModel):
-    """Global ``credential_proxy:`` section."""
+    """Global ``credential_proxy:`` section.
+
+    The ``port`` field is the *preferred* port the proxy will try to bind.
+    In multi-user setups the actual port may differ — see port-file discovery
+    in developer.md.
+    """
 
     model_config = ConfigDict(extra="forbid")
 
+    port: int = 18731
     bypass_no_secret_protection: bool = False
     transport: Literal["direct", "socket"] = "socket"
 

--- a/src/terok/lib/orchestration/container_doctor.py
+++ b/src/terok/lib/orchestration/container_doctor.py
@@ -144,7 +144,7 @@ def _terok_doctor_checks(
     checks.append(_git_identity_check(human_name, human_email, "email"))
 
     # Git remote URL check
-    from ..core.config import get_gate_server_port as _get_gate_port
+    from ..core.config import get_configured_gate_port as _get_gate_port
 
     gate_port = _get_gate_port()
     checks.append(_git_remote_check(project.security_class, gate_port))

--- a/src/terok/lib/orchestration/ports.py
+++ b/src/terok/lib/orchestration/ports.py
@@ -15,7 +15,7 @@ from ..util.yaml import load as _yaml_load
 _LOCALHOST = "127.0.0.1"
 
 
-def _is_port_free(port: int) -> bool:
+def is_port_free(port: int) -> bool:
     """Return True if *port* can be bound on localhost."""
     with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
         try:
@@ -63,7 +63,7 @@ def assign_web_port() -> int:
     max_tries = 200
     tries = 0
     while tries < max_tries:
-        if port not in used and _is_port_free(port):
+        if port not in used and is_port_free(port):
             return port
         port += 1
         tries += 1

--- a/src/terok/lib/orchestration/task_runners.py
+++ b/src/terok/lib/orchestration/task_runners.py
@@ -54,7 +54,7 @@ from .agent_config import resolve_agent_config
 from .container_exec import container_git_diff
 from .environment import build_task_env_and_volumes, ensure_credential_proxy
 from .hooks import run_hook
-from .ports import assign_web_port
+from .ports import assign_web_port, is_port_free
 from .tasks import (
     container_name,
     load_task_meta,
@@ -527,6 +527,11 @@ def task_run_toad(
     if not isinstance(port, int):
         port = assign_web_port()
         meta["web_port"] = port
+    elif not is_port_free(port):
+        old = port
+        port = assign_web_port()
+        meta["web_port"] = port
+        print(f"WARNING: Previously assigned port {old} is in use, reassigned to {port}")
 
     cname = container_name(project.id, "toad", task_id)
     container_state = get_container_state(cname)

--- a/tach.toml
+++ b/tach.toml
@@ -622,7 +622,7 @@ expose = [
     "load_global_config",
     "get_global_section",
     "get_global_agent_config",
-    "get_gate_server_port",
+    "get_configured_gate_port",
     "get_gate_server_suppress_warning",
     "get_task_name_categories",
     "get_prefix",
@@ -632,6 +632,7 @@ expose = [
     "get_claude_allow_oauth",
     "get_claude_expose_oauth_token",
     "is_claude_oauth_proxied",
+    "get_configured_proxy_port",
     "get_credential_proxy_bypass",
     "get_credential_proxy_transport",
     "get_shield_bypass_firewall_no_protection",
@@ -755,7 +756,7 @@ expose = ["ensure_dir", "ensure_dir_writable", "archive_timestamp", "unique_arch
 from = ["terok.lib.util.fs"]
 
 [[interfaces]]
-expose = ["assign_web_port"]
+expose = ["assign_web_port", "is_port_free"]
 from = ["terok.lib.orchestration.ports"]
 
 [[interfaces]]

--- a/tests/unit/lib/test_config.py
+++ b/tests/unit/lib/test_config.py
@@ -398,10 +398,10 @@ def test_get_credential_proxy_bypass(monkeypatch: pytest.MonkeyPatch, tmp_path: 
     assert cfg.get_credential_proxy_bypass() is True
 
 
-def test_get_gate_server_port_default(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
-    """``get_gate_server_port()`` defaults to 9418."""
+def test_get_configured_gate_port_default(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """``get_configured_gate_port()`` defaults to 9418."""
     monkeypatch.setenv("TEROK_CONFIG_FILE", str(write_config(tmp_path, "")))
-    assert cfg.get_gate_server_port() == 9418
+    assert cfg.get_configured_gate_port() == 9418
 
 
 def test_get_gate_server_suppress_warning(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:

--- a/tests/unit/lib/test_paths.py
+++ b/tests/unit/lib/test_paths.py
@@ -136,7 +136,7 @@ class TestStateRoot:
 
 
 class TestRuntimeRoot:
-    """Verify ``runtime_root()`` resolution."""
+    """Verify ``runtime_root()`` resolution — includes XDG_RUNTIME_DIR for port files."""
 
     def test_env_override(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
         """TEROK_RUNTIME_DIR takes first priority."""
@@ -149,8 +149,25 @@ class TestRuntimeRoot:
         monkeypatch.setattr(paths, "_is_root", lambda: True)
         assert paths.runtime_root() == Path("/run/terok")
 
-    def test_user_fallback(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        """Non-root fallback: ~/.cache/terok."""
+    def test_platformdirs_fallback(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Non-root with platformdirs delegates to user_runtime_dir."""
         monkeypatch.delenv("TEROK_RUNTIME_DIR", raising=False)
         monkeypatch.setattr(paths, "_is_root", lambda: False)
+        monkeypatch.setattr(paths, "_user_runtime_dir", lambda name: f"{MOCK_BASE}/run/{name}")
+        assert paths.runtime_root() == MOCK_BASE / "run" / "terok"
+
+    def test_xdg_runtime_dir_fallback(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Without platformdirs, XDG_RUNTIME_DIR is honored."""
+        monkeypatch.delenv("TEROK_RUNTIME_DIR", raising=False)
+        monkeypatch.setattr(paths, "_is_root", lambda: False)
+        monkeypatch.setattr(paths, "_user_runtime_dir", None)
+        monkeypatch.setenv("XDG_RUNTIME_DIR", str(MOCK_BASE / "xdg-run"))
+        assert paths.runtime_root() == MOCK_BASE / "xdg-run" / "terok"
+
+    def test_bare_fallback(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Last resort: ~/.cache/terok."""
+        monkeypatch.delenv("TEROK_RUNTIME_DIR", raising=False)
+        monkeypatch.delenv("XDG_RUNTIME_DIR", raising=False)
+        monkeypatch.setattr(paths, "_is_root", lambda: False)
+        monkeypatch.setattr(paths, "_user_runtime_dir", None)
         assert paths.runtime_root() == Path.home() / ".cache" / "terok"

--- a/tests/unit/lib/test_ports.py
+++ b/tests/unit/lib/test_ports.py
@@ -1,0 +1,59 @@
+# SPDX-FileCopyrightText: 2026 Jiri Vyskocil
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for web port allocation and validation."""
+
+from __future__ import annotations
+
+import socket
+from unittest.mock import patch
+
+import pytest
+
+from terok.lib.orchestration.ports import assign_web_port, is_port_free
+
+
+class TestIsPortFree:
+    """is_port_free() probes localhost bindability."""
+
+    def test_unbound_port(self) -> None:
+        """An unbound port reports as free."""
+        # Bind to 0, get an OS-assigned port, close it — it should be free.
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+            s.bind(("127.0.0.1", 0))
+            port = s.getsockname()[1]
+        assert is_port_free(port)
+
+    def test_occupied_port(self) -> None:
+        """A currently bound port reports as not free."""
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+            s.bind(("127.0.0.1", 0))
+            port = s.getsockname()[1]
+            assert not is_port_free(port)
+
+
+class TestAssignWebPort:
+    """assign_web_port() scans for free ports."""
+
+    def test_skips_occupied(self) -> None:
+        """Occupied base port is skipped, next free port returned."""
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+            s.bind(("127.0.0.1", 0))
+            occupied = s.getsockname()[1]
+
+            with (
+                patch("terok.lib.orchestration.ports.get_ui_base_port", return_value=occupied),
+                patch("terok.lib.orchestration.ports._collect_all_web_ports", return_value=set()),
+            ):
+                assigned = assign_web_port()
+                assert assigned > occupied
+
+    def test_exhaustion_raises(self) -> None:
+        """Raises SystemExit when all 200 ports are exhausted."""
+        with (
+            patch("terok.lib.orchestration.ports.get_ui_base_port", return_value=50000),
+            patch("terok.lib.orchestration.ports._collect_all_web_ports", return_value=set()),
+            patch("terok.lib.orchestration.ports.is_port_free", return_value=False),
+            pytest.raises(SystemExit, match="No free web ports"),
+        ):
+            assign_web_port()


### PR DESCRIPTION
## Summary

- Fix `runtime_root()` to honor `$XDG_RUNTIME_DIR` — port files need per-user transient directory
- Add `credential_proxy.port` to config schema (consistent with `gate_server.port`)
- Rename `get_gate_server_port` → `get_configured_gate_port` in config.py (disambiguate from sandbox's live-port getter)
- Fix Toad port reuse bug: validate saved `web_port` is still free before reusing
- Document multi-user port-file design in developer.md

Companion PR: terok-ai/terok-sandbox#125

## Test plan

- [x] All 1556 unit tests pass
- [x] `make check` passes (lint, tach, docstrings, reuse, deadcode)
- [ ] Manual: verify `runtime_root()` returns `/run/user/{uid}/terok` on systemd Linux
- [ ] Integration with terok-sandbox port-file PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)