### PR TITLE
fix: register SSH keys in ssh-keys.json from TUI init flows

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -3063,13 +3063,13 @@ url = "https://github.com/terok-ai/terok-dbus/releases/download/v0.5.6/terok_dbu
 
 [[package]]
 name = "terok-executor"
-version = "0.0.71"
+version = "0.0.72"
 description = "Single-agent task runner for hardened Podman containers"
 optional = false
 python-versions = ">=3.12,<4.0"
 groups = ["main"]
 files = [
-    {file = "terok_executor-0.0.71-py3-none-any.whl", hash = "sha256:a8a4d1c48e59137a3c2795caa35eede014acc5870a677cce2c1144a5b6027bd2"},
+    {file = "terok_executor-0.0.72-py3-none-any.whl", hash = "sha256:4d71e00eeb90c3e2d8ec7731c17906defefb4e34747aa809d3adfb540d94374d"},
 ]
 
 [package.dependencies]
@@ -3080,7 +3080,7 @@ tomli-w = ">=1.0"
 
 [package.source]
 type = "url"
-url = "https://github.com/terok-ai/terok-executor/releases/download/v0.0.71/terok_executor-0.0.71-py3-none-any.whl"
+url = "https://github.com/terok-ai/terok-executor/releases/download/v0.0.72/terok_executor-0.0.72-py3-none-any.whl"
 
 [[package]]
 name = "terok-sandbox"
@@ -3609,4 +3609,4 @@ propcache = ">=0.2.1"
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.12,<4.0"
-content-hash = "1f8cd157369656f28048faae6df481ecb2173b8b45e5fb82a53e7713903525e4"
+content-hash = "3555f6ddfe0436e1e02885aeccbd143d3b3dcf2278008950e6ec182e2ca00ce9"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ rich = ">=13.0"
 platformdirs = ">=4.5.1"
 unique-namer = ">=1.3"
 textual-serve = ">=1.1.0"
-terok-executor = {url = "https://github.com/terok-ai/terok-executor/releases/download/v0.0.71/terok_executor-0.0.71-py3-none-any.whl"}
+terok-executor = {url = "https://github.com/terok-ai/terok-executor/releases/download/v0.0.72/terok_executor-0.0.72-py3-none-any.whl"}
 terok-sandbox = {url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.0.63/terok_sandbox-0.0.63-py3-none-any.whl"}
 terok-dbus = {url = "https://github.com/terok-ai/terok-dbus/releases/download/v0.5.6/terok_dbus-0.5.6-py3-none-any.whl"}
 

--- a/src/terok/cli/commands/setup.py
+++ b/src/terok/cli/commands/setup.py
@@ -15,6 +15,7 @@ from ...lib.domain.facade import (
     build_images,
     generate_dockerfiles,
     maybe_pause_for_ssh_key_registration,
+    register_ssh_key,
 )
 from ...lib.domain.project import make_git_gate, make_ssh_manager
 from ._completers import complete_project_ids as _complete_project_ids, set_completer
@@ -124,7 +125,7 @@ def dispatch(args: argparse.Namespace) -> bool:
             key_name=getattr(args, "key_name", None),
             force=getattr(args, "force", False),
         )
-        _register_ssh_key(project.id, result)
+        register_ssh_key(project.id, result)
         return True
     if args.cmd == "gate-sync":
         res = make_git_gate(load_project(args.project_id)).sync(
@@ -147,22 +148,13 @@ def dispatch(args: argparse.Namespace) -> bool:
     return False
 
 
-def _register_ssh_key(project_id: str, result: dict) -> None:
-    """Register the SSH key in ssh-keys.json for the credential proxy's SSH agent."""
-    from terok_sandbox import update_ssh_keys_json
-
-    from ...lib.core.config import make_sandbox_config
-
-    update_ssh_keys_json(make_sandbox_config().ssh_keys_json_path, project_id, result)
-
-
 def cmd_project_init(project_id: str) -> None:
     """Full project setup: ssh-init, generate, build, gate-sync."""
     project = load_project(project_id)
 
     print("==> Initializing SSH...")
     result = make_ssh_manager(project).init()
-    _register_ssh_key(project_id, result)
+    register_ssh_key(project_id, result)
     maybe_pause_for_ssh_key_registration(project_id)
 
     print("==> Generating Dockerfiles...")

--- a/src/terok/lib/domain/facade.py
+++ b/src/terok/lib/domain/facade.py
@@ -104,6 +104,18 @@ def derive_project(source_id: str, new_id: str) -> Project:
 # ---------------------------------------------------------------------------
 
 
+def register_ssh_key(project_id: str, init_result: dict) -> None:
+    """Register an SSH key in ``ssh-keys.json`` for the credential proxy's SSH agent.
+
+    Call this after :meth:`SSHManager.init` with the returned result dict.
+    """
+    from terok_sandbox import update_ssh_keys_json
+
+    from ..core.config import make_sandbox_config
+
+    update_ssh_keys_json(make_sandbox_config().ssh_keys_json_path, project_id, init_result)
+
+
 def maybe_pause_for_ssh_key_registration(project_id: str) -> None:
     """If the project's upstream uses SSH, pause so the user can register the deploy key.
 
@@ -189,6 +201,7 @@ __all__ = [
     "make_ssh_manager",
     "make_git_gate",
     # Workflow helpers
+    "register_ssh_key",
     "maybe_pause_for_ssh_key_registration",
     # Auth
     "authenticate",

--- a/src/terok/lib/orchestration/environment.py
+++ b/src/terok/lib/orchestration/environment.py
@@ -504,7 +504,7 @@ def build_task_env_and_volumes(
             envs_dir=sandbox_live_mounts_dir(),
         ),
         get_roster(),
-        proxy_bypass=True,  # terok uses richer proxy handling below
+        caller_manages_proxy=True,  # terok injects richer per-provider proxy tokens below
     )
 
     env = dict(result.env)

--- a/src/terok/tui/project_actions.py
+++ b/src/terok/tui/project_actions.py
@@ -33,6 +33,7 @@ from ..lib.domain.facade import (
     find_projects_sharing_gate,
     generate_dockerfiles,
     maybe_pause_for_ssh_key_registration,
+    register_ssh_key,
 )
 from ..lib.domain.project import make_git_gate, make_ssh_manager
 from .shell_launch import launch_login
@@ -176,8 +177,13 @@ class ProjectActionsMixin:
             self.notify("No project selected.")
             return
         pid = self.current_project_id
+
+        def _init_and_register() -> None:
+            result = make_ssh_manager(load_project(pid)).init()
+            register_ssh_key(pid, result)
+
         await self._run_suspended(
-            lambda: make_ssh_manager(load_project(pid)).init(),
+            _init_and_register,
             success_msg=f"Initialized SSH dir for {pid}",
         )
 
@@ -217,7 +223,8 @@ class ProjectActionsMixin:
             nonlocal gate_ok
             print(f"=== Full Setup for {pid} ===\n")
             print("Step 1/4: Initializing SSH...")
-            make_ssh_manager(load_project(pid)).init()
+            result = make_ssh_manager(load_project(pid)).init()
+            register_ssh_key(pid, result)
             maybe_pause_for_ssh_key_registration(pid)
             print("\nStep 2/4: Generating Dockerfiles...")
             generate_dockerfiles(pid)

--- a/tach.toml
+++ b/tach.toml
@@ -716,6 +716,7 @@ expose = [
     "authenticate",
     "get_project_state",
     "is_task_image_old",
+    "register_ssh_key",
     "maybe_pause_for_ssh_key_registration",
 ]
 from = ["terok.lib.domain.facade"]

--- a/tests/unit/cli/test_cli_workflows.py
+++ b/tests/unit/cli/test_cli_workflows.py
@@ -116,6 +116,50 @@ class TestProjectInit:
             cmd_project_init("badproj")
 
 
+class TestCliSshInit:
+    """Tests for the CLI ssh-init command."""
+
+    @unittest.mock.patch("terok.cli.commands.setup.make_ssh_manager")
+    @unittest.mock.patch("terok.cli.commands.setup.register_ssh_key")
+    @unittest.mock.patch("terok.cli.commands.setup.load_project")
+    def test_ssh_init_registers_key(self, mock_load, mock_register, mock_ssh_cls) -> None:
+        """ssh-init must forward the init() result to register_ssh_key."""
+        fake_result = {"private_key": "/tmp/terok-testing/k", "dir": "/tmp/terok-testing/d"}
+        mock_ssh_cls.return_value.init.return_value = fake_result
+        mock_load.return_value = unittest.mock.Mock(id="proj")
+
+        from terok.cli.commands.setup import dispatch
+
+        args = unittest.mock.Mock(cmd="ssh-init", project_id="proj", key_type="ed25519")
+        args.key_name = None
+        args.force = False
+
+        result = dispatch(args)
+
+        assert result is True
+        mock_ssh_cls.return_value.init.assert_called_once_with(
+            key_type="ed25519", key_name=None, force=False
+        )
+        mock_register.assert_called_once_with("proj", fake_result)
+
+    @unittest.mock.patch("terok.cli.commands.setup.make_ssh_manager")
+    @unittest.mock.patch("terok.cli.commands.setup.register_ssh_key")
+    @unittest.mock.patch("terok.cli.commands.setup.load_project")
+    def test_ssh_init_passes_result_not_none(self, mock_load, mock_register, mock_ssh_cls) -> None:
+        """register_ssh_key must receive the actual result dict, not None."""
+        mock_ssh_cls.return_value.init.return_value = {"key": "value"}
+        mock_load.return_value = unittest.mock.Mock(id="proj2")
+
+        from terok.cli.commands.setup import dispatch
+
+        args = unittest.mock.Mock(cmd="ssh-init", project_id="proj2")
+        dispatch(args)
+
+        actual_result = mock_register.call_args[0][1]
+        assert actual_result is not None
+        assert actual_result == {"key": "value"}
+
+
 class TestSshPause:
     """Tests for the SSH key registration pause helper."""
 

--- a/tests/unit/cli/test_cli_workflows.py
+++ b/tests/unit/cli/test_cli_workflows.py
@@ -20,7 +20,7 @@ def _patch_init_steps[T](func: Callable[..., T]) -> Callable[..., T]:
     mock_gate_cls, mock_load.
     """
     func = unittest.mock.patch("terok.cli.commands.setup.make_ssh_manager")(func)
-    func = unittest.mock.patch("terok.cli.commands.setup._register_ssh_key")(func)
+    func = unittest.mock.patch("terok.cli.commands.setup.register_ssh_key")(func)
     func = unittest.mock.patch("terok.cli.commands.setup.maybe_pause_for_ssh_key_registration")(
         func
     )

--- a/tests/unit/lib/test_ssh.py
+++ b/tests/unit/lib/test_ssh.py
@@ -36,6 +36,45 @@ def write_keypair(ssh_dir: Path, key_name: str) -> None:
     (ssh_dir / f"{key_name}.pub").write_text("dummy", encoding="utf-8")
 
 
+class TestRegisterSshKey:
+    """Tests for register_ssh_key() in the domain facade."""
+
+    def test_register_calls_update_ssh_keys_json(self) -> None:
+        """register_ssh_key must delegate to update_ssh_keys_json with the right args."""
+        fake_result = {
+            "private_key": "/tmp/terok-testing/ssh/id_ed25519_proj",
+            "dir": "/tmp/terok-testing/ssh",
+        }
+        with (
+            unittest.mock.patch("terok_sandbox.update_ssh_keys_json") as m_update,
+            unittest.mock.patch("terok.lib.core.config.make_sandbox_config") as m_cfg,
+        ):
+            m_cfg.return_value.ssh_keys_json_path = Path("/tmp/terok-testing/ssh-keys.json")
+            from terok.lib.domain.facade import register_ssh_key
+
+            register_ssh_key("myproj", fake_result)
+
+        m_update.assert_called_once_with(
+            Path("/tmp/terok-testing/ssh-keys.json"), "myproj", fake_result
+        )
+
+    def test_register_propagates_errors(self) -> None:
+        """Errors from update_ssh_keys_json must propagate (no silent swallowing)."""
+        with (
+            unittest.mock.patch(
+                "terok_sandbox.update_ssh_keys_json", side_effect=OSError("disk full")
+            ),
+            unittest.mock.patch("terok.lib.core.config.make_sandbox_config") as m_cfg,
+        ):
+            m_cfg.return_value.ssh_keys_json_path = Path("/tmp/terok-testing/ssh-keys.json")
+            import pytest
+
+            from terok.lib.domain.facade import register_ssh_key
+
+            with pytest.raises(OSError, match="disk full"):
+                register_ssh_key("proj", {"private_key": "/tmp/terok-testing/k"})
+
+
 class TestSsh:
     """Tests for SSHManager init behavior."""
 

--- a/tests/unit/tui/test_detail_screens.py
+++ b/tests/unit/tui/test_detail_screens.py
@@ -676,6 +676,66 @@ class TestActionDispatch:
         instance._action_follow_logs.assert_called_once()
 
 
+class TestSSHKeyRegistration:
+    """TUI SSH init and project-init must register keys in ssh-keys.json."""
+
+    def _get_mixin(self):
+        """Import ProjectActionsMixin directly — avoids import_app() Textual stubs."""
+        from terok.tui.project_actions import ProjectActionsMixin
+
+        return ProjectActionsMixin
+
+    def test_action_init_ssh_registers_key(self) -> None:
+        """action_init_ssh must forward the init() result to register_ssh_key."""
+        mixin = self._get_mixin()
+        instance = mock.Mock(spec=mixin)
+        instance.current_project_id = "proj"
+        fake_result = {"private_key": "/tmp/terok-testing/k", "dir": "/tmp/terok-testing/d"}
+
+        with (
+            mock.patch("terok.tui.project_actions.make_ssh_manager") as m_ssh,
+            mock.patch("terok.tui.project_actions.register_ssh_key") as m_reg,
+            mock.patch("terok.tui.project_actions.load_project"),
+        ):
+            m_ssh.return_value.init.return_value = fake_result
+            instance._run_suspended = mock.AsyncMock(side_effect=lambda fn, **kw: fn())
+            run(mixin.action_init_ssh(instance))
+
+            m_reg.assert_called_once_with("proj", fake_result)
+
+    def test_action_project_init_registers_key(self) -> None:
+        """_action_project_init must register the SSH key (not discard the result)."""
+        mixin = self._get_mixin()
+        instance = mock.Mock(spec=mixin)
+        instance.current_project_id = "proj"
+        fake_result = {"private_key": "/tmp/terok-testing/k", "dir": "/tmp/terok-testing/d"}
+
+        with (
+            mock.patch("terok.tui.project_actions.make_ssh_manager") as m_ssh,
+            mock.patch("terok.tui.project_actions.register_ssh_key") as m_reg,
+            mock.patch("terok.tui.project_actions.load_project"),
+            mock.patch("terok.tui.project_actions.maybe_pause_for_ssh_key_registration"),
+            mock.patch("terok.tui.project_actions.generate_dockerfiles"),
+            mock.patch("terok.tui.project_actions.build_images"),
+            mock.patch("terok.tui.project_actions.make_git_gate") as m_gate,
+        ):
+            m_ssh.return_value.init.return_value = fake_result
+            m_gate.return_value.sync.return_value = {
+                "success": True,
+                "path": "/tmp/terok-testing/g",
+            }
+
+            async def run_work(fn, **kw):
+                fn()
+                return True
+
+            instance._run_suspended = run_work
+            instance.notify = mock.Mock()
+            run(mixin._action_project_init(instance))
+
+            m_reg.assert_called_once_with("proj", fake_result)
+
+
 class TestActionSelection:
     """Tests for task selection after task creation flows."""
 


### PR DESCRIPTION
## Summary

- TUI's `action_init_ssh()` and `_action_project_init()` called `SSHManager.init()` but **discarded the return value**, never writing the key to `ssh-keys.json`
- The credential proxy's SSH agent had no keys to serve → socat bridge inside containers died → git clone failed with "Host key verification failed"
- Extract `register_ssh_key()` to the domain facade (shared stable import boundary) and wire it into both TUI code paths
- CLI's `_register_ssh_key()` replaced with the shared facade function

## Test plan

- [x] New `TestSSHKeyRegistration` tests verify both `action_init_ssh` and `_action_project_init` forward the init result to `register_ssh_key`
- [x] Existing `TestProjectInit` CLI tests updated (mock target renamed)
- [x] Full unit suite passes (1634 tests)
- [ ] Manual: run `terok project-init` from TUI, verify `ssh-keys.json` is populated

Closes part of #685

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced SSH key registration workflow to ensure keys are properly registered across both CLI and TUI setup processes. SSH initialization and registration are now correctly sequenced during project setup.

* **Tests**
  * Added comprehensive unit tests for SSH key registration flows in project initialization and SSH-only setup workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->