### PR TITLE
feat: experimental Claude OAuth tiered config

### DIFF
--- a/examples/terok-config.yml
+++ b/examples/terok-config.yml
@@ -78,3 +78,22 @@ tui:
 # Note: GPU passthrough is a per-project opt-in only. Configure it in
 # <project>/project.yml under `run.gpus` (true or "all"). There is no
 # global or environment switch.
+
+# Experimental features (unstable, may change between versions).
+# Can also be enabled per-invocation with --experimental.
+# experimental: false
+
+# Agent-specific configuration
+# agent:
+#   claude:
+#     # Allow Claude Code OAuth through the credential proxy.
+#     # Default false — Claude OAuth is skipped because its hardcoded BASE_API_URL
+#     # sends phantom tokens directly to api.anthropic.com (which rejects them).
+#     # When true + experimental, the proxy handles OAuth normally and the shield
+#     # blocks api.anthropic.com to prevent phantom token leaks.
+#     # allow_oauth: false
+#     #
+#     # Bypass the credential proxy for Claude and expose the real OAuth token
+#     # via the shared .credentials.json mount. Claude manages its own refresh.
+#     # Shield must allow api.anthropic.com and platform.claude.com.
+#     # expose_oauth_token: false

--- a/poetry.lock
+++ b/poetry.lock
@@ -3045,24 +3045,24 @@ tomli-w = ">=1.0,<2.0"
 
 [[package]]
 name = "terok-agent"
-version = "0.0.65"
+version = "0.0.66"
 description = "Single-agent task runner for hardened Podman containers"
 optional = false
 python-versions = ">=3.12,<4.0"
 groups = ["main"]
 files = [
-    {file = "terok_agent-0.0.65-py3-none-any.whl", hash = "sha256:3d2c31de7e13fc4fb90c9965c62ac36cc91aec8554fd752149803854e49eefae"},
+    {file = "terok_agent-0.0.66-py3-none-any.whl", hash = "sha256:dc2445851d3483833e8719466d391d706db0f07490c2201271fa19804871ba03"},
 ]
 
 [package.dependencies]
 Jinja2 = ">=3.1"
 "ruamel.yaml" = ">=0.18"
-terok_sandbox = {url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.0.58/terok_sandbox-0.0.58-py3-none-any.whl"}
+terok_sandbox = {url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.0.59/terok_sandbox-0.0.59-py3-none-any.whl"}
 tomli-w = ">=1.0"
 
 [package.source]
 type = "url"
-url = "https://github.com/terok-ai/terok-agent/releases/download/v0.0.65/terok_agent-0.0.65-py3-none-any.whl"
+url = "https://github.com/terok-ai/terok-agent/releases/download/v0.0.66/terok_agent-0.0.66-py3-none-any.whl"
 
 [[package]]
 name = "terok-dbus"
@@ -3084,34 +3084,34 @@ url = "https://github.com/terok-ai/terok-dbus/releases/download/v0.5.6/terok_dbu
 
 [[package]]
 name = "terok-sandbox"
-version = "0.0.58"
+version = "0.0.59"
 description = "Hardened Podman container runner with gate server and shield integration"
 optional = false
 python-versions = ">=3.12,<4.0"
 groups = ["main"]
 files = [
-    {file = "terok_sandbox-0.0.58-py3-none-any.whl", hash = "sha256:7b17669b9250cc3fc3cacf60841dcc682601f7c2fff9210444ded9257f4c40e9"},
+    {file = "terok_sandbox-0.0.59-py3-none-any.whl", hash = "sha256:cdcddd03887dbcc9bdfd6781a2121403bdcac174934423257039f21f1be5228c"},
 ]
 
 [package.dependencies]
 aiohttp = ">=3.9"
 cryptography = ">=43.0"
 platformdirs = ">=4.0"
-terok_shield = {url = "https://github.com/terok-ai/terok-shield/releases/download/v0.6.17/terok_shield-0.6.17-py3-none-any.whl"}
+terok_shield = {url = "https://github.com/terok-ai/terok-shield/releases/download/v0.6.18/terok_shield-0.6.18-py3-none-any.whl"}
 
 [package.source]
 type = "url"
-url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.0.58/terok_sandbox-0.0.58-py3-none-any.whl"
+url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.0.59/terok_sandbox-0.0.59-py3-none-any.whl"
 
 [[package]]
 name = "terok-shield"
-version = "0.6.17"
+version = "0.6.18"
 description = "nftables-based egress firewalling for Podman containers"
 optional = false
 python-versions = ">=3.12,<4.0"
 groups = ["main"]
 files = [
-    {file = "terok_shield-0.6.17-py3-none-any.whl", hash = "sha256:447426b3d5401420ad498a3792730bc6aaf151beaa8584ff1d3d5c57db1573f0"},
+    {file = "terok_shield-0.6.18-py3-none-any.whl", hash = "sha256:0e50e2e83e580c8e17bc003edf613f929c0f12c6c3f062b92d0ff5271ebad1c2"},
 ]
 
 [package.dependencies]
@@ -3120,7 +3120,7 @@ PyYAML = ">=6.0"
 
 [package.source]
 type = "url"
-url = "https://github.com/terok-ai/terok-shield/releases/download/v0.6.17/terok_shield-0.6.17-py3-none-any.whl"
+url = "https://github.com/terok-ai/terok-shield/releases/download/v0.6.18/terok_shield-0.6.18-py3-none-any.whl"
 
 [[package]]
 name = "textual"
@@ -3609,4 +3609,4 @@ propcache = ">=0.2.1"
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.12,<4.0"
-content-hash = "b8c4b865866590479a13b9a6d1755a65ea2db74dfc61fe76e905c3af82aa5199"
+content-hash = "85535d0c84a785b7b1a52f3d83f384ef7e010631929f0773f027e2f78b14a21e"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,8 +44,8 @@ rich = ">=13.0"
 platformdirs = ">=4.5.1"
 unique-namer = ">=1.3"
 textual-serve = ">=1.1.0"
-terok-agent = {url = "https://github.com/terok-ai/terok-agent/releases/download/v0.0.65/terok_agent-0.0.65-py3-none-any.whl"}
-terok-sandbox = {url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.0.58/terok_sandbox-0.0.58-py3-none-any.whl"}
+terok-agent = {url = "https://github.com/terok-ai/terok-agent/releases/download/v0.0.66/terok_agent-0.0.66-py3-none-any.whl"}
+terok-sandbox = {url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.0.59/terok_sandbox-0.0.59-py3-none-any.whl"}
 terok-dbus = {url = "https://github.com/terok-ai/terok-dbus/releases/download/v0.5.6/terok_dbus-0.5.6-py3-none-any.whl"}
 
 [tool.poetry.group.dev.dependencies]

--- a/src/terok/lib/core/config.py
+++ b/src/terok/lib/core/config.py
@@ -497,11 +497,53 @@ _experimental: bool = False
 
 
 def is_experimental() -> bool:
-    """Return whether experimental features are enabled."""
-    return _experimental
+    """Return whether experimental features are enabled (CLI flag or config).
+
+    Checks the runtime flag (set by ``--experimental``) first, then falls
+    back to the ``experimental:`` key in ``config.yml``.
+    """
+    return _experimental or _load_validated().experimental
 
 
 def set_experimental(value: bool) -> None:
     """Enable or disable experimental features globally."""
     global _experimental  # noqa: PLW0603
     _experimental = value
+
+
+# ---------- Agent-specific config (agent: section) ----------
+
+
+def get_claude_allow_oauth() -> bool:
+    """Return ``agent.claude.allow_oauth`` from global config (default False).
+
+    When True (and experimental is enabled), the credential proxy handles
+    Claude OAuth credentials normally.  The shield blocks
+    ``api.anthropic.com`` to prevent phantom token leaks to Claude Code's
+    hardcoded ``BASE_API_URL``.
+
+    Global config (config.yml)::
+
+        agent:
+          claude:
+            allow_oauth: true
+    """
+    return _load_validated().agent.get("claude", {}).get("allow_oauth", False)
+
+
+def get_claude_expose_oauth_token() -> bool:
+    """Return ``agent.claude.expose_oauth_token`` from global config (default False).
+
+    When True (and experimental is enabled), the credential proxy is
+    bypassed for Claude entirely.  The real ``.credentials.json`` in the
+    shared mount is exposed to the container, and Claude Code manages its
+    own token refresh.  Shield must allow ``api.anthropic.com`` and
+    ``platform.claude.com``.
+
+    Global config (config.yml)::
+
+        agent:
+          claude:
+            expose_oauth_token: true
+    """
+    return _load_validated().agent.get("claude", {}).get("expose_oauth_token", False)

--- a/src/terok/lib/core/config.py
+++ b/src/terok/lib/core/config.py
@@ -514,6 +514,12 @@ def set_experimental(value: bool) -> None:
 # ---------- Agent-specific config (agent: section) ----------
 
 
+def _claude_agent_config() -> dict:
+    """Return the ``agent.claude`` sub-dict, guarding against non-dict values."""
+    claude = _load_validated().agent.get("claude")
+    return claude if isinstance(claude, dict) else {}
+
+
 def get_claude_allow_oauth() -> bool:
     """Return ``agent.claude.allow_oauth`` from global config (default False).
 
@@ -528,7 +534,7 @@ def get_claude_allow_oauth() -> bool:
           claude:
             allow_oauth: true
     """
-    return _load_validated().agent.get("claude", {}).get("allow_oauth", False)
+    return _claude_agent_config().get("allow_oauth", False)
 
 
 def get_claude_expose_oauth_token() -> bool:
@@ -546,4 +552,18 @@ def get_claude_expose_oauth_token() -> bool:
           claude:
             expose_oauth_token: true
     """
-    return _load_validated().agent.get("claude", {}).get("expose_oauth_token", False)
+    return _claude_agent_config().get("expose_oauth_token", False)
+
+
+def is_claude_oauth_proxied() -> bool:
+    """Return True when Claude OAuth is in tier 2 (proxy active, not exposed).
+
+    Centralises the three-tier decision so callers don't duplicate the
+    flag combination logic:
+
+    - **Tier 1** (default): experimental off or allow_oauth off — skip Claude OAuth.
+    - **Tier 2**: experimental + allow_oauth — proxy handles OAuth, shield denies
+      ``api.anthropic.com``.
+    - **Tier 3**: experimental + expose_oauth_token — proxy bypassed for Claude.
+    """
+    return is_experimental() and get_claude_allow_oauth() and not get_claude_expose_oauth_token()

--- a/src/terok/lib/core/config.py
+++ b/src/terok/lib/core/config.py
@@ -534,7 +534,7 @@ def get_claude_allow_oauth() -> bool:
           claude:
             allow_oauth: true
     """
-    return _claude_agent_config().get("allow_oauth", False)
+    return _claude_agent_config().get("allow_oauth", False) is True
 
 
 def get_claude_expose_oauth_token() -> bool:
@@ -552,7 +552,7 @@ def get_claude_expose_oauth_token() -> bool:
           claude:
             expose_oauth_token: true
     """
-    return _claude_agent_config().get("expose_oauth_token", False)
+    return _claude_agent_config().get("expose_oauth_token", False) is True
 
 
 def is_claude_oauth_proxied() -> bool:

--- a/src/terok/lib/core/yaml_schema.py
+++ b/src/terok/lib/core/yaml_schema.py
@@ -398,6 +398,7 @@ class RawGlobalConfig(BaseModel):
     tasks: RawTasksGlobalSection = Field(default_factory=RawTasksGlobalSection)
     git: RawGlobalGitSection = Field(default_factory=RawGlobalGitSection)
     hooks: RawHooksSection = Field(default_factory=RawHooksSection)
+    experimental: bool = False
     default_agent: str | None = None
     default_login: str | None = None
     agent: dict[str, Any] = Field(default_factory=dict)

--- a/src/terok/lib/orchestration/environment.py
+++ b/src/terok/lib/orchestration/environment.py
@@ -228,6 +228,28 @@ def ensure_credential_proxy() -> None:
         ) from exc
 
 
+def _skip_claude_oauth() -> bool:
+    """Return True when Claude OAuth should be excluded from the credential proxy.
+
+    Tier 1 (experimental off or allow_oauth off): skip — the path is broken
+    because Claude Code's hardcoded ``BASE_API_URL`` sends phantom tokens
+    directly to ``api.anthropic.com``.
+
+    Tier 3 (expose_oauth_token): skip — Claude manages ``.credentials.json``
+    directly via the shared mount, no proxy involvement.
+
+    Tier 2 (allow_oauth, not exposed): return False — proxy handles OAuth
+    normally, shield blocks ``api.anthropic.com``.
+    """
+    from ..core.config import get_claude_allow_oauth, get_claude_expose_oauth_token, is_experimental
+
+    if not is_experimental():
+        return True
+    if get_claude_expose_oauth_token():
+        return True
+    return not get_claude_allow_oauth()
+
+
 def _credential_proxy_env_and_volumes(
     project: ProjectConfig, task_id: str
 ) -> tuple[dict[str, str], list[str]]:
@@ -286,10 +308,12 @@ def _credential_proxy_env_and_volumes(
             cred = db.load_credential(credential_set, name)
             ctype = _credential_type(cred) if cred else "api_key"
             credential_types[name] = ctype
-            # Claude OAuth: the static marker in .credentials.json serves as
-            # the access token — no per-task phantom token needed.  The proxy
-            # accepts that marker directly (see credential_proxy.constants).
+            # Claude OAuth: gated by experimental config (see _skip_claude_oauth).
             if name == "claude" and ctype == "oauth":
+                if _skip_claude_oauth():
+                    continue
+                # The static marker in .credentials.json serves as the access
+                # token — no per-task phantom token needed.
                 continue
             tokens[name] = db.create_proxy_token(project.id, task_id, credential_set, name)
 
@@ -315,11 +339,13 @@ def _credential_proxy_env_and_volumes(
 
         is_oauth = credential_types[name] == "oauth"
 
-        # Claude OAuth: don't inject CLAUDE_CODE_OAUTH_TOKEN or ANTHROPIC_UNIX_SOCKET.
-        # Claude Code shows "Claude API" when the token source is the env var;
-        # subscription mode requires the token to come from .credentials.json.
-        # The static marker in that file is accepted by the proxy directly.
+        # Claude OAuth: experimental tiered handling.
+        # - Tier 1 (experimental off): skip entirely — broken path disabled.
+        # - Tier 2 (allow_oauth): proxy prompt API, shield blocks BASE_API_URL.
+        # - Tier 3 (expose_oauth_token): bypass proxy, real .credentials.json.
         if name == "claude" and is_oauth:
+            if _skip_claude_oauth():
+                continue
             if route.base_url_env:
                 env[route.base_url_env] = proxy_base
             continue
@@ -361,6 +387,12 @@ def _credential_proxy_env_and_volumes(
     from terok_agent import scan_leaked_credentials
 
     leaked = scan_leaked_credentials(sandbox_live_mounts_dir())
+    # Tier 3: suppress warning for Claude when expose_oauth_token is active —
+    # real credentials in the shared mount are intentional.
+    from ..core.config import get_claude_expose_oauth_token, is_experimental
+
+    if is_experimental() and get_claude_expose_oauth_token():
+        leaked = [(p, path) for p, path in leaked if p != "claude"]
     if leaked:
         import sys
 

--- a/src/terok/lib/orchestration/environment.py
+++ b/src/terok/lib/orchestration/environment.py
@@ -231,23 +231,14 @@ def ensure_credential_proxy() -> None:
 def _skip_claude_oauth() -> bool:
     """Return True when Claude OAuth should be excluded from the credential proxy.
 
-    Tier 1 (experimental off or allow_oauth off): skip — the path is broken
-    because Claude Code's hardcoded ``BASE_API_URL`` sends phantom tokens
-    directly to ``api.anthropic.com``.
-
-    Tier 3 (expose_oauth_token): skip — Claude manages ``.credentials.json``
-    directly via the shared mount, no proxy involvement.
-
-    Tier 2 (allow_oauth, not exposed): return False — proxy handles OAuth
-    normally, shield blocks ``api.anthropic.com``.
+    Only tier 2 (proxy active, not exposed) keeps Claude OAuth in the proxy.
+    Tiers 1 and 3 both skip it — tier 1 because the path is broken
+    (hardcoded ``BASE_API_URL``), tier 3 because Claude manages its own
+    credentials directly.
     """
-    from ..core.config import get_claude_allow_oauth, get_claude_expose_oauth_token, is_experimental
+    from ..core.config import is_claude_oauth_proxied
 
-    if not is_experimental():
-        return True
-    if get_claude_expose_oauth_token():
-        return True
-    return not get_claude_allow_oauth()
+    return not is_claude_oauth_proxied()
 
 
 def _credential_proxy_env_and_volumes(
@@ -308,12 +299,10 @@ def _credential_proxy_env_and_volumes(
             cred = db.load_credential(credential_set, name)
             ctype = _credential_type(cred) if cred else "api_key"
             credential_types[name] = ctype
-            # Claude OAuth: gated by experimental config (see _skip_claude_oauth).
+            # Claude OAuth never needs a per-task phantom token — the static
+            # marker in .credentials.json is accepted by the proxy directly.
+            # Tier gating (skip vs proxy vs expose) happens in the env loop below.
             if name == "claude" and ctype == "oauth":
-                if _skip_claude_oauth():
-                    continue
-                # The static marker in .credentials.json serves as the access
-                # token — no per-task phantom token needed.
                 continue
             tokens[name] = db.create_proxy_token(project.id, task_id, credential_set, name)
 
@@ -339,10 +328,7 @@ def _credential_proxy_env_and_volumes(
 
         is_oauth = credential_types[name] == "oauth"
 
-        # Claude OAuth: experimental tiered handling.
-        # - Tier 1 (experimental off): skip entirely — broken path disabled.
-        # - Tier 2 (allow_oauth): proxy prompt API, shield blocks BASE_API_URL.
-        # - Tier 3 (expose_oauth_token): bypass proxy, real .credentials.json.
+        # Claude OAuth: tier gating (see _skip_claude_oauth / is_claude_oauth_proxied).
         if name == "claude" and is_oauth:
             if _skip_claude_oauth():
                 continue
@@ -391,7 +377,7 @@ def _credential_proxy_env_and_volumes(
     # real credentials in the shared mount are intentional.
     from ..core.config import get_claude_expose_oauth_token, is_experimental
 
-    if is_experimental() and get_claude_expose_oauth_token():
+    if is_experimental() and get_claude_expose_oauth_token():  # tier 3: intentional
         leaked = [(p, path) for p, path in leaked if p != "claude"]
     if leaked:
         import sys

--- a/src/terok/lib/orchestration/task_runners.py
+++ b/src/terok/lib/orchestration/task_runners.py
@@ -258,14 +258,11 @@ def _maybe_deny_anthropic_api(cname: str, task_dir: Path) -> None:
     """Block ``api.anthropic.com`` when Claude OAuth is proxied (tier 2).
 
     When the shield is down, deny sets prevent phantom tokens from leaking
-    to Anthropic's hardcoded ``BASE_API_URL`` endpoint.  No-op when the
-    proxy is bypassed for Claude (tier 3) or experimental features are off.
+    to Anthropic's hardcoded ``BASE_API_URL`` endpoint.  No-op for tiers 1/3.
     """
-    from ..core.config import get_claude_allow_oauth, get_claude_expose_oauth_token, is_experimental
+    from ..core.config import is_claude_oauth_proxied
 
-    if not (is_experimental() and get_claude_allow_oauth()):
-        return
-    if get_claude_expose_oauth_token():
+    if not is_claude_oauth_proxied():
         return
     try:
         from terok_sandbox import make_shield

--- a/src/terok/lib/orchestration/task_runners.py
+++ b/src/terok/lib/orchestration/task_runners.py
@@ -254,6 +254,27 @@ def _drop_shield_on_creation(cname: str, task_dir: Path) -> None:
         warnings.warn(f"shield drop: {exc}", stacklevel=2)
 
 
+def _maybe_deny_anthropic_api(cname: str, task_dir: Path) -> None:
+    """Block ``api.anthropic.com`` when Claude OAuth is proxied (tier 2).
+
+    When the shield is down, deny sets prevent phantom tokens from leaking
+    to Anthropic's hardcoded ``BASE_API_URL`` endpoint.  No-op when the
+    proxy is bypassed for Claude (tier 3) or experimental features are off.
+    """
+    from ..core.config import get_claude_allow_oauth, get_claude_expose_oauth_token, is_experimental
+
+    if not (is_experimental() and get_claude_allow_oauth()):
+        return
+    if get_claude_expose_oauth_token():
+        return
+    try:
+        from terok_sandbox import make_shield
+
+        make_shield(task_dir).deny(cname, "api.anthropic.com")
+    except Exception:  # noqa: BLE001
+        pass  # best-effort, non-fatal
+
+
 def _apply_shield_policy(
     project: ProjectConfig, cname: str, task_dir: Path, *, is_restart: bool
 ) -> None:
@@ -276,12 +297,12 @@ def _apply_shield_policy(
             raise ValueError(
                 f"Unknown shield.on_task_restart value: {policy!r} (expected 'retain' or 'up')"
             )
-        return
-
-    if project.shield_drop_on_task_run:
+    elif project.shield_drop_on_task_run:
         _drop_shield_on_creation(cname, task_dir)
     else:
         _write_desired_shield_state(task_dir, "up")
+
+    _maybe_deny_anthropic_api(cname, task_dir)
 
 
 def _run_container(

--- a/src/terok/lib/orchestration/task_runners.py
+++ b/src/terok/lib/orchestration/task_runners.py
@@ -66,6 +66,7 @@ if TYPE_CHECKING:
 _LOCALHOST = "127.0.0.1"
 _LOOPBACK_HOSTS = frozenset({"127.0.0.1", "localhost", "::1"})
 _TOAD_CONTAINER_PORT = 8080
+_ANTHROPIC_API_HOST = "api.anthropic.com"
 _FALSE_STRINGS = frozenset({"false", "0", "no", "off"})
 
 
@@ -267,11 +268,11 @@ def _maybe_deny_anthropic_api(cname: str, task_dir: Path) -> None:
     try:
         from terok_sandbox import make_shield
 
-        make_shield(task_dir).deny(cname, "api.anthropic.com")
+        make_shield(task_dir).deny(cname, _ANTHROPIC_API_HOST)
     except Exception as exc:  # noqa: BLE001
         import warnings
 
-        warnings.warn(f"shield deny api.anthropic.com: {exc}", stacklevel=2)
+        warnings.warn(f"shield deny {_ANTHROPIC_API_HOST}: {exc}", stacklevel=2)
 
 
 def _apply_shield_policy(

--- a/src/terok/lib/orchestration/task_runners.py
+++ b/src/terok/lib/orchestration/task_runners.py
@@ -268,8 +268,10 @@ def _maybe_deny_anthropic_api(cname: str, task_dir: Path) -> None:
         from terok_sandbox import make_shield
 
         make_shield(task_dir).deny(cname, "api.anthropic.com")
-    except Exception:  # noqa: BLE001
-        pass  # best-effort, non-fatal
+    except Exception as exc:  # noqa: BLE001
+        import warnings
+
+        warnings.warn(f"shield deny api.anthropic.com: {exc}", stacklevel=2)
 
 
 def _apply_shield_policy(

--- a/tach.toml
+++ b/tach.toml
@@ -615,6 +615,7 @@ expose = [
     "get_global_hooks",
     "get_claude_allow_oauth",
     "get_claude_expose_oauth_token",
+    "is_claude_oauth_proxied",
     "get_credential_proxy_bypass",
     "get_credential_proxy_transport",
     "get_shield_bypass_firewall_no_protection",

--- a/tach.toml
+++ b/tach.toml
@@ -613,6 +613,8 @@ expose = [
     "is_experimental",
     "set_experimental",
     "get_global_hooks",
+    "get_claude_allow_oauth",
+    "get_claude_expose_oauth_token",
     "get_credential_proxy_bypass",
     "get_credential_proxy_transport",
     "get_shield_bypass_firewall_no_protection",

--- a/tests/unit/lib/test_config.py
+++ b/tests/unit/lib/test_config.py
@@ -525,3 +525,106 @@ def test_make_sandbox_config_shield_audit_default(
     """Factory defaults shield_audit to True."""
     monkeypatch.setenv("TEROK_CONFIG_FILE", str(write_config(tmp_path, "")))
     assert cfg.make_sandbox_config().shield_audit is True
+
+
+# ---------- Experimental flag from config ----------
+
+
+def test_is_experimental_reads_config(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """``is_experimental()`` falls back to the config file when the CLI flag is off."""
+    monkeypatch.setenv(
+        "TEROK_CONFIG_FILE",
+        str(write_config(tmp_path, "experimental: true\n")),
+    )
+    assert cfg.is_experimental() is True
+
+
+def test_is_experimental_cli_flag_wins(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """CLI flag (``set_experimental``) overrides the config file."""
+    monkeypatch.setenv(
+        "TEROK_CONFIG_FILE",
+        str(write_config(tmp_path, "experimental: false\n")),
+    )
+    cfg.set_experimental(True)
+    assert cfg.is_experimental() is True
+
+
+# ---------- Claude agent config getters ----------
+
+
+def test_claude_allow_oauth_default(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """``get_claude_allow_oauth()`` defaults to False."""
+    monkeypatch.setenv("TEROK_CONFIG_FILE", str(write_config(tmp_path, "")))
+    assert cfg.get_claude_allow_oauth() is False
+
+
+def test_claude_allow_oauth_enabled(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """``get_claude_allow_oauth()`` reads ``agent.claude.allow_oauth``."""
+    monkeypatch.setenv(
+        "TEROK_CONFIG_FILE",
+        str(write_config(tmp_path, "agent:\n  claude:\n    allow_oauth: true\n")),
+    )
+    assert cfg.get_claude_allow_oauth() is True
+
+
+def test_claude_allow_oauth_rejects_truthy_string(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """``get_claude_allow_oauth()`` returns False for non-bool values like ``"yes"``."""
+    monkeypatch.setenv(
+        "TEROK_CONFIG_FILE",
+        str(write_config(tmp_path, 'agent:\n  claude:\n    allow_oauth: "yes"\n')),
+    )
+    assert cfg.get_claude_allow_oauth() is False
+
+
+def test_claude_expose_oauth_token_default(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """``get_claude_expose_oauth_token()`` defaults to False."""
+    monkeypatch.setenv("TEROK_CONFIG_FILE", str(write_config(tmp_path, "")))
+    assert cfg.get_claude_expose_oauth_token() is False
+
+
+def test_claude_expose_oauth_token_enabled(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """``get_claude_expose_oauth_token()`` reads config."""
+    monkeypatch.setenv(
+        "TEROK_CONFIG_FILE",
+        str(write_config(tmp_path, "agent:\n  claude:\n    expose_oauth_token: true\n")),
+    )
+    assert cfg.get_claude_expose_oauth_token() is True
+
+
+def test_claude_agent_config_non_dict_returns_empty(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """``_claude_agent_config()`` returns ``{}`` when ``agent.claude`` is not a dict."""
+    monkeypatch.setenv(
+        "TEROK_CONFIG_FILE",
+        str(write_config(tmp_path, "agent:\n  claude: just-a-string\n")),
+    )
+    assert cfg.get_claude_allow_oauth() is False
+    assert cfg.get_claude_expose_oauth_token() is False
+
+
+def test_is_claude_oauth_proxied_tier2(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """``is_claude_oauth_proxied()`` returns True for tier 2."""
+    monkeypatch.setenv(
+        "TEROK_CONFIG_FILE",
+        str(
+            write_config(tmp_path, "experimental: true\nagent:\n  claude:\n    allow_oauth: true\n")
+        ),
+    )
+    assert cfg.is_claude_oauth_proxied() is True
+
+
+def test_is_claude_oauth_proxied_tier3(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """``is_claude_oauth_proxied()`` returns False for tier 3 (expose overrides)."""
+    monkeypatch.setenv(
+        "TEROK_CONFIG_FILE",
+        str(
+            write_config(
+                tmp_path,
+                "experimental: true\nagent:\n  claude:\n    allow_oauth: true\n    expose_oauth_token: true\n",
+            )
+        ),
+    )
+    assert cfg.is_claude_oauth_proxied() is False

--- a/tests/unit/lib/test_credential_proxy_env.py
+++ b/tests/unit/lib/test_credential_proxy_env.py
@@ -135,7 +135,48 @@ class TestCredentialProxyEnv:
 
     @pytest.mark.usefixtures("_enable_proxy")
     def test_claude_oauth_only_base_url(self, tmp_path: Path) -> None:
-        """Claude OAuth → only ANTHROPIC_BASE_URL (no token env vars, no socket flag)."""
+        """Claude OAuth (tier 2) → only ANTHROPIC_BASE_URL (no token env vars, no socket flag)."""
+        from terok_sandbox import CredentialDB
+
+        from terok.lib.orchestration.environment import _credential_proxy_env_and_volumes
+
+        db_path = tmp_path / "proxy" / "credentials.db"
+        db = CredentialDB(db_path)
+        db.store_credential("default", "claude", {"type": "oauth", "access_token": "tok"})
+        db.close()
+
+        sock_path = tmp_path / "proxy.sock"
+        sock_path.touch()
+
+        project = MagicMock()
+        project.id = "test-project"
+
+        with (
+            patch("terok_sandbox.credentials.lifecycle.is_daemon_running", return_value=True),
+            patch("terok_sandbox.ensure_proxy_reachable"),
+            patch("terok.lib.orchestration.environment.make_sandbox_config") as mock_cfg_fn,
+            patch("terok.lib.core.config.get_credential_proxy_transport", return_value="direct"),
+            patch("terok.lib.orchestration.environment._skip_claude_oauth", return_value=False),
+        ):
+            mock_cfg = mock_cfg_fn.return_value
+            mock_cfg.proxy_db_path = db_path
+            mock_cfg.proxy_socket_path = sock_path
+            mock_cfg.proxy_port = 18731
+            mock_cfg.ssh_keys_json_path = tmp_path / "ssh-keys.json"
+
+            env, _ = _credential_proxy_env_and_volumes(project, "task-1")
+
+        # Claude OAuth uses the static marker in .credentials.json — no env var token
+        assert "CLAUDE_CODE_OAUTH_TOKEN" not in env
+        assert "ANTHROPIC_API_KEY" not in env
+        assert "ANTHROPIC_UNIX_SOCKET" not in env
+        # Only base URL for HTTP routing to the proxy
+        assert "ANTHROPIC_BASE_URL" in env
+        assert "host.containers.internal:18731" in env["ANTHROPIC_BASE_URL"]
+
+    @pytest.mark.usefixtures("_enable_proxy")
+    def test_claude_oauth_skipped_by_default(self, tmp_path: Path) -> None:
+        """Claude OAuth (tier 1, default) → no ANTHROPIC env vars at all."""
         from terok_sandbox import CredentialDB
 
         from terok.lib.orchestration.environment import _credential_proxy_env_and_volumes
@@ -165,13 +206,10 @@ class TestCredentialProxyEnv:
 
             env, _ = _credential_proxy_env_and_volumes(project, "task-1")
 
-        # Claude OAuth uses the static marker in .credentials.json — no env var token
-        assert "CLAUDE_CODE_OAUTH_TOKEN" not in env
+        # Tier 1 (default): Claude OAuth is skipped entirely
         assert "ANTHROPIC_API_KEY" not in env
-        assert "ANTHROPIC_UNIX_SOCKET" not in env
-        # Only base URL for HTTP routing to the proxy
-        assert "ANTHROPIC_BASE_URL" in env
-        assert "host.containers.internal:18731" in env["ANTHROPIC_BASE_URL"]
+        assert "ANTHROPIC_BASE_URL" not in env
+        assert "CLAUDE_CODE_OAUTH_TOKEN" not in env
 
     @pytest.mark.usefixtures("_enable_proxy")
     def test_non_claude_oauth_still_uses_phantom_env(self, tmp_path: Path) -> None:
@@ -210,7 +248,7 @@ class TestCredentialProxyEnv:
 
     @pytest.mark.usefixtures("_enable_proxy")
     def test_claude_oauth_socket_transport_still_only_base_url(self, tmp_path: Path) -> None:
-        """Claude OAuth + socket transport → still only ANTHROPIC_BASE_URL (no socket flag)."""
+        """Claude OAuth (tier 2) + socket transport → still only ANTHROPIC_BASE_URL."""
         from terok_sandbox import CredentialDB
 
         from terok.lib.orchestration.environment import _credential_proxy_env_and_volumes
@@ -231,6 +269,7 @@ class TestCredentialProxyEnv:
             patch("terok_sandbox.ensure_proxy_reachable"),
             patch("terok.lib.orchestration.environment.make_sandbox_config") as mock_cfg_fn,
             patch("terok.lib.core.config.get_credential_proxy_transport", return_value="socket"),
+            patch("terok.lib.orchestration.environment._skip_claude_oauth", return_value=False),
         ):
             mock_cfg = mock_cfg_fn.return_value
             mock_cfg.proxy_db_path = db_path

--- a/tests/unit/lib/test_task_runner_internals.py
+++ b/tests/unit/lib/test_task_runner_internals.py
@@ -292,6 +292,47 @@ class TestApplyShieldPolicy:
             _apply_shield_policy(project, "ctr", tmp_path, is_restart=True)
 
 
+# ── _maybe_deny_anthropic_api ────────────────────────────
+
+
+class TestMaybeDenyAnthropicApi:
+    """Verify tier-2 shield deny for api.anthropic.com."""
+
+    def test_noop_when_not_proxied(self) -> None:
+        """No-op when Claude OAuth is not in tier 2."""
+        from terok.lib.orchestration.task_runners import _maybe_deny_anthropic_api
+
+        with patch(
+            "terok.lib.core.config.is_claude_oauth_proxied",
+            return_value=False,
+        ):
+            _maybe_deny_anthropic_api("ctr", MOCK_TASK_DIR)
+
+    def test_calls_shield_deny_when_proxied(self, tmp_path: Path) -> None:
+        """Calls shield.deny('api.anthropic.com') when tier 2 is active."""
+        from terok.lib.orchestration.task_runners import _maybe_deny_anthropic_api
+
+        mock_shield = MagicMock()
+        with (
+            patch("terok.lib.core.config.is_claude_oauth_proxied", return_value=True),
+            patch("terok_sandbox.make_shield", return_value=mock_shield),
+        ):
+            _maybe_deny_anthropic_api("ctr", tmp_path)
+
+        mock_shield.deny.assert_called_once_with("ctr", "api.anthropic.com")
+
+    def test_warns_on_failure(self) -> None:
+        """Emits a warning when shield.deny raises."""
+        from terok.lib.orchestration.task_runners import _maybe_deny_anthropic_api
+
+        with (
+            patch("terok.lib.core.config.is_claude_oauth_proxied", return_value=True),
+            patch("terok_sandbox.make_shield", side_effect=RuntimeError("nft missing")),
+            pytest.warns(match="shield deny api.anthropic.com"),
+        ):
+            _maybe_deny_anthropic_api("ctr", MOCK_TASK_DIR)
+
+
 # ── _run_container ────────────────────────────────────────
 
 

--- a/tests/unit/lib/test_yaml_schema.py
+++ b/tests/unit/lib/test_yaml_schema.py
@@ -204,6 +204,12 @@ class RawGlobalConfigTests(unittest.TestCase):
         self.assertEqual(cfg.shield.on_task_restart, "retain")
         self.assertEqual(cfg.gate_server.port, 9418)
         self.assertIsNone(cfg.default_agent)
+        self.assertFalse(cfg.experimental)
+
+    def test_experimental_flag(self) -> None:
+        """``experimental: true`` is accepted as a top-level bool."""
+        cfg = RawGlobalConfig.model_validate({"experimental": True})
+        self.assertTrue(cfg.experimental)
 
     def test_custom_values(self) -> None:
         """Custom values are parsed correctly."""


### PR DESCRIPTION
## Summary

- Add `experimental: bool` top-level config flag (persistent equivalent of `--experimental`)
- Add `agent.claude.allow_oauth` and `agent.claude.expose_oauth_token` config flags under the free-form `agent:` section
- Gate Claude OAuth credential proxy behavior in three tiers:
  - **Tier 1** (default): Claude OAuth credentials skipped — hardcoded `BASE_API_URL` leaks phantom tokens
  - **Tier 2** (`allow_oauth`): proxy works normally + `shield.deny("api.anthropic.com")` prevents leaks
  - **Tier 3** (`expose_oauth_token`): proxy bypassed for Claude, real `.credentials.json` exposed
- Suppress leaked-credential warning for Claude in tier 3
- Update tach interfaces for new config getters

Depends on terok-ai/terok-shield#230 for tier 2's shield deny to persist through shield-down.

### Background

Claude Code v2.1.101 has a hardcoded `BASE_API_URL` (`api.anthropic.com`) for subscription/usage API calls that ignores `ANTHROPIC_BASE_URL`. The credential proxy successfully handles prompt API and platform.claude.com, but these direct calls send phantom tokens which Anthropic rejects. Binary analysis confirms the only runtime-refreshable token source is `.credentials.json` (the env var `CLAUDE_CODE_OAUTH_TOKEN` is read once at startup).

## Test plan

- [x] `make lint` passes
- [x] `make tach` passes
- [x] `make docstrings` passes (99.6%)
- [x] `make reuse` passes
- [x] Config schema validates correctly (manual verification via Python)
- [x] `_skip_claude_oauth()` logic verified manually
- [ ] Unit tests (blocked by terok-sandbox version mismatch in dev env — pre-existing)
- [ ] End-to-end: store Claude OAuth cred, verify tier 1/2/3 behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a top-level experimental flag (off by default) and commented agent-specific Claude examples in the sample config.
  * Documented options to proxy vs expose Claude OAuth; when experimental mode is enabled the runtime can apply proxying, exposure, or skipping of Claude OAuth and adjust shielding/warnings accordingly.

* **Chores**
  * Added config accessors to surface the new flags to runtime.

* **Tests**
  * Updated and added tests covering experimental flag resolution, Claude OAuth tiers, and shield behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->