### PR TITLE
docs: remove misleading SSH config mount reference

### DIFF
--- a/docs/container-layers.md
+++ b/docs/container-layers.md
@@ -49,7 +49,7 @@ The `--full-rebuild` flag rebuilds from L0 with `--no-cache` and `--pull=always`
 ## Runtime Behavior
 
 - `terok task run-cli` starts `<project>:l2-cli`.
-- Mounts a per-task workspace to `/workspace`, shared credential directories, and optionally SSH config.
+- Mounts a per-task workspace to `/workspace` and shared credential directories.
 - The init script clones or syncs the project repository into `/workspace`.
 
 See [Shared Directories](shared-dirs.md) for mount details.


### PR DESCRIPTION
## Summary
- Remove inaccurate wording in `docs/container-layers.md` that implied SSH config is bind-mounted from the host
- SSH config is generated inside the container by `init-ssh-and-repo.sh`, not shared from host

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated documentation on container runtime behavior for task execution, clarifying mounted directories and configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->