### PR TITLE
feat: multi-user port isolation — shared registry + configurable service ports

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -3068,19 +3068,20 @@ description = "Single-agent task runner for hardened Podman containers"
 optional = false
 python-versions = ">=3.12,<4.0"
 groups = ["main"]
-files = [
-    {file = "terok_executor-0.0.74-py3-none-any.whl", hash = "sha256:34c4a0dc56e15a20ddc535e3e29f2672f75b3a550c256cc215eb207f1fe3b430"},
-]
+files = []
+develop = false
 
 [package.dependencies]
 Jinja2 = ">=3.1"
 "ruamel.yaml" = ">=0.18"
-terok_sandbox = {url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.0.64/terok_sandbox-0.0.64-py3-none-any.whl"}
+terok-sandbox = {git = "https://github.com/sliwowitz/terok-sandbox.git", branch = "feat/port-registry"}
 tomli-w = ">=1.0"
 
 [package.source]
-type = "url"
-url = "https://github.com/terok-ai/terok-executor/releases/download/v0.0.74/terok_executor-0.0.74-py3-none-any.whl"
+type = "git"
+url = "https://github.com/sliwowitz/terok-executor.git"
+reference = "feat/port-registry"
+resolved_reference = "f2afab2a01f5eb202bc7d349499b041da0b1bcf4"
 
 [[package]]
 name = "terok-sandbox"
@@ -3089,19 +3090,20 @@ description = "Hardened Podman container runner with gate server and shield inte
 optional = false
 python-versions = ">=3.12,<4.0"
 groups = ["main"]
-files = [
-    {file = "terok_sandbox-0.0.64-py3-none-any.whl", hash = "sha256:202b79e25f540bd7cd4100f809a61162ea1aa33347aabc2e237262caa5c7c56a"},
-]
+files = []
+develop = false
 
 [package.dependencies]
 aiohttp = ">=3.9"
 cryptography = ">=46.0.7"
 platformdirs = ">=4.9.6"
-terok_shield = {url = "https://github.com/terok-ai/terok-shield/releases/download/v0.6.18/terok_shield-0.6.18-py3-none-any.whl"}
+terok-shield = {url = "https://github.com/terok-ai/terok-shield/releases/download/v0.6.18/terok_shield-0.6.18-py3-none-any.whl"}
 
 [package.source]
-type = "url"
-url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.0.64/terok_sandbox-0.0.64-py3-none-any.whl"
+type = "git"
+url = "https://github.com/sliwowitz/terok-sandbox.git"
+reference = "feat/port-registry"
+resolved_reference = "14f34c9688dd8cf139b80148db5f9fca9b563b7f"
 
 [[package]]
 name = "terok-shield"
@@ -3609,4 +3611,4 @@ propcache = ">=0.2.1"
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.12,<4.0"
-content-hash = "1ce79f11b231f0bad313067d001f1fd079c99187d85e817fd25f6a110307c5e2"
+content-hash = "eb02bd6fde2bf6e6d2fa35cbc448eec21e88f4974b879a7ec36867775046f015"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,8 +44,8 @@ rich = ">=13.0"
 platformdirs = ">=4.5.1"
 unique-namer = ">=1.3"
 textual-serve = ">=1.1.0"
-terok-executor = {url = "https://github.com/terok-ai/terok-executor/releases/download/v0.0.74/terok_executor-0.0.74-py3-none-any.whl"}
-terok-sandbox = {url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.0.64/terok_sandbox-0.0.64-py3-none-any.whl"}
+terok-executor = {git = "https://github.com/sliwowitz/terok-executor.git", branch = "feat/port-registry"}
+terok-sandbox = {git = "https://github.com/sliwowitz/terok-sandbox.git", branch = "feat/port-registry"}
 terok-dbus = {url = "https://github.com/terok-ai/terok-dbus/releases/download/v0.5.6/terok_dbus-0.5.6-py3-none-any.whl"}
 
 [tool.poetry.group.dev.dependencies]

--- a/src/terok/lib/core/config.py
+++ b/src/terok/lib/core/config.py
@@ -341,6 +341,10 @@ def make_sandbox_config() -> "SandboxConfig":  # noqa: F821 — forward ref
     sandbox's plain dataclass.  Sandbox uses its own ``state_dir`` default
     (``~/.local/share/terok/sandbox/``) — terok no longer overrides it.
 
+    Port fields pass ``None`` (auto-allocate via sandbox's shared port
+    registry) or an explicit ``int`` from config.yml.  Resolution happens
+    in ``SandboxConfig.__post_init__``.
+
     This is the **single source of truth** for config bridging — every
     SandboxConfig field that terok controls must be set here.
     """
@@ -349,6 +353,8 @@ def make_sandbox_config() -> "SandboxConfig":  # noqa: F821 — forward ref
     return SandboxConfig(
         credentials_dir=credentials_dir(),
         gate_port=get_gate_server_port(),
+        proxy_port=get_credential_proxy_port(),
+        ssh_agent_port=get_credential_proxy_ssh_agent_port(),
         shield_bypass=get_shield_bypass_firewall_no_protection(),
         shield_audit=get_shield_audit(),
     )
@@ -432,6 +438,28 @@ def get_credential_proxy_transport() -> str:
     return _load_validated().credential_proxy.transport
 
 
+def get_credential_proxy_port() -> int | None:
+    """Return the explicit credential proxy port, or ``None`` for auto-allocation.
+
+    Global config (config.yml)::
+
+        credential_proxy:
+          port: 18700   # omit for auto-allocation
+    """
+    return _load_validated().credential_proxy.port
+
+
+def get_credential_proxy_ssh_agent_port() -> int | None:
+    """Return the explicit SSH agent proxy port, or ``None`` for auto-allocation.
+
+    Global config (config.yml)::
+
+        credential_proxy:
+          ssh_agent_port: 18701   # omit for auto-allocation
+    """
+    return _load_validated().credential_proxy.ssh_agent_port
+
+
 def get_shield_bypass_firewall_no_protection() -> bool:
     """Return whether the shield firewall is globally bypassed.
 
@@ -470,8 +498,8 @@ def get_public_host() -> str:
     return os.environ.get("TEROK_PUBLIC_HOST", "").strip() or "127.0.0.1"
 
 
-def get_gate_server_port() -> int:
-    """Return the gate server port from global config (default 9418)."""
+def get_gate_server_port() -> int | None:
+    """Return the explicit gate server port, or ``None`` for auto-allocation."""
     return _load_validated().gate_server.port
 
 

--- a/src/terok/lib/core/yaml_schema.py
+++ b/src/terok/lib/core/yaml_schema.py
@@ -342,6 +342,7 @@ class RawPathsSection(BaseModel):
     sandbox_live_dir: str | None = None
     user_projects_dir: str | None = None
     user_presets_dir: str | None = None
+    port_registry_dir: str | None = None
 
 
 class RawTUISection(BaseModel):
@@ -379,6 +380,8 @@ class RawCredentialProxySection(BaseModel):
 
     bypass_no_secret_protection: bool = False
     transport: Literal["direct", "socket"] = "socket"
+    port: int | None = Field(default=None, ge=1, le=65535)
+    ssh_agent_port: int | None = Field(default=None, ge=1, le=65535)
 
 
 class RawGateServerSection(BaseModel):
@@ -386,7 +389,7 @@ class RawGateServerSection(BaseModel):
 
     model_config = ConfigDict(extra="forbid")
 
-    port: int = 9418
+    port: int | None = Field(default=None, ge=1, le=65535)
     repos_dir: str | None = None
     suppress_systemd_warning: bool = False
 
@@ -397,6 +400,15 @@ class RawTasksGlobalSection(BaseModel):
     model_config = ConfigDict(extra="forbid")
 
     name_categories: NameCategories = None
+
+
+class RawNetworkSection(BaseModel):
+    """Global ``network:`` section — port range and future network settings."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    port_range_start: int = Field(default=18700, ge=1024, le=65535)
+    port_range_end: int = Field(default=32767, ge=1024, le=65535)
 
 
 # ---------------------------------------------------------------------------
@@ -417,6 +429,7 @@ class RawGlobalConfig(BaseModel):
     shield: RawShieldGlobalSection = Field(default_factory=RawShieldGlobalSection)
     credential_proxy: RawCredentialProxySection = Field(default_factory=RawCredentialProxySection)
     gate_server: RawGateServerSection = Field(default_factory=RawGateServerSection)
+    network: RawNetworkSection = Field(default_factory=RawNetworkSection)
     tasks: RawTasksGlobalSection = Field(default_factory=RawTasksGlobalSection)
     git: RawGlobalGitSection = Field(default_factory=RawGlobalGitSection)
     hooks: RawHooksSection = Field(default_factory=RawHooksSection)
@@ -435,6 +448,7 @@ class RawGlobalConfig(BaseModel):
             "shield",
             "credential_proxy",
             "gate_server",
+            "network",
             "tasks",
             "git",
             "hooks",

--- a/src/terok/lib/orchestration/container_doctor.py
+++ b/src/terok/lib/orchestration/container_doctor.py
@@ -112,8 +112,11 @@ def _git_remote_check(security_class: str, gate_port: int | None) -> DoctorCheck
                 )
             if gate_port is not None and parsed.port != gate_port:
                 return CheckVerdict(
-                    "warn",
-                    f"git origin: port {parsed.port} does not match gate port {gate_port}",
+                    "error",
+                    f"git origin: port {parsed.port} does not match gate port {gate_port}"
+                    " — ports were re-allocated; re-create this task with"
+                    " 'terok task delete' + 'terok task run'",
+                    fixable=False,
                 )
             return CheckVerdict("ok", "git origin: routed through gate")
         # Online mode: any URL is acceptable
@@ -127,8 +130,40 @@ def _git_remote_check(security_class: str, gate_port: int | None) -> DoctorCheck
     )
 
 
+_PORT_DRIFT_HINT = (
+    " — ports were re-allocated since this container was created;"
+    " re-create with 'terok task delete' + 'terok task run'"
+)
+
+
+def _port_drift_check(env_var: str, label: str, expected: int) -> DoctorCheck:
+    """Check that a baked-in port env var still matches the resolved port."""
+
+    def _eval(rc: int, stdout: str, stderr: str) -> CheckVerdict:
+        baked = stdout.strip()
+        if rc != 0 or not baked:
+            return CheckVerdict("ok", f"{label}: env not set (pre-registry container)")
+        try:
+            baked_port = int(baked)
+        except ValueError:
+            return CheckVerdict("warn", f"{label}: {env_var}={baked!r} is not a port number")
+        if baked_port == expected:
+            return CheckVerdict("ok", f"{label}: port {expected} matches")
+        return CheckVerdict("error", f"{label}: container has {baked_port}, host has {expected}{_PORT_DRIFT_HINT}", fixable=False)
+
+    return DoctorCheck(
+        category="network",
+        label=label,
+        probe_cmd=["printenv", env_var],
+        evaluate=_eval,
+    )
+
+
 def _terok_doctor_checks(
     project_id: str,
+    gate_port: int,
+    proxy_port: int,
+    ssh_agent_port: int,
 ) -> list[DoctorCheck]:
     """Build terok-level health checks from project config."""
     project = load_project(project_id)
@@ -143,11 +178,9 @@ def _terok_doctor_checks(
     checks.append(_git_identity_check(human_name, human_email, "name"))
     checks.append(_git_identity_check(human_name, human_email, "email"))
 
-    # Git remote URL check
-    from ..core.config import get_gate_server_port as _get_gate_port
-
-    gate_port = _get_gate_port()
     checks.append(_git_remote_check(project.security_class, gate_port))
+    checks.append(_port_drift_check("TEROK_PROXY_PORT", "Proxy port drift", proxy_port))
+    checks.append(_port_drift_check("TEROK_SSH_AGENT_PORT", "SSH agent port drift", ssh_agent_port))
 
     return checks
 
@@ -212,7 +245,7 @@ def _collect_all_checks(
         )
     )
     checks.extend(agent_doctor_checks(get_roster(), proxy_port=proxy_port))
-    checks.extend(_terok_doctor_checks(project_id))
+    checks.extend(_terok_doctor_checks(project_id, cfg.gate_port, proxy_port, ssh_agent_port))
     return checks
 
 

--- a/src/terok/lib/orchestration/ports.py
+++ b/src/terok/lib/orchestration/ports.py
@@ -3,68 +3,23 @@
 
 """Web port allocation for task containers.
 
-Scans existing task metadata to find used ports and allocates the next
-free port starting from the configured UI base port.
+All port allocation flows through the shared port registry in
+:mod:`terok_sandbox.port_registry` to prevent collisions between
+users on shared hosts.
 """
 
-import socket
-
-from ..core.config import get_ui_base_port, state_dir
-from ..util.yaml import load as _yaml_load
-
-_LOCALHOST = "127.0.0.1"
+from terok_sandbox import claim_port, release_port
 
 
-def _is_port_free(port: int) -> bool:
-    """Return True if *port* can be bound on localhost."""
-    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
-        try:
-            s.bind((_LOCALHOST, port))
-        except OSError:
-            return False
-    return True
+def assign_web_port(project_id: str, task_id: str, preferred: int | None = None) -> int:
+    """Claim a web port for a task via the shared registry.
 
-
-def _collect_all_web_ports() -> set[int]:
-    """Scan all task metadata files and return the set of assigned web ports."""
-    # Scan all task metas for any project
-    root = state_dir() / "projects"
-    ports: set[int] = set()
-    if not root.is_dir():
-        return ports
-    for proj_dir in root.iterdir():
-        tdir = proj_dir / "tasks"
-        if not tdir.is_dir():
-            continue
-        for f in tdir.glob("*.yml"):
-            try:
-                meta = _yaml_load(f.read_text()) or {}
-            except Exception as exc:
-                from ..util.logging_utils import log_warning
-
-                log_warning(f"Skipping malformed task metadata during port scan: {f}: {exc}")
-                continue
-            port = meta.get("web_port")
-            if isinstance(port, int):
-                ports.add(port)
-    return ports
-
-
-def assign_web_port() -> int:
-    """Find a free web port starting from the configured UI base port.
-
-    Scans up to 200 successive ports (base_port through base_port + 199),
-    skipping ports already recorded in task metadata or currently bound.
-    Raises SystemExit if no free port is found.
+    When *preferred* is set (e.g. from persisted task metadata), tries
+    that port first before scanning.
     """
-    used = _collect_all_web_ports()
-    base = get_ui_base_port()
-    port = base
-    max_tries = 200
-    tries = 0
-    while tries < max_tries:
-        if port not in used and _is_port_free(port):
-            return port
-        port += 1
-        tries += 1
-    raise SystemExit("No free web ports available")
+    return claim_port(f"web:{project_id}/{task_id}", preferred=preferred)
+
+
+def release_web_port(project_id: str, task_id: str) -> None:
+    """Release a previously claimed web port for a task."""
+    release_port(f"web:{project_id}/{task_id}")

--- a/src/terok/lib/orchestration/task_runners.py
+++ b/src/terok/lib/orchestration/task_runners.py
@@ -525,10 +525,11 @@ def task_run_toad(
     project = load_project(project_id)
     meta, meta_path = load_task_meta(project.id, task_id, "toad")
 
-    port = meta.get("web_port")
-    if not isinstance(port, int):
-        port = assign_web_port()
-        meta["web_port"] = port
+    port = assign_web_port(
+        project.id, task_id,
+        preferred=meta["web_port"] if isinstance(meta.get("web_port"), int) else None,
+    )
+    meta["web_port"] = port
 
     cname = container_name(project.id, "toad", task_id)
     container_state = get_container_state(cname)
@@ -1066,6 +1067,9 @@ def task_restart(project_id: str, task_id: str) -> None:
 
     if container_state is not None:
         # Container exists (stopped/exited, or just stopped above) - start it
+        web_port = meta.get("web_port")
+        if isinstance(web_port, int):
+            assign_web_port(project_id, task_id, preferred=web_port)
         task_dir = project.tasks_root / str(task_id)
         _podman_start(cname)
         _assert_running(cname)

--- a/src/terok/lib/orchestration/tasks.py
+++ b/src/terok/lib/orchestration/tasks.py
@@ -758,6 +758,11 @@ def _task_delete(project: ProjectConfig, task_id: str) -> TaskDeleteResult:
         _log_debug(f"task_delete: token revoke failed: {exc}")
         warnings.append(f"Token revoke failed: {exc}")
 
+    _log_debug("task_delete: releasing web port")
+    from .ports import release_web_port
+
+    release_web_port(project.id, task_id)
+
     _log_debug("task_delete: calling _stop_task_containers")
     names = [container_name(project.id, mode, str(task_id)) for mode in CONTAINER_MODES]
     try:
@@ -915,6 +920,9 @@ def _task_stop(project: ProjectConfig, task_id: str, *, timeout: int | None = No
         raise SystemExit(f"Failed to stop container: {e}")
 
     from .hooks import run_hook
+    from .ports import release_web_port
+
+    release_web_port(project.id, task_id)
 
     run_hook(
         "post_stop",

--- a/tach.toml
+++ b/tach.toml
@@ -266,11 +266,11 @@ path = "terok.lib.orchestration.image"
 layer = "orchestration"
 depends_on = ["terok.lib.core.config", "terok.lib.core.images", "terok.lib.core.projects", "terok.lib.util.fs"]
 
-# Task port allocation
+# Task port allocation (delegates to terok-sandbox port registry)
 [[modules]]
 path = "terok.lib.orchestration.ports"
 layer = "orchestration"
-depends_on = ["terok.lib.core.config", "terok.lib.util.yaml"]
+depends_on = []
 
 # Task lifecycle hooks (host-side)
 [[modules]]
@@ -635,6 +635,8 @@ expose = [
     "is_claude_oauth_exposed",
     "get_credential_proxy_bypass",
     "get_credential_proxy_transport",
+    "get_credential_proxy_port",
+    "get_credential_proxy_ssh_agent_port",
     "get_shield_bypass_firewall_no_protection",
     "get_shield_drop_on_task_run",
     "get_shield_on_task_restart",
@@ -757,7 +759,7 @@ expose = ["ensure_dir", "ensure_dir_writable", "archive_timestamp", "unique_arch
 from = ["terok.lib.util.fs"]
 
 [[interfaces]]
-expose = ["assign_web_port"]
+expose = ["assign_web_port", "release_web_port"]
 from = ["terok.lib.orchestration.ports"]
 
 [[interfaces]]

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -6,9 +6,14 @@
 Auto-mocks sandbox, shield, and credential proxy helpers so existing tests
 do not require a real OCI hook, nftables, podman, proxy daemon, or root
 privileges.
+
+The ``_isolate_port_registry`` fixture ensures that the flock-based port
+registry never writes to the real ``/tmp/terok-ports/`` or persists claims
+to ``~/.local/share/terok/sandbox/``.
 """
 
 from collections.abc import Iterator
+from pathlib import Path
 from unittest.mock import patch
 
 import pytest
@@ -21,11 +26,27 @@ def _reset_config_caches() -> Iterator[None]:
 
     import terok.lib.core.config as _config
 
-    _sandbox_paths._config_paths_cache = None
+    _sandbox_paths._config_section_cache.clear()
     _config._validated_config_cache = None
     yield
-    _sandbox_paths._config_paths_cache = None
+    _sandbox_paths._config_section_cache.clear()
     _config._validated_config_cache = None
+
+
+@pytest.fixture(autouse=True)
+def _isolate_port_registry(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Redirect port registry to tmp dirs so tests never touch the real FS.
+
+    Patches the flock directory and suppresses claims-file writes so that
+    tests never create ``port-claims.json`` in the real state directory.
+    """
+    import terok_sandbox.port_registry as _reg
+
+    registry = tmp_path / "terok-ports"
+    registry.mkdir()
+    monkeypatch.setattr(_reg, "REGISTRY_DIR", registry)
+    monkeypatch.setattr(_reg, "_save_ports", lambda _sd, _p: None)
+    _reg.reset_cache()
 
 
 @pytest.fixture(autouse=True)

--- a/tests/unit/lib/test_config.py
+++ b/tests/unit/lib/test_config.py
@@ -10,6 +10,7 @@ from collections.abc import Callable, Iterator
 from pathlib import Path
 
 import pytest
+from terok_sandbox import port_registry as reg
 
 from terok.lib.core import config as cfg
 
@@ -20,6 +21,7 @@ def reset_experimental() -> Iterator[None]:
     cfg.set_experimental(False)
     yield
     cfg.set_experimental(False)
+
 
 
 def write_config(tmp_path: Path, content: str) -> Path:
@@ -398,10 +400,57 @@ def test_get_credential_proxy_bypass(monkeypatch: pytest.MonkeyPatch, tmp_path: 
     assert cfg.get_credential_proxy_bypass() is True
 
 
-def test_get_gate_server_port_default(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
-    """``get_gate_server_port()`` defaults to 9418."""
+def test_get_gate_server_port_default_none(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """``get_gate_server_port()`` defaults to None (auto-allocate)."""
     monkeypatch.setenv("TEROK_CONFIG_FILE", str(write_config(tmp_path, "")))
-    assert cfg.get_gate_server_port() == 9418
+    assert cfg.get_gate_server_port() is None
+
+
+def test_get_gate_server_port_explicit(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """``get_gate_server_port()`` returns explicit port from config."""
+    monkeypatch.setenv(
+        "TEROK_CONFIG_FILE",
+        str(write_config(tmp_path, "gate_server:\n  port: 9500\n")),
+    )
+    assert cfg.get_gate_server_port() == 9500
+
+
+def test_get_credential_proxy_port_default_none(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """``get_credential_proxy_port()`` defaults to None (auto-allocate)."""
+    monkeypatch.setenv("TEROK_CONFIG_FILE", str(write_config(tmp_path, "")))
+    assert cfg.get_credential_proxy_port() is None
+
+
+def test_get_credential_proxy_port_explicit(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """``get_credential_proxy_port()`` returns explicit port from config."""
+    monkeypatch.setenv(
+        "TEROK_CONFIG_FILE",
+        str(write_config(tmp_path, "credential_proxy:\n  port: 19000\n")),
+    )
+    assert cfg.get_credential_proxy_port() == 19000
+
+
+def test_get_credential_proxy_ssh_agent_port_default_none(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """``get_credential_proxy_ssh_agent_port()`` defaults to None (auto-allocate)."""
+    monkeypatch.setenv("TEROK_CONFIG_FILE", str(write_config(tmp_path, "")))
+    assert cfg.get_credential_proxy_ssh_agent_port() is None
+
+
+def test_get_credential_proxy_ssh_agent_port_explicit(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """``get_credential_proxy_ssh_agent_port()`` returns explicit port from config."""
+    monkeypatch.setenv(
+        "TEROK_CONFIG_FILE",
+        str(write_config(tmp_path, "credential_proxy:\n  ssh_agent_port: 19001\n")),
+    )
+    assert cfg.get_credential_proxy_ssh_agent_port() == 19001
 
 
 def test_get_gate_server_suppress_warning(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
@@ -474,12 +523,49 @@ def test_make_sandbox_config_from_config_file(
 
 
 def test_make_sandbox_config_gate_port(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
-    """Factory propagates gate_server.port from global config."""
+    """Factory propagates explicit gate_server.port from global config."""
     monkeypatch.setenv(
         "TEROK_CONFIG_FILE",
         str(write_config(tmp_path, "gate_server:\n  port: 1234\n")),
     )
     assert cfg.make_sandbox_config().gate_port == 1234
+
+
+def test_make_sandbox_config_proxy_port(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """Factory propagates explicit credential_proxy.port from global config."""
+    monkeypatch.setenv(
+        "TEROK_CONFIG_FILE",
+        str(write_config(tmp_path, "credential_proxy:\n  port: 19000\n")),
+    )
+    assert cfg.make_sandbox_config().proxy_port == 19000
+
+
+def test_make_sandbox_config_ssh_agent_port(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Factory propagates explicit credential_proxy.ssh_agent_port from global config."""
+    monkeypatch.setenv(
+        "TEROK_CONFIG_FILE",
+        str(write_config(tmp_path, "credential_proxy:\n  ssh_agent_port: 19001\n")),
+    )
+    assert cfg.make_sandbox_config().ssh_agent_port == 19001
+
+
+def test_make_sandbox_config_auto_allocates_ports(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Factory auto-allocates distinct ports and reuses them on second call."""
+    monkeypatch.setenv("TEROK_CONFIG_FILE", str(write_config(tmp_path, "")))
+    sc = cfg.make_sandbox_config()
+    ports = {sc.gate_port, sc.proxy_port, sc.ssh_agent_port}
+    assert len(ports) == 3, "Auto-allocated ports must be distinct"
+    for p in ports:
+        assert p in reg.PORT_RANGE, f"Port {p} outside expected range"
+
+    sc2 = cfg.make_sandbox_config()
+    assert sc2.gate_port == sc.gate_port
+    assert sc2.proxy_port == sc.proxy_port
+    assert sc2.ssh_agent_port == sc.ssh_agent_port
 
 
 def test_make_sandbox_config_credentials_propagation(

--- a/tests/unit/lib/test_container_doctor.py
+++ b/tests/unit/lib/test_container_doctor.py
@@ -15,6 +15,7 @@ from terok.lib.orchestration.container_doctor import (
     _exec_in_container,
     _git_identity_check,
     _git_remote_check,
+    _port_drift_check,
     _read_desired_shield_state,
     run_container_doctor,
 )
@@ -96,17 +97,35 @@ class TestGitRemoteCheck:
         verdict = check.evaluate(1, "", "fatal: no remote")
         assert verdict.severity == "warn"
 
-    def test_warn_when_port_mismatch(self) -> None:
+    def test_error_when_port_mismatch(self) -> None:
         check = _git_remote_check("gatekeeping", 9418)
         verdict = check.evaluate(0, "http://abc@host.containers.internal:5555/proj.git\n", "")
-        assert verdict.severity == "warn"
+        assert verdict.severity == "error"
         assert "5555" in verdict.detail
-        assert "9418" in verdict.detail
+        assert "re-allocated" in verdict.detail
 
     def test_ok_when_gate_port_none(self) -> None:
         check = _git_remote_check("gatekeeping", None)
         verdict = check.evaluate(0, "http://abc@host.containers.internal:5555/proj.git\n", "")
         assert verdict.severity == "ok"
+
+
+class TestPortDriftCheck:
+    """Port drift detection for re-allocated ports."""
+
+    def test_ok_when_ports_match(self) -> None:
+        check = _port_drift_check("TEROK_PROXY_PORT", "Proxy", 18700)
+        assert check.evaluate(0, "18700\n", "").severity == "ok"
+
+    def test_error_when_ports_differ(self) -> None:
+        check = _port_drift_check("TEROK_PROXY_PORT", "Proxy", 18700)
+        verdict = check.evaluate(0, "18731\n", "")
+        assert verdict.severity == "error"
+        assert "re-allocated" in verdict.detail
+
+    def test_ok_when_env_not_set(self) -> None:
+        check = _port_drift_check("TEROK_PROXY_PORT", "Proxy", 18700)
+        assert check.evaluate(1, "", "").severity == "ok"
 
 
 class TestReadDesiredShieldState:

--- a/tests/unit/lib/test_shield.py
+++ b/tests/unit/lib/test_shield.py
@@ -56,12 +56,20 @@ def make_mock_shield(
 @pytest.mark.parametrize(
     ("cfg_kwargs", "expected_profiles", "expected_port", "audit_enabled"),
     [
-        pytest.param({}, ("dev-standard",), GATE_PORT, True, id="defaults"),
+        pytest.param(
+            {"gate_port": GATE_PORT, "proxy_port": 18731, "ssh_agent_port": 18732},
+            ("dev-standard",),
+            GATE_PORT,
+            True,
+            id="defaults",
+        ),
         pytest.param(
             {
                 "shield_profiles": ("custom-a", "custom-b"),
                 "shield_audit": False,
                 "gate_port": CUSTOM_GATE_PORT,
+                "proxy_port": 18731,
+                "ssh_agent_port": 18732,
             },
             ("custom-a", "custom-b"),
             CUSTOM_GATE_PORT,
@@ -69,7 +77,12 @@ def make_mock_shield(
             id="custom-values",
         ),
         pytest.param(
-            {"shield_profiles": ("single-profile",)},
+            {
+                "shield_profiles": ("single-profile",),
+                "gate_port": GATE_PORT,
+                "proxy_port": 18731,
+                "ssh_agent_port": 18732,
+            },
             ("single-profile",),
             GATE_PORT,
             True,
@@ -160,7 +173,7 @@ def test_shield_down_allow_all(mock_make: MagicMock) -> None:
 
 def test_status_defaults() -> None:
     """Status reflects the default configured shield state."""
-    cfg = SandboxConfig()
+    cfg = SandboxConfig(gate_port=9418, proxy_port=18731, ssh_agent_port=18732)
     assert status(cfg=cfg) == {
         "mode": "hook",
         "profiles": ["dev-standard"],

--- a/tests/unit/lib/test_yaml_schema.py
+++ b/tests/unit/lib/test_yaml_schema.py
@@ -232,7 +232,7 @@ class RawGlobalConfigTests(unittest.TestCase):
         self.assertFalse(cfg.shield.bypass_firewall_no_protection)
         self.assertTrue(cfg.shield.drop_on_task_run)
         self.assertEqual(cfg.shield.on_task_restart, "retain")
-        self.assertEqual(cfg.gate_server.port, 9418)
+        self.assertIsNone(cfg.gate_server.port)
         self.assertIsNone(cfg.default_agent)
         self.assertFalse(cfg.experimental)
 
@@ -266,6 +266,27 @@ class RawGlobalConfigTests(unittest.TestCase):
         self.assertEqual(cfg.gate_server.port, 1234)
         self.assertTrue(cfg.gate_server.suppress_systemd_warning)
         self.assertEqual(cfg.default_agent, "codex")
+
+    def test_port_validation_rejects_out_of_range(self) -> None:
+        """Port fields reject values outside 1–65535."""
+        for section, field in [
+            ("gate_server", "port"),
+            ("credential_proxy", "port"),
+            ("credential_proxy", "ssh_agent_port"),
+        ]:
+            for bad in (0, -1, 65536, 100000):
+                with self.assertRaises(ValidationError, msg=f"{section}.{field}={bad}"):
+                    RawGlobalConfig.model_validate({section: {field: bad}})
+
+    def test_port_validation_accepts_valid(self) -> None:
+        """Port fields accept valid values and None."""
+        cfg = RawGlobalConfig.model_validate({
+            "gate_server": {"port": 9418},
+            "credential_proxy": {"port": 1, "ssh_agent_port": 65535},
+        })
+        self.assertEqual(cfg.gate_server.port, 9418)
+        self.assertEqual(cfg.credential_proxy.port, 1)
+        self.assertEqual(cfg.credential_proxy.ssh_agent_port, 65535)
 
     def test_unknown_key_rejected(self) -> None:
         """Unknown top-level key raises ValidationError."""

--- a/tests/unit/test_error_surfacing.py
+++ b/tests/unit/test_error_surfacing.py
@@ -182,7 +182,7 @@ class TestLoadValidatedErrorPaths:
         assert str(bad_file) in captured.err
         # Returns defaults
         assert result.ui.base_port == 7860
-        assert result.gate_server.port == 9418
+        assert result.gate_server.port is None
 
     def test_invalid_schema_warns_with_field_errors_and_returns_defaults(
         self,
@@ -399,41 +399,6 @@ class TestImageCleanupWarning:
         assert result is None
         mock_warn.assert_called_once()
         assert "Project discovery failed" in mock_warn.call_args[0][0]
-
-
-# ===========================================================================
-# ports.py — malformed task metadata during port scan
-# ===========================================================================
-
-
-class TestPortScanWarning:
-    """Cover the exception branch in _collect_all_web_ports()."""
-
-    @pytest.fixture(autouse=True)
-    def _isolate_log(self, tmp_path: Path) -> None:
-        with patch("terok.lib.core.paths.state_root", return_value=tmp_path):
-            yield
-
-    def test_malformed_metadata_logged(self, tmp_path: Path) -> None:
-        """Corrupt task YAML is caught and logged during port scan."""
-        from terok.lib.orchestration.ports import _collect_all_web_ports
-
-        # Set up the state directory structure
-        proj_dir = tmp_path / "projects" / "myproj" / "tasks"
-        proj_dir.mkdir(parents=True)
-        (proj_dir / "bad.yml").write_text(": [broken yaml")
-        (proj_dir / "good.yml").write_text("web_port: 8080\n")
-
-        with (
-            patch("terok.lib.orchestration.ports.state_dir", return_value=tmp_path),
-            patch("terok.lib.util.logging_utils.log_warning") as mock_warn,
-        ):
-            ports = _collect_all_web_ports()
-
-        # Good port still collected, bad file warned
-        assert 8080 in ports
-        mock_warn.assert_called_once()
-        assert "port scan" in mock_warn.call_args[0][0].lower()
 
 
 # ===========================================================================


### PR DESCRIPTION
## Summary

Integrates terok-sandbox's file-based port registry for dynamic port
allocation on shared hosts. Replaces hardcoded service ports with
auto-allocation, preventing collisions between users.

### Changes

- **yaml_schema.py**: `RawNetworkSection` (port range config), port validation
  on `RawCredentialProxySection`/`RawGateServerSection`, `port_registry_dir`
  in `RawPathsSection`
- **config.py**: `get_credential_proxy_port()`, `get_credential_proxy_ssh_agent_port()`,
  `get_gate_server_port()` returns `int | None` (None = auto-allocate)
- **ports.py**: rewritten as thin wrapper delegating to `terok_sandbox.claim_port`/`release_port`
- **task_runners.py**: web port reclaim via registry on `task_run_toad` and `task_restart`
- **tasks.py**: `release_web_port` calls on `_task_stop` and `_task_delete`
- **container_doctor.py**: port drift detection for proxy/SSH agent ports
- **conftest.py**: autouse fixture isolates port registry from real filesystem
- **tach.toml**: `tasks` module depends on `ports`

### Dependencies

- Requires terok-ai/terok-sandbox#144 (shared port registry)
- `pyproject.toml` temporarily pins sandbox+executor to fork branches

## Test plan

- [x] 1642 unit tests pass
- [x] Ruff + tach clean
- [x] Port validation tests, config accessor tests, drift detection tests
- [ ] Integration test on shared host (manual)

Closes terok-ai/terok#692

🤖 Generated with [Claude Code](https://claude.com/claude-code)