### PR TITLE
feat: unified hex task IDs with CLI prefix matching

### DIFF
--- a/src/terok/cli/commands/task.py
+++ b/src/terok/cli/commands/task.py
@@ -31,6 +31,7 @@ from ...lib.domain.facade import (
     task_status,
     task_stop,
 )
+from ...lib.orchestration.tasks import resolve_task_id
 from ._completers import complete_project_ids as _complete_project_ids, set_completer
 
 
@@ -272,7 +273,8 @@ def register(subparsers: argparse._SubParsersAction[argparse.ArgumentParser]) ->
 def dispatch(args: argparse.Namespace) -> bool:
     """Handle task-related commands.  Returns True if handled."""
     if args.cmd == "login":
-        task_login(args.project_id, args.task_id)
+        tid = resolve_task_id(args.project_id, args.task_id)
+        task_login(args.project_id, tid)
         return True
     if args.cmd == "run":
         # Read instructions file if provided via --instructions
@@ -320,72 +322,65 @@ def dispatch(args: argparse.Namespace) -> bool:
 
 def _dispatch_task_sub(args: argparse.Namespace) -> bool:
     """Dispatch ``task <subcommand>`` to the right handler."""
+    pid = args.project_id
+    tid = resolve_task_id(pid, args.task_id) if hasattr(args, "task_id") else ""
     if args.task_cmd == "new":
-        task_new(args.project_id, name=getattr(args, "name", None))
+        task_new(pid, name=getattr(args, "name", None))
     elif args.task_cmd == "list":
         task_list(
-            args.project_id,
+            pid,
             status=getattr(args, "filter_status", None),
             mode=getattr(args, "filter_mode", None),
             agent=getattr(args, "filter_agent", None),
         )
     elif args.task_cmd == "run-cli":
         task_run_cli(
-            args.project_id,
-            args.task_id,
+            pid,
+            tid,
             agents=getattr(args, "selected_agents", None),
             preset=getattr(args, "preset", None),
             unrestricted=_resolve_unrestricted(args),
         )
     elif args.task_cmd == "run-toad":
         task_run_toad(
-            args.project_id,
-            args.task_id,
+            pid,
+            tid,
             agents=getattr(args, "selected_agents", None),
             preset=getattr(args, "preset", None),
             unrestricted=_resolve_unrestricted(args),
         )
     elif args.task_cmd == "delete":
-        result = task_delete(args.project_id, args.task_id)
+        result = task_delete(pid, tid)
         if result.warnings:
             for w in result.warnings:
                 print(f"  Warning: {w}", file=sys.stderr)
-            print(
-                f"Deleted task {args.task_id} (with warnings)."
-                f" Archive: terok task archive list {args.project_id}"
-            )
+            print(f"Deleted task {tid} (with warnings). Archive: terok task archive list {pid}")
         else:
-            print(
-                f"Deleted task {args.task_id}. Archive: terok task archive list {args.project_id}"
-            )
+            print(f"Deleted task {tid}. Archive: terok task archive list {pid}")
     elif args.task_cmd == "stop":
-        task_stop(args.project_id, args.task_id, timeout=getattr(args, "timeout", None))
+        task_stop(pid, tid, timeout=getattr(args, "timeout", None))
     elif args.task_cmd == "restart":
-        task_restart(args.project_id, args.task_id)
+        task_restart(pid, tid)
     elif args.task_cmd == "followup":
         task_followup_headless(
-            args.project_id,
-            args.task_id,
+            pid,
+            tid,
             args.prompt,
             follow=not getattr(args, "no_follow", False),
         )
     elif args.task_cmd == "start":
-        task_id = task_new(args.project_id, name=getattr(args, "name", None))
+        task_id = task_new(pid, name=getattr(args, "name", None))
         selected = getattr(args, "selected_agents", None)
         preset = getattr(args, "preset", None)
         restriction = _resolve_unrestricted(args)
         if getattr(args, "toad", False):
-            task_run_toad(
-                args.project_id, task_id, agents=selected, preset=preset, unrestricted=restriction
-            )
+            task_run_toad(pid, task_id, agents=selected, preset=preset, unrestricted=restriction)
         else:
-            task_run_cli(
-                args.project_id, task_id, agents=selected, preset=preset, unrestricted=restriction
-            )
+            task_run_cli(pid, task_id, agents=selected, preset=preset, unrestricted=restriction)
     elif args.task_cmd == "rename":
-        task_rename(args.project_id, args.task_id, args.name)
+        task_rename(pid, tid, args.name)
     elif args.task_cmd == "status":
-        task_status(args.project_id, args.task_id)
+        task_status(pid, tid)
     elif args.task_cmd == "logs":
         # Resolve streaming: CLI flag → config → default (True)
         if getattr(args, "no_stream", None):
@@ -395,8 +390,8 @@ def _dispatch_task_sub(args: argparse.Namespace) -> bool:
         else:
             stream = _get_logs_partial_streaming()
         task_logs(
-            args.project_id,
-            args.task_id,
+            pid,
+            tid,
             LogViewOptions(
                 follow=getattr(args, "follow", False),
                 raw=getattr(args, "raw", False),

--- a/src/terok/lib/core/task_display.py
+++ b/src/terok/lib/core/task_display.py
@@ -152,3 +152,14 @@ def mode_info(mode: str | None) -> ModeInfo:
     """Return the display info for a task mode string."""
     info = MODE_DISPLAY.get(mode if isinstance(mode, str) else None)
     return info if info else MODE_DISPLAY[None]
+
+
+# ---------- Container naming ----------
+
+CONTAINER_MODES = ("cli", "web", "run", "toad")
+"""All valid container mode suffixes used in container naming."""
+
+
+def container_name(project_id: str, mode: str, task_id: str) -> str:
+    """Return the canonical container name for a task."""
+    return f"{project_id}-{mode}-{task_id}"

--- a/src/terok/lib/domain/project_state.py
+++ b/src/terok/lib/domain/project_state.py
@@ -17,6 +17,7 @@ from typing import TYPE_CHECKING, Any
 from ..core.config import build_dir, make_sandbox_config
 from ..core.images import project_cli_image
 from ..core.projects import load_project
+from ..core.task_display import container_name as _container_name
 
 if TYPE_CHECKING:
     from ..core.project_model import ProjectConfig
@@ -249,7 +250,7 @@ def is_task_image_old(project_id: str | None, task: Any) -> bool | None:
     if task.mode != "cli":
         return None
 
-    container_name = f"{project_id}-{task.mode}-{task.task_id}"
+    cname = _container_name(project_id, task.mode, task.task_id)
     try:
         result = subprocess.run(
             [
@@ -258,7 +259,7 @@ def is_task_image_old(project_id: str | None, task: Any) -> bool | None:
                 "inspect",
                 "--format",
                 "{{.State.Running}}\t{{.Image}}",
-                container_name,
+                cname,
             ],
             capture_output=True,
             text=True,

--- a/src/terok/lib/domain/task.py
+++ b/src/terok/lib/domain/task.py
@@ -79,7 +79,7 @@ class Task:
 
     @property
     def id(self) -> str:
-        """Return the task's numeric ID."""
+        """Return the task's hex ID."""
         return self._meta.task_id
 
     @property

--- a/src/terok/lib/orchestration/container_exec.py
+++ b/src/terok/lib/orchestration/container_exec.py
@@ -12,12 +12,8 @@ import subprocess
 
 from terok_sandbox import get_container_state
 
+from ..core.task_display import container_name as _container_name
 from ..util.logging_utils import _log_debug
-
-
-def _container_name(project_id: str, mode: str, task_id: str) -> str:
-    """Inline container naming to avoid circular import with tasks."""
-    return f"{project_id}-{mode}-{task_id}"
 
 
 def _podman_start(cname: str) -> bool:

--- a/src/terok/lib/orchestration/tasks.py
+++ b/src/terok/lib/orchestration/tasks.py
@@ -14,6 +14,7 @@ Container runner functions (``task_run_cli``,
 
 import os
 import re
+import secrets
 import shutil
 import subprocess
 from dataclasses import dataclass
@@ -28,8 +29,10 @@ from terok_sandbox import (
 from ..core.config import archive_dir, state_dir
 from ..core.projects import ProjectConfig, load_project
 from ..core.task_display import (
+    CONTAINER_MODES,
     STATUS_DISPLAY,
     TaskState,
+    container_name,
     effective_status,
     mode_info,
 )
@@ -47,9 +50,16 @@ from ..util.logging_utils import _log_debug
 from ..util.yaml import dump as _yaml_dump, load as _yaml_load
 from .container_exec import container_git_diff
 
-# ---------- Container naming (orchestration policy) ----------
+# ---------- Task ID generation ----------
 
-CONTAINER_MODES = ("cli", "web", "run", "toad")
+
+def _generate_unique_id(existing: set[str]) -> str:
+    """Generate a unique 8-char hex task ID not present in *existing*."""
+    for _ in range(100):
+        candidate = secrets.token_hex(4)
+        if candidate not in existing:
+            return candidate
+    raise RuntimeError("Failed to generate unique task ID after 100 attempts")
 
 
 def _is_initialized(meta: dict) -> bool:
@@ -57,9 +67,22 @@ def _is_initialized(meta: dict) -> bool:
     return "ready_at" in meta
 
 
-def container_name(project_id: str, mode: str, task_id: str) -> str:
-    """Return the canonical container name for a task."""
-    return f"{project_id}-{mode}-{task_id}"
+def resolve_task_id(project_id: str, prefix: str) -> str:
+    """Resolve a (possibly partial) hex task ID to its full 8-char form.
+
+    Raises ``SystemExit`` with an actionable message on zero or multiple matches.
+    """
+    meta_dir = tasks_meta_dir(project_id)
+    if not meta_dir.is_dir():
+        raise SystemExit(f"No tasks found for project {project_id}")
+    if (meta_dir / f"{prefix}.yml").is_file():
+        return prefix
+    matches = [p.stem for p in meta_dir.glob("*.yml") if p.stem.startswith(prefix)]
+    if len(matches) == 1:
+        return matches[0]
+    if not matches:
+        raise SystemExit(f"No task matching '{prefix}' in project {project_id}")
+    raise SystemExit(f"Ambiguous task ID '{prefix}' — matches: {', '.join(sorted(matches))}")
 
 
 def get_task_container_state(project_id: str, task_id: str, mode: str | None) -> str | None:
@@ -344,8 +367,8 @@ def _task_new(project: ProjectConfig, *, name: str | None = None) -> str:
     meta_dir = tasks_meta_dir(project.id)
     ensure_dir(meta_dir)
 
-    existing = sorted([p.stem for p in meta_dir.glob("*.yml") if p.stem.isdigit()], key=int)
-    next_id = str(int(existing[-1]) + 1 if existing else 1)
+    existing = {p.stem for p in meta_dir.glob("*.yml")}
+    next_id = _generate_unique_id(existing)
 
     ws = tasks_root / next_id
     ensure_dir(ws)
@@ -484,14 +507,7 @@ def _get_tasks(project_id: str, reverse: bool = False) -> list[TaskMeta]:
             log_warning(f"Skipping malformed task metadata file: {f}: {exc}")
             continue
 
-    def _sort_key(t: TaskMeta) -> tuple[bool, int, str]:
-        """Sort numeric IDs first (ascending), then non-numeric lexically."""
-        try:
-            return (False, int(t.task_id), t.task_id)
-        except (ValueError, TypeError):
-            return (True, 0, t.task_id or "")
-
-    tasks.sort(key=_sort_key, reverse=reverse)
+    tasks.sort(key=lambda t: t.task_id or "", reverse=reverse)
     return tasks
 
 
@@ -570,7 +586,7 @@ def task_list(
         if t.work_status:
             extra.append(f"work={t.work_status}")
         extra_s = f" [{'; '.join(extra)}]" if extra else ""
-        print(f"- {t.task_id:>3}: {t.name} {t_status}{extra_s}")
+        print(f"- {t.task_id}: {t.name} {t_status}{extra_s}")
 
 
 def _check_mode(meta: dict, expected: str) -> None:

--- a/src/terok/lib/orchestration/tasks.py
+++ b/src/terok/lib/orchestration/tasks.py
@@ -53,6 +53,10 @@ from .container_exec import container_git_diff
 # ---------- Task ID generation ----------
 
 
+_META_GLOB = "*.yml"
+"""Glob pattern for task metadata YAML files."""
+
+
 def _generate_unique_id(existing: set[str]) -> str:
     """Generate a unique 8-char hex task ID not present in *existing*."""
     for _ in range(100):
@@ -72,12 +76,15 @@ def resolve_task_id(project_id: str, prefix: str) -> str:
 
     Raises ``SystemExit`` with an actionable message on zero or multiple matches.
     """
+    if not re.fullmatch(r"[0-9a-f]{1,8}", prefix):
+        raise SystemExit(f"Invalid task ID prefix {prefix!r}; expected 1-8 lowercase hex chars")
+
     meta_dir = tasks_meta_dir(project_id)
     if not meta_dir.is_dir():
         raise SystemExit(f"No tasks found for project {project_id}")
     if (meta_dir / f"{prefix}.yml").is_file():
         return prefix
-    matches = [p.stem for p in meta_dir.glob("*.yml") if p.stem.startswith(prefix)]
+    matches = [p.stem for p in meta_dir.glob(_META_GLOB) if p.stem.startswith(prefix)]
     if len(matches) == 1:
         return matches[0]
     if not matches:
@@ -367,7 +374,7 @@ def _task_new(project: ProjectConfig, *, name: str | None = None) -> str:
     meta_dir = tasks_meta_dir(project.id)
     ensure_dir(meta_dir)
 
-    existing = {p.stem for p in meta_dir.glob("*.yml")}
+    existing = {p.stem for p in meta_dir.glob(_META_GLOB)}
     next_id = _generate_unique_id(existing)
 
     ws = tasks_root / next_id
@@ -471,7 +478,7 @@ def _get_tasks(project_id: str, reverse: bool = False) -> list[TaskMeta]:
         tasks_root = project.tasks_root
     except SystemExit:
         tasks_root = None
-    for f in meta_dir.glob("*.yml"):
+    for f in meta_dir.glob(_META_GLOB):
         try:
             meta = _yaml_load(f.read_text()) or {}
             tid = str(meta.get("task_id", ""))

--- a/src/terok/tui/widgets/task_list.py
+++ b/src/terok/tui/widgets/task_list.py
@@ -82,7 +82,7 @@ class TaskList(ListView):
         if task.web_port is not None:
             extra_parts.append(f"port={task.web_port}")
 
-        label = f"{task.task_id:>3} {m_emoji} {s_emoji} {task.name}"
+        label = f"{task.task_id[:4]} {m_emoji} {s_emoji} {task.name}"
         if extra_parts:
             label += f" [{'; '.join(extra_parts)}]"
         return label

--- a/tach.toml
+++ b/tach.toml
@@ -181,6 +181,7 @@ depends_on = [
     "terok.lib.core.config",
     "terok.lib.core.images",
     "terok.lib.core.projects",
+    "terok.lib.core.task_display",
 ]
 
 # Interactive project creation
@@ -270,7 +271,7 @@ depends_on = ["terok.lib.util.yaml"]
 [[modules]]
 path = "terok.lib.orchestration.container_exec"
 layer = "orchestration"
-depends_on = ["terok.lib.util.logging_utils"]
+depends_on = ["terok.lib.core.task_display", "terok.lib.util.logging_utils"]
 
 # In-container health checks (layered doctor protocol via podman exec)
 [[modules]]
@@ -482,6 +483,8 @@ expose = [
     "effective_status",
     "mode_info",
     "has_gpu",
+    "CONTAINER_MODES",
+    "container_name",
 ]
 from = ["terok.lib.core.task_display"]
 
@@ -539,6 +542,7 @@ expose = [
     "TaskMeta",
     "tasks_meta_dir",
     "tasks_archive_dir",
+    "resolve_task_id",
 ]
 from = ["terok.lib.orchestration.tasks"]
 

--- a/tests/integration/launch/test_task_start.py
+++ b/tests/integration/launch/test_task_start.py
@@ -7,12 +7,14 @@ from __future__ import annotations
 
 import json
 import os
+import re
 from pathlib import Path
 from typing import Any
 
 import pytest
 
 from terok.lib.util.yaml import load as yaml_load
+from tests.test_utils import assert_hex_id
 from tests.testnet import EXAMPLE_UPSTREAM_URL, LOCALHOST, localhost_url
 
 from ..helpers import TerokIntegrationEnv, write_fake_podman
@@ -20,9 +22,6 @@ from ..helpers import TerokIntegrationEnv, write_fake_podman
 pytestmark = pytest.mark.needs_host_features
 
 PROJECT_ID = "demo"
-TASK_ID = "1"
-CLI_CONTAINER = f"{PROJECT_ID}-cli-{TASK_ID}"
-TOAD_CONTAINER = f"{PROJECT_ID}-toad-{TASK_ID}"
 WEB_PORT = 7860
 TOAD_PORT = 8080
 
@@ -77,6 +76,13 @@ def _env_entries(args: list[str]) -> set[str]:
     return {args[index + 1] for index, arg in enumerate(args[:-1]) if arg == "-e"}
 
 
+def _extract_task_id(stdout: str) -> str:
+    """Extract the hex task ID from 'Created task <id> ...' output."""
+    match = re.search(r"Created task ([0-9a-f]{8})", stdout)
+    assert match, f"Could not extract task ID from: {stdout!r}"
+    return match.group(1)
+
+
 class TestLaunchWorkflows:
     """Verify host-only task start/restart flows through the real CLI."""
 
@@ -96,16 +102,19 @@ class TestLaunchWorkflows:
             extra_env=extra_env,
         )
 
-        meta = yaml_load(terok_env.task_meta_path(PROJECT_ID, TASK_ID).read_text(encoding="utf-8"))
+        tid = _extract_task_id(result.stdout)
+        assert_hex_id(tid)
+        cli_container = f"{PROJECT_ID}-cli-{tid}"
+        meta = yaml_load(terok_env.task_meta_path(PROJECT_ID, tid).read_text(encoding="utf-8"))
         state = _load_fake_podman_state(state_path)
-        args = _container_args(state, CLI_CONTAINER)
+        args = _container_args(state, cli_container)
 
-        assert "Created task 1 (fix-login-bug)" in result.stdout
+        assert f"Created task {tid} (fix-login-bug)" in result.stdout
         assert "CLI container is running in the background." in result.stdout
-        assert "Login with: terok login demo 1" in result.stdout
-        assert state["containers"][CLI_CONTAINER]["status"] == "running"
-        assert state["containers"][CLI_CONTAINER]["marker"] == "__CLI_READY__"
-        assert "--name" in args and args[args.index("--name") + 1] == CLI_CONTAINER
+        assert f"Login with: terok login demo {tid}" in result.stdout
+        assert state["containers"][cli_container]["status"] == "running"
+        assert state["containers"][cli_container]["marker"] == "__CLI_READY__"
+        assert "--name" in args and args[args.index("--name") + 1] == cli_container
         assert f"{PROJECT_ID}:l2-cli" in args
         assert "-p" not in args
         assert meta["mode"] == "cli"
@@ -127,13 +136,15 @@ class TestLaunchWorkflows:
             extra_env=extra_env,
         )
 
-        meta = yaml_load(terok_env.task_meta_path(PROJECT_ID, TASK_ID).read_text(encoding="utf-8"))
+        tid = _extract_task_id(result.stdout)
+        toad_container = f"{PROJECT_ID}-toad-{tid}"
+        meta = yaml_load(terok_env.task_meta_path(PROJECT_ID, tid).read_text(encoding="utf-8"))
         state = _load_fake_podman_state(state_path)
-        args = _container_args(state, TOAD_CONTAINER)
+        args = _container_args(state, toad_container)
 
         assert "Toad is serving." in result.stdout
         assert localhost_url(WEB_PORT) in result.stdout
-        assert state["containers"][TOAD_CONTAINER]["marker"] == "Serving http://0.0.0.0:8080"
+        assert state["containers"][toad_container]["marker"] == "Serving http://0.0.0.0:8080"
         assert args[args.index("-p") + 1] == f"{LOCALHOST}:{WEB_PORT}:{TOAD_PORT}"
         assert f"{PROJECT_ID}:l2-cli" in args
         assert "toad --serve -H 0.0.0.0 -p 8080" in args[-1]
@@ -149,17 +160,19 @@ class TestLaunchWorkflows:
         terok_env.write_project(PROJECT_ID, PROJECT_CONFIG)
         state_path, extra_env = _configure_fake_runtime(terok_env, tmp_path)
 
-        terok_env.run_cli("task", "start", PROJECT_ID, extra_env=extra_env)
+        start_result = terok_env.run_cli("task", "start", PROJECT_ID, extra_env=extra_env)
+        tid = _extract_task_id(start_result.stdout)
+        cli_container = f"{PROJECT_ID}-cli-{tid}"
 
         state = _load_fake_podman_state(state_path)
-        state["containers"][CLI_CONTAINER]["status"] = "exited"
+        state["containers"][cli_container]["status"] = "exited"
         state_path.write_text(json.dumps(state, indent=2, sort_keys=True), encoding="utf-8")
 
-        result = terok_env.run_cli("task", "restart", PROJECT_ID, TASK_ID, extra_env=extra_env)
+        result = terok_env.run_cli("task", "restart", PROJECT_ID, tid, extra_env=extra_env)
         restarted = _load_fake_podman_state(state_path)
 
-        assert "Restarting task demo/1 (cli)..." in result.stdout
-        assert "Restarted task 1:" in result.stdout
-        assert "Login with: terok login demo 1" in result.stdout
-        assert restarted["containers"][CLI_CONTAINER]["status"] == "running"
-        assert any(command == ["start", CLI_CONTAINER] for command in restarted["commands"])
+        assert f"Restarting task demo/{tid} (cli)..." in result.stdout
+        assert f"Restarted task {tid}:" in result.stdout
+        assert f"Login with: terok login demo {tid}" in result.stdout
+        assert restarted["containers"][cli_container]["status"] == "running"
+        assert any(command == ["start", cli_container] for command in restarted["commands"])

--- a/tests/integration/tasks/test_lifecycle.py
+++ b/tests/integration/tasks/test_lifecycle.py
@@ -5,8 +5,11 @@
 
 from __future__ import annotations
 
+import re
+
 import pytest
 
+from tests.test_utils import assert_hex_id
 from tests.testnet import EXAMPLE_UPSTREAM_URL
 
 from ..helpers import NEW_TASK_MARKER, TerokIntegrationEnv
@@ -22,6 +25,13 @@ git:
 """
 
 
+def _extract_task_id(stdout: str) -> str:
+    """Extract the hex task ID from 'Created task <id> ...' output."""
+    match = re.search(r"Created task ([0-9a-f]{8})", stdout)
+    assert match, f"Could not extract task ID from: {stdout!r}"
+    return match.group(1)
+
+
 class TestTaskLifecycle:
     """Verify task creation, status, rename, and archive flows."""
 
@@ -34,11 +44,13 @@ class TestTaskLifecycle:
         created = terok_env.run_cli("task", "new", "demo", "--name", "Fix Login Bug")
         terok_env.run_cli("task", "new", "demo", "--name", "Docs Sweep")
 
-        workspace = terok_env.task_workspace("demo", "1")
-        assert "Created task 1 (fix-login-bug)" in created.stdout
+        tid = _extract_task_id(created.stdout)
+        assert_hex_id(tid)
+        workspace = terok_env.task_workspace("demo", tid)
+        assert f"Created task {tid} (fix-login-bug)" in created.stdout
         assert workspace.is_dir()
         assert (workspace / NEW_TASK_MARKER).is_file()
-        assert (terok_env.task_dir("demo", "1") / "README.md").is_file()
+        assert (terok_env.task_dir("demo", tid) / "README.md").is_file()
 
         listed = terok_env.run_cli("task", "list", "demo")
         assert "fix-login-bug created" in listed.stdout
@@ -47,21 +59,22 @@ class TestTaskLifecycle:
     def test_task_rename_status_and_archive_delete(self, terok_env: TerokIntegrationEnv) -> None:
         """A task can be renamed, inspected, deleted, and listed from the archive."""
         terok_env.write_project("demo", PROJECT_CONFIG)
-        terok_env.run_cli("task", "new", "demo", "--name", "Draft")
+        created = terok_env.run_cli("task", "new", "demo", "--name", "Draft")
+        tid = _extract_task_id(created.stdout)
 
-        renamed = terok_env.run_cli("task", "rename", "demo", "1", "Ship It")
-        assert "Renamed task 1 to ship-it" in renamed.stdout
+        renamed = terok_env.run_cli("task", "rename", "demo", tid, "Ship It")
+        assert f"Renamed task {tid} to ship-it" in renamed.stdout
 
-        status = terok_env.run_cli("task", "status", "demo", "1")
-        assert "Task 1:" in status.stdout
+        status = terok_env.run_cli("task", "status", "demo", tid)
+        assert f"Task {tid}:" in status.stdout
         assert "Name:            ship-it" in status.stdout
         assert "[created]" in status.stdout
         assert "Mode:" in status.stdout
         assert "not set" in status.stdout
 
-        terok_env.run_cli("task", "delete", "demo", "1")
-        assert not terok_env.task_meta_path("demo", "1").exists()
-        assert not terok_env.task_dir("demo", "1").exists()
+        terok_env.run_cli("task", "delete", "demo", tid)
+        assert not terok_env.task_meta_path("demo", tid).exists()
+        assert not terok_env.task_dir("demo", tid).exists()
 
         archive_root = terok_env.task_archive_root("demo")
         archived_entries = [entry for entry in archive_root.iterdir() if entry.is_dir()]
@@ -69,4 +82,4 @@ class TestTaskLifecycle:
         assert any((entry / "task.yml").is_file() for entry in archived_entries)
 
         archived = terok_env.run_cli("task", "archive", "list", "demo")
-        assert "#1: ship-it" in archived.stdout
+        assert f"#{tid}: ship-it" in archived.stdout

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -112,6 +112,12 @@ def make_staleness_info(**overrides: Any) -> GateStalenessInfo:
     return GateStalenessInfo(**defaults)
 
 
+def assert_hex_id(task_id: str) -> None:
+    """Assert that *task_id* is a valid 8-char hex string."""
+    assert len(task_id) == 8, f"Expected 8-char hex ID, got {task_id!r}"
+    assert all(c in "0123456789abcdef" for c in task_id), f"Not a hex string: {task_id!r}"
+
+
 def make_mock_http_response(data: dict[str, object]) -> unittest.mock.Mock:
     """Create a mock HTTP response that returns JSON data as a context manager."""
     mock_response = unittest.mock.Mock()

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -112,8 +112,9 @@ def make_staleness_info(**overrides: Any) -> GateStalenessInfo:
     return GateStalenessInfo(**defaults)
 
 
-def assert_hex_id(task_id: str) -> None:
+def assert_hex_id(task_id: str | None) -> None:
     """Assert that *task_id* is a valid 8-char hex string."""
+    assert isinstance(task_id, str), f"Expected task ID string, got {task_id!r}"
     assert len(task_id) == 8, f"Expected 8-char hex ID, got {task_id!r}"
     assert all(c in "0123456789abcdef" for c in task_id), f"Not a hex string: {task_id!r}"
 

--- a/tests/unit/cli/test_cli_autopilot.py
+++ b/tests/unit/cli/test_cli_autopilot.py
@@ -172,7 +172,10 @@ def test_task_run_commands_forward_selected_agents(
     expected_kwargs: dict[str, object],
 ) -> None:
     """Selected agents and permission mode are forwarded to task runners."""
-    with patch(target) as mock_run:
+    with (
+        patch("terok.cli.commands.task.resolve_task_id", side_effect=lambda _pid, tid: tid),
+        patch(target) as mock_run,
+    ):
         run_cli(*argv)
 
     mock_run.assert_called_once_with(*expected_args, **expected_kwargs)

--- a/tests/unit/cli/test_cli_workflows.py
+++ b/tests/unit/cli/test_cli_workflows.py
@@ -225,6 +225,11 @@ class TestTaskStart:
         patch_target: str,
         expected_call: tuple[str, ...],
     ) -> None:
-        with unittest.mock.patch(patch_target) as mock_fn:
+        with (
+            unittest.mock.patch(
+                "terok.cli.commands.task.resolve_task_id", side_effect=lambda _pid, tid: tid
+            ),
+            unittest.mock.patch(patch_target) as mock_fn,
+        ):
             run_main(argv)
         mock_fn.assert_called_once_with(*expected_call)

--- a/tests/unit/lib/test_autopilot.py
+++ b/tests/unit/lib/test_autopilot.py
@@ -33,7 +33,7 @@ from terok.lib.orchestration.task_runners import (
     task_followup_headless,
     task_run_headless,
 )
-from tests.test_utils import mock_git_config, write_project
+from tests.test_utils import assert_hex_id, mock_git_config, write_project
 
 
 @dataclass
@@ -319,8 +319,8 @@ class TestTaskRunHeadless:
                 HeadlessRunRequest("proj_hl", "Fix the auth bug"),
             )
 
-            assert result.task_id == "1"
-            agent_config_dir, _meta_path = task_paths(base, "proj_hl")
+            assert_hex_id(result.task_id)
+            agent_config_dir, _meta_path = task_paths(base, "proj_hl", result.task_id)
             prompt_file = agent_config_dir / "prompt.txt"
             assert prompt_file.is_file()
             assert prompt_file.read_text() == "Fix the auth bug"
@@ -341,13 +341,13 @@ class TestTaskRunHeadless:
         with tempfile.TemporaryDirectory() as td:
             base = Path(td)
 
-            run_headless_request(
+            result = run_headless_request(
                 base,
                 write_runner_project(base, "proj_wrap"),
                 HeadlessRunRequest("proj_wrap", "test"),
             )
 
-            wrapper = task_paths(base, "proj_wrap")[0] / "terok-agent.sh"
+            wrapper = task_paths(base, "proj_wrap", result.task_id)[0] / "terok-agent.sh"
             assert wrapper.is_file()
             content = wrapper.read_text()
             assert "claude()" in content
@@ -372,13 +372,13 @@ class TestTaskRunHeadless:
         with tempfile.TemporaryDirectory() as td:
             base = Path(td)
 
-            run_headless_request(
+            result = run_headless_request(
                 base,
                 write_runner_project(base, "proj_agents", DEFAULT_SUBAGENTS_YAML),
                 HeadlessRunRequest("proj_agents", "test"),
             )
 
-            agents_data = read_task_agents(base, "proj_agents")
+            agents_data = read_task_agents(base, "proj_agents", result.task_id)
             assert isinstance(agents_data, dict)
             assert "reviewer" in agents_data
             assert "debugger" not in agents_data
@@ -389,13 +389,13 @@ class TestTaskRunHeadless:
         with tempfile.TemporaryDirectory() as td:
             base = Path(td)
 
-            run_headless_request(
+            result = run_headless_request(
                 base,
                 write_runner_project(base, "proj_sel", DEFAULT_SUBAGENTS_YAML),
                 HeadlessRunRequest("proj_sel", "test", agents=["debugger"]),
             )
 
-            agents_data = read_task_agents(base, "proj_sel")
+            agents_data = read_task_agents(base, "proj_sel", result.task_id)
             assert "reviewer" in agents_data
             assert "debugger" in agents_data
 
@@ -415,7 +415,7 @@ class TestTaskRunHeadless:
             assert "--max-turns 100" in bash_cmd
             assert "--terok-timeout" in bash_cmd
 
-            wrapper = task_paths(base, "proj_flags")[0] / "terok-agent.sh"
+            wrapper = task_paths(base, "proj_flags", result.task_id)[0] / "terok-agent.sh"
             content = wrapper.read_text()
             assert "--model" not in content
             assert "--max-turns" not in content
@@ -430,20 +430,21 @@ class TestTaskRunHeadless:
                 write_runner_project(base, "proj_name"),
                 HeadlessRunRequest("proj_name", "test"),
             )
-            assert result.last_spec.container_name == "proj_name-run-1"
+            assert_hex_id(result.task_id)
+            assert result.last_spec.container_name == f"proj_name-run-{result.task_id}"
 
     def test_headless_metadata_updated(self) -> None:
         """task_run_headless sets mode=run and updates status on completion."""
         with tempfile.TemporaryDirectory() as td:
             base = Path(td)
 
-            run_headless_request(
+            result = run_headless_request(
                 base,
                 write_runner_project(base, "proj_meta"),
                 HeadlessRunRequest("proj_meta", "test"),
             )
 
-            meta = read_task_meta(base, "proj_meta")
+            meta = read_task_meta(base, "proj_meta", result.task_id)
             assert meta["mode"] == "run"
             assert meta["exit_code"] == 0
 
@@ -459,7 +460,8 @@ class TestTaskRunHeadless:
 
             result.wait_mock.assert_not_called()
             assert "detached" in result.output.lower()
-            assert "proj_nf-run-1" in result.output
+            assert_hex_id(result.task_id)
+            assert f"proj_nf-run-{result.task_id}" in result.output
 
     def test_headless_uses_claude_function_in_command(self) -> None:
         """task_run_headless uses claude wrapper via --terok-timeout."""
@@ -494,13 +496,13 @@ class TestTaskRunHeadless:
                 encoding="utf-8",
             )
 
-            run_headless_request(
+            result = run_headless_request(
                 base,
                 write_runner_project(base, "proj_cfgfile"),
                 HeadlessRunRequest("proj_cfgfile", "test", config_path=str(agent_config)),
             )
 
-            agents_data = read_task_agents(base, "proj_cfgfile")
+            agents_data = read_task_agents(base, "proj_cfgfile", result.task_id)
             assert "extra-agent" in agents_data
             assert agents_data["extra-agent"]["prompt"] == "I am an extra agent"
 
@@ -533,7 +535,7 @@ class TestTaskFollowupHeadless:
                 container_state=["exited", "running"],
             )
 
-            agent_cfg, _meta_path = task_paths(base, "proj_fu")
+            agent_cfg, _meta_path = task_paths(base, "proj_fu", task_id)
             assert (agent_cfg / "prompt.txt").read_text() == "fix the remaining tests"
             history = (agent_cfg / "prompt-history.txt").read_text()
             assert "initial prompt" in history

--- a/tests/unit/lib/test_hex_task_ids.py
+++ b/tests/unit/lib/test_hex_task_ids.py
@@ -1,0 +1,182 @@
+# SPDX-FileCopyrightText: 2026 Jiri Vyskocil
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for hex task ID generation, resolution, and container naming."""
+
+from __future__ import annotations
+
+import unittest.mock
+
+import pytest
+
+from terok.lib.core.task_display import CONTAINER_MODES, container_name
+from terok.lib.orchestration.tasks import (
+    _generate_unique_id,
+    resolve_task_id,
+    tasks_meta_dir,
+)
+from terok.lib.util.yaml import dump as yaml_dump
+from tests.test_utils import assert_hex_id, project_env
+
+MINIMAL_PROJECT = """
+project:
+  id: test-proj
+  security_class: online
+git:
+  upstream_url: https://example.com/repo.git
+"""
+
+
+# ---------- _generate_unique_id ----------
+
+
+class TestGenerateUniqueId:
+    """Tests for the internal hex ID generator."""
+
+    def test_produces_8_char_hex(self) -> None:
+        """Generated IDs must be exactly 8 lowercase hex characters."""
+        result = _generate_unique_id(set())
+        assert_hex_id(result)
+
+    def test_avoids_existing_ids(self) -> None:
+        """Generated ID must not collide with any member of *existing*."""
+        existing = {_generate_unique_id(set()) for _ in range(20)}
+        new_id = _generate_unique_id(existing)
+        assert new_id not in existing
+        assert_hex_id(new_id)
+
+    def test_uniqueness_across_calls(self) -> None:
+        """Multiple generated IDs should all be distinct."""
+        ids = {_generate_unique_id(set()) for _ in range(50)}
+        assert len(ids) == 50
+
+    def test_raises_after_exhaustion(self) -> None:
+        """Should raise RuntimeError if it can't find a unique ID in 100 tries."""
+        with unittest.mock.patch("terok.lib.orchestration.tasks.secrets") as mock_secrets:
+            mock_secrets.token_hex.return_value = "deadbeef"
+            with pytest.raises(RuntimeError, match="Failed to generate unique task ID"):
+                _generate_unique_id({"deadbeef"})
+
+
+# ---------- resolve_task_id ----------
+
+
+class TestResolveTaskId:
+    """Tests for CLI prefix-matching task ID resolution."""
+
+    def _write_meta(self, project_id: str, task_id: str) -> None:
+        """Write a minimal task metadata file."""
+        meta_dir = tasks_meta_dir(project_id)
+        meta_dir.mkdir(parents=True, exist_ok=True)
+        meta = {"task_id": task_id, "name": "test-task", "mode": None, "workspace": "/tmp/ws"}
+        (meta_dir / f"{task_id}.yml").write_text(yaml_dump(meta))
+
+    def test_exact_match(self) -> None:
+        """Full 8-char ID should resolve immediately."""
+        with project_env(MINIMAL_PROJECT) as _ctx:
+            self._write_meta("test-proj", "abcd1234")
+            assert resolve_task_id("test-proj", "abcd1234") == "abcd1234"
+
+    def test_prefix_match(self) -> None:
+        """A unique prefix shorter than 8 chars should resolve to the full ID."""
+        with project_env(MINIMAL_PROJECT) as _ctx:
+            self._write_meta("test-proj", "abcd1234")
+            assert resolve_task_id("test-proj", "abcd") == "abcd1234"
+
+    def test_single_char_prefix(self) -> None:
+        """Even a 1-char prefix resolves if it uniquely matches."""
+        with project_env(MINIMAL_PROJECT) as _ctx:
+            self._write_meta("test-proj", "f1234567")
+            assert resolve_task_id("test-proj", "f") == "f1234567"
+
+    def test_ambiguous_prefix(self) -> None:
+        """Should raise SystemExit listing the matches when prefix is ambiguous."""
+        with project_env(MINIMAL_PROJECT) as _ctx:
+            self._write_meta("test-proj", "abcd1111")
+            self._write_meta("test-proj", "abcd2222")
+            with pytest.raises(SystemExit, match="Ambiguous task ID 'abcd'"):
+                resolve_task_id("test-proj", "abcd")
+
+    def test_no_match(self) -> None:
+        """Should raise SystemExit when no task matches the prefix."""
+        with project_env(MINIMAL_PROJECT) as _ctx:
+            self._write_meta("test-proj", "abcd1234")
+            with pytest.raises(SystemExit, match="No task matching 'ffff'"):
+                resolve_task_id("test-proj", "ffff")
+
+    def test_no_tasks_dir(self) -> None:
+        """Should raise SystemExit when the project has no tasks directory."""
+        with project_env(MINIMAL_PROJECT) as _ctx:
+            with pytest.raises(SystemExit, match="No tasks found"):
+                resolve_task_id("test-proj", "abcd")
+
+    def test_rejects_non_hex_input(self) -> None:
+        """Should reject prefixes containing non-hex characters."""
+        with project_env(MINIMAL_PROJECT) as _ctx:
+            with pytest.raises(SystemExit, match="Invalid task ID prefix"):
+                resolve_task_id("test-proj", "../../etc")
+
+    def test_rejects_uppercase_hex(self) -> None:
+        """Should reject uppercase hex characters."""
+        with project_env(MINIMAL_PROJECT) as _ctx:
+            with pytest.raises(SystemExit, match="Invalid task ID prefix"):
+                resolve_task_id("test-proj", "ABCD")
+
+    def test_rejects_empty_string(self) -> None:
+        """Should reject an empty prefix."""
+        with project_env(MINIMAL_PROJECT) as _ctx:
+            with pytest.raises(SystemExit, match="Invalid task ID prefix"):
+                resolve_task_id("test-proj", "")
+
+    def test_rejects_too_long_prefix(self) -> None:
+        """Should reject prefixes longer than 8 characters."""
+        with project_env(MINIMAL_PROJECT) as _ctx:
+            with pytest.raises(SystemExit, match="Invalid task ID prefix"):
+                resolve_task_id("test-proj", "abcdef0123")
+
+
+# ---------- container_name ----------
+
+
+class TestContainerName:
+    """Tests for the centralized container naming function."""
+
+    def test_format(self) -> None:
+        """Container name should be {project}-{mode}-{task_id}."""
+        assert container_name("myproj", "cli", "a1b2c3d4") == "myproj-cli-a1b2c3d4"
+
+    def test_all_modes(self) -> None:
+        """Every declared mode should produce a valid container name."""
+        for mode in CONTAINER_MODES:
+            result = container_name("proj", mode, "deadbeef")
+            assert result == f"proj-{mode}-deadbeef"
+
+    def test_container_modes_tuple(self) -> None:
+        """CONTAINER_MODES must include the four known modes."""
+        assert set(CONTAINER_MODES) == {"cli", "web", "run", "toad"}
+
+
+# ---------- assert_hex_id ----------
+
+
+class TestAssertHexId:
+    """Tests for the test utility itself."""
+
+    def test_valid_id(self) -> None:
+        """Should pass for a valid 8-char hex string."""
+        assert_hex_id("abcd1234")
+
+    def test_rejects_none(self) -> None:
+        """Should raise AssertionError for None."""
+        with pytest.raises(AssertionError, match="Expected task ID string"):
+            assert_hex_id(None)
+
+    def test_rejects_short_id(self) -> None:
+        """Should raise AssertionError for IDs shorter than 8 chars."""
+        with pytest.raises(AssertionError, match="Expected 8-char hex ID"):
+            assert_hex_id("abcd")
+
+    def test_rejects_non_hex(self) -> None:
+        """Should raise AssertionError for non-hex characters."""
+        with pytest.raises(AssertionError, match="Not a hex string"):
+            assert_hex_id("abcdXYZW")

--- a/tests/unit/lib/test_login.py
+++ b/tests/unit/lib/test_login.py
@@ -25,27 +25,33 @@ def setup_task_with_mode(
     project_id: str,
     *,
     mode: str | None = None,
-) -> None:
-    """Create a task and optionally set its execution mode in metadata."""
-    task_new(project_id)
+) -> str:
+    """Create a task and optionally set its execution mode in metadata.
+
+    Returns the task ID.
+    """
+    task_id = task_new(project_id)
     if mode:
-        meta_path = ctx.state_dir / "projects" / project_id / "tasks" / "1.yml"
+        meta_path = ctx.state_dir / "projects" / project_id / "tasks" / f"{task_id}.yml"
         meta = yaml_load(meta_path.read_text())
         meta["mode"] = mode
         meta_path.write_text(yaml_dump(meta), encoding="utf-8")
+    return task_id
 
 
-LOGIN_COMMAND = [
-    "podman",
-    "exec",
-    "-it",
-    "proj-cli-cli-1",
-    "tmux",
-    "new-session",
-    "-A",
-    "-s",
-    "main",
-]
+def _login_command(container: str) -> list[str]:
+    """Return the expected podman exec command for a given container name."""
+    return [
+        "podman",
+        "exec",
+        "-it",
+        container,
+        "tmux",
+        "new-session",
+        "-A",
+        "-s",
+        "main",
+    ]
 
 
 class TestLogin:
@@ -69,21 +75,24 @@ class TestLogin:
         error_text: str,
     ) -> None:
         with project_env(project_yaml(project_id), project_id=project_id) as ctx:
+            task_id = "deadbeef"  # nonexistent by default
             if project_id != "proj_login_unknown":
-                setup_task_with_mode(ctx, project_id, mode=mode)
+                task_id = setup_task_with_mode(ctx, project_id, mode=mode)
             with unittest.mock.patch(
                 "terok.lib.orchestration.tasks.get_container_state",
                 return_value=container_state,
             ):
                 with pytest.raises(SystemExit) as exc_ctx:
-                    task_login(project_id, "999" if project_id == "proj_login_unknown" else "1")
+                    task_login(
+                        project_id, "deadbeef" if project_id == "proj_login_unknown" else task_id
+                    )
             assert error_text in str(exc_ctx.value)
 
     def test_task_login_success(self) -> None:
         """task_login calls os.execvp with the correct podman+tmux command."""
         project_id = "proj-cli"
         with project_env(project_yaml(project_id), project_id=project_id) as ctx:
-            setup_task_with_mode(ctx, project_id, mode="cli")
+            task_id = setup_task_with_mode(ctx, project_id, mode="cli")
             with (
                 unittest.mock.patch(
                     "terok.lib.orchestration.tasks.get_container_state",
@@ -91,27 +100,28 @@ class TestLogin:
                 ),
                 unittest.mock.patch("terok.lib.orchestration.tasks.os.execvp") as mock_exec,
             ):
-                task_login(project_id, "1")
-        mock_exec.assert_called_once_with("podman", LOGIN_COMMAND)
+                task_login(project_id, task_id)
+        expected_container = f"{project_id}-cli-{task_id}"
+        mock_exec.assert_called_once_with("podman", _login_command(expected_container))
 
     @pytest.mark.parametrize(
-        ("mode", "expected_container"),
-        [("cli", "proj_logincmd-cli-1"), ("web", "proj_loginweb-web-1")],
+        "mode",
+        ["cli", "web"],
         ids=["cli", "web"],
     )
     def test_get_login_command_returns_expected_container_name(
         self,
         mode: str,
-        expected_container: str,
     ) -> None:
         project_id = "proj_logincmd" if mode == "cli" else "proj_loginweb"
         with project_env(project_yaml(project_id), project_id=project_id) as ctx:
-            setup_task_with_mode(ctx, project_id, mode=mode)
+            task_id = setup_task_with_mode(ctx, project_id, mode=mode)
             with unittest.mock.patch(
                 "terok.lib.orchestration.tasks.get_container_state",
                 return_value="running",
             ):
-                command = get_login_command(project_id, "1")
+                command = get_login_command(project_id, task_id)
+        expected_container = f"{project_id}-{mode}-{task_id}"
         assert command[3] == expected_container
         assert command[-5:] == ["tmux", "new-session", "-A", "-s", "main"]
 
@@ -120,7 +130,7 @@ class TestLogin:
         project_id = "proj_login_cfg"
         yaml_text = f"project:\n  id: {project_id}\nagent:\n  model: sonnet\n"
         with project_env(yaml_text, project_id=project_id) as ctx:
-            setup_task_with_mode(ctx, project_id, mode="cli")
+            task_id = setup_task_with_mode(ctx, project_id, mode="cli")
             with (
                 unittest.mock.patch(
                     "terok.lib.orchestration.tasks.get_container_state",
@@ -129,8 +139,8 @@ class TestLogin:
                 mock_git_config(),
                 unittest.mock.patch("terok.lib.orchestration.tasks.subprocess.run") as mock_run,
             ):
-                command = get_login_command(project_id, "1")
+                command = get_login_command(project_id, task_id)
 
-        assert command[3] == f"{project_id}-cli-1"
+        assert command[3] == f"{project_id}-cli-{task_id}"
         assert "tmux" in command
         mock_run.assert_not_called()

--- a/tests/unit/lib/test_task_names.py
+++ b/tests/unit/lib/test_task_names.py
@@ -38,7 +38,7 @@ def project_yaml(project_id: str, *, name_categories: list[str] | None = None) -
     return yaml_text
 
 
-def task_meta_name(ctx, project_id: str, task_id: str = "1") -> str:
+def task_meta_name(ctx, project_id: str, task_id: str) -> str:
     """Return the persisted task name from task metadata."""
     meta_path = ctx.state_dir / "projects" / project_id / "tasks" / f"{task_id}.yml"
     return yaml_load(meta_path.read_text())["name"]
@@ -135,7 +135,8 @@ def test_task_new_rejects_invalid_names(bad_name: str) -> None:
     with project_env(project_yaml(project_id), project_id=project_id) as ctx:
         with pytest.raises(SystemExit):
             task_new(project_id, name=bad_name)
-        assert not (ctx.state_dir / "projects" / project_id / "tasks" / "1.yml").exists()
+        tasks_dir = ctx.state_dir / "projects" / project_id / "tasks"
+        assert not tasks_dir.exists() or not list(tasks_dir.glob("*.yml"))
 
 
 def test_task_new_prints_name() -> None:
@@ -166,13 +167,13 @@ def test_task_rename_updates_or_rejects(
     """Task renaming persists the sanitized value or rejects invalid names."""
     project_id = "proj_rename"
     with project_env(project_yaml(project_id), project_id=project_id) as ctx:
-        task_new(project_id, name=initial_name)
+        task_id = task_new(project_id, name=initial_name)
         if raises:
             with pytest.raises(SystemExit):
-                task_rename(project_id, "1", new_name)
+                task_rename(project_id, task_id, new_name)
         else:
-            task_rename(project_id, "1", new_name)
-            assert task_meta_name(ctx, project_id) == expected
+            task_rename(project_id, task_id, new_name)
+            assert task_meta_name(ctx, project_id, task_id) == expected
 
 
 def test_task_rename_unknown_task_raises() -> None:

--- a/tests/unit/lib/test_tasks.py
+++ b/tests/unit/lib/test_tasks.py
@@ -29,7 +29,13 @@ from terok.tui.clipboard import (
     copy_to_clipboard_detailed,
     get_clipboard_helper_status,
 )
-from tests.test_utils import mock_git_config, parse_meta_value, project_env, write_project
+from tests.test_utils import (
+    assert_hex_id,
+    mock_git_config,
+    parse_meta_value,
+    project_env,
+    write_project,
+)
 from tests.testfs import CONTAINER_SSH_DIR
 from tests.testnet import CONTAINER_HOSTNAME, GATE_PORT
 
@@ -73,22 +79,23 @@ class TestTask:
             project_id=project_id,
         ) as ctx:
             returned_id = task_new(project_id)
-            assert returned_id == "1"
+            assert_hex_id(returned_id)
             meta_dir = ctx.state_dir / "projects" / project_id / "tasks"
-            meta_path = meta_dir / "1.yml"
+            meta_path = meta_dir / f"{returned_id}.yml"
             assert meta_path.is_file()
 
             meta_text = meta_path.read_text(encoding="utf-8")
-            assert parse_meta_value(meta_text, "task_id") == "1"
+            assert parse_meta_value(meta_text, "task_id") == returned_id
             workspace_value = parse_meta_value(meta_text, "workspace")
             assert workspace_value is not None
             assert workspace_value != ""
             workspace = Path(workspace_value)  # type: ignore[arg-type]
             assert workspace.is_dir()
 
-            # Verify second task returns incremented ID
+            # Verify second task returns a different hex ID
             second_id = task_new(project_id)
-            assert second_id == "2"
+            assert_hex_id(second_id)
+            assert second_id != returned_id
 
             with (
                 unittest.mock.patch("terok.lib.orchestration.tasks.subprocess.run") as run_mock,
@@ -98,7 +105,7 @@ class TestTask:
                 mock_git_config(),
             ):
                 run_mock.return_value.returncode = 0
-                result = task_delete(project_id, "1")
+                result = task_delete(project_id, returned_id)
 
             assert isinstance(result, TaskDeleteResult)
             assert not meta_path.exists()
@@ -116,11 +123,11 @@ class TestTask:
             f"project:\n  id: {project_id}\n",
             project_id=project_id,
         ) as ctx:
-            task_new(project_id)
+            task_id = task_new(project_id)
 
             # Verify marker file exists in the workspace subdirectory
             sandbox_live = ctx.base / "sandbox-live"
-            workspace_dir = sandbox_live / "tasks" / project_id / "1" / "workspace-dangerous"
+            workspace_dir = sandbox_live / "tasks" / project_id / task_id / "workspace-dangerous"
             marker_path = workspace_dir / ".new-task-marker"
             assert marker_path.is_file()
 
@@ -155,7 +162,7 @@ class TestTask:
     @staticmethod
     def _task_row_pattern(task_id: str) -> re.Pattern[str]:
         """Return the regex pattern matching a task row for ``task_id``."""
-        return re.compile(rf"(?m)^-{' ' * max(1, 4 - len(task_id))}{re.escape(task_id)}:")
+        return re.compile(rf"(?m)^- {re.escape(task_id)}:")
 
     def test_task_list_no_filters(self) -> None:
         """task_list with no filters prints all tasks."""
@@ -164,17 +171,16 @@ class TestTask:
             f"project:\n  id: {project_id}\n",
             project_id=project_id,
         ) as ctx:
-            task_new(project_id)
-            task_new(project_id)
+            tid1 = task_new(project_id)
+            tid2 = task_new(project_id)
 
-            self._patch_task_meta(ctx, project_id, "1", mode="cli")
-            self._patch_task_meta(ctx, project_id, "2", mode="web")
+            self._patch_task_meta(ctx, project_id, tid1, mode="cli")
+            self._patch_task_meta(ctx, project_id, tid2, mode="web")
 
-            output = self._task_list_output(project_id, {"1": "running", "2": "exited"})
-            # Task IDs are right-aligned to 3 characters
-            assert re.search(r"(?m)^- {3}1:", output)
+            output = self._task_list_output(project_id, {tid1: "running", tid2: "exited"})
+            assert self._task_row_pattern(tid1).search(output)
             assert "running" in output
-            assert re.search(r"(?m)^- {3}2:", output)
+            assert self._task_row_pattern(tid2).search(output)
             assert "stopped" in output
 
     def test_task_list_filter_by_status(self) -> None:
@@ -184,62 +190,41 @@ class TestTask:
             f"project:\n  id: {project_id}\n",
             project_id=project_id,
         ) as ctx:
-            task_new(project_id)
-            task_new(project_id)
+            tid1 = task_new(project_id)
+            tid2 = task_new(project_id)
 
-            self._patch_task_meta(ctx, project_id, "1", mode="cli")
-            self._patch_task_meta(ctx, project_id, "2", mode="cli")
+            self._patch_task_meta(ctx, project_id, tid1, mode="cli")
+            self._patch_task_meta(ctx, project_id, tid2, mode="cli")
 
             output = self._task_list_output(
-                project_id, {"1": "running", "2": "exited"}, status="running"
+                project_id, {tid1: "running", tid2: "exited"}, status="running"
             )
-            # Task IDs are right-aligned to 3 characters
-            assert re.search(r"(?m)^- {3}1:", output)
+            assert self._task_row_pattern(tid1).search(output)
             assert "running" in output
-            assert not re.search(r"(?m)^- {3}2:", output)
+            assert not self._task_row_pattern(tid2).search(output)
 
-    def test_task_list_id_alignment(self) -> None:
-        """task_list right-aligns task IDs to 3 characters."""
+    def test_task_list_id_format(self) -> None:
+        """task_list prints hex task IDs with no alignment padding."""
         project_id = "proj_align"
         with project_env(
             f"project:\n  id: {project_id}\n",
             project_id=project_id,
         ) as ctx:
-            # Create tasks 1 and 2 normally
-            task_new(project_id)
-            task_new(project_id)
-            self._patch_task_meta(ctx, project_id, "1", mode="cli")
-            self._patch_task_meta(ctx, project_id, "2", mode="cli")
-
-            # Manually create a 2-digit task (10) and a 3-digit task (100)
-            meta_dir = ctx.state_dir / "projects" / project_id / "tasks"
-            ws_base = ctx.state_dir / "projects" / project_id / "workspaces"
-            for tid, name in [("10", "double-digit"), ("100", "triple-digit")]:
-                ws_dir = ws_base / tid
-                ws_dir.mkdir(parents=True, exist_ok=True)
-                meta = {
-                    "task_id": tid,
-                    "name": name,
-                    "mode": "cli",
-                    "workspace": str(ws_dir),
-                    "web_port": None,
-                }
-                (meta_dir / f"{tid}.yml").write_text(yaml_dump(meta))
+            tid1 = task_new(project_id)
+            tid2 = task_new(project_id)
+            self._patch_task_meta(ctx, project_id, tid1, mode="cli")
+            self._patch_task_meta(ctx, project_id, tid2, mode="cli")
 
             output = self._task_list_output(
                 project_id,
                 {
-                    "1": "running",
-                    "2": "exited",
-                    "10": "running",
-                    "100": "running",
+                    tid1: "running",
+                    tid2: "exited",
                 },
             )
-            # 1-digit: 2 leading spaces; 2-digit: 1 leading space; 3-digit: none
-            assert re.search(r"(?m)^- {3}1:", output)
-            assert re.search(r"(?m)^- {3}2:", output)
-            assert re.search(r"(?m)^- {2}10:", output)
-            assert re.search(r"(?m)^- 100:", output)
+            # Hex IDs are printed without alignment padding
+            assert self._task_row_pattern(tid1).search(output)
+            assert self._task_row_pattern(tid2).search(output)
 
     def test_task_list_filter_by_mode(self) -> None:
         """task_list --mode filters tasks by their mode field."""
@@ -248,15 +233,15 @@ class TestTask:
             f"project:\n  id: {project_id}\n",
             project_id=project_id,
         ) as ctx:
-            task_new(project_id)
-            task_new(project_id)
+            tid1 = task_new(project_id)
+            tid2 = task_new(project_id)
 
-            self._patch_task_meta(ctx, project_id, "1", mode="cli")
-            self._patch_task_meta(ctx, project_id, "2", mode="web")
+            self._patch_task_meta(ctx, project_id, tid1, mode="cli")
+            self._patch_task_meta(ctx, project_id, tid2, mode="web")
 
-            output = self._task_list_output(project_id, {"2": None}, mode="web")
-            assert not self._task_row_pattern("1").search(output)
-            assert self._task_row_pattern("2").search(output)
+            output = self._task_list_output(project_id, {tid2: None}, mode="web")
+            assert not self._task_row_pattern(tid1).search(output)
+            assert self._task_row_pattern(tid2).search(output)
 
     def test_task_list_filter_by_agent(self) -> None:
         """task_list --agent filters tasks by their preset field."""
@@ -265,15 +250,15 @@ class TestTask:
             f"project:\n  id: {project_id}\n",
             project_id=project_id,
         ) as ctx:
-            task_new(project_id)
-            task_new(project_id)
+            tid1 = task_new(project_id)
+            tid2 = task_new(project_id)
 
-            self._patch_task_meta(ctx, project_id, "1", preset="claude")
-            self._patch_task_meta(ctx, project_id, "2", preset="codex")
+            self._patch_task_meta(ctx, project_id, tid1, preset="claude")
+            self._patch_task_meta(ctx, project_id, tid2, preset="codex")
 
-            output = self._task_list_output(project_id, {"1": None, "2": None}, agent="claude")
-            assert self._task_row_pattern("1").search(output)
-            assert not self._task_row_pattern("2").search(output)
+            output = self._task_list_output(project_id, {tid1: None, tid2: None}, agent="claude")
+            assert self._task_row_pattern(tid1).search(output)
+            assert not self._task_row_pattern(tid2).search(output)
 
     def test_task_list_combined_filters(self) -> None:
         """task_list with multiple filters applies all of them (AND logic)."""
@@ -282,24 +267,24 @@ class TestTask:
             f"project:\n  id: {project_id}\n",
             project_id=project_id,
         ) as ctx:
-            task_new(project_id)
-            task_new(project_id)
-            task_new(project_id)
+            tid1 = task_new(project_id)
+            tid2 = task_new(project_id)
+            tid3 = task_new(project_id)
 
             for tid, mode in [
-                ("1", "cli"),
-                ("2", "web"),
-                ("3", "cli"),
+                (tid1, "cli"),
+                (tid2, "web"),
+                (tid3, "cli"),
             ]:
                 self._patch_task_meta(ctx, project_id, tid, mode=mode)
 
             # mode filter narrows to cli first, then status=running keeps only task 1
             output = self._task_list_output(
-                project_id, {"1": "running", "3": "exited"}, status="running", mode="cli"
+                project_id, {tid1: "running", tid3: "exited"}, status="running", mode="cli"
             )
-            assert self._task_row_pattern("1").search(output)
-            assert not self._task_row_pattern("2").search(output)
-            assert not self._task_row_pattern("3").search(output)
+            assert self._task_row_pattern(tid1).search(output)
+            assert not self._task_row_pattern(tid2).search(output)
+            assert not self._task_row_pattern(tid3).search(output)
 
     def test_task_list_no_match(self) -> None:
         """task_list prints 'No tasks found' when filters match nothing."""
@@ -308,10 +293,10 @@ class TestTask:
             f"project:\n  id: {project_id}\n",
             project_id=project_id,
         ):
-            task_new(project_id)
+            tid = task_new(project_id)
 
             # New task has no mode → effective status is "created", not "running"
-            output = self._task_list_output(project_id, {"1": None}, status="running")
+            output = self._task_list_output(project_id, {tid: None}, status="running")
             assert "No tasks found" in output
 
     @unittest.mock.patch("terok.lib.orchestration.environment.ensure_server_reachable")
@@ -423,7 +408,7 @@ class TestTask:
             with_config_file=True,
             clear_env=True,
         ):
-            task_new(project_id)
+            tid = task_new(project_id)
             with (
                 mock_git_config(),
                 unittest.mock.patch(
@@ -445,12 +430,13 @@ class TestTask:
                 run_mock.return_value = subprocess.CompletedProcess([], 0)
                 buffer = StringIO()
                 with redirect_stdout(buffer):
-                    task_run_cli(project_id, "1")
+                    task_run_cli(project_id, tid)
 
             output = buffer.getvalue()
-            expected_name = f"\x1b[32m{project_id}-cli-1\x1b[0m"
-            expected_enter = f"\x1b[34mpodman exec -it {project_id}-cli-1 bash\x1b[0m"
-            expected_stop = f"\x1b[31mpodman stop {project_id}-cli-1\x1b[0m"
+            cname = f"{project_id}-cli-{tid}"
+            expected_name = f"\x1b[32m{cname}\x1b[0m"
+            expected_enter = f"\x1b[34mpodman exec -it {cname} bash\x1b[0m"
+            expected_stop = f"\x1b[31mpodman stop {cname}\x1b[0m"
             assert expected_name in output
             assert expected_enter in output
             assert expected_stop in output
@@ -464,9 +450,9 @@ class TestTask:
             with_config_file=True,
             clear_env=True,
         ) as ctx:
-            task_new(project_id)
+            tid = task_new(project_id)
             sandbox_live = ctx.base / "sandbox-live"
-            workspace_dir = sandbox_live / "tasks" / project_id / "1" / "workspace-dangerous"
+            workspace_dir = sandbox_live / "tasks" / project_id / tid / "workspace-dangerous"
             assert sorted(p.name for p in workspace_dir.iterdir()) == [".new-task-marker"]
             with (
                 mock_git_config(),
@@ -483,7 +469,7 @@ class TestTask:
                 ) as run_mock,
             ):
                 run_mock.return_value = subprocess.CompletedProcess([], 0)
-                task_run_cli(project_id, "1")
+                task_run_cli(project_id, tid)
 
             assert sorted(p.name for p in workspace_dir.iterdir()) == [".new-task-marker"]
             agent_mounts = ctx.base / "sandbox-live" / "mounts"
@@ -498,7 +484,7 @@ class TestTask:
             with_config_file=True,
             clear_env=True,
         ):
-            task_new(project_id)
+            tid = task_new(project_id)
             with (
                 mock_git_config(),
                 unittest.mock.patch(
@@ -521,7 +507,7 @@ class TestTask:
                     "terok.lib.orchestration.task_runners._sandbox"
                 ) as sandbox_factory,
             ):
-                task_run_toad(project_id, "1")
+                task_run_toad(project_id, tid)
 
             spec = sandbox_factory.return_value.run.call_args[0][0]
             bash_cmd = spec.command[-1]
@@ -545,7 +531,7 @@ class TestTask:
         ):
             # Re-apply after clear_env
             monkeypatch.setenv("TEROK_PUBLIC_HOST", "myserver")
-            task_new(project_id)
+            tid = task_new(project_id)
             with (
                 mock_git_config(),
                 unittest.mock.patch(
@@ -568,7 +554,7 @@ class TestTask:
                     "terok.lib.orchestration.task_runners._sandbox"
                 ) as sandbox_factory,
             ):
-                task_run_toad(project_id, "1")
+                task_run_toad(project_id, tid)
 
             spec = sandbox_factory.return_value.run.call_args[0][0]
             bash_cmd = spec.command[-1]
@@ -586,7 +572,7 @@ class TestTask:
             f"project:\n  id: {project_id}\n",
             project_id=project_id,
         ):
-            task_new(project_id)
+            tid = task_new(project_id)
             with (
                 mock_git_config(),
                 unittest.mock.patch(
@@ -599,7 +585,7 @@ class TestTask:
             ):
                 buffer = StringIO()
                 with redirect_stdout(buffer):
-                    task_run_cli(project_id, "1")
+                    task_run_cli(project_id, tid)
 
                 # Verify no podman run was called
                 run_mock.assert_not_called()
@@ -615,9 +601,9 @@ class TestTask:
             f"project:\n  id: {project_id}\n",
             project_id=project_id,
         ) as ctx:
-            task_new(project_id)
+            tid = task_new(project_id)
             meta_dir = ctx.state_dir / "projects" / project_id / "tasks"
-            meta_path = meta_dir / "1.yml"
+            meta_path = meta_dir / f"{tid}.yml"
 
             # Simulate task was previously run
             meta = yaml_load(meta_path.read_text())
@@ -637,7 +623,7 @@ class TestTask:
                 run_mock.return_value = subprocess.CompletedProcess(args=[], returncode=0)
                 buffer = StringIO()
                 with redirect_stdout(buffer):
-                    task_run_cli(project_id, "1")
+                    task_run_cli(project_id, tid)
 
                 # Verify podman start was called
                 run_mock.assert_called_once()
@@ -665,9 +651,9 @@ class TestTask:
             f"project:\n  id: {project_id}\n",
             project_id=project_id,
         ):
-            task_new(project_id)
+            tid = task_new(project_id)
             # Task exists but has never been run (mode=None)
-            result = get_workspace_git_diff(project_id, "1")
+            result = get_workspace_git_diff(project_id, tid)
             assert result is None
 
     def test_get_workspace_git_diff_delegates_to_container(self) -> None:
@@ -677,10 +663,10 @@ class TestTask:
             f"project:\n  id: {project_id}\n",
             project_id=project_id,
         ):
-            task_new(project_id)
+            tid = task_new(project_id)
             from terok.lib.orchestration.tasks import tasks_meta_dir
 
-            meta_path = tasks_meta_dir(project_id) / "1.yml"
+            meta_path = tasks_meta_dir(project_id) / f"{tid}.yml"
             meta = yaml_load(meta_path.read_text())
             meta["mode"] = "cli"
             meta_path.write_text(yaml_dump(meta))
@@ -690,9 +676,9 @@ class TestTask:
                 "terok.lib.orchestration.tasks.container_git_diff",
                 return_value=expected,
             ) as mock_diff:
-                result = get_workspace_git_diff(project_id, "1", "HEAD")
+                result = get_workspace_git_diff(project_id, tid, "HEAD")
                 assert result == expected
-                mock_diff.assert_called_once_with(project_id, "1", "cli", "HEAD")
+                mock_diff.assert_called_once_with(project_id, tid, "cli", "HEAD")
 
     def test_get_workspace_git_diff_prev_commit(self) -> None:
         """Test get_workspace_git_diff with PREV option passes HEAD~1..HEAD."""
@@ -701,10 +687,10 @@ class TestTask:
             f"project:\n  id: {project_id}\n",
             project_id=project_id,
         ):
-            task_new(project_id)
+            tid = task_new(project_id)
             from terok.lib.orchestration.tasks import tasks_meta_dir
 
-            meta_path = tasks_meta_dir(project_id) / "1.yml"
+            meta_path = tasks_meta_dir(project_id) / f"{tid}.yml"
             meta = yaml_load(meta_path.read_text())
             meta["mode"] = "run"
             meta_path.write_text(yaml_dump(meta))
@@ -714,9 +700,9 @@ class TestTask:
                 "terok.lib.orchestration.tasks.container_git_diff",
                 return_value=expected,
             ) as mock_diff:
-                result = get_workspace_git_diff(project_id, "1", "PREV")
+                result = get_workspace_git_diff(project_id, tid, "PREV")
                 assert result == expected
-                mock_diff.assert_called_once_with(project_id, "1", "run", "HEAD~1", "HEAD")
+                mock_diff.assert_called_once_with(project_id, tid, "run", "HEAD~1", "HEAD")
 
     def test_get_workspace_git_diff_container_failure(self) -> None:
         """Test get_workspace_git_diff returns None when container exec fails."""
@@ -725,10 +711,10 @@ class TestTask:
             f"project:\n  id: {project_id}\n",
             project_id=project_id,
         ):
-            task_new(project_id)
+            tid = task_new(project_id)
             from terok.lib.orchestration.tasks import tasks_meta_dir
 
-            meta_path = tasks_meta_dir(project_id) / "1.yml"
+            meta_path = tasks_meta_dir(project_id) / f"{tid}.yml"
             meta = yaml_load(meta_path.read_text())
             meta["mode"] = "cli"
             meta_path.write_text(yaml_dump(meta))
@@ -737,7 +723,7 @@ class TestTask:
                 "terok.lib.orchestration.tasks.container_git_diff",
                 return_value=None,
             ):
-                result = get_workspace_git_diff(project_id, "1")
+                result = get_workspace_git_diff(project_id, tid)
                 assert result is None
 
     def test_copy_to_clipboard_empty_text(self) -> None:


### PR DESCRIPTION
## Summary

- Replace sequential numeric task IDs with 8-char random hex identifiers (`secrets.token_hex(4)`), eliminating stale container collisions across installations
- Add `resolve_task_id()` with prefix matching — CLI users can type partial hex prefixes (e.g. `terok task login proj a3f` resolves to `a3f7b2e1`)
- Extract `container_name()` to `core.task_display` as single source of truth, breaking the circular import between `tasks.py` and `container_exec.py`
- TUI task list shows 4-char hex prefix, detail pane shows full 8-char ID
- Container names simplify to `{project}-{mode}-{hex8}`

## Test plan

- [x] All 1558 unit tests pass
- [x] `make check` passes (lint + test + tach + docstrings + deadcode + reuse)
- [ ] Manual: create a task, verify 8-char hex ID in output
- [ ] Manual: `terok task login <project> <3-char-prefix>` resolves correctly
- [ ] Manual: TUI shows 4-char prefix in list, full ID in detail
- [ ] Manual: delete + recreate tasks — no stale container collisions

Closes #653

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Tasks now use 8-character lowercase hex IDs.
  * CLI accepts partial hex prefixes and resolves them to full task IDs.

* **Improvements**
  * CLI consistently resolves and displays full task and project IDs in commands and confirmations.
  * Container naming unified across the UI/CLI; task list shows the first 4 chars of the hex ID.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->