### PR TITLE
chore: enforce import-linter in GitHub CI

### DIFF
--- a/.github/requirements-ci.txt
+++ b/.github/requirements-ci.txt
@@ -4,3 +4,4 @@ docstr-coverage>=2.3.2,<3.0.0
 tach>=0.33.3,<0.35.0
 vulture>=2.12,<3.0.0
 bandit>=1.7,<2.0.0
+import-linter>=2.11,<3.0.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,19 +102,37 @@ jobs:
       - name: Run SAST scan
         run: bandit -r src/terok/ -ll
 
-  lint-imports:
+  import-linter:
     if: github.repository == 'terok-ai/terok'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
 
       - name: Set up Python
+        id: setup-python
         uses: actions/setup-python@v6
         with:
           python-version: "3.12"
 
-      - name: Install tools
-        run: pip install -r .github/requirements-ci.txt
+      - name: Install Poetry
+        uses: snok/install-poetry@76e04a911780d5b312d89783f7b1cd627778900a # v1.4.1
+        with:
+          version: "2.3.3"
+          virtualenvs-create: true
+          virtualenvs-in-project: true
+          plugins: poetry-dynamic-versioning[plugin]
+
+      - name: Load cached venv
+        id: cached-poetry-dependencies
+        uses: actions/cache@v5
+        with:
+          path: .venv
+          key: venv-${{ runner.os }}-py${{ steps.setup-python.outputs.python-version }}-lint-imports-${{ hashFiles('**/pyproject.toml', '**/poetry.lock') }}
+
+      - name: Install project and tools
+        run: |
+          poetry install --no-interaction
+          pip install -r .github/requirements-ci.txt
 
       - name: Check cross-package import boundaries
         run: lint-imports

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -129,13 +129,11 @@ jobs:
           path: .venv
           key: venv-${{ runner.os }}-py${{ steps.setup-python.outputs.python-version }}-lint-imports-${{ hashFiles('**/pyproject.toml', '**/poetry.lock') }}
 
-      - name: Install project and tools
-        run: |
-          poetry install --no-interaction
-          pip install -r .github/requirements-ci.txt
+      - name: Install project
+        run: poetry install --no-interaction
 
       - name: Check cross-package import boundaries
-        run: lint-imports
+        run: poetry run lint-imports
 
   # Keep host-only integration tests in CI, but outside the Sonar-producing workflow.
   # That keeps the Sonar path fast while still exercising Linux host features on PRs.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,6 +102,23 @@ jobs:
       - name: Run SAST scan
         run: bandit -r src/terok/ -ll
 
+  lint-imports:
+    if: github.repository == 'terok-ai/terok'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      - name: Install tools
+        run: pip install -r .github/requirements-ci.txt
+
+      - name: Check cross-package import boundaries
+        run: lint-imports
+
   # Keep host-only integration tests in CI, but outside the Sonar-producing workflow.
   # That keeps the Sonar path fast while still exercising Linux host features on PRs.
   integration-tests-host:

--- a/.importlinter
+++ b/.importlinter
@@ -40,6 +40,7 @@ allowed_importers =
     terok.cli.wiring
     terok.lib.core.config
     terok.lib.core.projects
+    terok.lib.domain.facade
     terok.lib.domain.panic
     terok.lib.domain.project
     terok.lib.domain.storage


### PR DESCRIPTION
## Summary
- Add `lint-imports` job to `.github/workflows/ci.yml` so cross-package import boundary contracts (`.importlinter`) are enforced on every PR — previously only ran locally via `make check`
- Add `import-linter` to `.github/requirements-ci.txt`
- Fix pre-existing sandbox-boundary violation: add `terok.lib.domain.facade` to allowed importers (facade is the designated consolidation point for external package access per the `.importlinter` TODO)

## Test plan
- [ ] CI `lint-imports` job passes on this PR (all 4 contracts kept, 0 broken)
- [ ] `make lint-imports` passes locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added automated import-boundary checks to the CI pipeline as a dedicated job.
  * Updated CI configuration to allow one additional internal importer for import-boundary validation.
  * Pinned a CI-only tooling dependency to a specific version used by the new job.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->