### PR TITLE
fix: warn and pass expose_token for Claude OAuth tier 3

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -3045,13 +3045,13 @@ tomli-w = ">=1.0,<2.0"
 
 [[package]]
 name = "terok-agent"
-version = "0.0.66"
+version = "0.0.67"
 description = "Single-agent task runner for hardened Podman containers"
 optional = false
 python-versions = ">=3.12,<4.0"
 groups = ["main"]
 files = [
-    {file = "terok_agent-0.0.66-py3-none-any.whl", hash = "sha256:dc2445851d3483833e8719466d391d706db0f07490c2201271fa19804871ba03"},
+    {file = "terok_agent-0.0.67-py3-none-any.whl", hash = "sha256:0c836aff64d28e9889c753ed376b035db16705a51abc8933ab91eb0a0f5e8822"},
 ]
 
 [package.dependencies]
@@ -3062,7 +3062,7 @@ tomli-w = ">=1.0"
 
 [package.source]
 type = "url"
-url = "https://github.com/terok-ai/terok-agent/releases/download/v0.0.66/terok_agent-0.0.66-py3-none-any.whl"
+url = "https://github.com/terok-ai/terok-agent/releases/download/v0.0.67/terok_agent-0.0.67-py3-none-any.whl"
 
 [[package]]
 name = "terok-dbus"
@@ -3609,4 +3609,4 @@ propcache = ">=0.2.1"
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.12,<4.0"
-content-hash = "85535d0c84a785b7b1a52f3d83f384ef7e010631929f0773f027e2f78b14a21e"
+content-hash = "1ca42a74d03d6bfbcfd330887b14e624346b4c2214714db4e356e48cb02e8f06"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ rich = ">=13.0"
 platformdirs = ">=4.5.1"
 unique-namer = ">=1.3"
 textual-serve = ">=1.1.0"
-terok-agent = {url = "https://github.com/terok-ai/terok-agent/releases/download/v0.0.66/terok_agent-0.0.66-py3-none-any.whl"}
+terok-agent = {url = "https://github.com/terok-ai/terok-agent/releases/download/v0.0.67/terok_agent-0.0.67-py3-none-any.whl"}
 terok-sandbox = {url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.0.59/terok_sandbox-0.0.59-py3-none-any.whl"}
 terok-dbus = {url = "https://github.com/terok-ai/terok-dbus/releases/download/v0.5.6/terok_dbus-0.5.6-py3-none-any.whl"}
 

--- a/src/terok/lib/domain/facade.py
+++ b/src/terok/lib/domain/facade.py
@@ -125,14 +125,23 @@ def authenticate(project_id: str, provider: str) -> None:
 
     Thin wrapper around the instrumentation-layer ``authenticate()`` that
     supplies ``mounts_dir`` and ``image`` from terok's config/image system.
+    When ``expose_oauth_token`` is active (tier 3), passes ``expose_token``
+    so the real credential file is preserved instead of being replaced with
+    a phantom marker.
     """
-    from ..core.config import sandbox_live_mounts_dir
+    from ..core.config import (
+        get_claude_expose_oauth_token,
+        is_experimental,
+        sandbox_live_mounts_dir,
+    )
 
+    expose = provider == "claude" and is_experimental() and get_claude_expose_oauth_token()
     _authenticate_raw(
         project_id,
         provider,
         mounts_dir=sandbox_live_mounts_dir(),
         image=project_cli_image(project_id),
+        expose_token=expose,
     )
 
 

--- a/src/terok/lib/orchestration/environment.py
+++ b/src/terok/lib/orchestration/environment.py
@@ -378,6 +378,16 @@ def _credential_proxy_env_and_volumes(
     from ..core.config import get_claude_expose_oauth_token, is_experimental
 
     if is_experimental() and get_claude_expose_oauth_token():  # tier 3: intentional
+        import sys
+
+        print(
+            "\n\033[1;33m"  # bold yellow
+            "  WARNING: Claude OAuth token is EXPOSED to all task containers.\n"
+            "  The credential proxy does NOT protect this token — it is mounted\n"
+            "  directly via .credentials.json in the shared config directory.\n"
+            "  Every task container managed by terok can read the real token.\033[0m\n",
+            file=sys.stderr,
+        )
         leaked = [(p, path) for p, path in leaked if p != "claude"]
     if leaked:
         import sys


### PR DESCRIPTION
## Summary

- Bold yellow stderr warning at task launch when `expose_oauth_token` is active — the real token is shared with all containers
- `facade.authenticate()` passes `expose_token=True` to terok-agent when tier 3 is detected, so the real `.credentials.json` is preserved instead of being replaced with a phantom marker

## Context

Follow-up to #671 (experimental Claude OAuth tiered config). Without this, tier 3 is broken: the capture flow always overwrites `.credentials.json` with a phantom marker, and there's no warning that the real token is exposed.

Depends on terok-ai/terok-agent#145 for the `expose_token` parameter.

## Test plan

- [ ] `make check` passes
- [ ] Launch task with `expose_oauth_token: true` → yellow warning on stderr
- [ ] Auth capture with tier 3 → real `.credentials.json` preserved

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Conditional OAuth token exposure for the Claude provider in experimental environments (preserves real credential file when active).

* **Bug Fixes**
  * Added a clear stderr warning when running in the experimental mode that exposes credentials.

* **Chores**
  * Updated internal agent dependency to a newer patch version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->