### PR TITLE
fix: combine docker snippet file and inline instead of shadowing

### DIFF
--- a/src/terok/lib/orchestration/docker.py
+++ b/src/terok/lib/orchestration/docker.py
@@ -110,8 +110,8 @@ def _resolve_user_snippet(project: ProjectConfig) -> str:
                 f"  (configured in project '{project.id}')"
             )
         try:
-            parts.append(us_path.read_text())
-        except OSError as exc:
+            parts.append(us_path.read_text(encoding="utf-8"))
+        except (OSError, UnicodeError) as exc:
             raise SystemExit(f"Failed to read docker.user_snippet_file {us_path}: {exc}")
     if project.docker_snippet_inline and project.docker_snippet_inline.strip():
         parts.append(project.docker_snippet_inline)

--- a/src/terok/lib/orchestration/docker.py
+++ b/src/terok/lib/orchestration/docker.py
@@ -91,13 +91,15 @@ def _tmux_config_hash() -> str:
 
 
 def _resolve_user_snippet(project: ProjectConfig) -> str:
-    """Resolve the docker user snippet from project config (inline or file).
+    """Resolve the docker user snippet from project config (file and/or inline).
+
+    When both ``docker.user_snippet_file`` and ``docker.user_snippet_inline``
+    are set, the file is included first and the inline block is appended.
 
     Raises :class:`SystemExit` if ``docker.user_snippet_file`` is configured but
     the file does not exist or cannot be read.
     """
-    if project.docker_snippet_inline and project.docker_snippet_inline.strip():
-        return project.docker_snippet_inline
+    parts: list[str] = []
     if project.docker_snippet_file:
         us_path = Path(project.docker_snippet_file).expanduser()
         if not us_path.is_absolute():
@@ -108,10 +110,12 @@ def _resolve_user_snippet(project: ProjectConfig) -> str:
                 f"  (configured in project '{project.id}')"
             )
         try:
-            return us_path.read_text()
+            parts.append(us_path.read_text())
         except OSError as exc:
             raise SystemExit(f"Failed to read docker.user_snippet_file {us_path}: {exc}")
-    return ""
+    if project.docker_snippet_inline and project.docker_snippet_inline.strip():
+        parts.append(project.docker_snippet_inline)
+    return "\n".join(parts)
 
 
 def _render_l2(project: ProjectConfig) -> str:

--- a/src/terok/resources/templates/projects/gatekeeping-nvidia.yml
+++ b/src/terok/resources/templates/projects/gatekeeping-nvidia.yml
@@ -13,7 +13,8 @@ git:
 docker:
   base_image: "nvcr.io/nvidia/nvhpc:25.9-devel-cuda13.0-ubuntu24.04"
   # Optional: extra Dockerfile commands injected into the project image.
-  # Use user_snippet_file to point to an external .dockerinclude file instead.
+  # Use user_snippet_file to point to an external .dockerinclude file.
+  # Both can be set — file is included first, inline appended.
   user_snippet_inline: |
     {{USER_SNIPPET}}
 

--- a/src/terok/resources/templates/projects/gatekeeping-ubuntu.yml
+++ b/src/terok/resources/templates/projects/gatekeeping-ubuntu.yml
@@ -13,7 +13,8 @@ git:
 docker:
   base_image: "ubuntu:24.04"
   # Optional: extra Dockerfile commands injected into the project image.
-  # Use user_snippet_file to point to an external .dockerinclude file instead.
+  # Use user_snippet_file to point to an external .dockerinclude file.
+  # Both can be set — file is included first, inline appended.
   user_snippet_inline: |
     {{USER_SNIPPET}}
 

--- a/src/terok/resources/templates/projects/online-nvidia.yml
+++ b/src/terok/resources/templates/projects/online-nvidia.yml
@@ -12,7 +12,8 @@ git:
 docker:
   base_image: "nvcr.io/nvidia/nvhpc:25.9-devel-cuda13.0-ubuntu24.04"
   # Optional: extra Dockerfile commands injected into the project image.
-  # Use user_snippet_file to point to an external .dockerinclude file instead.
+  # Use user_snippet_file to point to an external .dockerinclude file.
+  # Both can be set — file is included first, inline appended.
   user_snippet_inline: |
     {{USER_SNIPPET}}
 

--- a/src/terok/resources/templates/projects/online-ubuntu.yml
+++ b/src/terok/resources/templates/projects/online-ubuntu.yml
@@ -12,6 +12,7 @@ git:
 docker:
   base_image: "ubuntu:24.04"
   # Optional: extra Dockerfile commands injected into the project image.
-  # Use user_snippet_file to point to an external .dockerinclude file instead.
+  # Use user_snippet_file to point to an external .dockerinclude file.
+  # Both can be set — file is included first, inline appended.
   user_snippet_inline: |
     {{USER_SNIPPET}}

--- a/tests/unit/lib/test_docker.py
+++ b/tests/unit/lib/test_docker.py
@@ -154,6 +154,35 @@ def test_l2_includes_user_snippet_from_file() -> None:
         Path(snippet_path).unlink(missing_ok=True)
 
 
+def test_l2_combines_snippet_file_and_inline() -> None:
+    """L2 includes both snippet file and inline, file first."""
+    import tempfile
+    from pathlib import Path
+
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".dockerfile", delete=False) as f:
+        f.write("RUN pip install numpy\n")
+        snippet_path = f.name
+
+    try:
+        yaml = (
+            "project:\n  id: proj_both_snippets\n"
+            "git:\n  upstream_url: https://example.com/repo.git\n"
+            f"docker:\n  user_snippet_file: {snippet_path}\n"
+            "  user_snippet_inline: RUN apt-get install -y fortran-compiler\n"
+        )
+        with project_env(yaml, project_id="proj_both_snippets"):
+            generate_dockerfiles("proj_both_snippets")
+            content = (build_dir() / "proj_both_snippets" / "L2.Dockerfile").read_text(
+                encoding="utf-8"
+            )
+            assert "RUN pip install numpy" in content
+            assert "RUN apt-get install -y fortran-compiler" in content
+            # File comes before inline
+            assert content.index("pip install numpy") < content.index("fortran-compiler")
+    finally:
+        Path(snippet_path).unlink(missing_ok=True)
+
+
 def test_l2_missing_snippet_file_exits() -> None:
     """Missing user_snippet_file raises SystemExit."""
     import pytest


### PR DESCRIPTION
## Summary

- `_resolve_user_snippet()` now concatenates both sources (file first, inline appended) instead of silently ignoring the file when inline is set
- Allows a shared base snippet file with per-project inline additions

## Test plan

- [x] Existing docker tests pass
- [x] New test verifies both snippet sources are included with correct ordering

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Docker user snippets can combine file-based and inline snippets; file content is included first, then inline content.

* **Tests**
  * Added unit test to verify both file and inline snippets are injected in order.

* **Documentation**
  * Updated project templates to clarify snippet precedence and usage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->