### PR TITLE
chore: rename `docker:` config key to `image:`

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ A tool for managing containerized AI coding agent projects using Podman. Provide
 |----------|-------------|
 | [Full Usage Guide](docs/usage.md) | Complete user documentation |
 | [Developer Guide](docs/developer.md) | Internal architecture and contributor docs |
-| [Container Layers](docs/container-layers.md) | Docker image architecture |
+| [Container Layers](docs/container-layers.md) | Container image architecture |
 | [Container Lifecycle](docs/container-lifecycle.md) | Container and image lifecycle |
 | [Shared Directories](docs/shared-dirs.md) | Volume mounts and SSH configuration |
 | [Security Modes](docs/git-gate-and-security-modes.md) | Online vs gatekeeping modes |

--- a/docs/container-layers.md
+++ b/docs/container-layers.md
@@ -8,7 +8,7 @@ terok builds project containers in three logical layers. L0 (dev) and L1 (agent)
 
 ### L0 — Development Base (`terok-l0:<base-tag>`)
 
-- Based on Ubuntu 24.04 by default (override via `docker.base_image`).
+- Based on Ubuntu 24.04 by default (override via `image.base_image`).
 - Installs common tooling (git, openssh-client, ripgrep, vim, etc.).
 - Creates `/workspace` and sets `WORKDIR` to `/workspace`.
 - Creates a `dev` user with passwordless sudo and runs containers as that user.
@@ -44,7 +44,7 @@ The `--agents` flag rebuilds from L0 and passes a unique `AGENT_CACHE_BUST` buil
 
 The `--full-rebuild` flag rebuilds from L0 with `--no-cache` and `--pull=always`, forcing a fresh base-image pull and fresh apt-package layers.
 
-`<base-tag>` is derived from `docker.base_image` (sanitized), e.g. `ubuntu:24.04` becomes `ubuntu-24.04`.
+`<base-tag>` is derived from `image.base_image` (sanitized), e.g. `ubuntu:24.04` becomes `ubuntu-24.04`.
 
 ## Runtime Behavior
 

--- a/docs/gen_config_reference.py
+++ b/docs/gen_config_reference.py
@@ -70,10 +70,10 @@ _FIELD_DOCS: dict[str, str] = {
     # shield
     "shield.drop_on_task_run": "Drop shield (bypass firewall) when task container is created",
     "shield.on_task_restart": "Shield policy on container restart: ``retain`` or ``up``",
-    # docker
-    "docker.base_image": "Base Docker image for container builds",
-    "docker.user_snippet_inline": "Inline Dockerfile snippet injected into the project image",
-    "docker.user_snippet_file": "Path to a file containing a Dockerfile snippet",
+    # image
+    "image.base_image": "Base container image for builds",
+    "image.user_snippet_inline": "Inline Dockerfile snippet injected into the project image",
+    "image.user_snippet_file": "Path to a file containing a Dockerfile snippet",
     # shared dir
     "shared_dir": "Shared directory for multi-agent IPC (``true`` = auto-create under tasks root, or absolute path)",
     # top-level

--- a/docs/index.md
+++ b/docs/index.md
@@ -17,7 +17,7 @@ provisioning.
 - **Multi-Agent Teams**: Run multiple specialized sub-agents in a single task
 - **Task Lifecycle**: Create, run, stop, restart, follow up, and archive tasks
 - **Security Modes**: Online and gatekeeping modes for different trust levels
-- **Container Layers**: Efficient three-layer Docker image architecture (L0/L1/L2)
+- **Container Layers**: Efficient three-layer container image architecture (L0/L1/L2)
 - **Hardened Runtime**: Defence-in-depth via [terok-sandbox](https://github.com/terok-ai/terok-sandbox) — egress firewall, gated git access, SSH isolation, GPU passthrough
 - **Agent Instructions**: Layered, inheritable instruction system delivered to every task
 - **Interactive TUI**: Full-featured Textual interface with project/task management, log viewing, and login sessions
@@ -96,7 +96,7 @@ per-project in `<project>/presets/`. See the
 
 - [Concepts](concepts.md) — Architecture, security model, and design rationale
 - [User Guide](usage.md) — Complete user documentation
-- [Container Layers](container-layers.md) — Docker image architecture
+- [Container Layers](container-layers.md) — Container image architecture
 - [Container Lifecycle](container-lifecycle.md) — Container and image lifecycle
 - [Shared Directories](shared-dirs.md) — Volume mounts and SSH configuration
 - [Security Modes](git-gate-and-security-modes.md) — Online vs gatekeeping modes

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -123,7 +123,7 @@ project:
   id: myproj
   security_class: online        # or "gatekeeping"
 
-docker:
+image:
   base_image: docker.io/library/ubuntu:24.04
 
 git:
@@ -176,7 +176,7 @@ project:
   id: myproj
   security_class: online    # or "gatekeeping" for restricted mode
 
-docker:
+image:
   base_image: docker.io/library/ubuntu:24.04
   user_snippet_file: user.dockerinclude  # optional
 
@@ -186,7 +186,7 @@ git:
   # authorship: human-agent  # optional: author = human, committer = agent
 ```
 
-### Step 3: (Optional) Docker Include Snippet
+### Step 3: (Optional) Image Snippet
 
 Create `~/.config/terok/projects/myproj/user.dockerinclude`:
 ```dockerfile
@@ -963,7 +963,7 @@ run:
 
 Set the base image in `project.yml`:
 ```yaml
-docker:
+image:
   base_image: nvcr.io/nvidia/nvhpc:25.9-devel-cuda13.0-ubuntu24.04
 ```
 

--- a/examples/projects/alpaka3/project.yml
+++ b/examples/projects/alpaka3/project.yml
@@ -10,7 +10,7 @@ git:
   upstream_url: "git@github.com:sliwowitz/alpaka3.git"
   default_branch: "dev"
 
-docker:
+image:
   # GPU-capable base image (NVIDIA HPC SDK, CUDA 13, Ubuntu 24.04)
   base_image: "nvcr.io/nvidia/nvhpc:25.9-devel-cuda13.0-ubuntu24.04"
   # This is executed when building the L2 project image

--- a/examples/projects/cp2k/project.yml
+++ b/examples/projects/cp2k/project.yml
@@ -7,7 +7,7 @@ git:
   upstream_url: "https://github.com/cp2k/cp2k.git"
   default_branch: "master"
 
-docker:
+image:
   base_image: "nvcr.io/nvidia/nvhpc:25.11-devel-cuda13.0-ubuntu24.04"
   user_snippet_inline: |
     RUN apt-get update && apt-get install -y --no-install-recommends \

--- a/examples/projects/uc/project.yml
+++ b/examples/projects/uc/project.yml
@@ -7,7 +7,7 @@ git:
   upstream_url: "https://gitlab.com/electric-sheep/ultimate-container.git"
   default_branch: "main"
 
-docker:
+image:
   base_image: "ubuntu:24.04"
   user_snippet_file: "user.dockerinclude"
 
@@ -32,5 +32,5 @@ run:
   # Enable GPU passthrough for this project (per-project only). Default is disabled.
   # Accepts boolean true or string "all" to enable; omitted/false disables.
   # Note: GPU-enabled projects typically require a CUDA/NVIDIA-capable base image.
-  # Configure under docker.base_image accordingly.
+  # Configure under image.base_image accordingly.
   # gpus: all

--- a/src/terok/lib/core/project_model.py
+++ b/src/terok/lib/core/project_model.py
@@ -65,10 +65,10 @@ class ProjectConfig(BaseModel):
     hook_post_start: str | None = None
     hook_post_ready: str | None = None
     hook_post_stop: str | None = None
-    # Docker configuration (flattened from docker: section)
-    docker_base_image: str = "ubuntu:24.04"
-    docker_snippet_inline: str | None = None
-    docker_snippet_file: str | None = None
+    # Image configuration (flattened from image: section)
+    base_image: str = "ubuntu:24.04"
+    snippet_inline: str | None = None
+    snippet_file: str | None = None
     # Shared task directory (multi-agent IPC)
     shared_dir: Path | None = None
 

--- a/src/terok/lib/core/projects.py
+++ b/src/terok/lib/core/projects.py
@@ -209,9 +209,9 @@ def _build_project_config(
         hook_post_start=hook_post,
         hook_post_ready=hook_ready,
         hook_post_stop=hook_stop,
-        docker_base_image=raw.docker.base_image,
-        docker_snippet_inline=raw.docker.user_snippet_inline,
-        docker_snippet_file=raw.docker.user_snippet_file,
+        base_image=raw.image.base_image,
+        snippet_inline=raw.image.user_snippet_inline,
+        snippet_file=raw.image.user_snippet_file,
         shared_dir=shared_dir,
     )
 

--- a/src/terok/lib/core/yaml_schema.py
+++ b/src/terok/lib/core/yaml_schema.py
@@ -238,8 +238,8 @@ class RawShieldProjectSection(BaseModel):
     on_task_restart: Literal["retain", "up"] | None = None
 
 
-class RawDockerSection(BaseModel):
-    """The ``docker:`` section of project.yml."""
+class RawImageSection(BaseModel):
+    """The ``image:`` section of project.yml."""
 
     model_config = ConfigDict(extra="forbid")
 
@@ -266,7 +266,7 @@ class RawProjectYaml(BaseModel):
     gatekeeping: RawGatekeepingSection = Field(default_factory=RawGatekeepingSection)
     run: RawRunSection = Field(default_factory=RawRunSection)
     shield: RawShieldProjectSection = Field(default_factory=RawShieldProjectSection)
-    docker: RawDockerSection = Field(default_factory=RawDockerSection)
+    image: RawImageSection = Field(default_factory=RawImageSection)
     default_agent: str | None = None
     default_login: str | None = None
     shared_dir: bool | str | None = Field(
@@ -285,7 +285,7 @@ class RawProjectYaml(BaseModel):
             "gatekeeping",
             "run",
             "shield",
-            "docker",
+            "image",
             "agent",
         }
     )

--- a/src/terok/lib/domain/facade.py
+++ b/src/terok/lib/domain/facade.py
@@ -35,7 +35,7 @@ from terok_agent import (
 
 from ..core.images import project_cli_image
 from ..core.projects import load_project
-from ..orchestration.docker import build_images, generate_dockerfiles
+from ..orchestration.image import build_images, generate_dockerfiles
 from ..orchestration.task_runners import (  # noqa: F401 — re-exported public API
     HeadlessRunRequest,
     task_followup_headless,
@@ -153,7 +153,7 @@ __all__ = [
     # Rich domain objects
     "Project",
     "Task",
-    # Docker / image management
+    # Image management
     "generate_dockerfiles",
     "build_images",
     # Image listing & cleanup

--- a/src/terok/lib/domain/project.py
+++ b/src/terok/lib/domain/project.py
@@ -64,7 +64,7 @@ from ..core.config import (
 from ..core.project_model import ProjectConfig
 from ..core.projects import list_presets, load_project
 from ..orchestration.agent_config import resolve_agent_config
-from ..orchestration.docker import build_images, generate_dockerfiles
+from ..orchestration.image import build_images, generate_dockerfiles
 from ..orchestration.task_runners import HeadlessRunRequest, task_run_headless
 from ..orchestration.tasks import (
     TaskMeta,

--- a/src/terok/lib/domain/project_state.py
+++ b/src/terok/lib/domain/project_state.py
@@ -83,7 +83,7 @@ def get_project_state(
     dockerfiles_old = False
     if has_dockerfiles:
         try:
-            from ..orchestration.docker import render_all_dockerfiles
+            from ..orchestration.image import render_all_dockerfiles
         except ImportError:
             dockerfiles_old = False
         else:
@@ -113,7 +113,7 @@ def get_project_state(
             context_hash = None
             if rendered:
                 try:
-                    from ..orchestration.docker import build_context_hash_from_rendered
+                    from ..orchestration.image import build_context_hash_from_rendered
 
                     context_hash = build_context_hash_from_rendered(project, rendered)
                 except (OSError, ValueError, KeyError, ImportError) as exc:
@@ -278,7 +278,7 @@ def is_task_image_old(project_id: str | None, task: Any) -> bool | None:
         return None
 
     try:
-        from ..orchestration.docker import build_context_hash
+        from ..orchestration.image import build_context_hash
 
         current_hash = build_context_hash(project_id)
     except Exception:

--- a/src/terok/lib/domain/wizards/new_project.py
+++ b/src/terok/lib/domain/wizards/new_project.py
@@ -66,12 +66,12 @@ def _prompt_template() -> int | None:
     return None
 
 
-def _prompt_docker_snippet() -> str:
-    """Optionally open an editor for a custom Docker snippet.
+def _prompt_image_snippet() -> str:
+    """Optionally open an editor for a custom image snippet.
 
     Returns the snippet text (may be empty if the user skips or the file is empty).
     """
-    answer = input("\nAdd a custom Docker snippet? [y/N]: ").strip().lower()
+    answer = input("\nAdd a custom image snippet? [y/N]: ").strip().lower()
     if answer not in ("y", "yes"):
         return ""
 
@@ -146,8 +146,8 @@ def collect_wizard_inputs() -> dict | None:
         # Default branch (empty = use remote's default branch)
         default_branch = _prompt("Default branch (empty → remote default)")
 
-        # Docker snippet
-        user_snippet = _prompt_docker_snippet()
+        # Image snippet
+        user_snippet = _prompt_image_snippet()
 
         return {
             "template_index": template_idx,

--- a/src/terok/lib/orchestration/image.py
+++ b/src/terok/lib/orchestration/image.py
@@ -91,37 +91,37 @@ def _tmux_config_hash() -> str:
 
 
 def _resolve_user_snippet(project: ProjectConfig) -> str:
-    """Resolve the docker user snippet from project config (file and/or inline).
+    """Resolve the user snippet from project config (file and/or inline).
 
-    When both ``docker.user_snippet_file`` and ``docker.user_snippet_inline``
+    When both ``image.user_snippet_file`` and ``image.user_snippet_inline``
     are set, the file is included first and the inline block is appended.
 
-    Raises :class:`SystemExit` if ``docker.user_snippet_file`` is configured but
+    Raises :class:`SystemExit` if ``image.user_snippet_file`` is configured but
     the file does not exist or cannot be read.
     """
     parts: list[str] = []
-    if project.docker_snippet_file:
-        us_path = Path(project.docker_snippet_file).expanduser()
+    if project.snippet_file:
+        us_path = Path(project.snippet_file).expanduser()
         if not us_path.is_absolute():
             us_path = project.root / us_path
         if not us_path.is_file():
             raise SystemExit(
-                f"docker.user_snippet_file not found: {us_path}\n"
+                f"image.user_snippet_file not found: {us_path}\n"
                 f"  (configured in project '{project.id}')"
             )
         try:
             parts.append(us_path.read_text(encoding="utf-8"))
         except (OSError, UnicodeError) as exc:
-            raise SystemExit(f"Failed to read docker.user_snippet_file {us_path}: {exc}")
-    if project.docker_snippet_inline and project.docker_snippet_inline.strip():
-        parts.append(project.docker_snippet_inline)
+            raise SystemExit(f"Failed to read image.user_snippet_file {us_path}: {exc}")
+    if project.snippet_inline and project.snippet_inline.strip():
+        parts.append(project.snippet_inline)
     return "\n".join(parts)
 
 
 def _render_l2(project: ProjectConfig) -> str:
     """Render the L2 (project customisation) Dockerfile.
 
-    L2 contains the user docker snippet wrapped in USER root/dev.
+    L2 contains the user image snippet wrapped in USER root/dev.
     Runtime env vars (CODE_REPO, GIT_BRANCH) are set by environment.py
     at container launch time.
     """
@@ -133,7 +133,7 @@ def _render_l2(project: ProjectConfig) -> str:
         "SECURITY_CLASS": project.security_class,
         "UPSTREAM_URL": project.upstream_url or "",
         "DEFAULT_BRANCH": project.default_branch or "",
-        "BASE_IMAGE": project.docker_base_image,
+        "BASE_IMAGE": project.base_image,
         "CODE_REPO_DEFAULT": (
             "file:///git-gate/gate.git"
             if project.security_class == "gatekeeping"
@@ -156,8 +156,8 @@ def render_all_dockerfiles(project: ProjectConfig) -> dict[str, str]:
     from terok_agent.container.build import render_l0, render_l1
 
     return {
-        "L0.Dockerfile": render_l0(project.docker_base_image),
-        "L1.cli.Dockerfile": render_l1(l0_image_tag(project.docker_base_image)),
+        "L0.Dockerfile": render_l0(project.base_image),
+        "L1.cli.Dockerfile": render_l1(l0_image_tag(project.base_image)),
         "L2.Dockerfile": _render_l2(project),
     }
 
@@ -173,7 +173,7 @@ def build_context_hash_from_rendered(project: ProjectConfig, rendered: dict[str,
         rendered: name→content mapping returned by :func:`render_all_dockerfiles`.
     """
     hasher = hashlib.sha256()
-    hasher.update(f"base_image={project.docker_base_image}".encode())
+    hasher.update(f"base_image={project.base_image}".encode())
     hasher.update(b"\0")
     for name in sorted(rendered):
         hasher.update(name.encode("utf-8"))
@@ -249,7 +249,7 @@ def build_images(
     _check_podman_available()
 
     project = load_project(project_id)
-    base_image = project.docker_base_image
+    base_image = project.base_image
     stage_dir = build_dir() / project.id
 
     # Delegate L0+L1 to terok-agent (uses its own temp dir for build context)

--- a/src/terok/resources/templates/projects/gatekeeping-nvidia.yml
+++ b/src/terok/resources/templates/projects/gatekeeping-nvidia.yml
@@ -10,7 +10,7 @@ git:
   upstream_url: "{{UPSTREAM_URL}}"
   default_branch: "{{DEFAULT_BRANCH}}"
 
-docker:
+image:
   base_image: "nvcr.io/nvidia/nvhpc:25.9-devel-cuda13.0-ubuntu24.04"
   # Optional: extra Dockerfile commands injected into the project image.
   # Use user_snippet_file to point to an external .dockerinclude file.

--- a/src/terok/resources/templates/projects/gatekeeping-ubuntu.yml
+++ b/src/terok/resources/templates/projects/gatekeeping-ubuntu.yml
@@ -10,7 +10,7 @@ git:
   upstream_url: "{{UPSTREAM_URL}}"
   default_branch: "{{DEFAULT_BRANCH}}"
 
-docker:
+image:
   base_image: "ubuntu:24.04"
   # Optional: extra Dockerfile commands injected into the project image.
   # Use user_snippet_file to point to an external .dockerinclude file.

--- a/src/terok/resources/templates/projects/online-nvidia.yml
+++ b/src/terok/resources/templates/projects/online-nvidia.yml
@@ -9,7 +9,7 @@ git:
   upstream_url: "{{UPSTREAM_URL}}"
   default_branch: "{{DEFAULT_BRANCH}}"
 
-docker:
+image:
   base_image: "nvcr.io/nvidia/nvhpc:25.9-devel-cuda13.0-ubuntu24.04"
   # Optional: extra Dockerfile commands injected into the project image.
   # Use user_snippet_file to point to an external .dockerinclude file.

--- a/src/terok/resources/templates/projects/online-ubuntu.yml
+++ b/src/terok/resources/templates/projects/online-ubuntu.yml
@@ -9,7 +9,7 @@ git:
   upstream_url: "{{UPSTREAM_URL}}"
   default_branch: "{{DEFAULT_BRANCH}}"
 
-docker:
+image:
   base_image: "ubuntu:24.04"
   # Optional: extra Dockerfile commands injected into the project image.
   # Use user_snippet_file to point to an external .dockerinclude file.

--- a/tach.toml
+++ b/tach.toml
@@ -98,7 +98,7 @@ depends_on = [
 path = "terok.lib.domain.facade"
 layer = "domain"
 depends_on = [
-    "terok.lib.orchestration.docker",
+    "terok.lib.orchestration.image",
     "terok.lib.orchestration.environment",
     "terok.lib.domain.image_cleanup",
     "terok.lib.domain.project_state",
@@ -116,7 +116,7 @@ path = "terok.lib.domain.project"
 layer = "domain"
 depends_on = [
     "terok.lib.orchestration.agent_config",
-    "terok.lib.orchestration.docker",
+    "terok.lib.orchestration.image",
     "terok.lib.domain.project_state",
     "terok.lib.orchestration.task_runners",
     "terok.lib.orchestration.tasks",
@@ -188,7 +188,7 @@ depends_on = ["terok.lib.core.config", "terok.lib.core.projects"]
 path = "terok.lib.domain.project_state"
 layer = "domain"
 depends_on = [
-    "terok.lib.orchestration.docker",
+    "terok.lib.orchestration.image",
     "terok.lib.core.config",
     "terok.lib.core.images",
     "terok.lib.core.projects",
@@ -262,7 +262,7 @@ depends_on = [
 
 # Dockerfile generation & image building
 [[modules]]
-path = "terok.lib.orchestration.docker"
+path = "terok.lib.orchestration.image"
 layer = "orchestration"
 depends_on = ["terok.lib.core.config", "terok.lib.core.images", "terok.lib.core.projects", "terok.lib.util.fs"]
 
@@ -577,7 +577,7 @@ expose = [
     "build_context_hash_from_rendered",
     "render_all_dockerfiles",
 ]
-from = ["terok.lib.orchestration.docker"]
+from = ["terok.lib.orchestration.image"]
 
 [[interfaces]]
 expose = ["list_images", "find_orphaned_images", "cleanup_images", "ImageInfo", "CleanupResult"]

--- a/tests/unit/lib/test_image.py
+++ b/tests/unit/lib/test_image.py
@@ -10,7 +10,7 @@ from unittest.mock import Mock, patch
 from terok_agent import ImageSet
 
 from terok.lib.core.config import build_dir
-from terok.lib.orchestration.docker import build_images, generate_dockerfiles
+from terok.lib.orchestration.image import build_images, generate_dockerfiles
 from tests.test_utils import mock_git_config, project_env
 
 UPSTREAM_URL = "https://example.com/repo.git"
@@ -18,7 +18,7 @@ DEFAULT_BRANCH = "main"
 
 
 @contextmanager
-def docker_project(project_id: str, *, security_class: str = "online") -> Iterator[object]:
+def image_project(project_id: str, *, security_class: str = "online") -> Iterator[object]:
     """Create a minimal project config suitable for Dockerfile generation tests."""
     lines = [f"project:\n  id: {project_id}\n"]
     if security_class != "online":
@@ -58,15 +58,15 @@ def build_commands(
         return Mock(returncode=0)
 
     image_exists_patch = (
-        patch("terok.lib.orchestration.docker._image_exists", side_effect=image_exists_side_effect)
+        patch("terok.lib.orchestration.image._image_exists", side_effect=image_exists_side_effect)
         if image_exists_side_effect is not None
-        else patch("terok.lib.orchestration.docker._image_exists", return_value=image_exists)
+        else patch("terok.lib.orchestration.image._image_exists", return_value=image_exists)
     )
     with (
         patch("subprocess.run", side_effect=mock_run),
-        patch("terok.lib.orchestration.docker._check_podman_available"),
+        patch("terok.lib.orchestration.image._check_podman_available"),
         patch(
-            "terok.lib.orchestration.docker.build_base_images",
+            "terok.lib.orchestration.image.build_base_images",
             return_value=_mock_base_images(),
         ),
         image_exists_patch,
@@ -79,7 +79,7 @@ def build_commands(
 def test_generate_dockerfiles_outputs_expected_files_and_content() -> None:
     """Dockerfile generation writes all expected layers and helper scripts."""
     project_id = "proj4"
-    with docker_project(project_id):
+    with image_project(project_id):
         generate_dockerfiles(project_id)
         out_dir = build_dir() / project_id
 
@@ -109,7 +109,7 @@ def test_generate_dockerfiles_outputs_expected_files_and_content() -> None:
 
 def test_generate_dockerfiles_uses_gatekeeping_code_repo() -> None:
     """Gatekeeping projects clone from the local git gate instead of upstream."""
-    with docker_project("proj_gated", security_class="gatekeeping"):
+    with image_project("proj_gated", security_class="gatekeeping"):
         generate_dockerfiles("proj_gated")
         content = (build_dir() / "proj_gated" / "L2.Dockerfile").read_text(encoding="utf-8")
         assert 'CODE_REPO="file:///git-gate/gate.git"' in content
@@ -117,11 +117,11 @@ def test_generate_dockerfiles_uses_gatekeeping_code_repo() -> None:
 
 
 def test_l2_includes_user_snippet_inline() -> None:
-    """L2 renders inline user docker snippet into the Dockerfile."""
+    """L2 renders inline user image snippet into the Dockerfile."""
     yaml = (
         "project:\n  id: proj_snippet\n"
         "git:\n  upstream_url: https://example.com/repo.git\n"
-        "docker:\n  user_snippet_inline: RUN apt-get install -y fortran-compiler\n"
+        "image:\n  user_snippet_inline: RUN apt-get install -y fortran-compiler\n"
     )
     with project_env(yaml, project_id="proj_snippet"):
         generate_dockerfiles("proj_snippet")
@@ -130,7 +130,7 @@ def test_l2_includes_user_snippet_inline() -> None:
 
 
 def test_l2_includes_user_snippet_from_file() -> None:
-    """L2 renders user docker snippet from a file reference."""
+    """L2 renders user image snippet from a file reference."""
     import tempfile
     from pathlib import Path
 
@@ -142,7 +142,7 @@ def test_l2_includes_user_snippet_from_file() -> None:
         yaml = (
             "project:\n  id: proj_snippet_file\n"
             "git:\n  upstream_url: https://example.com/repo.git\n"
-            f"docker:\n  user_snippet_file: {snippet_path}\n"
+            f"image:\n  user_snippet_file: {snippet_path}\n"
         )
         with project_env(yaml, project_id="proj_snippet_file"):
             generate_dockerfiles("proj_snippet_file")
@@ -167,7 +167,7 @@ def test_l2_combines_snippet_file_and_inline() -> None:
         yaml = (
             "project:\n  id: proj_both_snippets\n"
             "git:\n  upstream_url: https://example.com/repo.git\n"
-            f"docker:\n  user_snippet_file: {snippet_path}\n"
+            f"image:\n  user_snippet_file: {snippet_path}\n"
             "  user_snippet_inline: RUN apt-get install -y fortran-compiler\n"
         )
         with project_env(yaml, project_id="proj_both_snippets"):
@@ -190,7 +190,7 @@ def test_l2_missing_snippet_file_exits() -> None:
     yaml = (
         "project:\n  id: proj_bad_snippet\n"
         "git:\n  upstream_url: https://example.com/repo.git\n"
-        "docker:\n  user_snippet_file: /nonexistent/snippet.dockerfile\n"
+        "image:\n  user_snippet_file: /nonexistent/snippet.dockerfile\n"
     )
     with project_env(yaml, project_id="proj_bad_snippet"):
         with pytest.raises(SystemExit, match="not found"):
@@ -199,7 +199,7 @@ def test_l2_missing_snippet_file_exits() -> None:
 
 def test_l1_cli_pipx_inject_has_env_vars() -> None:
     """The CLI image sets the expected pipx env vars and package installation lines."""
-    with docker_project("proj_pipx_test"):
+    with image_project("proj_pipx_test"):
         generate_dockerfiles("proj_pipx_test")
         content = (build_dir() / "proj_pipx_test" / "L1.cli.Dockerfile").read_text(encoding="utf-8")
         assert "PIPX_HOME=/opt/pipx" in content
@@ -210,7 +210,7 @@ def test_l1_cli_pipx_inject_has_env_vars() -> None:
 
 def test_build_images_builds_l2() -> None:
     """build_images always produces an L2 podman build command."""
-    with docker_project("proj_build_l2"):
+    with image_project("proj_build_l2"):
         generate_dockerfiles("proj_build_l2")
         commands = build_commands("proj_build_l2")
 
@@ -223,7 +223,7 @@ def test_build_images_builds_l2() -> None:
 
 def test_build_images_include_dev_adds_second_l2() -> None:
     """include_dev produces two L2 commands: cli + dev."""
-    with docker_project("proj_build_dev"):
+    with image_project("proj_build_dev"):
         generate_dockerfiles("proj_build_dev")
         commands = build_commands("proj_build_dev", include_dev=True)
 
@@ -235,7 +235,7 @@ def test_build_images_include_dev_adds_second_l2() -> None:
 
 def test_build_images_full_rebuild_passes_no_cache() -> None:
     """full_rebuild passes --no-cache to L2 build."""
-    with docker_project("proj_build_full"):
+    with image_project("proj_build_full"):
         generate_dockerfiles("proj_build_full")
         commands = build_commands("proj_build_full", full_rebuild=True)
 

--- a/tests/unit/lib/test_yaml_schema.py
+++ b/tests/unit/lib/test_yaml_schema.py
@@ -29,7 +29,7 @@ class RawProjectYamlTests(unittest.TestCase):
         raw = RawProjectYaml.model_validate({})
         self.assertEqual(raw.project.security_class, "online")
         self.assertIsNone(raw.git.upstream_url)
-        self.assertEqual(raw.docker.base_image, "ubuntu:24.04")
+        self.assertEqual(raw.image.base_image, "ubuntu:24.04")
         self.assertEqual(raw.run.shutdown_timeout, 10)
         self.assertIsNone(raw.shield.drop_on_task_run)
         self.assertIsNone(raw.shield.on_task_restart)
@@ -49,7 +49,7 @@ class RawProjectYamlTests(unittest.TestCase):
             },
             "run": {"shutdown_timeout": 30, "gpus": "all"},
             "shield": {"drop_on_task_run": False, "on_task_restart": "up"},
-            "docker": {"base_image": "nvidia/cuda:12.0", "user_snippet_inline": "RUN echo hi"},
+            "image": {"base_image": "nvidia/cuda:12.0", "user_snippet_inline": "RUN echo hi"},
             "default_agent": "claude",
             "agent": {"model": "opus"},
         }
@@ -66,7 +66,7 @@ class RawProjectYamlTests(unittest.TestCase):
         self.assertEqual(raw.run.gpus, "all")
         self.assertFalse(raw.shield.drop_on_task_run)
         self.assertEqual(raw.shield.on_task_restart, "up")
-        self.assertEqual(raw.docker.base_image, "nvidia/cuda:12.0")
+        self.assertEqual(raw.image.base_image, "nvidia/cuda:12.0")
         self.assertEqual(raw.default_agent, "claude")
 
     def test_unknown_key_rejected(self) -> None:
@@ -362,10 +362,10 @@ class ProjectYamlValidationErrorTests(unittest.TestCase):
             RawProjectYaml.model_validate({"shield": {"on_task_restart": "invalid"}})
         self.assertIn("on_task_restart", str(ctx.exception))
 
-    def test_docker_unknown_key(self) -> None:
-        """Typo in docker section key is caught."""
+    def test_image_unknown_key(self) -> None:
+        """Typo in image section key is caught."""
         with self.assertRaises(ValidationError) as ctx:
-            RawProjectYaml.model_validate({"docker": {"base_imagee": "ubuntu:24.04"}})
+            RawProjectYaml.model_validate({"image": {"base_imagee": "ubuntu:24.04"}})
         self.assertIn("base_imagee", str(ctx.exception))
 
 

--- a/tests/unit/test_error_surfacing.py
+++ b/tests/unit/test_error_surfacing.py
@@ -330,7 +330,7 @@ class TestProjectStateWarnings:
             patch("terok.lib.domain.project_state.load_project", return_value=mock_project),
             patch("terok.lib.domain.project_state.build_dir", return_value=tmp_path / "build"),
             patch(
-                "terok.lib.orchestration.docker.render_all_dockerfiles",
+                "terok.lib.orchestration.image.render_all_dockerfiles",
                 side_effect=RuntimeError("template broken"),
             ),
             patch("subprocess.run", side_effect=FileNotFoundError("no podman")),


### PR DESCRIPTION
## Summary

- Rename the `docker:` YAML config section to `image:` — terok uses Podman, not Docker, and the old name was misleading
- Rename module `orchestration/docker.py` → `orchestration/image.py`
- Rename Pydantic model `RawDockerSection` → `RawImageSection`
- Flatten ProjectConfig fields: `docker_base_image` → `base_image`, `docker_snippet_inline` → `snippet_inline`, `docker_snippet_file` → `snippet_file`
- Update all imports, tach boundaries, tests, templates, examples, and docs

**Intentionally untouched:** `Dockerfile` references (Podman reads Dockerfiles), `docker.io` registry URLs, `docs/docker.md` (terok-in-Docker guide), competitor comparison in `docs/concepts.md`.

## Test plan

- [x] `make lint` — passes
- [x] `make test` — 1632 tests pass
- [x] `make tach` — module boundaries valid
- [x] `make docstrings` — 99.6% coverage
- [x] `make reuse` — SPDX compliant
- [x] Grep verification: no stale `docker` references remain (excluding allowed exceptions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Project configuration section renamed from `docker` to `image` with updated field names (`docker_base_image` → `base_image`, `docker_snippet_inline`/`docker_snippet_file` → `snippet_inline`/`snippet_file`).
  * Documentation terminology updated to "container" throughout for consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->