### PR TITLE
chore: bump version to 0.7.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry_dynamic_versioning.backend"
 
 [tool.poetry]
 name = "terok"
-version = "0.6.1"
+version = "0.7.0"
 description = "Manage containerized projects and per-run tasks with Podman"
 readme = "README.md"
 license = "Apache-2.0"


### PR DESCRIPTION
## Summary
- Bump version in `pyproject.toml` from 0.6.1 to 0.7.0 for the Habitat Ring Decompression release

## Test plan
- [ ] `poetry lock` still resolves
- [ ] Version string correct in installed package

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Package version updated to 0.7.0

<!-- end of auto-generated comment: release notes by coderabbit.ai -->