### PR TITLE
feat: delegate proxy injection to executor, shrink terok proxy code (#688)

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -3063,13 +3063,13 @@ url = "https://github.com/terok-ai/terok-dbus/releases/download/v0.5.6/terok_dbu
 
 [[package]]
 name = "terok-executor"
-version = "0.0.72"
+version = "0.0.73"
 description = "Single-agent task runner for hardened Podman containers"
 optional = false
 python-versions = ">=3.12,<4.0"
 groups = ["main"]
 files = [
-    {file = "terok_executor-0.0.72-py3-none-any.whl", hash = "sha256:4d71e00eeb90c3e2d8ec7731c17906defefb4e34747aa809d3adfb540d94374d"},
+    {file = "terok_executor-0.0.73-py3-none-any.whl", hash = "sha256:5c5ee75f0262bda7c90933f436a26d4f30b62eebd39ac5604d7d20d02d65669d"},
 ]
 
 [package.dependencies]
@@ -3080,7 +3080,7 @@ tomli-w = ">=1.0"
 
 [package.source]
 type = "url"
-url = "https://github.com/terok-ai/terok-executor/releases/download/v0.0.72/terok_executor-0.0.72-py3-none-any.whl"
+url = "https://github.com/terok-ai/terok-executor/releases/download/v0.0.73/terok_executor-0.0.73-py3-none-any.whl"
 
 [[package]]
 name = "terok-sandbox"
@@ -3609,4 +3609,4 @@ propcache = ">=0.2.1"
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.12,<4.0"
-content-hash = "3555f6ddfe0436e1e02885aeccbd143d3b3dcf2278008950e6ec182e2ca00ce9"
+content-hash = "412841fe4067e89623033078cfa23ffb6957bd694c1e8b6064a41fccdc0e392b"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ rich = ">=13.0"
 platformdirs = ">=4.5.1"
 unique-namer = ">=1.3"
 textual-serve = ">=1.1.0"
-terok-executor = {url = "https://github.com/terok-ai/terok-executor/releases/download/v0.0.72/terok_executor-0.0.72-py3-none-any.whl"}
+terok-executor = {url = "https://github.com/terok-ai/terok-executor/releases/download/v0.0.73/terok_executor-0.0.73-py3-none-any.whl"}
 terok-sandbox = {url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.0.63/terok_sandbox-0.0.63-py3-none-any.whl"}
 terok-dbus = {url = "https://github.com/terok-ai/terok-dbus/releases/download/v0.5.6/terok_dbus-0.5.6-py3-none-any.whl"}
 

--- a/src/terok/lib/core/config.py
+++ b/src/terok/lib/core/config.py
@@ -556,14 +556,16 @@ def get_claude_expose_oauth_token() -> bool:
 
 
 def is_claude_oauth_proxied() -> bool:
-    """Return True when Claude OAuth is in tier 2 (proxy active, not exposed).
+    """Return True when Claude OAuth traffic is routed through the proxy.
 
-    Centralises the three-tier decision so callers don't duplicate the
+    Centralises the three-mode decision so callers don't duplicate the
     flag combination logic:
 
-    - **Tier 1** (default): experimental off or allow_oauth off — skip Claude OAuth.
-    - **Tier 2**: experimental + allow_oauth — proxy handles OAuth, shield denies
-      ``api.anthropic.com``.
-    - **Tier 3**: experimental + expose_oauth_token — proxy bypassed for Claude.
+    - **Skipped** (default): experimental off or allow_oauth off — Claude
+      OAuth bypasses the proxy entirely.
+    - **Proxied**: experimental + allow_oauth — proxy handles OAuth auth,
+      shield denies ``api.anthropic.com`` to prevent direct access.
+    - **Exposed**: experimental + expose_oauth_token — real OAuth token
+      mounted directly for Claude Code subscription features.
     """
     return is_experimental() and get_claude_allow_oauth() and not get_claude_expose_oauth_token()

--- a/src/terok/lib/core/config.py
+++ b/src/terok/lib/core/config.py
@@ -569,3 +569,13 @@ def is_claude_oauth_proxied() -> bool:
       mounted directly for Claude Code subscription features.
     """
     return is_experimental() and get_claude_allow_oauth() and not get_claude_expose_oauth_token()
+
+
+def is_claude_oauth_exposed() -> bool:
+    """Return True when the real Claude OAuth token is intentionally exposed.
+
+    Exposed mode trades token security for Claude Code subscription
+    features — the real ``.credentials.json`` is mounted directly
+    instead of being replaced with a phantom marker.
+    """
+    return is_experimental() and get_claude_expose_oauth_token()

--- a/src/terok/lib/domain/facade.py
+++ b/src/terok/lib/domain/facade.py
@@ -137,9 +137,9 @@ def authenticate(project_id: str, provider: str) -> None:
 
     Thin wrapper around the instrumentation-layer ``authenticate()`` that
     supplies ``mounts_dir`` and ``image`` from terok's config/image system.
-    When ``expose_oauth_token`` is active (tier 3), passes ``expose_token``
-    so the real credential file is preserved instead of being replaced with
-    a phantom marker.
+    When ``expose_oauth_token`` is active (exposed mode), passes
+    ``expose_token`` so the real credential file is preserved instead of
+    being replaced with a phantom marker.
     """
     from ..core.config import (
         get_claude_expose_oauth_token,

--- a/src/terok/lib/orchestration/environment.py
+++ b/src/terok/lib/orchestration/environment.py
@@ -266,7 +266,8 @@ def _warn_leaked_credentials() -> None:
         leaked = [(p, path) for p, path in leaked if p != "claude"]
 
     for provider, path in leaked:
-        _logger.warning("Real credential in shared mount: %s: %s", provider, path)
+        _logger.warning("Real credential in shared mount for provider %s", provider)
+        _logger.debug("  path: %s", path)
 
 
 # ---------- Clone-cache workspace seeding ----------

--- a/src/terok/lib/orchestration/environment.py
+++ b/src/terok/lib/orchestration/environment.py
@@ -382,8 +382,7 @@ def build_task_env_and_volumes(
     if "EXTERNAL_REMOTE_URL" in sec_env:
         env["EXTERNAL_REMOTE_URL"] = sec_env["EXTERNAL_REMOTE_URL"]
 
-    # Claude OAuth tier gating (terok-specific policy on top of executor's
-    # generic proxy injection) + leaked-cred scan with tier 3 filtering
+    # Claude OAuth overrides + leaked-cred scan with exposed-token filtering
     if not proxy_bypass:
         _apply_claude_oauth_overrides(env)
         _warn_leaked_credentials()

--- a/src/terok/lib/orchestration/environment.py
+++ b/src/terok/lib/orchestration/environment.py
@@ -225,7 +225,7 @@ def _apply_claude_oauth_overrides(env: dict[str, str]) -> None:
     if is_claude_oauth_proxied():
         # Proxied: remove phantom token (the mounted .credentials.json
         # marker is used for auth), keep ANTHROPIC_BASE_URL for routing
-        del env["CLAUDE_CODE_OAUTH_TOKEN"]
+        env.pop("CLAUDE_CODE_OAUTH_TOKEN", None)
     else:
         # Skipped or exposed: remove all Claude proxy env vars
         for key in ("CLAUDE_CODE_OAUTH_TOKEN", "ANTHROPIC_BASE_URL", "ANTHROPIC_UNIX_SOCKET"):
@@ -240,19 +240,27 @@ def _warn_leaked_credentials() -> None:
     """
     from terok_executor import scan_leaked_credentials
 
-    from ..core.config import get_claude_expose_oauth_token, is_experimental
+    from ..core.config import is_claude_oauth_exposed
+    from ..util.ansi import bold, supports_color, yellow
 
     leaked = scan_leaked_credentials(sandbox_live_mounts_dir())
 
-    if is_experimental() and get_claude_expose_oauth_token():
+    if is_claude_oauth_exposed():
         import sys
 
+        color = supports_color()
         print(
-            "\n\033[1;33m"
-            "  WARNING: Claude OAuth token is EXPOSED to all task containers.\n"
-            "  The credential proxy does NOT protect this token — it is mounted\n"
-            "  directly via .credentials.json in the shared config directory.\n"
-            "  Every task container managed by terok can read the real token.\033[0m\n",
+            "\n"
+            + bold(
+                yellow(
+                    "  WARNING: Claude OAuth token is EXPOSED to all task containers.\n"
+                    "  The credential proxy does NOT protect this token — it is mounted\n"
+                    "  directly via .credentials.json in the shared config directory.\n"
+                    "  Every task container managed by terok can read the real token.\n",
+                    color,
+                ),
+                color,
+            ),
             file=sys.stderr,
         )
         leaked = [(p, path) for p, path in leaked if p != "claude"]
@@ -364,12 +372,13 @@ def build_task_env_and_volumes(
             human_email=project.human_email or "nobody@localhost",
             credential_scope=project.id,
             proxy_transport=get_credential_proxy_transport(),
-            proxy_required=True,
+            proxy_required=not proxy_bypass,
             unrestricted=False,  # task_runners resolves per-provider config
             shared_dir=None if sealed else project.shared_dir,
             envs_dir=sandbox_live_mounts_dir(),
         ),
         get_roster(),
+        # bypass → skip proxy entirely (no tokens, no check)
         caller_manages_proxy=proxy_bypass,
     )
 

--- a/src/terok/lib/orchestration/environment.py
+++ b/src/terok/lib/orchestration/environment.py
@@ -483,6 +483,8 @@ def build_task_env_and_volumes(
 
     from terok_executor import ContainerEnvSpec, assemble_container_env, get_roster
 
+    from ..core.config import get_credential_proxy_transport
+
     result = assemble_container_env(
         ContainerEnvSpec(
             task_id=task_id,
@@ -499,6 +501,9 @@ def build_task_env_and_volumes(
             human_name=project.human_name or "Nobody",
             human_email=project.human_email or "nobody@localhost",
             credential_scope=project.id,
+            proxy_transport=get_credential_proxy_transport(),
+            proxy_required=True,
+            scan_leaked_creds=True,
             unrestricted=False,  # task_runners resolves per-provider config
             shared_dir=None if sealed else project.shared_dir,
             envs_dir=sandbox_live_mounts_dir(),

--- a/src/terok/lib/orchestration/environment.py
+++ b/src/terok/lib/orchestration/environment.py
@@ -171,34 +171,7 @@ def apply_git_identity_env(
     )
 
 
-# ---------- SSH keys JSON ----------
-
-
-def _load_ssh_keys_json(path: Path) -> dict[str, list[dict[str, str]]]:
-    """Load the SSH key mapping JSON.  Returns empty dict if missing or malformed."""
-    import json
-
-    from ..util.logging_utils import warn_user
-
-    if not path.is_file():
-        return {}
-    try:
-        result = json.loads(path.read_text(encoding="utf-8"))
-        return result if isinstance(result, dict) else {}
-    except json.JSONDecodeError as exc:
-        warn_user("ssh", f"Malformed SSH keys file {path}: {exc}. SSH key injection disabled.")
-        return {}
-    except (OSError, UnicodeDecodeError) as exc:
-        warn_user("ssh", f"Cannot read SSH keys file {path}: {exc}. SSH key injection disabled.")
-        return {}
-
-
 # ---------- Credential proxy ----------
-
-
-def _credential_type(cred: dict) -> str:
-    """Return the credential type from the stored ``type`` field."""
-    return cred.get("type") or "api_key"
 
 
 def ensure_credential_proxy() -> None:
@@ -229,160 +202,53 @@ def ensure_credential_proxy() -> None:
         ) from exc
 
 
-def _skip_claude_oauth() -> bool:
-    """Return True when Claude OAuth should be excluded from the credential proxy.
+def _apply_claude_oauth_overrides(env: dict[str, str]) -> None:
+    """Adjust Claude OAuth env vars based on the experimental proxy config.
 
-    Only tier 2 (proxy active, not exposed) keeps Claude OAuth in the proxy.
-    Tiers 1 and 3 both skip it — tier 1 because the path is broken
-    (hardcoded ``BASE_API_URL``), tier 3 because Claude manages its own
-    credentials directly.
+    Executor handles all generic proxy plumbing (phantom tokens, transport,
+    SSH agent).  This function only adjusts Claude-specific env vars:
+
+    - **Proxied** (``is_claude_oauth_proxied``): remove phantom token, keep
+      ``ANTHROPIC_BASE_URL`` — the container uses the mounted
+      ``.credentials.json`` marker directly with the proxy.
+    - **Skipped** (default): remove all Claude proxy env vars — Claude Code's
+      hardcoded ``BASE_API_URL`` bypasses the proxy anyway.
+    - **Exposed** (``expose_oauth_token``): also removes vars — the real
+      OAuth token is mounted directly for Claude Code subscription features.
     """
     from ..core.config import is_claude_oauth_proxied
 
-    return not is_claude_oauth_proxied()
+    # Only act when executor injected Claude OAuth vars
+    if "CLAUDE_CODE_OAUTH_TOKEN" not in env:
+        return
+
+    if is_claude_oauth_proxied():
+        # Proxied: remove phantom token (the mounted .credentials.json
+        # marker is used for auth), keep ANTHROPIC_BASE_URL for routing
+        del env["CLAUDE_CODE_OAUTH_TOKEN"]
+    else:
+        # Skipped or exposed: remove all Claude proxy env vars
+        for key in ("CLAUDE_CODE_OAUTH_TOKEN", "ANTHROPIC_BASE_URL", "ANTHROPIC_UNIX_SOCKET"):
+            env.pop(key, None)
 
 
-def _credential_proxy_env_and_volumes(
-    project: ProjectConfig, task_id: str
-) -> tuple[dict[str, str], list[str]]:
-    """Return env vars and volumes for the credential proxy.
+def _warn_leaked_credentials() -> None:
+    """Warn about real credential files in shared mounts.
 
-    Injects phantom token env vars and transport overrides (HTTP base URL or
-    Unix socket path) pointing to the proxy.  The choice of env vars depends
-    on two orthogonal dimensions:
-
-    - **Auth**: stored credential type (``api_key`` → :attr:`phantom_env`,
-      ``oauth`` → :attr:`oauth_phantom_env`).
-    - **Transport**: global config ``credential_proxy.transport``
-      (``direct`` → :attr:`base_url_env`, ``socket`` → :attr:`socket_env`).
-
-    Raises ``SystemExit`` if the proxy is not running — no silent fallback.
-    The only way to skip the proxy is the explicit bypass flag
-    ``credential_proxy.bypass_no_secret_protection`` in global config.
+    When the Claude OAuth token is intentionally exposed (for Claude Code
+    subscription features), the Claude-specific warning is suppressed.
     """
-    from ..core.config import get_credential_proxy_bypass, get_credential_proxy_transport
-
-    if get_credential_proxy_bypass():
-        return {}, []
-
-    from terok_executor import get_roster
-    from terok_sandbox import (
-        CredentialDB,
-        ProxyUnreachableError,
-        ensure_proxy_reachable,
-        get_proxy_port,
-        get_ssh_agent_port,
-    )
-
-    cfg = make_sandbox_config()
-    try:
-        ensure_proxy_reachable(cfg)
-    except ProxyUnreachableError as exc:
-        raise SystemExit(
-            f"{exc}\n\n"
-            "Start it with:\n"
-            "  terok credential-proxy install   (systemd socket activation)\n"
-            "  terok credential-proxy start     (manual daemon)"
-        ) from exc
-
-    roster = get_roster()
-    proxy_routes = roster.proxy_routes
-    use_socket = get_credential_proxy_transport() == "socket"
-
-    db = CredentialDB(cfg.proxy_db_path)
-    try:
-        credential_set = "default"
-        stored_providers = set(db.list_credentials(credential_set))
-        routed = stored_providers & proxy_routes.keys()
-        tokens: dict[str, str] = {}
-        credential_types: dict[str, str] = {}
-        for name in routed:
-            cred = db.load_credential(credential_set, name)
-            ctype = _credential_type(cred) if cred else "api_key"
-            credential_types[name] = ctype
-            # Claude OAuth never needs a per-task phantom token — the static
-            # marker in .credentials.json is accepted by the proxy directly.
-            # Tier gating (skip vs proxy vs expose) happens in the env loop below.
-            if name == "claude" and ctype == "oauth":
-                continue
-            tokens[name] = db.create_proxy_token(project.id, task_id, credential_set, name)
-
-        # SSH agent: create phantom token if project has at least one valid key registered
-        ssh_keys = _load_ssh_keys_json(cfg.ssh_keys_json_path)
-        ssh_entry = ssh_keys.get(project.id)
-        if isinstance(ssh_entry, list) and any(
-            e.get("private_key") and e.get("public_key") for e in ssh_entry
-        ):
-            ssh_token = db.create_proxy_token(project.id, task_id, project.id, "ssh")
-        else:
-            ssh_token = None
-    finally:
-        db.close()
-
-    port = get_proxy_port(cfg)
-    proxy_base = f"http://host.containers.internal:{port}"
-    env: dict[str, str] = {}
-
-    for name, route in proxy_routes.items():
-        if name not in routed:
-            continue
-
-        is_oauth = credential_types[name] == "oauth"
-
-        # Claude OAuth: tier gating (see _skip_claude_oauth / is_claude_oauth_proxied).
-        if name == "claude" and is_oauth:
-            if _skip_claude_oauth():
-                continue
-            if route.base_url_env:
-                env[route.base_url_env] = proxy_base
-            continue
-
-        # Auth dimension: select phantom env vars by credential type.
-        # Providers with oauth_phantom_env get OAuth-specific env vars;
-        # others fall back to phantom_env (same env var for both auth types).
-        token_vars = (
-            route.oauth_phantom_env if (is_oauth and route.oauth_phantom_env) else route.phantom_env
-        )
-        for env_var in token_vars:
-            env[env_var] = tokens[name]
-
-        # Transport dimension: socket flag + HTTP base URL.
-        if use_socket and route.socket_path and route.socket_env:
-            env[route.socket_env] = route.socket_path
-        if route.base_url_env:
-            env[route.base_url_env] = proxy_base
-
-        # Override OpenCode base URL for proxied providers (the original
-        # value from collect_opencode_provider_env points to the real upstream;
-        # this override redirects through the proxy instead)
-        oc_provider = roster.providers.get(name)
-        if oc_provider and oc_provider.opencode_config:
-            env[f"TEROK_OC_{name.upper()}_BASE_URL"] = f"{proxy_base}/v1"
-        if name == "glab":
-            env["GITLAB_API_HOST"] = f"host.containers.internal:{port}"
-            env["API_PROTOCOL"] = "http"
-
-    if routed:
-        env["TEROK_PROXY_PORT"] = str(port)
-
-    if ssh_token:
-        env["TEROK_SSH_AGENT_TOKEN"] = ssh_token
-        env["TEROK_SSH_AGENT_PORT"] = str(get_ssh_agent_port(cfg))
-
-    # Warn about real credential files in shared mounts that will be visible
-    # to the container alongside proxy phantom tokens.
     from terok_executor import scan_leaked_credentials
 
-    leaked = scan_leaked_credentials(sandbox_live_mounts_dir())
-    # Tier 3: suppress warning for Claude when expose_oauth_token is active —
-    # real credentials in the shared mount are intentional.
     from ..core.config import get_claude_expose_oauth_token, is_experimental
 
-    if is_experimental() and get_claude_expose_oauth_token():  # tier 3: intentional
+    leaked = scan_leaked_credentials(sandbox_live_mounts_dir())
+
+    if is_experimental() and get_claude_expose_oauth_token():
         import sys
 
         print(
-            "\n\033[1;33m"  # bold yellow
+            "\n\033[1;33m"
             "  WARNING: Claude OAuth token is EXPOSED to all task containers.\n"
             "  The credential proxy does NOT protect this token — it is mounted\n"
             "  directly via .credentials.json in the shared config directory.\n"
@@ -390,18 +256,9 @@ def _credential_proxy_env_and_volumes(
             file=sys.stderr,
         )
         leaked = [(p, path) for p, path in leaked if p != "claude"]
-    if leaked:
-        import sys
 
-        print("WARNING: Real credentials in shared mounts:", file=sys.stderr)
-        for provider, path in leaked:
-            print(f"  {provider}: {path}", file=sys.stderr)
-        print(
-            "Remove these files — containers should only see proxy tokens.",
-            file=sys.stderr,
-        )
-
-    return env, []
+    for provider, path in leaked:
+        _logger.warning("Real credential in shared mount: %s: %s", provider, path)
 
 
 # ---------- Clone-cache workspace seeding ----------
@@ -483,7 +340,12 @@ def build_task_env_and_volumes(
 
     from terok_executor import ContainerEnvSpec, assemble_container_env, get_roster
 
-    from ..core.config import get_credential_proxy_transport
+    from ..core.config import get_credential_proxy_bypass, get_credential_proxy_transport
+
+    # Proxy: bypass → no proxy at all; otherwise ensure it's up before assembly
+    proxy_bypass = get_credential_proxy_bypass()
+    if not proxy_bypass:
+        ensure_credential_proxy()
 
     result = assemble_container_env(
         ContainerEnvSpec(
@@ -503,13 +365,12 @@ def build_task_env_and_volumes(
             credential_scope=project.id,
             proxy_transport=get_credential_proxy_transport(),
             proxy_required=True,
-            scan_leaked_creds=True,
             unrestricted=False,  # task_runners resolves per-provider config
             shared_dir=None if sealed else project.shared_dir,
             envs_dir=sandbox_live_mounts_dir(),
         ),
         get_roster(),
-        caller_manages_proxy=True,  # terok injects richer per-provider proxy tokens below
+        caller_manages_proxy=proxy_bypass,
     )
 
     env = dict(result.env)
@@ -521,8 +382,10 @@ def build_task_env_and_volumes(
     if "EXTERNAL_REMOTE_URL" in sec_env:
         env["EXTERNAL_REMOTE_URL"] = sec_env["EXTERNAL_REMOTE_URL"]
 
-    # Credential proxy: full OAuth / socket / SSH support (terok-specific)
-    proxy_env, _proxy_volumes = _credential_proxy_env_and_volumes(project, task_id)
-    env.update(proxy_env)
+    # Claude OAuth tier gating (terok-specific policy on top of executor's
+    # generic proxy injection) + leaked-cred scan with tier 3 filtering
+    if not proxy_bypass:
+        _apply_claude_oauth_overrides(env)
+        _warn_leaked_credentials()
 
     return env, volumes

--- a/src/terok/lib/orchestration/task_runners.py
+++ b/src/terok/lib/orchestration/task_runners.py
@@ -259,10 +259,11 @@ def _drop_shield_on_creation(cname: str, task_dir: Path) -> None:
 
 
 def _maybe_deny_anthropic_api(cname: str, task_dir: Path) -> None:
-    """Block ``api.anthropic.com`` when Claude OAuth is proxied (tier 2).
+    """Block ``api.anthropic.com`` when Claude OAuth is proxied.
 
     When the shield is down, deny sets prevent phantom tokens from leaking
-    to Anthropic's hardcoded ``BASE_API_URL`` endpoint.  No-op for tiers 1/3.
+    to Anthropic's hardcoded ``BASE_API_URL`` endpoint.  No-op when Claude
+    OAuth is skipped or exposed.
     """
     from ..core.config import is_claude_oauth_proxied
 

--- a/tach.toml
+++ b/tach.toml
@@ -632,6 +632,7 @@ expose = [
     "get_claude_allow_oauth",
     "get_claude_expose_oauth_token",
     "is_claude_oauth_proxied",
+    "is_claude_oauth_exposed",
     "get_credential_proxy_bypass",
     "get_credential_proxy_transport",
     "get_shield_bypass_firewall_no_protection",

--- a/tests/unit/lib/test_config.py
+++ b/tests/unit/lib/test_config.py
@@ -632,3 +632,28 @@ def test_is_claude_oauth_not_proxied_when_exposed(
         ),
     )
     assert cfg.is_claude_oauth_proxied() is False
+
+
+def test_is_claude_oauth_exposed(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """``is_claude_oauth_exposed()`` returns True when experimental + expose_oauth_token."""
+    monkeypatch.setenv(
+        "TEROK_CONFIG_FILE",
+        str(
+            write_config(
+                tmp_path,
+                "experimental: true\nagent:\n  claude:\n    expose_oauth_token: true\n",
+            )
+        ),
+    )
+    assert cfg.is_claude_oauth_exposed() is True
+
+
+def test_is_claude_oauth_not_exposed_by_default(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """``is_claude_oauth_exposed()`` returns False when experimental is off."""
+    monkeypatch.setenv(
+        "TEROK_CONFIG_FILE",
+        str(write_config(tmp_path, "agent:\n  claude:\n    expose_oauth_token: true\n")),
+    )
+    assert cfg.is_claude_oauth_exposed() is False

--- a/tests/unit/lib/test_config.py
+++ b/tests/unit/lib/test_config.py
@@ -605,8 +605,10 @@ def test_claude_agent_config_non_dict_returns_empty(
     assert cfg.get_claude_expose_oauth_token() is False
 
 
-def test_is_claude_oauth_proxied_tier2(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
-    """``is_claude_oauth_proxied()`` returns True for tier 2."""
+def test_is_claude_oauth_proxied_when_allowed(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """``is_claude_oauth_proxied()`` returns True when experimental + allow_oauth."""
     monkeypatch.setenv(
         "TEROK_CONFIG_FILE",
         str(
@@ -616,8 +618,10 @@ def test_is_claude_oauth_proxied_tier2(monkeypatch: pytest.MonkeyPatch, tmp_path
     assert cfg.is_claude_oauth_proxied() is True
 
 
-def test_is_claude_oauth_proxied_tier3(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
-    """``is_claude_oauth_proxied()`` returns False for tier 3 (expose overrides)."""
+def test_is_claude_oauth_not_proxied_when_exposed(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """``is_claude_oauth_proxied()`` returns False when token is exposed."""
     monkeypatch.setenv(
         "TEROK_CONFIG_FILE",
         str(

--- a/tests/unit/lib/test_credential_proxy_env.py
+++ b/tests/unit/lib/test_credential_proxy_env.py
@@ -95,7 +95,10 @@ class TestLeakedCredentialsScan:
         ):
             _warn_leaked_credentials()
 
-        assert any("claude" in r.message for r in caplog.records)
+        warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+        assert any("claude" in r.message for r in warnings)
+        # Full path must not leak at WARNING — only at DEBUG
+        assert not any(".credentials.json" in r.message for r in warnings)
 
     def test_exposed_token_suppresses_claude_warning(
         self, capsys: pytest.CaptureFixture[str], caplog: pytest.LogCaptureFixture

--- a/tests/unit/lib/test_credential_proxy_env.py
+++ b/tests/unit/lib/test_credential_proxy_env.py
@@ -5,7 +5,7 @@
 
 Generic proxy plumbing (phantom tokens, socket transport, SSH agent) is
 tested in terok-executor (test_env_builder.py).  These tests cover the
-terok-only Claude OAuth tier gating and leaked-credential scan with
+terok-only Claude OAuth mode overrides and leaked-credential scan with
 exposed-token filtering.
 """
 
@@ -19,7 +19,7 @@ import pytest
 
 
 class TestClaudeOAuthOverrides:
-    """Verify _apply_claude_oauth_overrides tier gating."""
+    """Verify _apply_claude_oauth_overrides mode selection."""
 
     def test_proxied_removes_token_keeps_base_url(self) -> None:
         """Claude OAuth proxied → remove phantom token, keep base URL."""

--- a/tests/unit/lib/test_credential_proxy_env.py
+++ b/tests/unit/lib/test_credential_proxy_env.py
@@ -91,7 +91,7 @@ class TestLeakedCredentialsScan:
                 "terok_executor.scan_leaked_credentials",
                 return_value=[("claude", Path("/tmp/terok-testing/m/.credentials.json"))],
             ),
-            patch("terok.lib.core.config.is_experimental", return_value=False),
+            patch("terok.lib.core.config.is_claude_oauth_exposed", return_value=False),
         ):
             _warn_leaked_credentials()
 
@@ -116,8 +116,7 @@ class TestLeakedCredentialsScan:
                     ("vibe", Path("/tmp/terok-testing/m/config.toml")),
                 ],
             ),
-            patch("terok.lib.core.config.is_experimental", return_value=True),
-            patch("terok.lib.core.config.get_claude_expose_oauth_token", return_value=True),
+            patch("terok.lib.core.config.is_claude_oauth_exposed", return_value=True),
         ):
             _warn_leaked_credentials()
 

--- a/tests/unit/lib/test_credential_proxy_env.py
+++ b/tests/unit/lib/test_credential_proxy_env.py
@@ -1,490 +1,130 @@
 # SPDX-FileCopyrightText: 2026 Jiri Vyskocil
 # SPDX-License-Identifier: Apache-2.0
 
-"""Tests for credential proxy environment integration.
+"""Tests for terok-specific credential proxy overrides.
 
-These tests exercise the proxy-enabled path by overriding the autouse
-bypass fixture and mocking proxy/DB dependencies directly.
+Generic proxy plumbing (phantom tokens, socket transport, SSH agent) is
+tested in terok-executor (test_env_builder.py).  These tests cover the
+terok-only Claude OAuth tier gating and leaked-credential scan with
+exposed-token filtering.
 """
 
 from __future__ import annotations
 
-from collections.abc import Iterator
+import logging
 from pathlib import Path
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 import pytest
-from pytest import CaptureFixture
 
 
-@pytest.fixture()
-def _enable_proxy() -> Iterator[None]:
-    """Override the autouse bypass to test the proxy-enabled path."""
-    with (
-        patch("terok.lib.core.config.get_credential_proxy_bypass", return_value=False),
-        patch("terok_sandbox.credentials.lifecycle._wait_for_ready", return_value=True),
-        patch("terok_sandbox.credentials.lifecycle._wait_for_tcp_port", return_value=True),
-    ):
-        yield
+class TestClaudeOAuthOverrides:
+    """Verify _apply_claude_oauth_overrides tier gating."""
 
+    def test_proxied_removes_token_keeps_base_url(self) -> None:
+        """Claude OAuth proxied → remove phantom token, keep base URL."""
+        from terok.lib.orchestration.environment import _apply_claude_oauth_overrides
 
-class TestCredentialProxyEnv:
-    """Verify _credential_proxy_env_and_volumes."""
+        env = {
+            "CLAUDE_CODE_OAUTH_TOKEN": "terok-p-abc",
+            "ANTHROPIC_BASE_URL": "http://host.containers.internal:18731",
+            "ANTHROPIC_UNIX_SOCKET": "/tmp/terok-claude-proxy.sock",
+            "TEROK_PROXY_PORT": "18731",
+        }
+        with patch("terok.lib.core.config.is_claude_oauth_proxied", return_value=True):
+            _apply_claude_oauth_overrides(env)
 
-    def test_bypass_returns_empty(self) -> None:
-        """When bypass is set, returns empty env and volumes."""
-        from terok.lib.orchestration.environment import _credential_proxy_env_and_volumes
-
-        project = MagicMock()
-        # The autouse fixture sets bypass=True, so this should return empty
-        env, volumes = _credential_proxy_env_and_volumes(project, "task-1")
-        assert env == {}
-        assert volumes == []
-
-    @pytest.mark.usefixtures("_enable_proxy")
-    def test_proxy_not_running_raises(self) -> None:
-        """When proxy is not running and bypass is off, raises SystemExit."""
-        from terok.lib.orchestration.environment import _credential_proxy_env_and_volumes
-
-        project = MagicMock()
-        with (
-            patch("terok_sandbox.credentials.lifecycle.is_socket_active", return_value=False),
-            patch("terok_sandbox.credentials.lifecycle.is_daemon_running", return_value=False),
-            pytest.raises(SystemExit, match="not reachable"),
-        ):
-            _credential_proxy_env_and_volumes(project, "task-1")
-
-    @pytest.mark.usefixtures("_enable_proxy")
-    def test_proxy_running_injects_phantom_tokens(self, tmp_path: Path) -> None:
-        """When proxy runs and API key credentials exist, injects phantom env vars."""
-        from terok_sandbox import CredentialDB
-
-        from terok.lib.orchestration.environment import _credential_proxy_env_and_volumes
-
-        # Set up a real DB with a credential
-        db_path = tmp_path / "proxy" / "credentials.db"
-        db = CredentialDB(db_path)
-        db.store_credential("default", "claude", {"type": "api_key", "key": "sk-test"})
-        db.close()
-
-        sock_path = tmp_path / "proxy.sock"
-        sock_path.touch()
-
-        project = MagicMock()
-        project.id = "test-project"
-
-        with (
-            patch("terok_sandbox.credentials.lifecycle.is_daemon_running", return_value=True),
-            patch("terok_sandbox.ensure_proxy_reachable"),
-            patch("terok.lib.orchestration.environment.make_sandbox_config") as mock_cfg_fn,
-            patch("terok.lib.core.config.get_credential_proxy_transport", return_value="direct"),
-        ):
-            mock_cfg = mock_cfg_fn.return_value
-            mock_cfg.proxy_db_path = db_path
-            mock_cfg.proxy_socket_path = sock_path
-            mock_cfg.proxy_port = 18731
-            mock_cfg.ssh_keys_json_path = tmp_path / "ssh-keys.json"
-
-            env, volumes = _credential_proxy_env_and_volumes(project, "task-1")
-
-        # Phantom token should be injected for Claude
-        assert "ANTHROPIC_API_KEY" in env
-        assert env["ANTHROPIC_API_KEY"].startswith("terok-p-")  # prefixed phantom token
-        # Base URL override — TCP via host.containers.internal
-        assert "ANTHROPIC_BASE_URL" in env
-        assert "host.containers.internal:18731" in env["ANTHROPIC_BASE_URL"]
-        # No socket mount (TCP transport)
-        assert volumes == []
-
-    @pytest.mark.usefixtures("_enable_proxy")
-    def test_only_stored_providers_get_phantom_tokens(self, tmp_path: Path) -> None:
-        """Providers without stored credentials don't get phantom tokens."""
-        from terok_sandbox import CredentialDB
-
-        from terok.lib.orchestration.environment import _credential_proxy_env_and_volumes
-
-        db_path = tmp_path / "proxy" / "credentials.db"
-        db = CredentialDB(db_path)
-        db.store_credential("default", "vibe", {"type": "api_key", "key": "k"})
-        db.close()
-
-        sock_path = tmp_path / "proxy.sock"
-        sock_path.touch()
-
-        project = MagicMock()
-        project.id = "test-project"
-
-        with (
-            patch("terok_sandbox.credentials.lifecycle.is_daemon_running", return_value=True),
-            patch("terok_sandbox.ensure_proxy_reachable"),
-            patch("terok.lib.orchestration.environment.make_sandbox_config") as mock_cfg_fn,
-            patch("terok.lib.core.config.get_credential_proxy_transport", return_value="direct"),
-        ):
-            mock_cfg = mock_cfg_fn.return_value
-            mock_cfg.proxy_db_path = db_path
-            mock_cfg.proxy_socket_path = sock_path
-            mock_cfg.proxy_port = 18731
-            mock_cfg.ssh_keys_json_path = tmp_path / "ssh-keys.json"
-
-            env, _volumes = _credential_proxy_env_and_volumes(project, "task-1")
-
-        # Vibe credential stored → phantom token injected
-        assert "MISTRAL_API_KEY" in env
-        # Claude NOT stored → no phantom token
-        assert "ANTHROPIC_API_KEY" not in env
-
-    @pytest.mark.usefixtures("_enable_proxy")
-    def test_claude_oauth_only_base_url(self, tmp_path: Path) -> None:
-        """Claude OAuth (tier 2) → only ANTHROPIC_BASE_URL (no token env vars, no socket flag)."""
-        from terok_sandbox import CredentialDB
-
-        from terok.lib.orchestration.environment import _credential_proxy_env_and_volumes
-
-        db_path = tmp_path / "proxy" / "credentials.db"
-        db = CredentialDB(db_path)
-        db.store_credential("default", "claude", {"type": "oauth", "access_token": "tok"})
-        db.close()
-
-        sock_path = tmp_path / "proxy.sock"
-        sock_path.touch()
-
-        project = MagicMock()
-        project.id = "test-project"
-
-        with (
-            patch("terok_sandbox.credentials.lifecycle.is_daemon_running", return_value=True),
-            patch("terok_sandbox.ensure_proxy_reachable"),
-            patch("terok.lib.orchestration.environment.make_sandbox_config") as mock_cfg_fn,
-            patch("terok.lib.core.config.get_credential_proxy_transport", return_value="direct"),
-            patch("terok.lib.orchestration.environment._skip_claude_oauth", return_value=False),
-        ):
-            mock_cfg = mock_cfg_fn.return_value
-            mock_cfg.proxy_db_path = db_path
-            mock_cfg.proxy_socket_path = sock_path
-            mock_cfg.proxy_port = 18731
-            mock_cfg.ssh_keys_json_path = tmp_path / "ssh-keys.json"
-
-            env, _ = _credential_proxy_env_and_volumes(project, "task-1")
-
-        # Claude OAuth uses the static marker in .credentials.json — no env var token
         assert "CLAUDE_CODE_OAUTH_TOKEN" not in env
-        assert "ANTHROPIC_API_KEY" not in env
-        assert "ANTHROPIC_UNIX_SOCKET" not in env
-        # Only base URL for HTTP routing to the proxy
         assert "ANTHROPIC_BASE_URL" in env
-        assert "host.containers.internal:18731" in env["ANTHROPIC_BASE_URL"]
+        # Socket and proxy port are unrelated to Claude tier — untouched
+        assert "ANTHROPIC_UNIX_SOCKET" in env
+        assert "TEROK_PROXY_PORT" in env
 
-    @pytest.mark.usefixtures("_enable_proxy")
-    def test_claude_oauth_skipped_by_default(self, tmp_path: Path) -> None:
-        """Claude OAuth (tier 1, default) → no ANTHROPIC env vars at all."""
-        from terok_sandbox import CredentialDB
+    def test_skipped_removes_all_claude_vars(self) -> None:
+        """Claude OAuth skipped (default) → remove all Claude proxy env vars."""
+        from terok.lib.orchestration.environment import _apply_claude_oauth_overrides
 
-        from terok.lib.orchestration.environment import _credential_proxy_env_and_volumes
+        env = {
+            "CLAUDE_CODE_OAUTH_TOKEN": "terok-p-abc",
+            "ANTHROPIC_BASE_URL": "http://host.containers.internal:18731",
+            "ANTHROPIC_UNIX_SOCKET": "/tmp/terok-claude-proxy.sock",
+            "TEROK_PROXY_PORT": "18731",
+            "MISTRAL_API_KEY": "terok-p-vibe",
+        }
+        with patch("terok.lib.core.config.is_claude_oauth_proxied", return_value=False):
+            _apply_claude_oauth_overrides(env)
 
-        db_path = tmp_path / "proxy" / "credentials.db"
-        db = CredentialDB(db_path)
-        db.store_credential("default", "claude", {"type": "oauth", "access_token": "tok"})
-        db.close()
-
-        sock_path = tmp_path / "proxy.sock"
-        sock_path.touch()
-
-        project = MagicMock()
-        project.id = "test-project"
-
-        with (
-            patch("terok_sandbox.credentials.lifecycle.is_daemon_running", return_value=True),
-            patch("terok_sandbox.ensure_proxy_reachable"),
-            patch("terok.lib.orchestration.environment.make_sandbox_config") as mock_cfg_fn,
-            patch("terok.lib.core.config.get_credential_proxy_transport", return_value="direct"),
-        ):
-            mock_cfg = mock_cfg_fn.return_value
-            mock_cfg.proxy_db_path = db_path
-            mock_cfg.proxy_socket_path = sock_path
-            mock_cfg.proxy_port = 18731
-            mock_cfg.ssh_keys_json_path = tmp_path / "ssh-keys.json"
-
-            env, _ = _credential_proxy_env_and_volumes(project, "task-1")
-
-        # Tier 1 (default): Claude OAuth is skipped entirely
-        assert "ANTHROPIC_API_KEY" not in env
+        assert "CLAUDE_CODE_OAUTH_TOKEN" not in env
         assert "ANTHROPIC_BASE_URL" not in env
-        assert "CLAUDE_CODE_OAUTH_TOKEN" not in env
-
-    @pytest.mark.usefixtures("_enable_proxy")
-    def test_non_claude_oauth_still_uses_phantom_env(self, tmp_path: Path) -> None:
-        """Non-Claude OAuth provider still gets phantom token env vars."""
-        from terok_sandbox import CredentialDB
-
-        from terok.lib.orchestration.environment import _credential_proxy_env_and_volumes
-
-        db_path = tmp_path / "proxy" / "credentials.db"
-        db = CredentialDB(db_path)
-        db.store_credential("default", "codex", {"type": "oauth", "access_token": "tok"})
-        db.close()
-
-        sock_path = tmp_path / "proxy.sock"
-        sock_path.touch()
-        project = MagicMock()
-        project.id = "test-project"
-
-        with (
-            patch("terok_sandbox.credentials.lifecycle.is_daemon_running", return_value=True),
-            patch("terok_sandbox.ensure_proxy_reachable"),
-            patch("terok.lib.orchestration.environment.make_sandbox_config") as mock_cfg_fn,
-            patch("terok.lib.core.config.get_credential_proxy_transport", return_value="direct"),
-        ):
-            mock_cfg = mock_cfg_fn.return_value
-            mock_cfg.proxy_db_path = db_path
-            mock_cfg.proxy_socket_path = sock_path
-            mock_cfg.proxy_port = 18731
-            mock_cfg.ssh_keys_json_path = tmp_path / "ssh-keys.json"
-
-            env, _ = _credential_proxy_env_and_volumes(project, "task-1")
-
-        # Codex OAuth still gets phantom token env var (static marker is Claude-only)
-        assert "OPENAI_API_KEY" in env
-        assert env["OPENAI_API_KEY"].startswith("terok-p-")
-
-    @pytest.mark.usefixtures("_enable_proxy")
-    def test_claude_oauth_socket_transport_still_only_base_url(self, tmp_path: Path) -> None:
-        """Claude OAuth (tier 2) + socket transport → still only ANTHROPIC_BASE_URL."""
-        from terok_sandbox import CredentialDB
-
-        from terok.lib.orchestration.environment import _credential_proxy_env_and_volumes
-
-        db_path = tmp_path / "proxy" / "credentials.db"
-        db = CredentialDB(db_path)
-        db.store_credential("default", "claude", {"type": "oauth", "access_token": "tok"})
-        db.close()
-
-        sock_path = tmp_path / "proxy.sock"
-        sock_path.touch()
-
-        project = MagicMock()
-        project.id = "test-project"
-
-        with (
-            patch("terok_sandbox.credentials.lifecycle.is_daemon_running", return_value=True),
-            patch("terok_sandbox.ensure_proxy_reachable"),
-            patch("terok.lib.orchestration.environment.make_sandbox_config") as mock_cfg_fn,
-            patch("terok.lib.core.config.get_credential_proxy_transport", return_value="socket"),
-            patch("terok.lib.orchestration.environment._skip_claude_oauth", return_value=False),
-        ):
-            mock_cfg = mock_cfg_fn.return_value
-            mock_cfg.proxy_db_path = db_path
-            mock_cfg.proxy_socket_path = sock_path
-            mock_cfg.proxy_port = 18731
-            mock_cfg.ssh_keys_json_path = tmp_path / "ssh-keys.json"
-
-            env, _ = _credential_proxy_env_and_volumes(project, "task-1")
-
-        # Claude OAuth bypasses socket/token env vars even with socket transport
-        assert "CLAUDE_CODE_OAUTH_TOKEN" not in env
         assert "ANTHROPIC_UNIX_SOCKET" not in env
-        assert "ANTHROPIC_API_KEY" not in env
-        assert "ANTHROPIC_BASE_URL" in env
+        # Non-Claude vars untouched
+        assert "MISTRAL_API_KEY" in env
+        assert "TEROK_PROXY_PORT" in env
 
-    @pytest.mark.usefixtures("_enable_proxy")
-    def test_api_key_socket_transport(self, tmp_path: Path) -> None:
-        """API key + socket → ANTHROPIC_API_KEY + ANTHROPIC_UNIX_SOCKET + ANTHROPIC_BASE_URL."""
-        from terok_sandbox import CredentialDB
+    def test_noop_when_no_claude_oauth(self) -> None:
+        """No-op when executor didn't inject Claude OAuth token (API key or no Claude)."""
+        from terok.lib.orchestration.environment import _apply_claude_oauth_overrides
 
-        from terok.lib.orchestration.environment import _credential_proxy_env_and_volumes
+        env = {
+            "ANTHROPIC_API_KEY": "terok-p-abc",
+            "ANTHROPIC_BASE_URL": "http://host.containers.internal:18731",
+        }
+        original = dict(env)
+        _apply_claude_oauth_overrides(env)
+        assert env == original
 
-        db_path = tmp_path / "proxy" / "credentials.db"
-        db = CredentialDB(db_path)
-        db.store_credential("default", "claude", {"type": "api_key", "key": "sk-test"})
-        db.close()
 
-        sock_path = tmp_path / "proxy.sock"
-        sock_path.touch()
+class TestLeakedCredentialsScan:
+    """Verify _warn_leaked_credentials with exposed-token filtering."""
 
-        project = MagicMock()
-        project.id = "test-project"
-
-        with (
-            patch("terok_sandbox.credentials.lifecycle.is_daemon_running", return_value=True),
-            patch("terok_sandbox.ensure_proxy_reachable"),
-            patch("terok.lib.orchestration.environment.make_sandbox_config") as mock_cfg_fn,
-            patch("terok.lib.core.config.get_credential_proxy_transport", return_value="socket"),
-        ):
-            mock_cfg = mock_cfg_fn.return_value
-            mock_cfg.proxy_db_path = db_path
-            mock_cfg.proxy_socket_path = sock_path
-            mock_cfg.proxy_port = 18731
-            mock_cfg.ssh_keys_json_path = tmp_path / "ssh-keys.json"
-
-            env, _ = _credential_proxy_env_and_volumes(project, "task-1")
-
-        assert "ANTHROPIC_API_KEY" in env
-        assert env["ANTHROPIC_API_KEY"].startswith("terok-p-")
-        assert env["ANTHROPIC_UNIX_SOCKET"] == "/tmp/terok-claude-proxy.sock"
-        assert "CLAUDE_CODE_OAUTH_TOKEN" not in env
-        # Socket flag AND base URL — SDK needs base URL for HTTP, socket is a mode flag
-        assert "ANTHROPIC_BASE_URL" in env
-
-    @pytest.mark.usefixtures("_enable_proxy")
-    def test_leaked_credentials_warning(self, tmp_path: Path, capsys: CaptureFixture[str]) -> None:
-        """Leaked credential files in shared mounts trigger a stderr warning."""
-        from terok_sandbox import CredentialDB
-
-        from terok.lib.orchestration.environment import _credential_proxy_env_and_volumes
-
-        db_path = tmp_path / "proxy" / "credentials.db"
-        db = CredentialDB(db_path)
-        db.store_credential("default", "claude", {"type": "api_key", "key": "sk-test"})
-        db.close()
-
-        # Create a leaked credential file in the shared mount
-        from terok_executor import get_roster
-
-        roster = get_roster()
-        auth = roster.auth_providers["claude"]
-        route = roster.proxy_routes["claude"]
-        mounts_base = tmp_path / "mounts"
-        cred_dir = mounts_base / auth.host_dir_name
-        cred_dir.mkdir(parents=True)
-        (cred_dir / route.credential_file).write_text('{"leaked": true}')
-
-        project = MagicMock()
-        project.id = "test-project"
+    def test_warns_for_leaked_files(self, caplog: pytest.LogCaptureFixture) -> None:
+        """Leaked credential files produce log warnings."""
+        from terok.lib.orchestration.environment import _warn_leaked_credentials
 
         with (
-            patch("terok_sandbox.credentials.lifecycle.is_daemon_running", return_value=True),
-            patch("terok_sandbox.ensure_proxy_reachable"),
-            patch("terok.lib.orchestration.environment.make_sandbox_config") as mock_cfg_fn,
+            caplog.at_level(logging.WARNING, logger="terok.lib.orchestration.environment"),
             patch(
                 "terok.lib.orchestration.environment.sandbox_live_mounts_dir",
-                return_value=mounts_base,
+                return_value=Path("/tmp/terok-testing/mounts"),
             ),
-            patch("terok.lib.core.config.get_credential_proxy_transport", return_value="direct"),
+            patch(
+                "terok_executor.scan_leaked_credentials",
+                return_value=[("claude", Path("/tmp/terok-testing/m/.credentials.json"))],
+            ),
+            patch("terok.lib.core.config.is_experimental", return_value=False),
         ):
-            mock_cfg = mock_cfg_fn.return_value
-            mock_cfg.proxy_db_path = db_path
-            mock_cfg.proxy_socket_path = tmp_path / "proxy.sock"
-            mock_cfg.proxy_port = 18731
-            mock_cfg.ssh_keys_json_path = tmp_path / "ssh-keys.json"
+            _warn_leaked_credentials()
 
-            _credential_proxy_env_and_volumes(project, "task-1")
+        assert any("claude" in r.message for r in caplog.records)
 
+    def test_exposed_token_suppresses_claude_warning(
+        self, capsys: pytest.CaptureFixture[str], caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Exposed Claude OAuth token: Claude warning suppressed, other providers still warned."""
+        from terok.lib.orchestration.environment import _warn_leaked_credentials
+
+        with (
+            caplog.at_level(logging.WARNING, logger="terok.lib.orchestration.environment"),
+            patch(
+                "terok.lib.orchestration.environment.sandbox_live_mounts_dir",
+                return_value=Path("/tmp/terok-testing/mounts"),
+            ),
+            patch(
+                "terok_executor.scan_leaked_credentials",
+                return_value=[
+                    ("claude", Path("/tmp/terok-testing/m/.credentials.json")),
+                    ("vibe", Path("/tmp/terok-testing/m/config.toml")),
+                ],
+            ),
+            patch("terok.lib.core.config.is_experimental", return_value=True),
+            patch("terok.lib.core.config.get_claude_expose_oauth_token", return_value=True),
+        ):
+            _warn_leaked_credentials()
+
+        # Exposed-token warning printed to stderr
         err = capsys.readouterr().err
-        assert "WARNING" in err
-        assert "claude" in err
-
-    @pytest.mark.usefixtures("_enable_proxy")
-    def test_ssh_agent_token_when_keys_registered(self, tmp_path: Path) -> None:
-        """SSH agent token and port injected when project has keys in ssh-keys.json."""
-        import json
-
-        from terok_sandbox import CredentialDB
-
-        from terok.lib.orchestration.environment import _credential_proxy_env_and_volumes
-
-        db_path = tmp_path / "proxy" / "credentials.db"
-        db = CredentialDB(db_path)
-        db.store_credential("default", "claude", {"type": "api_key", "key": "sk"})
-        db.close()
-
-        keys_json = tmp_path / "ssh-keys.json"
-        keys_json.write_text(
-            json.dumps({"test-project": [{"private_key": "/k/id", "public_key": "/k/id.pub"}]})
-        )
-
-        project = MagicMock()
-        project.id = "test-project"
-
-        with (
-            patch("terok_sandbox.credentials.lifecycle.is_daemon_running", return_value=True),
-            patch("terok_sandbox.ensure_proxy_reachable"),
-            patch("terok.lib.orchestration.environment.make_sandbox_config") as mock_cfg_fn,
-        ):
-            mock_cfg = mock_cfg_fn.return_value
-            mock_cfg.proxy_db_path = db_path
-            mock_cfg.proxy_socket_path = tmp_path / "proxy.sock"
-            mock_cfg.proxy_port = 18731
-            mock_cfg.ssh_keys_json_path = keys_json
-            mock_cfg.ssh_agent_port = 18732
-
-            env, _ = _credential_proxy_env_and_volumes(project, "task-1")
-
-        assert "TEROK_SSH_AGENT_TOKEN" in env
-        assert env["TEROK_SSH_AGENT_TOKEN"].startswith("terok-p-")
-        assert env["TEROK_SSH_AGENT_PORT"] == "18732"
-
-    @pytest.mark.usefixtures("_enable_proxy")
-    def test_no_ssh_token_when_no_keys(self, tmp_path: Path) -> None:
-        """No SSH agent env vars when project has no keys registered."""
-        from terok_sandbox import CredentialDB
-
-        from terok.lib.orchestration.environment import _credential_proxy_env_and_volumes
-
-        db_path = tmp_path / "proxy" / "credentials.db"
-        db = CredentialDB(db_path)
-        db.store_credential("default", "claude", {"type": "api_key", "key": "sk"})
-        db.close()
-
-        project = MagicMock()
-        project.id = "no-ssh-project"
-
-        with (
-            patch("terok_sandbox.credentials.lifecycle.is_daemon_running", return_value=True),
-            patch("terok_sandbox.ensure_proxy_reachable"),
-            patch("terok.lib.orchestration.environment.make_sandbox_config") as mock_cfg_fn,
-        ):
-            mock_cfg = mock_cfg_fn.return_value
-            mock_cfg.proxy_db_path = db_path
-            mock_cfg.proxy_socket_path = tmp_path / "proxy.sock"
-            mock_cfg.proxy_port = 18731
-            mock_cfg.ssh_keys_json_path = tmp_path / "nonexistent.json"
-
-            env, _ = _credential_proxy_env_and_volumes(project, "task-1")
-
-        assert "TEROK_SSH_AGENT_TOKEN" not in env
-        assert "TEROK_SSH_AGENT_PORT" not in env
-
-
-class TestLoadSshKeysJson:
-    """Verify _load_ssh_keys_json edge cases."""
-
-    def test_missing_file_returns_empty(self, tmp_path: Path) -> None:
-        """Non-existent file returns empty dict."""
-        from terok.lib.orchestration.environment import _load_ssh_keys_json
-
-        assert _load_ssh_keys_json(tmp_path / "nope.json") == {}
-
-    def test_corrupt_json_returns_empty(self, tmp_path: Path) -> None:
-        """Corrupt JSON returns empty dict."""
-        from terok.lib.orchestration.environment import _load_ssh_keys_json
-
-        bad = tmp_path / "bad.json"
-        bad.write_text("{not valid")
-        assert _load_ssh_keys_json(bad) == {}
-
-    def test_valid_json_parsed(self, tmp_path: Path) -> None:
-        """Valid JSON is parsed correctly."""
-        import json
-
-        from terok.lib.orchestration.environment import _load_ssh_keys_json
-
-        kf = tmp_path / "keys.json"
-        kf.write_text(json.dumps({"proj": {"private_key": "/a", "public_key": "/b"}}))
-        assert _load_ssh_keys_json(kf) == {"proj": {"private_key": "/a", "public_key": "/b"}}
-
-    def test_string_payload_returns_empty(self, tmp_path: Path) -> None:
-        """JSON string payload (e.g. a project name) returns empty dict."""
-        from terok.lib.orchestration.environment import _load_ssh_keys_json
-
-        f = tmp_path / "keys.json"
-        f.write_text('"test-project"')
-        assert _load_ssh_keys_json(f) == {}
-
-    def test_list_payload_returns_empty(self, tmp_path: Path) -> None:
-        """JSON list payload returns empty dict."""
-        import json
-
-        from terok.lib.orchestration.environment import _load_ssh_keys_json
-
-        f = tmp_path / "keys.json"
-        f.write_text(json.dumps(["test-project"]))
-        assert _load_ssh_keys_json(f) == {}
+        assert "EXPOSED" in err
+        # Claude filtered out, vibe still warned via logger
+        log_messages = [r.message for r in caplog.records]
+        assert not any("claude" in m for m in log_messages)
+        assert any("vibe" in m for m in log_messages)

--- a/tests/unit/lib/test_task_runner_internals.py
+++ b/tests/unit/lib/test_task_runner_internals.py
@@ -296,10 +296,10 @@ class TestApplyShieldPolicy:
 
 
 class TestMaybeDenyAnthropicApi:
-    """Verify tier-2 shield deny for api.anthropic.com."""
+    """Verify shield deny for api.anthropic.com when Claude OAuth is proxied."""
 
     def test_noop_when_not_proxied(self) -> None:
-        """No-op when Claude OAuth is not in tier 2."""
+        """No-op when Claude OAuth is not proxied."""
         from terok.lib.orchestration.task_runners import _maybe_deny_anthropic_api
 
         with patch(
@@ -309,7 +309,7 @@ class TestMaybeDenyAnthropicApi:
             _maybe_deny_anthropic_api("ctr", MOCK_TASK_DIR)
 
     def test_calls_shield_deny_when_proxied(self, tmp_path: Path) -> None:
-        """Calls shield.deny('api.anthropic.com') when tier 2 is active."""
+        """Calls shield.deny('api.anthropic.com') when Claude OAuth is proxied."""
         from terok.lib.orchestration.task_runners import _maybe_deny_anthropic_api
 
         mock_shield = MagicMock()

--- a/tests/unit/test_error_surfacing.py
+++ b/tests/unit/test_error_surfacing.py
@@ -449,42 +449,6 @@ class TestEnvironmentWarnings:
         with patch("terok.lib.core.paths.state_root", return_value=tmp_path):
             yield
 
-    def test_ssh_keys_json_decode_error_warns(
-        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
-    ) -> None:
-        """Malformed JSON in SSH keys file warns and returns empty dict."""
-        from terok.lib.orchestration.environment import _load_ssh_keys_json
-
-        keys_file = tmp_path / "ssh-keys.json"
-        keys_file.write_text("{not valid json")
-        result = _load_ssh_keys_json(keys_file)
-        assert result == {}
-        assert "Malformed SSH keys file" in capsys.readouterr().err
-
-    def test_ssh_keys_os_error_warns(
-        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
-    ) -> None:
-        """Unreadable SSH keys file warns and returns empty dict."""
-        from terok.lib.orchestration.environment import _load_ssh_keys_json
-
-        keys_file = tmp_path / "ssh-keys.json"
-        keys_file.write_text('{"proj": []}')
-        keys_file.chmod(0o000)
-        result = _load_ssh_keys_json(keys_file)
-        keys_file.chmod(0o644)
-        assert result == {}
-        assert "Cannot read SSH keys file" in capsys.readouterr().err
-
-    def test_ssh_keys_missing_file_no_warning(
-        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
-    ) -> None:
-        """Missing SSH keys file returns empty dict without warning."""
-        from terok.lib.orchestration.environment import _load_ssh_keys_json
-
-        result = _load_ssh_keys_json(tmp_path / "nonexistent.json")
-        assert result == {}
-        assert capsys.readouterr().err == ""
-
     def test_gate_fallback_warns(self, capsys: pytest.CaptureFixture[str]) -> None:
         """Gate server unreachable triggers an informational warning on stderr."""
         from terok.lib.orchestration.environment import _security_mode_env_and_volumes


### PR DESCRIPTION
## Summary

- Bump `terok-executor` to v0.0.73 (terok-ai/terok-executor#157)
- **Drop `caller_manages_proxy`** — executor now handles all generic proxy plumbing
- Delete ~120 lines of duplicated proxy code (`_credential_proxy_env_and_volumes`, `_credential_type`, `_load_ssh_keys_json`)
- Keep only terok-specific concerns:
  - `ensure_credential_proxy()`: triggers systemd socket activation before assembly
  - `_apply_claude_oauth_overrides()`: adjusts Claude env vars (proxied/skipped/exposed)
  - `_warn_leaked_credentials()`: leaked-cred scan with exposed-token filtering

Net: **+136/-669 lines** — the proxy plumbing that was duplicated between terok and executor now lives in one place.

Closes #688.

## Test plan

- [x] `make lint` passes
- [x] `make test` passes (1623 tests)
- [x] `make tach` passes
- [x] `make docstrings` passes (99.5%)
- [x] `make reuse` passes
- [x] `make security` passes
- [ ] Manual: `terok task start <project>` with Claude (API key + OAuth) and Vibe credentials

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated terok-executor dependency from v0.0.72 to v0.0.73.

* **New Features**
  * Added a config flag to indicate when Claude OAuth tokens are intentionally exposed.

* **Refactor**
  * Credential-proxy responsibilities moved to the execution layer; environment assembly now only applies service-specific OAuth adjustments.
  * Leaked-credential notices now use logger warnings; Claude-related warnings are suppressed when OAuth is exposed.

* **Tests**
  * Unit tests adjusted and simplified to cover the new behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->