### PR TITLE
feat: add `terok storage` command for disk usage summary

### DIFF
--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -31,13 +31,12 @@ jobs:
           python-version: "3.12"
 
       - name: Install Poetry
-        uses: snok/install-poetry@76e04a911780d5b312d89783f7b1cd627778900a # v1
+        uses: snok/install-poetry@76e04a911780d5b312d89783f7b1cd627778900a # v1.4.1
         with:
+          version: "2.3.3"
           virtualenvs-create: true
           virtualenvs-in-project: true
-
-      - name: Install dynamic versioning plugin
-        run: poetry self add "poetry-dynamic-versioning[plugin]"
+          plugins: poetry-dynamic-versioning[plugin]
 
       - name: Load cached venv
         id: cached-poetry-dependencies

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -120,13 +120,12 @@ jobs:
           python-version: "3.12"
 
       - name: Install Poetry
-        uses: snok/install-poetry@76e04a911780d5b312d89783f7b1cd627778900a # v1
+        uses: snok/install-poetry@76e04a911780d5b312d89783f7b1cd627778900a # v1.4.1
         with:
+          version: "2.3.3"
           virtualenvs-create: true
           virtualenvs-in-project: true
-
-      - name: Install dynamic versioning plugin
-        run: poetry self add "poetry-dynamic-versioning[plugin]"
+          plugins: poetry-dynamic-versioning[plugin]
 
       - name: Load cached venv
         id: cached-poetry-dependencies

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -31,8 +31,9 @@ jobs:
           python-version: "3.12"
 
       - name: Install Poetry
-        uses: snok/install-poetry@76e04a911780d5b312d89783f7b1cd627778900a # v1
+        uses: snok/install-poetry@76e04a911780d5b312d89783f7b1cd627778900a # v1.4.1
         with:
+          version: "2.3.3"
           virtualenvs-create: true
           virtualenvs-in-project: true
 

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -22,13 +22,12 @@ jobs:
           python-version: "3.12"
 
       - name: Install Poetry
-        uses: snok/install-poetry@76e04a911780d5b312d89783f7b1cd627778900a # v1
+        uses: snok/install-poetry@76e04a911780d5b312d89783f7b1cd627778900a # v1.4.1
         with:
+          version: "2.3.3"
           virtualenvs-create: true
           virtualenvs-in-project: true
-
-      - name: Install dynamic versioning plugin
-        run: poetry self add "poetry-dynamic-versioning[plugin]"
+          plugins: poetry-dynamic-versioning[plugin]
 
       - name: Load cached venv
         id: cached-poetry-dependencies

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,13 +26,12 @@ jobs:
           python-version: "3.12"
 
       - name: Install Poetry
-        uses: snok/install-poetry@76e04a911780d5b312d89783f7b1cd627778900a # v1
+        uses: snok/install-poetry@76e04a911780d5b312d89783f7b1cd627778900a # v1.4.1
         with:
+          version: "2.3.3"
           virtualenvs-create: true
           virtualenvs-in-project: true
-
-      - name: Install dynamic versioning plugin
-        run: poetry self add "poetry-dynamic-versioning[plugin]"
+          plugins: poetry-dynamic-versioning[plugin]
 
       - name: Cache virtualenv
         id: cached-poetry-dependencies

--- a/poetry.lock
+++ b/poetry.lock
@@ -3045,25 +3045,24 @@ tomli-w = ">=1.0,<2.0"
 
 [[package]]
 name = "terok-agent"
-version = "0.0.67"
+version = "0.0.68"
 description = "Single-agent task runner for hardened Podman containers"
 optional = false
 python-versions = ">=3.12,<4.0"
 groups = ["main"]
-files = []
-develop = false
+files = [
+    {file = "terok_agent-0.0.68-py3-none-any.whl", hash = "sha256:234c780d042fa2d1673d046d445e451c5a3f238f8683390b3fdaefaa4e6be098"},
+]
 
 [package.dependencies]
 Jinja2 = ">=3.1"
 "ruamel.yaml" = ">=0.18"
-terok-sandbox = {git = "https://github.com/sliwowitz/terok-sandbox.git", branch = "feat/container-rw-sizes"}
+terok_sandbox = {url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.0.60/terok_sandbox-0.0.60-py3-none-any.whl"}
 tomli-w = ">=1.0"
 
 [package.source]
-type = "git"
-url = "https://github.com/sliwowitz/terok-agent.git"
-reference = "feat/storage-queries"
-resolved_reference = "4d7a2a6d7de126ff62d70ae8df8f35eb768679c3"
+type = "url"
+url = "https://github.com/terok-ai/terok-agent/releases/download/v0.0.68/terok_agent-0.0.68-py3-none-any.whl"
 
 [[package]]
 name = "terok-dbus"
@@ -3085,25 +3084,24 @@ url = "https://github.com/terok-ai/terok-dbus/releases/download/v0.5.6/terok_dbu
 
 [[package]]
 name = "terok-sandbox"
-version = "0.0.59"
+version = "0.0.60"
 description = "Hardened Podman container runner with gate server and shield integration"
 optional = false
 python-versions = ">=3.12,<4.0"
 groups = ["main"]
-files = []
-develop = false
+files = [
+    {file = "terok_sandbox-0.0.60-py3-none-any.whl", hash = "sha256:0ad9859b1b548c8cea60bb1f2e1de40bf24dcf3e4187233f0e5493403102234a"},
+]
 
 [package.dependencies]
 aiohttp = ">=3.9"
 cryptography = ">=43.0"
 platformdirs = ">=4.0"
-terok-shield = {url = "https://github.com/terok-ai/terok-shield/releases/download/v0.6.18/terok_shield-0.6.18-py3-none-any.whl"}
+terok_shield = {url = "https://github.com/terok-ai/terok-shield/releases/download/v0.6.18/terok_shield-0.6.18-py3-none-any.whl"}
 
 [package.source]
-type = "git"
-url = "https://github.com/sliwowitz/terok-sandbox.git"
-reference = "feat/container-rw-sizes"
-resolved_reference = "61697467a7b1a6d577ae24d03ddf1eb8605dfb1e"
+type = "url"
+url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.0.60/terok_sandbox-0.0.60-py3-none-any.whl"
 
 [[package]]
 name = "terok-shield"
@@ -3611,4 +3609,4 @@ propcache = ">=0.2.1"
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.12,<4.0"
-content-hash = "5ad68a84fd8da97ca65f03d0e7a61334a024794a394a7f5ce9bd9ef858c86f9f"
+content-hash = "21e46665a3bec46f6f120e73e5f9a58f190cc9b3a0e20cae8382125c6b5cc597"

--- a/poetry.lock
+++ b/poetry.lock
@@ -2894,14 +2894,14 @@ file-magic = ["file-magic (>=0.4.1)"]
 
 [[package]]
 name = "rich"
-version = "14.3.4"
+version = "15.0.0"
 description = "Render rich text, tables, progress bars, syntax highlighting, markdown and more to the terminal"
 optional = false
-python-versions = ">=3.8.0"
+python-versions = ">=3.9.0"
 groups = ["main", "dev"]
 files = [
-    {file = "rich-14.3.4-py3-none-any.whl", hash = "sha256:07e7adb4690f68864777b1450859253bed81a99a31ac321ac1817b2313558952"},
-    {file = "rich-14.3.4.tar.gz", hash = "sha256:817e02727f2b25b40ef56f5aa2217f400c8489f79ca8f46ea2b70dd5e14558a9"},
+    {file = "rich-15.0.0-py3-none-any.whl", hash = "sha256:33bd4ef74232fb73fe9279a257718407f169c09b78a87ad3d296f548e27de0bb"},
+    {file = "rich-15.0.0.tar.gz", hash = "sha256:edd07a4824c6b40189fb7ac9bc4c52536e9780fbbfbddf6f1e2502c31b068c36"},
 ]
 
 [package.dependencies]
@@ -3045,7 +3045,7 @@ tomli-w = ">=1.0,<2.0"
 
 [[package]]
 name = "terok-agent"
-version = "0.0.64"
+version = "0.0.67"
 description = "Single-agent task runner for hardened Podman containers"
 optional = false
 python-versions = ">=3.12,<4.0"
@@ -3063,7 +3063,7 @@ tomli-w = ">=1.0"
 type = "git"
 url = "https://github.com/sliwowitz/terok-agent.git"
 reference = "feat/storage-queries"
-resolved_reference = "829f1f94c5229624ffc2064950a3cbf91ea03ad4"
+resolved_reference = "18edcd346b64008861cb35f3f69bef845d919727"
 
 [[package]]
 name = "terok-dbus"
@@ -3085,7 +3085,7 @@ url = "https://github.com/terok-ai/terok-dbus/releases/download/v0.5.6/terok_dbu
 
 [[package]]
 name = "terok-sandbox"
-version = "0.0.57"
+version = "0.0.59"
 description = "Hardened Podman container runner with gate server and shield integration"
 optional = false
 python-versions = ">=3.12,<4.0"
@@ -3097,23 +3097,23 @@ develop = false
 aiohttp = ">=3.9"
 cryptography = ">=43.0"
 platformdirs = ">=4.0"
-terok-shield = {url = "https://github.com/terok-ai/terok-shield/releases/download/v0.6.17/terok_shield-0.6.17-py3-none-any.whl"}
+terok-shield = {url = "https://github.com/terok-ai/terok-shield/releases/download/v0.6.18/terok_shield-0.6.18-py3-none-any.whl"}
 
 [package.source]
 type = "git"
 url = "https://github.com/sliwowitz/terok-sandbox.git"
 reference = "feat/container-rw-sizes"
-resolved_reference = "b140224df5d6e21e688e5d4f96a1b2197d029a3c"
+resolved_reference = "0043c543990ea8a26eea6e529ab17a9309d1bc08"
 
 [[package]]
 name = "terok-shield"
-version = "0.6.17"
+version = "0.6.18"
 description = "nftables-based egress firewalling for Podman containers"
 optional = false
 python-versions = ">=3.12,<4.0"
 groups = ["main"]
 files = [
-    {file = "terok_shield-0.6.17-py3-none-any.whl", hash = "sha256:447426b3d5401420ad498a3792730bc6aaf151beaa8584ff1d3d5c57db1573f0"},
+    {file = "terok_shield-0.6.18-py3-none-any.whl", hash = "sha256:0e50e2e83e580c8e17bc003edf613f929c0f12c6c3f062b92d0ff5271ebad1c2"},
 ]
 
 [package.dependencies]
@@ -3122,7 +3122,7 @@ PyYAML = ">=6.0"
 
 [package.source]
 type = "url"
-url = "https://github.com/terok-ai/terok-shield/releases/download/v0.6.17/terok_shield-0.6.17-py3-none-any.whl"
+url = "https://github.com/terok-ai/terok-shield/releases/download/v0.6.18/terok_shield-0.6.18-py3-none-any.whl"
 
 [[package]]
 name = "textual"

--- a/poetry.lock
+++ b/poetry.lock
@@ -3063,7 +3063,7 @@ tomli-w = ">=1.0"
 type = "git"
 url = "https://github.com/sliwowitz/terok-agent.git"
 reference = "feat/storage-queries"
-resolved_reference = "18edcd346b64008861cb35f3f69bef845d919727"
+resolved_reference = "4d7a2a6d7de126ff62d70ae8df8f35eb768679c3"
 
 [[package]]
 name = "terok-dbus"
@@ -3103,7 +3103,7 @@ terok-shield = {url = "https://github.com/terok-ai/terok-shield/releases/downloa
 type = "git"
 url = "https://github.com/sliwowitz/terok-sandbox.git"
 reference = "feat/container-rw-sizes"
-resolved_reference = "0043c543990ea8a26eea6e529ab17a9309d1bc08"
+resolved_reference = "61697467a7b1a6d577ae24d03ddf1eb8605dfb1e"
 
 [[package]]
 name = "terok-shield"

--- a/poetry.lock
+++ b/poetry.lock
@@ -3045,24 +3045,25 @@ tomli-w = ">=1.0,<2.0"
 
 [[package]]
 name = "terok-agent"
-version = "0.0.67"
+version = "0.0.64"
 description = "Single-agent task runner for hardened Podman containers"
 optional = false
 python-versions = ">=3.12,<4.0"
 groups = ["main"]
-files = [
-    {file = "terok_agent-0.0.67-py3-none-any.whl", hash = "sha256:0c836aff64d28e9889c753ed376b035db16705a51abc8933ab91eb0a0f5e8822"},
-]
+files = []
+develop = false
 
 [package.dependencies]
 Jinja2 = ">=3.1"
 "ruamel.yaml" = ">=0.18"
-terok_sandbox = {url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.0.59/terok_sandbox-0.0.59-py3-none-any.whl"}
+terok-sandbox = {git = "https://github.com/sliwowitz/terok-sandbox.git", branch = "feat/container-rw-sizes"}
 tomli-w = ">=1.0"
 
 [package.source]
-type = "url"
-url = "https://github.com/terok-ai/terok-agent/releases/download/v0.0.67/terok_agent-0.0.67-py3-none-any.whl"
+type = "git"
+url = "https://github.com/sliwowitz/terok-agent.git"
+reference = "feat/storage-queries"
+resolved_reference = "829f1f94c5229624ffc2064950a3cbf91ea03ad4"
 
 [[package]]
 name = "terok-dbus"
@@ -3084,34 +3085,35 @@ url = "https://github.com/terok-ai/terok-dbus/releases/download/v0.5.6/terok_dbu
 
 [[package]]
 name = "terok-sandbox"
-version = "0.0.59"
+version = "0.0.57"
 description = "Hardened Podman container runner with gate server and shield integration"
 optional = false
 python-versions = ">=3.12,<4.0"
 groups = ["main"]
-files = [
-    {file = "terok_sandbox-0.0.59-py3-none-any.whl", hash = "sha256:cdcddd03887dbcc9bdfd6781a2121403bdcac174934423257039f21f1be5228c"},
-]
+files = []
+develop = false
 
 [package.dependencies]
 aiohttp = ">=3.9"
 cryptography = ">=43.0"
 platformdirs = ">=4.0"
-terok_shield = {url = "https://github.com/terok-ai/terok-shield/releases/download/v0.6.18/terok_shield-0.6.18-py3-none-any.whl"}
+terok-shield = {url = "https://github.com/terok-ai/terok-shield/releases/download/v0.6.17/terok_shield-0.6.17-py3-none-any.whl"}
 
 [package.source]
-type = "url"
-url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.0.59/terok_sandbox-0.0.59-py3-none-any.whl"
+type = "git"
+url = "https://github.com/sliwowitz/terok-sandbox.git"
+reference = "feat/container-rw-sizes"
+resolved_reference = "b140224df5d6e21e688e5d4f96a1b2197d029a3c"
 
 [[package]]
 name = "terok-shield"
-version = "0.6.18"
+version = "0.6.17"
 description = "nftables-based egress firewalling for Podman containers"
 optional = false
 python-versions = ">=3.12,<4.0"
 groups = ["main"]
 files = [
-    {file = "terok_shield-0.6.18-py3-none-any.whl", hash = "sha256:0e50e2e83e580c8e17bc003edf613f929c0f12c6c3f062b92d0ff5271ebad1c2"},
+    {file = "terok_shield-0.6.17-py3-none-any.whl", hash = "sha256:447426b3d5401420ad498a3792730bc6aaf151beaa8584ff1d3d5c57db1573f0"},
 ]
 
 [package.dependencies]
@@ -3120,7 +3122,7 @@ PyYAML = ">=6.0"
 
 [package.source]
 type = "url"
-url = "https://github.com/terok-ai/terok-shield/releases/download/v0.6.18/terok_shield-0.6.18-py3-none-any.whl"
+url = "https://github.com/terok-ai/terok-shield/releases/download/v0.6.17/terok_shield-0.6.17-py3-none-any.whl"
 
 [[package]]
 name = "textual"
@@ -3609,4 +3611,4 @@ propcache = ">=0.2.1"
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.12,<4.0"
-content-hash = "1ca42a74d03d6bfbcfd330887b14e624346b4c2214714db4e356e48cb02e8f06"
+content-hash = "5ad68a84fd8da97ca65f03d0e7a61334a024794a394a7f5ce9bd9ef858c86f9f"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,8 +44,8 @@ rich = ">=13.0"
 platformdirs = ">=4.5.1"
 unique-namer = ">=1.3"
 textual-serve = ">=1.1.0"
-terok-agent = {git = "https://github.com/sliwowitz/terok-agent.git", branch = "feat/storage-queries"}
-terok-sandbox = {git = "https://github.com/sliwowitz/terok-sandbox.git", branch = "feat/container-rw-sizes"}
+terok-agent = {url = "https://github.com/terok-ai/terok-agent/releases/download/v0.0.68/terok_agent-0.0.68-py3-none-any.whl"}
+terok-sandbox = {url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.0.60/terok_sandbox-0.0.60-py3-none-any.whl"}
 terok-dbus = {url = "https://github.com/terok-ai/terok-dbus/releases/download/v0.5.6/terok_dbus-0.5.6-py3-none-any.whl"}
 
 [tool.poetry.group.dev.dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,8 +44,8 @@ rich = ">=13.0"
 platformdirs = ">=4.5.1"
 unique-namer = ">=1.3"
 textual-serve = ">=1.1.0"
-terok-agent = {url = "https://github.com/terok-ai/terok-agent/releases/download/v0.0.67/terok_agent-0.0.67-py3-none-any.whl"}
-terok-sandbox = {url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.0.59/terok_sandbox-0.0.59-py3-none-any.whl"}
+terok-agent = {git = "https://github.com/sliwowitz/terok-agent.git", branch = "feat/storage-queries"}
+terok-sandbox = {git = "https://github.com/sliwowitz/terok-sandbox.git", branch = "feat/container-rw-sizes"}
 terok-dbus = {url = "https://github.com/terok-ai/terok-dbus/releases/download/v0.5.6/terok_dbus-0.5.6-py3-none-any.whl"}
 
 [tool.poetry.group.dev.dependencies]

--- a/src/terok/cli/commands/storage.py
+++ b/src/terok/cli/commands/storage.py
@@ -1,0 +1,314 @@
+# SPDX-FileCopyrightText: 2026 Jiri Vyskocil
+# SPDX-License-Identifier: Apache-2.0
+
+"""Storage usage summary: how much disk space terok is using.
+
+Two modes:
+- Default (``terok storage``): fast overview with per-project one-liners
+- Detail (``terok storage --project <id>``): per-task breakdown with overlays
+"""
+
+from __future__ import annotations
+
+import argparse
+
+from ...lib.util.ansi import blue, bold, color, supports_color
+from ._completers import complete_project_ids as _complete_project_ids, set_completer
+
+# ---------------------------------------------------------------------------
+# Column formatting helpers
+# ---------------------------------------------------------------------------
+
+_TABLE_WIDTH = 50
+
+
+def _c(enabled: bool) -> bool:
+    """Alias for the color-enabled flag threading."""
+    return enabled
+
+
+def _section(title: str, enabled: bool) -> str:
+    """Render a section header: ``═══ Title ═════...``."""
+    pad = max(0, _TABLE_WIDTH - len(title) - 5)
+    bar = f"═══ {title} {'═' * pad}"
+    return bold(color(bar, "35", enabled), enabled)
+
+
+def _sub_header(text: str, enabled: bool) -> str:
+    """Render a sub-section header like ``Images:``."""
+    return bold(text, enabled)
+
+
+def _size(text: str, enabled: bool) -> str:
+    """Render a size value in blue."""
+    return blue(text, enabled)
+
+
+def _dim(text: str, enabled: bool) -> str:
+    """Render secondary text in gray."""
+    return color(text, "90", enabled)
+
+
+def _separator(width: int, enabled: bool) -> str:
+    """Render a thin separator line."""
+    return _dim("─" * width, enabled)
+
+
+def _heavy_separator(enabled: bool) -> str:
+    """Render a heavy separator for grand totals."""
+    return _dim("═" * _TABLE_WIDTH, enabled)
+
+
+# ---------------------------------------------------------------------------
+# CLI registration and dispatch
+# ---------------------------------------------------------------------------
+
+
+def register(subparsers: argparse._SubParsersAction[argparse.ArgumentParser]) -> None:
+    """Register the ``storage`` subcommand."""
+    p = subparsers.add_parser("storage", help="Show storage usage summary")
+    set_completer(
+        p.add_argument(
+            "--project",
+            default=None,
+            help="Show detailed per-task breakdown for one project",
+        ),
+        _complete_project_ids,
+    )
+    p.add_argument(
+        "--json",
+        action="store_true",
+        dest="json_output",
+        help="Machine-readable JSON output",
+    )
+
+
+def dispatch(args: argparse.Namespace) -> bool:
+    """Handle the ``storage`` command.  Returns True if handled."""
+    if args.cmd != "storage":
+        return False
+    project_id = getattr(args, "project", None)
+    json_output = getattr(args, "json_output", False)
+    if project_id:
+        _cmd_detail(project_id, json_output=json_output)
+    else:
+        _cmd_overview(json_output=json_output)
+    return True
+
+
+# ---------------------------------------------------------------------------
+# Overview mode — the fast, wide-angle view
+# ---------------------------------------------------------------------------
+
+
+def _cmd_overview(*, json_output: bool = False) -> None:
+    """Print the global storage overview."""
+    from ...lib.domain.storage import format_bytes, get_storage_overview
+
+    overview = get_storage_overview()
+
+    if json_output:
+        _json_overview(overview)
+        return
+
+    c = _c(supports_color())
+
+    # ── Global section ──
+    print(_section("Global", c))
+
+    # Images
+    if overview.global_images:
+        print(_sub_header("Images:", c))
+        name_w = max(len(img.full_name) for img in overview.global_images)
+        size_w = max(len(img.size) for img in overview.global_images)
+        print(
+            f"  {bold('NAME', c):<{name_w + 10}}  {bold('SIZE', c):>{size_w + 10}}  {bold('CREATED', c)}"
+        )
+        for img in overview.global_images:
+            print(
+                f"  {img.full_name:<{name_w}}  "
+                f"{_size(f'{img.size:>{size_w}}', c)}  "
+                f"{_dim(img.created, c)}"
+            )
+        total = format_bytes(overview.global_images_bytes)
+        print(f"  {'':<{name_w}}  {_separator(size_w, c)}")
+        print(f"  {'':<{name_w}}  {_size(bold(f'{total:>{size_w}}', c), c)}")
+
+    # Shared mounts
+    if overview.shared_mounts:
+        print(_sub_header("Shared mounts:", c))
+        label_w = max(len(m.label) for m in overview.shared_mounts)
+        sizes = [format_bytes(m.bytes) for m in overview.shared_mounts]
+        size_w = max(len(s) for s in sizes)
+        for m, s in zip(overview.shared_mounts, sizes, strict=True):
+            print(f"  {m.label:<{label_w}}  {_size(f'{s:>{size_w}}', c)}")
+        total = format_bytes(overview.shared_mounts_bytes)
+        print(f"  {'':<{label_w}}  {_separator(size_w, c)}")
+        print(f"  {'':<{label_w}}  {_size(bold(f'{total:>{size_w}}', c), c)}")
+
+    # ── Projects section ──
+    if overview.projects:
+        print(_section("Projects", c))
+        pid_w = max(len(p.project_id) for p in overview.projects)
+        img_sizes = [format_bytes(p.image_bytes) for p in overview.projects]
+        ws_sizes = [format_bytes(p.workspace_bytes) for p in overview.projects]
+        img_w = max(len(s) for s in img_sizes + ["IMAGES"])
+        ws_w = max(len(s) for s in ws_sizes + ["WORKSPACES"])
+        task_w = max(len(str(p.task_count)) for p in overview.projects)
+        task_w = max(task_w, len("TASKS"))
+
+        print(
+            f"  {bold('PROJECT', c):<{pid_w + 10}}  "
+            f"{bold('IMAGES', c):>{img_w + 10}}  "
+            f"{bold('WORKSPACES', c):>{ws_w + 10}}  "
+            f"{bold('TASKS', c):>{task_w + 10}}"
+        )
+        for p, img_s, ws_s in zip(overview.projects, img_sizes, ws_sizes, strict=True):
+            print(
+                f"  {p.project_id:<{pid_w}}  "
+                f"{_size(f'{img_s:>{img_w}}', c)}  "
+                f"{_size(f'{ws_s:>{ws_w}}', c)}  "
+                f"{p.task_count:>{task_w}}"
+            )
+
+        total_img = format_bytes(sum(p.image_bytes for p in overview.projects))
+        total_ws = format_bytes(sum(p.workspace_bytes for p in overview.projects))
+        total_tasks = sum(p.task_count for p in overview.projects)
+        print(f"  {'':<{pid_w}}  {_separator(img_w, c)}  {_separator(ws_w, c)}")
+        print(
+            f"  {'':<{pid_w}}  "
+            f"{_size(bold(f'{total_img:>{img_w}}', c), c)}  "
+            f"{_size(bold(f'{total_ws:>{ws_w}}', c), c)}  "
+            f"{bold(f'{total_tasks:>{task_w}}', c)}"
+        )
+
+    # ── Grand total ──
+    print(_heavy_separator(c))
+    gt = format_bytes(overview.grand_total)
+    label = "Grand total"
+    print(f"{bold(label, c)}  {_size(bold(f'{gt:>{_TABLE_WIDTH - len(label) - 2}}', c), c)}")
+
+
+# ---------------------------------------------------------------------------
+# Detail mode — zooming into one project
+# ---------------------------------------------------------------------------
+
+
+def _cmd_detail(project_id: str, *, json_output: bool = False) -> None:
+    """Print per-task storage detail for one project."""
+    from ...lib.domain.storage import format_bytes, get_project_storage_detail
+
+    detail = get_project_storage_detail(project_id)
+
+    if json_output:
+        _json_detail(detail)
+        return
+
+    c = _c(supports_color())
+    print(_section(project_id, c))
+
+    # Images
+    if detail.images:
+        print(_sub_header("Images:", c))
+        name_w = max(len(img.full_name) for img in detail.images)
+        size_w = max(len(img.size) for img in detail.images)
+        for img in detail.images:
+            print(f"  {img.full_name:<{name_w}}  {_size(f'{img.size:>{size_w}}', c)}")
+
+    # Tasks with overlay sizes
+    if detail.tasks:
+        print(_sub_header("Tasks:", c))
+        tid_w = max(len(t.task_id) for t in detail.tasks)
+        ws_strs = [format_bytes(t.workspace_bytes) for t in detail.tasks]
+        ws_w = max(len(s) for s in ws_strs + ["WORKSPACE"])
+        ov_strs = [format_bytes(detail.overlays.get(t.task_id, 0)) for t in detail.tasks]
+        ov_w = max(len(s) for s in ov_strs + ["OVERLAY"])
+
+        print(
+            f"  {bold('ID', c):<{tid_w + 10}}  "
+            f"{bold('WORKSPACE', c):>{ws_w + 10}}  "
+            f"{bold('OVERLAY', c):>{ov_w + 10}}"
+        )
+        for t, ws_s, ov_s in zip(detail.tasks, ws_strs, ov_strs, strict=True):
+            print(
+                f"  {t.task_id:<{tid_w}}  "
+                f"{_size(f'{ws_s:>{ws_w}}', c)}  "
+                f"{_size(f'{ov_s:>{ov_w}}', c)}"
+            )
+
+        total_ws = format_bytes(detail.workspace_bytes)
+        total_ov = format_bytes(detail.overlay_bytes)
+        print(f"  {'':<{tid_w}}  {_separator(ws_w, c)}  {_separator(ov_w, c)}")
+        print(
+            f"  {'':<{tid_w}}  "
+            f"{_size(bold(f'{total_ws:>{ws_w}}', c), c)}  "
+            f"{_size(bold(f'{total_ov:>{ov_w}}', c), c)}"
+        )
+
+    # Project total
+    print(_separator(_TABLE_WIDTH, c))
+    gt = format_bytes(detail.total_bytes)
+    label = "Project total"
+    print(f"{bold(label, c)}  {_size(bold(f'{gt:>{_TABLE_WIDTH - len(label) - 2}}', c), c)}")
+
+
+# ---------------------------------------------------------------------------
+# JSON output — machine-readable alternative
+# ---------------------------------------------------------------------------
+
+
+def _json_overview(overview: StorageOverview) -> None:  # noqa: F821
+    """Emit the overview as JSON."""
+    import json
+
+    from ...lib.domain.storage import parse_image_size
+
+    data = {
+        "global": {
+            "images": [
+                {"name": img.full_name, "size": img.size, "bytes": parse_image_size(img.size)}
+                for img in overview.global_images
+            ],
+            "shared_mounts": [
+                {"name": m.name, "label": m.label, "bytes": m.bytes} for m in overview.shared_mounts
+            ],
+        },
+        "projects": [
+            {
+                "id": p.project_id,
+                "image_bytes": p.image_bytes,
+                "workspace_bytes": p.workspace_bytes,
+                "task_count": p.task_count,
+                "total_bytes": p.total_bytes,
+            }
+            for p in overview.projects
+        ],
+        "grand_total_bytes": overview.grand_total,
+    }
+    print(json.dumps(data, indent=2))
+
+
+def _json_detail(detail: ProjectDetail) -> None:  # noqa: F821
+    """Emit the project detail as JSON."""
+    import json
+
+    from ...lib.domain.storage import parse_image_size
+
+    data = {
+        "project_id": detail.project_id,
+        "images": [
+            {"name": img.full_name, "size": img.size, "bytes": parse_image_size(img.size)}
+            for img in detail.images
+        ],
+        "tasks": [
+            {
+                "task_id": t.task_id,
+                "workspace_bytes": t.workspace_bytes,
+                "agent_config_bytes": t.agent_config_bytes,
+                "overlay_bytes": detail.overlays.get(t.task_id, 0),
+            }
+            for t in detail.tasks
+        ],
+        "total_bytes": detail.total_bytes,
+    }
+    print(json.dumps(data, indent=2))

--- a/src/terok/cli/main.py
+++ b/src/terok/cli/main.py
@@ -27,6 +27,7 @@ from .commands import (
     setup,
     shield,
     sickbay,
+    storage,
     task,
 )
 from .wiring import wire_dispatch, wire_group
@@ -46,6 +47,7 @@ _DISPATCHERS = [
     credentials.dispatch,
     setup.dispatch,
     image.dispatch,
+    storage.dispatch,
     wire_dispatch,
     shield.dispatch,
     dbus.dispatch,
@@ -113,6 +115,7 @@ def main() -> None:
     credentials.register(sub)  # credential-proxy-serve (standalone)
     setup.register(sub)
     image.register(sub)
+    storage.register(sub)
     shield.register(sub)
     dbus.register(sub)
     clearance.register(sub)

--- a/src/terok/lib/domain/storage.py
+++ b/src/terok/lib/domain/storage.py
@@ -60,7 +60,10 @@ def parse_image_size(text: str) -> int:
     if not m:
         return 0
     try:
-        return int(float(m.group(1)) * _UNITS.get(m.group(2).upper(), 1))
+        multiplier = _UNITS.get(m.group(2).upper())
+        if multiplier is None:
+            return 0
+        return int(float(m.group(1)) * multiplier)
     except (ValueError, OverflowError):
         return 0
 

--- a/src/terok/lib/domain/storage.py
+++ b/src/terok/lib/domain/storage.py
@@ -1,0 +1,250 @@
+# SPDX-FileCopyrightText: 2026 Jiri Vyskocil
+# SPDX-License-Identifier: Apache-2.0
+
+"""Storage usage aggregation across the package stack.
+
+Orchestrates queries from three layers:
+- **terok-sandbox** — container overlay sizes (podman)
+- **terok-agent** — task workspace and shared mount sizes (filesystem)
+- **terok** itself — image knowledge (L0/L1/L2 classification)
+
+Two entry points mirror two levels of detail:
+
+- :func:`get_storage_overview` — fast global summary with per-project
+  one-liners (no per-container podman ``--size`` queries)
+- :func:`get_project_storage_detail` — per-task breakdown for one
+  project, including the expensive overlay size computation
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+
+from terok_agent import (
+    SharedMountStorageInfo,
+    TaskStorageInfo,
+    get_shared_mounts_storage,
+    get_tasks_storage,
+)
+
+from ..core.config import sandbox_live_mounts_dir
+from ..core.projects import list_projects
+from .image_cleanup import ImageInfo, list_images
+
+# ---------------------------------------------------------------------------
+# Size parsing — translate podman's human-readable strings to bytes
+# ---------------------------------------------------------------------------
+
+_SIZE_RE = re.compile(r"([\d.]+)\s*([a-zA-Z]+)")
+_UNITS: dict[str, int] = {
+    "B": 1,
+    "KB": 1_000,
+    "MB": 1_000_000,
+    "GB": 1_000_000_000,
+    "TB": 1_000_000_000_000,
+    "KIB": 1 << 10,
+    "MIB": 1 << 20,
+    "GIB": 1 << 30,
+    "TIB": 1 << 40,
+}
+
+
+def parse_image_size(text: str) -> int:
+    """Best-effort parse of podman's human-readable image size strings.
+
+    Returns 0 for unparseable input — storage reporting should never crash
+    on a formatting surprise from podman.
+    """
+    m = _SIZE_RE.search(text)
+    if not m:
+        return 0
+    try:
+        return int(float(m.group(1)) * _UNITS.get(m.group(2).upper(), 1))
+    except (ValueError, OverflowError):
+        return 0
+
+
+def format_bytes(n: int) -> str:
+    """Format bytes as a right-aligned human-readable string.
+
+    Uses SI units (1000-based) to match podman's output convention.
+    Always returns a fixed-width string suitable for column alignment.
+    """
+    for unit, threshold in (("TB", 1e12), ("GB", 1e9), ("MB", 1e6), ("KB", 1e3)):
+        if n >= threshold:
+            return f"{n / threshold:.1f} {unit}"
+    return f"{n} B"
+
+
+# ---------------------------------------------------------------------------
+# Image classification — terok's layering knowledge
+# ---------------------------------------------------------------------------
+
+_GLOBAL_PREFIXES = ("terok-l0", "terok-l1-cli")
+
+
+def _is_global_image(img: ImageInfo) -> bool:
+    """L0/L1 base images and dangling images belong to the global section."""
+    if img.repository == "<none>":
+        return True
+    return img.repository.startswith(_GLOBAL_PREFIXES)
+
+
+def _image_project_id(img: ImageInfo) -> str | None:
+    """Extract the project ID from an L2 image, or None for global images."""
+    if _is_global_image(img):
+        return None
+    if img.tag in ("l2-cli", "l2-dev"):
+        return img.repository
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Overview dataclasses — the fast global view
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class ProjectSummary:
+    """One-line digest of a project's storage footprint."""
+
+    project_id: str
+    image_bytes: int
+    workspace_bytes: int
+    task_count: int
+
+    @property
+    def total_bytes(self) -> int:
+        """Sum of images and workspaces (overlays excluded in overview mode)."""
+        return self.image_bytes + self.workspace_bytes
+
+
+@dataclass(frozen=True)
+class StorageOverview:
+    """Fast global summary: globals expanded, projects as one-liners."""
+
+    global_images: list[ImageInfo]
+    shared_mounts: list[SharedMountStorageInfo]
+    projects: list[ProjectSummary]
+
+    @property
+    def global_images_bytes(self) -> int:
+        """Total size of global images."""
+        return sum(parse_image_size(img.size) for img in self.global_images)
+
+    @property
+    def shared_mounts_bytes(self) -> int:
+        """Total size of shared mount directories."""
+        return sum(m.bytes for m in self.shared_mounts)
+
+    @property
+    def projects_bytes(self) -> int:
+        """Total size across all projects."""
+        return sum(p.total_bytes for p in self.projects)
+
+    @property
+    def grand_total(self) -> int:
+        """Everything combined."""
+        return self.global_images_bytes + self.shared_mounts_bytes + self.projects_bytes
+
+
+# ---------------------------------------------------------------------------
+# Detail dataclass — per-task breakdown for one project
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class ProjectDetail:
+    """Full per-task storage breakdown for a single project."""
+
+    project_id: str
+    images: list[ImageInfo]
+    tasks: list[TaskStorageInfo]
+    overlays: dict[str, int]
+
+    @property
+    def images_bytes(self) -> int:
+        """Total size of project images."""
+        return sum(parse_image_size(img.size) for img in self.images)
+
+    @property
+    def workspace_bytes(self) -> int:
+        """Total workspace size across all tasks."""
+        return sum(t.workspace_bytes for t in self.tasks)
+
+    @property
+    def overlay_bytes(self) -> int:
+        """Total overlay size across all running containers."""
+        return sum(self.overlays.values())
+
+    @property
+    def total_bytes(self) -> int:
+        """Everything for this project."""
+        return self.images_bytes + self.workspace_bytes + self.overlay_bytes
+
+
+# ---------------------------------------------------------------------------
+# Public queries
+# ---------------------------------------------------------------------------
+
+
+def get_storage_overview() -> StorageOverview:
+    """Gather global summary — fast, no per-container podman queries.
+
+    Iterates all projects, sums workspace sizes via terok-agent, and
+    classifies images into global vs per-project.
+    """
+    all_images = list_images()
+    global_images = [img for img in all_images if _is_global_image(img)]
+
+    shared_mounts = get_shared_mounts_storage(sandbox_live_mounts_dir())
+
+    # Per-project: sum image sizes + workspace sizes
+    projects_conf = list_projects()
+    project_image_bytes: dict[str, int] = {}
+    for img in all_images:
+        pid = _image_project_id(img)
+        if pid:
+            project_image_bytes[pid] = project_image_bytes.get(pid, 0) + parse_image_size(img.size)
+
+    summaries = []
+    for proj in projects_conf:
+        tasks = get_tasks_storage(proj.tasks_root)
+        summaries.append(
+            ProjectSummary(
+                project_id=proj.id,
+                image_bytes=project_image_bytes.get(proj.id, 0),
+                workspace_bytes=sum(t.workspace_bytes for t in tasks),
+                task_count=len(tasks),
+            )
+        )
+
+    return StorageOverview(
+        global_images=global_images,
+        shared_mounts=shared_mounts,
+        projects=summaries,
+    )
+
+
+def get_project_storage_detail(project_id: str) -> ProjectDetail:
+    """Detailed view for one project, including overlay sizes.
+
+    This triggers ``podman ps --size`` for the project's containers —
+    expect a brief pause while podman computes overlay diffs.
+    """
+    from terok_sandbox import get_container_rw_sizes
+
+    from ..core.projects import load_project
+
+    project = load_project(project_id)
+    project_images = [img for img in list_images(project_id) if not _is_global_image(img)]
+    tasks = get_tasks_storage(project.tasks_root)
+    overlays = get_container_rw_sizes(project_id)
+
+    return ProjectDetail(
+        project_id=project_id,
+        images=project_images,
+        tasks=tasks,
+        overlays=overlays,
+    )

--- a/src/terok/lib/util/ansi.py
+++ b/src/terok/lib/util/ansi.py
@@ -41,6 +41,11 @@ def color(text: str, code: str, enabled: bool) -> str:
     return f"\x1b[{code}m{text}\x1b[0m"
 
 
+def bold(text: str, enabled: bool) -> str:
+    """Return *text* in bold (ANSI 1) when *enabled*."""
+    return color(text, "1", enabled)
+
+
 def yellow(text: str, enabled: bool) -> str:
     """Return *text* in yellow (ANSI 33) when *enabled*."""
     return color(text, "33", enabled)

--- a/src/terok/ui_utils/terminal.py
+++ b/src/terok/ui_utils/terminal.py
@@ -11,6 +11,7 @@ This module re-exports them and adds higher-level helpers.
 
 from terok.lib.util.ansi import (  # noqa: F401  -- re-exports
     blue,
+    bold,
     color,
     green,
     red,

--- a/tach.toml
+++ b/tach.toml
@@ -52,6 +52,8 @@ depends_on = [
     "terok.lib.core.projects",
     "terok.lib.core.version",
     "terok.lib.domain.facade",
+    "terok.lib.domain.storage",
+    "terok.lib.util.ansi",
     "terok.lib.util.emoji",
     "terok.lib.util.yaml",
     "terok.lib.domain.wizards.new_project",
@@ -164,6 +166,16 @@ depends_on = ["terok.lib.util.ansi"]
 path = "terok.lib.domain.image_cleanup"
 layer = "domain"
 depends_on = ["terok.lib.core.projects"]
+
+# Storage usage aggregation across package stack
+[[modules]]
+path = "terok.lib.domain.storage"
+layer = "domain"
+depends_on = [
+    "terok.lib.domain.image_cleanup",
+    "terok.lib.core.config",
+    "terok.lib.core.projects",
+]
 
 # Agent config resolution (terok-specific stack composition)
 [[modules]]
@@ -570,6 +582,10 @@ from = ["terok.lib.orchestration.docker"]
 [[interfaces]]
 expose = ["list_images", "find_orphaned_images", "cleanup_images", "ImageInfo", "CleanupResult"]
 from = ["terok.lib.domain.image_cleanup"]
+
+[[interfaces]]
+expose = ["StorageOverview", "ProjectDetail", "ProjectSummary", "get_storage_overview", "get_project_storage_detail", "format_bytes", "parse_image_size"]
+from = ["terok.lib.domain.storage"]
 
 [[interfaces]]
 expose = ["PanicResult", "execute_panic", "panic_stop_containers", "is_panicked", "clear_panic_lock", "format_panic_report"]

--- a/tests/unit/cli/test_cli_storage.py
+++ b/tests/unit/cli/test_cli_storage.py
@@ -1,0 +1,202 @@
+# SPDX-FileCopyrightText: 2026 Jiri Vyskocil
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the ``terok storage`` CLI command.
+
+Verifies argument parsing, dispatch routing, and output for both
+overview and detail modes — all with mocked domain calls.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from unittest.mock import patch
+
+from terok.cli.commands.storage import dispatch, register
+from terok.lib.domain.image_cleanup import ImageInfo
+from terok.lib.domain.storage import ProjectDetail, ProjectSummary, StorageOverview
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+def _parser() -> argparse.ArgumentParser:
+    """Build a parser with the storage command registered."""
+    p = argparse.ArgumentParser()
+    sub = p.add_subparsers(dest="cmd")
+    register(sub)
+    return p
+
+
+def _make_overview(**kwargs) -> StorageOverview:
+    """Build a minimal StorageOverview for testing."""
+    defaults = {
+        "global_images": [ImageInfo("terok-l0", "bkwm", "id1", "1GB", "2d ago")],
+        "shared_mounts": [],
+        "projects": [ProjectSummary("proj1", 500_000_000, 200_000_000, 2)],
+    }
+    defaults.update(kwargs)
+    return StorageOverview(**defaults)
+
+
+def _make_detail(**kwargs) -> ProjectDetail:
+    """Build a minimal ProjectDetail for testing."""
+    defaults = {
+        "project_id": "myproject",
+        "images": [ImageInfo("myproject", "l2-cli", "id2", "3GB", "1d ago")],
+        "tasks": [],
+        "overlays": {},
+    }
+    defaults.update(kwargs)
+    return ProjectDetail(**defaults)
+
+
+# ---------------------------------------------------------------------------
+# Argument parsing
+# ---------------------------------------------------------------------------
+
+
+class TestRegister:
+    """The ``storage`` command registers cleanly."""
+
+    def test_default_mode(self):
+        args = _parser().parse_args(["storage"])
+        assert args.cmd == "storage"
+        assert args.project is None
+        assert args.json_output is False
+
+    def test_project_flag(self):
+        args = _parser().parse_args(["storage", "--project", "myproj"])
+        assert args.project == "myproj"
+
+    def test_json_flag(self):
+        args = _parser().parse_args(["storage", "--json"])
+        assert args.json_output is True
+
+
+# ---------------------------------------------------------------------------
+# Dispatch routing
+# ---------------------------------------------------------------------------
+
+
+class TestDispatch:
+    """Dispatch returns True for ``storage`` and False for anything else."""
+
+    def test_handles_storage(self):
+        args = argparse.Namespace(cmd="storage", project=None, json_output=False)
+        with patch("terok.cli.commands.storage._cmd_overview") as mock:
+            assert dispatch(args) is True
+            mock.assert_called_once()
+
+    def test_ignores_other_commands(self):
+        args = argparse.Namespace(cmd="image")
+        assert dispatch(args) is False
+
+    def test_routes_to_detail_with_project(self):
+        args = argparse.Namespace(cmd="storage", project="myproj", json_output=False)
+        with patch("terok.cli.commands.storage._cmd_detail") as mock:
+            assert dispatch(args) is True
+            mock.assert_called_once_with("myproj", json_output=False)
+
+
+# ---------------------------------------------------------------------------
+# Overview output
+# ---------------------------------------------------------------------------
+
+
+class TestOverviewOutput:
+    """Overview mode prints a human-readable summary."""
+
+    @patch("terok.lib.domain.storage.sandbox_live_mounts_dir")
+    @patch("terok.lib.domain.storage.list_projects", return_value=[])
+    @patch("terok.lib.domain.storage.get_shared_mounts_storage", return_value=[])
+    @patch("terok.lib.domain.storage.list_images")
+    @patch("terok.cli.commands.storage.supports_color", return_value=False)
+    def test_prints_without_error(self, _color, mock_imgs, _shared, _projs, _mdir, capsys):
+        mock_imgs.return_value = [ImageInfo("terok-l0", "bkwm", "id1", "1GB", "2d ago")]
+        from terok.cli.commands.storage import _cmd_overview
+
+        _cmd_overview()
+        output = capsys.readouterr().out
+        assert "Global" in output
+        assert "terok-l0" in output
+        assert "Grand total" in output
+
+    @patch("terok.lib.domain.storage.sandbox_live_mounts_dir")
+    @patch("terok.lib.domain.storage.list_projects", return_value=[])
+    @patch("terok.lib.domain.storage.get_shared_mounts_storage", return_value=[])
+    @patch("terok.lib.domain.storage.list_images", return_value=[])
+    @patch("terok.cli.commands.storage.supports_color", return_value=False)
+    def test_empty_system(self, _color, _imgs, _shared, _projs, _mdir, capsys):
+        from terok.cli.commands.storage import _cmd_overview
+
+        _cmd_overview()
+        output = capsys.readouterr().out
+        assert "Grand total" in output
+
+    @patch("terok.lib.domain.storage.sandbox_live_mounts_dir")
+    @patch("terok.lib.domain.storage.list_projects", return_value=[])
+    @patch("terok.lib.domain.storage.get_shared_mounts_storage", return_value=[])
+    @patch("terok.lib.domain.storage.list_images")
+    def test_json_output(self, mock_imgs, _shared, _projs, _mdir, capsys):
+        mock_imgs.return_value = [ImageInfo("terok-l0", "bkwm", "id1", "1GB", "2d ago")]
+        from terok.cli.commands.storage import _cmd_overview
+
+        _cmd_overview(json_output=True)
+        data = json.loads(capsys.readouterr().out)
+        assert "global" in data
+        assert "projects" in data
+        assert "grand_total_bytes" in data
+
+
+# ---------------------------------------------------------------------------
+# Detail output
+# ---------------------------------------------------------------------------
+
+
+class TestDetailOutput:
+    """Detail mode prints per-task breakdown."""
+
+    @patch("terok_sandbox.get_container_rw_sizes", return_value={})
+    @patch("terok.lib.domain.storage.get_tasks_storage", return_value=[])
+    @patch("terok.lib.domain.storage.list_images")
+    @patch("terok.lib.core.projects.load_project")
+    @patch("terok.cli.commands.storage.supports_color", return_value=False)
+    def test_prints_without_error(self, _color, mock_load, mock_imgs, _tasks, _ov, capsys):
+        from unittest.mock import MagicMock
+
+        from tests.testfs import MOCK_BASE
+
+        proj = MagicMock()
+        proj.tasks_root = MOCK_BASE / "tasks" / "myproject"
+        mock_load.return_value = proj
+        mock_imgs.return_value = [ImageInfo("myproject", "l2-cli", "id2", "3GB", "1d ago")]
+        from terok.cli.commands.storage import _cmd_detail
+
+        _cmd_detail("myproject")
+        output = capsys.readouterr().out
+        assert "myproject" in output
+        assert "Project total" in output
+
+    @patch("terok_sandbox.get_container_rw_sizes", return_value={})
+    @patch("terok.lib.domain.storage.get_tasks_storage", return_value=[])
+    @patch("terok.lib.domain.storage.list_images")
+    @patch("terok.lib.core.projects.load_project")
+    def test_json_output(self, mock_load, mock_imgs, _tasks, _ov, capsys):
+        from unittest.mock import MagicMock
+
+        from tests.testfs import MOCK_BASE
+
+        proj = MagicMock()
+        proj.tasks_root = MOCK_BASE / "tasks" / "myproject"
+        mock_load.return_value = proj
+        mock_imgs.return_value = [ImageInfo("myproject", "l2-cli", "id2", "3GB", "1d ago")]
+        from terok.cli.commands.storage import _cmd_detail
+
+        _cmd_detail("myproject", json_output=True)
+        data = json.loads(capsys.readouterr().out)
+        assert data["project_id"] == "myproject"
+        assert "images" in data
+        assert "tasks" in data

--- a/tests/unit/lib/test_storage.py
+++ b/tests/unit/lib/test_storage.py
@@ -1,0 +1,193 @@
+# SPDX-FileCopyrightText: 2026 Jiri Vyskocil
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the storage usage aggregation domain layer.
+
+The domain module is the bridge between raw queries (agent, sandbox)
+and the CLI presentation.  Tests verify classification, aggregation,
+and the size parser — all with mocked sub-package calls.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from terok.lib.domain.image_cleanup import ImageInfo
+from terok.lib.domain.storage import (
+    ProjectSummary,
+    StorageOverview,
+    _is_global_image,
+    format_bytes,
+    get_project_storage_detail,
+    get_storage_overview,
+    parse_image_size,
+)
+from tests.testfs import MOCK_BASE
+
+# ---------------------------------------------------------------------------
+# parse_image_size — translating podman prose to integers
+# ---------------------------------------------------------------------------
+
+
+class TestParseImageSize:
+    """Podman returns sizes as human-readable strings; we need bytes."""
+
+    def test_gigabytes(self):
+        assert parse_image_size("1.23GB") == 1_230_000_000
+
+    def test_megabytes(self):
+        assert parse_image_size("456MB") == 456_000_000
+
+    def test_kilobytes(self):
+        assert parse_image_size("12KB") == 12_000
+
+    def test_bytes(self):
+        assert parse_image_size("1024B") == 1024
+
+    def test_garbage_returns_zero(self):
+        assert parse_image_size("???") == 0
+
+    def test_empty_returns_zero(self):
+        assert parse_image_size("") == 0
+
+
+# ---------------------------------------------------------------------------
+# format_bytes — the inverse: integers to human-readable
+# ---------------------------------------------------------------------------
+
+
+class TestFormatBytes:
+    """Symmetric companion to parse: bytes back to readable strings."""
+
+    def test_gigabytes(self):
+        assert format_bytes(1_500_000_000) == "1.5 GB"
+
+    def test_megabytes(self):
+        assert format_bytes(12_500_000) == "12.5 MB"
+
+    def test_kilobytes(self):
+        assert format_bytes(4_000) == "4.0 KB"
+
+    def test_bytes(self):
+        assert format_bytes(42) == "42 B"
+
+    def test_zero(self):
+        assert format_bytes(0) == "0 B"
+
+
+# ---------------------------------------------------------------------------
+# Image classification — global vs per-project
+# ---------------------------------------------------------------------------
+
+
+class TestImageClassification:
+    """L0/L1 and dangling images are global; L2 images belong to a project."""
+
+    def test_l0_is_global(self):
+        img = ImageInfo("terok-l0", "bookworm", "sha256:abc", "1GB", "2d ago")
+        assert _is_global_image(img)
+
+    def test_l1_is_global(self):
+        img = ImageInfo("terok-l1-cli", "bookworm", "sha256:def", "2GB", "3d ago")
+        assert _is_global_image(img)
+
+    def test_dangling_is_global(self):
+        img = ImageInfo("<none>", "<none>", "sha256:ghi", "500MB", "1d ago")
+        assert _is_global_image(img)
+
+    def test_l2_is_not_global(self):
+        img = ImageInfo("myproject", "l2-cli", "sha256:jkl", "3GB", "1d ago")
+        assert not _is_global_image(img)
+
+
+# ---------------------------------------------------------------------------
+# StorageOverview properties
+# ---------------------------------------------------------------------------
+
+
+class TestStorageOverviewProperties:
+    """The overview dataclass computes totals from its children."""
+
+    def test_grand_total(self):
+        overview = StorageOverview(
+            global_images=[ImageInfo("terok-l0", "bkwm", "id1", "1GB", "2d")],
+            shared_mounts=[],
+            projects=[
+                ProjectSummary(
+                    "proj1", image_bytes=500_000_000, workspace_bytes=200_000_000, task_count=1
+                )
+            ],
+        )
+        # 1 GB image + 500M project images + 200M workspaces
+        assert overview.grand_total == 1_000_000_000 + 500_000_000 + 200_000_000
+
+
+# ---------------------------------------------------------------------------
+# get_storage_overview — the orchestrator
+# ---------------------------------------------------------------------------
+
+
+_MOCK_IMAGES = [
+    ImageInfo("terok-l0", "bookworm", "id1", "1GB", "2d ago"),
+    ImageInfo("myproject", "l2-cli", "id2", "3GB", "1d ago"),
+]
+
+
+class TestGetStorageOverview:
+    """Overview wires together image listing, mount queries, and project enumeration."""
+
+    @patch("terok.lib.domain.storage.get_shared_mounts_storage", return_value=[])
+    @patch("terok.lib.domain.storage.get_tasks_storage", return_value=[])
+    @patch("terok.lib.domain.storage.list_projects")
+    @patch("terok.lib.domain.storage.list_images", return_value=_MOCK_IMAGES)
+    @patch("terok.lib.domain.storage.sandbox_live_mounts_dir", return_value=MOCK_BASE / "mounts")
+    def test_classifies_images(self, _mounts, _imgs, mock_projects, _tasks, _shared):
+        mock_projects.return_value = [_fake_project("myproject")]
+        overview = get_storage_overview()
+        assert len(overview.global_images) == 1
+        assert overview.global_images[0].repository == "terok-l0"
+        assert len(overview.projects) == 1
+        assert overview.projects[0].project_id == "myproject"
+
+    @patch("terok.lib.domain.storage.get_shared_mounts_storage", return_value=[])
+    @patch("terok.lib.domain.storage.get_tasks_storage", return_value=[])
+    @patch("terok.lib.domain.storage.list_projects", return_value=[])
+    @patch("terok.lib.domain.storage.list_images", return_value=[])
+    @patch("terok.lib.domain.storage.sandbox_live_mounts_dir", return_value=MOCK_BASE / "mounts")
+    def test_empty_system(self, _mounts, _imgs, _projects, _tasks, _shared):
+        overview = get_storage_overview()
+        assert overview.grand_total == 0
+
+
+# ---------------------------------------------------------------------------
+# get_project_storage_detail — zooming in
+# ---------------------------------------------------------------------------
+
+
+class TestGetProjectStorageDetail:
+    """Detail mode queries per-task sizes and overlay data."""
+
+    @patch("terok_sandbox.get_container_rw_sizes", return_value={"abc": 1024})
+    @patch("terok.lib.domain.storage.get_tasks_storage", return_value=[])
+    @patch("terok.lib.domain.storage.list_images", return_value=[])
+    @patch("terok.lib.core.projects.load_project")
+    def test_returns_project_detail(self, mock_load, _imgs, _tasks, _overlays):
+        mock_load.return_value = _fake_project("myproject")
+        detail = get_project_storage_detail("myproject")
+        assert detail.project_id == "myproject"
+        assert detail.overlays == {"abc": 1024}
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _fake_project(pid: str):
+    """Minimal stand-in for ProjectConfig."""
+    from unittest.mock import MagicMock
+
+    p = MagicMock()
+    p.id = pid
+    p.tasks_root = MOCK_BASE / "tasks" / pid
+    return p


### PR DESCRIPTION
Closes #646

## Summary
- New `terok storage` command with two modes:
  - **Overview** (default): global images + shared mounts expanded, per-project one-liners. Fast — no per-container podman `--size` queries.
  - **Detail** (`--project <id>`): per-task workspace and overlay sizes for one project. Triggers the expensive `podman ps --size` only for that project.
- `--json` flag for machine-readable output
- Colored output: bold violet section headers, blue sizes, gray separators. Respects `NO_COLOR`/`FORCE_COLOR`.
- New domain module `lib/domain/storage.py` aggregating across the package stack
- New `bold()` helper in `lib/util/ansi.py`

## Dependencies
- terok-ai/terok-sandbox#126 — `get_container_rw_size(s)` for overlay queries
- terok-ai/terok-agent#137 — `get_task_storage()`, `get_shared_mounts_storage()` for filesystem queries

Merge sandbox and agent PRs first, then bump versions in `pyproject.toml` before this can land.

## Test plan
- [x] 19 domain tests (size parsing, image classification, aggregation)
- [x] 11 CLI tests (arg parsing, dispatch, overview/detail output, JSON)
- [x] `make check` passes (lint, 1580 tests, tach, docstrings 99.6%, reuse)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Add a storage command to the CLI: system-wide overview or per-project breakdown, human-readable table with optional ANSI styling and a JSON output mode.

* **Tests**
  * Add unit tests for CLI arguments, text/JSON outputs, and storage aggregation logic.

* **Chores**
  * Add small terminal styling helper export and update CI workflow and dependency configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->