### PR TITLE
fix: per-layer image staleness detection with build manifest

### DIFF
--- a/src/terok/lib/domain/project_state.py
+++ b/src/terok/lib/domain/project_state.py
@@ -306,4 +306,4 @@ def is_task_image_old(project_id: str | None, task: Any) -> bool | None:
             return True
         return label != current_hash
 
-    return bool(stale) or None
+    return len(stale) > 0

--- a/src/terok/lib/domain/project_state.py
+++ b/src/terok/lib/domain/project_state.py
@@ -10,7 +10,7 @@ for overview displays.
 
 import subprocess
 from collections.abc import Callable
-from datetime import UTC, datetime
+from datetime import datetime
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
@@ -100,46 +100,14 @@ def get_project_state(
                 dockerfiles_old = False
 
     images_old = False
+    stale_layers: list[str] = []
     if has_images and has_dockerfiles:
         if dockerfiles_old:
             images_old = True
+            stale_layers = ["l0", "l1", "l2"]
         else:
-            docker_mtime = None
-            try:
-                docker_mtime = max(p.stat().st_mtime for p in dockerfiles if p.is_file())
-            except Exception:
-                docker_mtime = None
-
-            context_hash = None
-            if rendered:
-                try:
-                    from ..orchestration.image import build_context_hash_from_rendered
-
-                    context_hash = build_context_hash_from_rendered(project, rendered)
-                except (OSError, ValueError, KeyError, ImportError) as exc:
-                    from ..util.logging_utils import _log_debug
-
-                    _log_debug(f"Build context hash failed for {project_id}: {exc}")
-                    context_hash = None
-
-            if docker_mtime is not None or context_hash is not None:
-                docker_dt = (
-                    datetime.fromtimestamp(docker_mtime, tz=UTC)
-                    if docker_mtime is not None
-                    else None
-                )
-                for tag in required_tags:
-                    created, label = _get_image_metadata(tag, "terok.build_context_hash")
-                    if created is None and label is None:
-                        images_old = True
-                        break
-                    if docker_dt is not None and created is not None and created < docker_dt:
-                        images_old = True
-                        break
-                    if context_hash is not None:
-                        if label is None or label != context_hash:
-                            images_old = True
-                            break
+            stale_layers = _detect_stale_layers(project, rendered)
+            images_old = bool(stale_layers)
 
     # SSH: consider SSH "ready" when the key directory and its config file exist.
     # Falls back to the managed ssh-keys store (same as SSHManager / git gate).
@@ -168,10 +136,52 @@ def get_project_state(
         "dockerfiles_old": dockerfiles_old,
         "images": has_images,
         "images_old": images_old,
+        "stale_layers": stale_layers,
         "ssh": has_ssh,
         "gate": has_gate,
         "gate_last_commit": gate_last_commit,
     }
+
+
+def _detect_stale_layers(project: "ProjectConfig", rendered: dict[str, str] | None) -> list[str]:
+    """Compare per-layer content hashes against the build manifest.
+
+    Returns a list of stale layer names (``"l0"``, ``"l1"``, ``"l2"``).
+    Missing manifest → all layers stale.
+    """
+    if not rendered:
+        return ["l0", "l1", "l2"]
+
+    try:
+        from ..orchestration.image import (
+            l0_content_hash,
+            l1_content_hash,
+            l2_content_hash,
+            read_build_manifest,
+        )
+
+        current = {
+            "l0": l0_content_hash(project.base_image, rendered),
+            "l1": l1_content_hash(rendered),
+            "l2": l2_content_hash(rendered),
+        }
+        manifest = read_build_manifest(project.id)
+    except (ImportError, OSError, ValueError, KeyError):
+        return ["l0", "l1", "l2"]
+
+    if manifest is None:
+        return ["l0", "l1", "l2"]
+
+    stale: list[str] = []
+    for layer in ("l0", "l1"):
+        entry = manifest.get(layer)
+        if not isinstance(entry, dict) or entry.get("content_hash") != current[layer]:
+            stale.append(layer)
+    # L2 uses "l2_cli" key in the manifest
+    l2_entry = manifest.get("l2_cli")
+    if not isinstance(l2_entry, dict) or l2_entry.get("content_hash") != current["l2"]:
+        stale.append("l2")
+    return stale
 
 
 def _get_image_metadata(tag: str, label_key: str) -> tuple[datetime | None, str | None]:
@@ -278,32 +288,22 @@ def is_task_image_old(project_id: str | None, task: Any) -> bool | None:
         return None
 
     try:
-        from ..orchestration.image import build_context_hash
+        from ..orchestration.image import render_all_dockerfiles
 
-        current_hash = build_context_hash(project_id)
+        project = load_project(project_id)
+        rendered = render_all_dockerfiles(project)
+        stale = _detect_stale_layers(project, rendered)
     except Exception:
-        return None
+        # Fall back to L2 label check if manifest approach fails
+        try:
+            from ..orchestration.image import build_context_hash
 
-    try:
-        label_result = subprocess.run(
-            [
-                "podman",
-                "image",
-                "inspect",
-                "--format",
-                '{{index .Config.Labels "terok.build_context_hash"}}',
-                image_id,
-            ],
-            capture_output=True,
-            text=True,
-            timeout=10,
-        )
-    except (FileNotFoundError, OSError, subprocess.TimeoutExpired):
-        return None
-    if label_result.returncode != 0:
-        return None
+            current_hash = build_context_hash(project_id)
+        except Exception:
+            return None
+        _, label = _get_image_metadata(image_id, "terok.build_context_hash")
+        if label is None:
+            return True
+        return label != current_hash
 
-    label = label_result.stdout.strip()
-    if not label or label == "<no value>":
-        return True
-    return label != current_hash
+    return bool(stale) or None

--- a/src/terok/lib/orchestration/image.py
+++ b/src/terok/lib/orchestration/image.py
@@ -10,12 +10,15 @@ three layers together.
 """
 
 import hashlib
+import json
+import logging
 import shlex
 import shutil
 import subprocess
 from functools import lru_cache
 from importlib import resources
 from pathlib import Path
+from typing import Any
 
 from terok_executor import (
     BuildError,
@@ -165,25 +168,46 @@ def render_all_dockerfiles(project: ProjectConfig) -> dict[str, str]:
 # ---------- Build context hash ----------
 
 
+def _sha256(*parts: str) -> str:
+    """Compute SHA-256 from a sequence of string parts, null-separated."""
+    hasher = hashlib.sha256()
+    for i, part in enumerate(parts):
+        if i:
+            hasher.update(b"\0")
+        hasher.update(part.encode("utf-8"))
+    return hasher.hexdigest()
+
+
+def l0_content_hash(base_image: str, rendered: dict[str, str]) -> str:
+    """Content hash for the L0 (base dev) layer."""
+    return _sha256(f"base_image={base_image}", rendered["L0.Dockerfile"])
+
+
+def l1_content_hash(rendered: dict[str, str]) -> str:
+    """Content hash for the L1 (agent CLI) layer."""
+    return _sha256(rendered["L1.cli.Dockerfile"], _scripts_hash(), _tmux_config_hash())
+
+
+def l2_content_hash(rendered: dict[str, str]) -> str:
+    """Content hash for the L2 (project customisation) layer."""
+    return _sha256(rendered["L2.Dockerfile"])
+
+
 def build_context_hash_from_rendered(project: ProjectConfig, rendered: dict[str, str]) -> str:
-    """Compute a SHA-256 digest from pre-rendered Dockerfiles.
+    """Compute a combined SHA-256 digest from pre-rendered Dockerfiles.
+
+    The combined hash is derived from the three per-layer hashes.  It is
+    stored on L2 images as the ``terok.build_context_hash`` label.
 
     Args:
         project: The resolved project configuration.
         rendered: name→content mapping returned by :func:`render_all_dockerfiles`.
     """
-    hasher = hashlib.sha256()
-    hasher.update(f"base_image={project.base_image}".encode())
-    hasher.update(b"\0")
-    for name in sorted(rendered):
-        hasher.update(name.encode("utf-8"))
-        hasher.update(b"\0")
-        hasher.update(rendered[name].encode("utf-8"))
-        hasher.update(b"\0")
-    hasher.update(_scripts_hash().encode("utf-8"))
-    hasher.update(b"\0")
-    hasher.update(_tmux_config_hash().encode("utf-8"))
-    return hasher.hexdigest()
+    return _sha256(
+        l0_content_hash(project.base_image, rendered),
+        l1_content_hash(rendered),
+        l2_content_hash(rendered),
+    )
 
 
 def build_context_hash(project_id: str) -> str:
@@ -191,6 +215,35 @@ def build_context_hash(project_id: str) -> str:
     project = load_project(project_id)
     rendered = render_all_dockerfiles(project)
     return build_context_hash_from_rendered(project, rendered)
+
+
+# ---------- Build manifest ----------
+
+_MANIFEST_SCHEMA = 1
+_logger = logging.getLogger(__name__)
+
+
+def _manifest_path(project_id: str) -> Path:
+    """Return the path to the build manifest for *project_id*."""
+    return build_dir() / project_id / "build_manifest.json"
+
+
+def read_build_manifest(project_id: str) -> dict[str, Any] | None:
+    """Load the build manifest for *project_id*, or ``None`` if absent/corrupt."""
+    path = _manifest_path(project_id)
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+    return data if isinstance(data, dict) and data.get("schema") == _MANIFEST_SCHEMA else None
+
+
+def _write_build_manifest(project_id: str, manifest: dict[str, Any]) -> None:
+    """Atomically write the build manifest for *project_id*."""
+    path = _manifest_path(project_id)
+    tmp = path.with_suffix(".tmp")
+    tmp.write_text(json.dumps(manifest, indent=2) + "\n", encoding="utf-8")
+    tmp.replace(path)
 
 
 # ---------- Dockerfile generation ----------
@@ -251,6 +304,7 @@ def build_images(
     project = load_project(project_id)
     base_image = project.base_image
     stage_dir = build_dir() / project.id
+    rebuilt_base = rebuild_agents or full_rebuild
 
     # Delegate L0+L1 to terok-executor (uses its own temp dir for build context)
     try:
@@ -271,8 +325,21 @@ def build_images(
     generate_dockerfiles(project_id)
     l2_path = stage_dir / "L2.Dockerfile"
 
-    context_hash = build_context_hash(project_id)
+    rendered = render_all_dockerfiles(project)
+    l0_hash = l0_content_hash(base_image, rendered)
+    l1_hash = l1_content_hash(rendered)
+    l2_hash = l2_content_hash(rendered)
+    context_hash = _sha256(l0_hash, l1_hash, l2_hash)
     context_dir = str(stage_dir)
+
+    # Resolve manifest L0/L1 hashes: use current hashes if rebuilt,
+    # carry forward from previous manifest if skipped.
+    if rebuilt_base:
+        manifest_l0_hash, manifest_l1_hash = l0_hash, l1_hash
+    else:
+        prev = read_build_manifest(project_id)
+        manifest_l0_hash = prev["l0"]["content_hash"] if prev else l0_hash
+        manifest_l1_hash = prev["l1"]["content_hash"] if prev else l1_hash
 
     def _build_l2(base_arg: str, target: str) -> None:
         """Build one L2 image variant."""
@@ -297,3 +364,17 @@ def build_images(
     # Optionally build L2 dev image (project layer on top of L0)
     if include_dev:
         _build_l2(l0_image, l2_dev_image)
+
+    # Write build manifest so staleness detection knows what each
+    # layer was actually built from.
+    _write_build_manifest(
+        project_id,
+        {
+            "schema": _MANIFEST_SCHEMA,
+            "base_image": base_image,
+            "l0": {"tag": l0_image, "content_hash": manifest_l0_hash},
+            "l1": {"tag": l1_cli_image, "content_hash": manifest_l1_hash},
+            "l2_cli": {"tag": l2_cli_image, "content_hash": l2_hash},
+            "combined_hash": context_hash,
+        },
+    )

--- a/src/terok/tui/widgets/project_state.py
+++ b/src/terok/tui/widgets/project_state.py
@@ -17,7 +17,8 @@ from ...lib.core.task_display import GPU_DISPLAY, SECURITY_CLASS_DISPLAY, has_gp
 from ...lib.util.emoji import render_emoji
 from .task_detail import _get_css_variables
 
-_STALE_LAYER_HINTS = {
+_LAYER_LABELS = {"l0": "L0", "l1": "L1", "l2": "L2"}
+_REBUILD_COMMANDS = {
     "l0": "build --full-rebuild",
     "l1": "build --agents",
     "l2": "build",
@@ -25,14 +26,15 @@ _STALE_LAYER_HINTS = {
 
 
 def _stale_layer_hint(stale_layers: list[str]) -> str:
-    """Return an actionable hint for the deepest stale layer.
+    """Format a concise ``old L0/L1 (build --agents)`` hint.
 
-    Deepest layer first — rebuilding L0 cascades through L1 and L2.
+    Shows which layers are stale and the rebuild command for the deepest
+    one (since rebuilding L0 cascades through L1 and L2).
     """
-    for layer in ("l0", "l1", "l2"):
-        if layer in stale_layers:
-            return _STALE_LAYER_HINTS[layer]
-    return ""
+    layer_order = ("l0", "l1", "l2")
+    labels = "/".join(_LAYER_LABELS[ly] for ly in layer_order if ly in stale_layers)
+    cmd = next((_REBUILD_COMMANDS[ly] for ly in layer_order if ly in stale_layers), "")
+    return f"{labels} ({cmd})" if labels else ""
 
 
 def render_project_loading(

--- a/src/terok/tui/widgets/project_state.py
+++ b/src/terok/tui/widgets/project_state.py
@@ -17,6 +17,23 @@ from ...lib.core.task_display import GPU_DISPLAY, SECURITY_CLASS_DISPLAY, has_gp
 from ...lib.util.emoji import render_emoji
 from .task_detail import _get_css_variables
 
+_STALE_LAYER_HINTS = {
+    "l0": "build --full-rebuild",
+    "l1": "build --agents",
+    "l2": "build",
+}
+
+
+def _stale_layer_hint(stale_layers: list[str]) -> str:
+    """Return an actionable hint for the deepest stale layer.
+
+    Deepest layer first — rebuilding L0 cascades through L1 and L2.
+    """
+    for layer in ("l0", "l1", "l2"):
+        if layer in stale_layers:
+            return _STALE_LAYER_HINTS[layer]
+    return ""
+
 
 def render_project_loading(
     project: ProjectConfig | None,
@@ -83,6 +100,13 @@ def render_project_details(
     if images_value == "yes" and state.get("images_old"):
         images_value = "old"
     images_s = _status_text(images_value)
+
+    # Append actionable hint when specific layers are stale
+    stale = state.get("stale_layers", [])
+    if images_value == "old" and stale:
+        hint = _stale_layer_hint(stale)
+        if hint:
+            images_s.append(f" ({hint})", style=Style(color=warning_color, dim=True))
     ssh_s = _status_text("yes" if state.get("ssh") else "no")
 
     # Gate line: server status overrides repo status when server is down

--- a/src/terok/tui/widgets/project_state.py
+++ b/src/terok/tui/widgets/project_state.py
@@ -18,23 +18,11 @@ from ...lib.util.emoji import render_emoji
 from .task_detail import _get_css_variables
 
 _LAYER_LABELS = {"l0": "L0", "l1": "L1", "l2": "L2"}
-_REBUILD_COMMANDS = {
-    "l0": "build --full-rebuild",
-    "l1": "build --agents",
-    "l2": "build",
-}
 
 
 def _stale_layer_hint(stale_layers: list[str]) -> str:
-    """Format a concise ``old L0/L1 (build --agents)`` hint.
-
-    Shows which layers are stale and the rebuild command for the deepest
-    one (since rebuilding L0 cascades through L1 and L2).
-    """
-    layer_order = ("l0", "l1", "l2")
-    labels = "/".join(_LAYER_LABELS[ly] for ly in layer_order if ly in stale_layers)
-    cmd = next((_REBUILD_COMMANDS[ly] for ly in layer_order if ly in stale_layers), "")
-    return f"{labels} ({cmd})" if labels else ""
+    """Format a concise ``L0/L1`` label for stale layers."""
+    return "/".join(_LAYER_LABELS[ly] for ly in ("l0", "l1", "l2") if ly in stale_layers)
 
 
 def render_project_loading(
@@ -100,15 +88,10 @@ def render_project_details(
 
     images_value = "yes" if state.get("images") else "no"
     if images_value == "yes" and state.get("images_old"):
-        images_value = "old"
-    images_s = _status_text(images_value)
-
-    # Append actionable hint when specific layers are stale
-    stale = state.get("stale_layers", [])
-    if images_value == "old" and stale:
+        stale = state.get("stale_layers", [])
         hint = _stale_layer_hint(stale)
-        if hint:
-            images_s.append(f" ({hint})", style=Style(color=warning_color, dim=True))
+        images_value = f"old {hint}" if hint else "old"
+    images_s = _status_text(images_value)
     ssh_s = _status_text("yes" if state.get("ssh") else "no")
 
     # Gate line: server status overrides repo status when server is down

--- a/tach.toml
+++ b/tach.toml
@@ -575,6 +575,10 @@ expose = [
     "build_images",
     "build_context_hash",
     "build_context_hash_from_rendered",
+    "l0_content_hash",
+    "l1_content_hash",
+    "l2_content_hash",
+    "read_build_manifest",
     "render_all_dockerfiles",
 ]
 from = ["terok.lib.orchestration.image"]

--- a/tests/unit/lib/test_image.py
+++ b/tests/unit/lib/test_image.py
@@ -283,6 +283,48 @@ class TestPerLayerHashes:
         )
         assert l1_content_hash(rendered_a) == l1_content_hash(rendered_b)
 
+    def test_l2_changes_dont_affect_l0_or_l1_hash(self) -> None:
+        """Changing L2 Dockerfile does not change L0 or L1 hashes."""
+        from terok.lib.orchestration.image import l0_content_hash, l1_content_hash
+
+        rendered_a = {
+            "L0.Dockerfile": "FROM ubuntu:24.04",
+            "L1.cli.Dockerfile": "FROM l0-tag",
+            "L2.Dockerfile": "FROM l1-tag",
+        }
+        rendered_b = {**rendered_a, "L2.Dockerfile": "FROM l1-tag\nRUN echo added"}
+
+        assert l0_content_hash("ubuntu:24.04", rendered_a) == l0_content_hash(
+            "ubuntu:24.04", rendered_b
+        )
+        assert l1_content_hash(rendered_a) == l1_content_hash(rendered_b)
+
+    def test_l1_dockerfile_change_changes_l1_hash(self) -> None:
+        """Changing L1 Dockerfile content changes the L1 hash."""
+        from terok.lib.orchestration.image import l1_content_hash
+
+        rendered_a = {
+            "L0.Dockerfile": "FROM ubuntu:24.04",
+            "L1.cli.Dockerfile": "FROM l0-tag\nRUN install agents",
+            "L2.Dockerfile": "FROM l1-tag",
+        }
+        rendered_b = {**rendered_a, "L1.cli.Dockerfile": "FROM l0-tag\nRUN install NEW agents"}
+
+        assert l1_content_hash(rendered_a) != l1_content_hash(rendered_b)
+
+    def test_base_image_change_changes_l0_hash(self) -> None:
+        """Changing base_image string changes L0 hash."""
+        from terok.lib.orchestration.image import l0_content_hash
+
+        rendered = {
+            "L0.Dockerfile": "FROM base",
+            "L1.cli.Dockerfile": "x",
+            "L2.Dockerfile": "y",
+        }
+        assert l0_content_hash("ubuntu:24.04", rendered) != l0_content_hash(
+            "ubuntu:26.04", rendered
+        )
+
     def test_combined_hash_derives_from_per_layer(self) -> None:
         """Combined hash changes when any per-layer hash changes."""
         from terok.lib.orchestration.image import (
@@ -348,6 +390,18 @@ class TestBuildManifest:
             path.write_text("not json", encoding="utf-8")
             assert read_build_manifest("proj_corrupt") is None
 
+    def test_wrong_schema_version_returns_none(self) -> None:
+        """Manifest with wrong schema version returns None."""
+        import json
+
+        from terok.lib.orchestration.image import _manifest_path, read_build_manifest
+
+        with image_project("proj_bad_schema"):
+            generate_dockerfiles("proj_bad_schema")
+            path = _manifest_path("proj_bad_schema")
+            path.write_text(json.dumps({"schema": 999, "l0": {}}), encoding="utf-8")
+            assert read_build_manifest("proj_bad_schema") is None
+
     def test_build_images_writes_manifest(self) -> None:
         """build_images writes a build manifest after successful build."""
         from terok.lib.orchestration.image import read_build_manifest
@@ -361,6 +415,36 @@ class TestBuildManifest:
         assert manifest["schema"] == 1
         assert "l0" in manifest and "l1" in manifest and "l2_cli" in manifest
         assert all(manifest[k]["content_hash"] for k in ("l0", "l1"))
+
+    def test_rebuild_agents_writes_fresh_hashes(self) -> None:
+        """rebuild_agents=True records current hashes, not carried-forward ones."""
+        from terok.lib.orchestration.image import (
+            _write_build_manifest,
+            read_build_manifest,
+        )
+
+        with image_project("proj_rebuild"):
+            generate_dockerfiles("proj_rebuild")
+            # Seed a manifest with stale hashes
+            _write_build_manifest(
+                "proj_rebuild",
+                {
+                    "schema": 1,
+                    "base_image": "ubuntu:24.04",
+                    "l0": {"tag": "terok-l0:ubuntu-24-04", "content_hash": "old-l0"},
+                    "l1": {"tag": "terok-l1-cli:ubuntu-24-04", "content_hash": "old-l1"},
+                    "l2_cli": {"tag": "proj_rebuild:l2-cli", "content_hash": "old-l2"},
+                    "combined_hash": "old-combined",
+                },
+            )
+            # Build with --agents → L0/L1 rebuilt → fresh hashes
+            build_commands("proj_rebuild", rebuild_agents=True)
+            manifest = read_build_manifest("proj_rebuild")
+
+        assert manifest is not None
+        # Hashes must NOT be the old carried-forward values
+        assert manifest["l0"]["content_hash"] != "old-l0"
+        assert manifest["l1"]["content_hash"] != "old-l1"
 
     def test_skipped_base_carries_forward_manifest_hashes(self) -> None:
         """When L0/L1 are skipped, manifest preserves previous hashes."""

--- a/tests/unit/lib/test_image.py
+++ b/tests/unit/lib/test_image.py
@@ -240,3 +240,156 @@ def test_build_images_full_rebuild_passes_no_cache() -> None:
         commands = build_commands("proj_build_full", full_rebuild=True)
 
     assert any("--no-cache" in cmd for cmd in commands[0])
+
+
+# ---------- Per-layer hashing ----------
+
+
+class TestPerLayerHashes:
+    """Verify per-layer content hashes are stable and independent."""
+
+    def test_per_layer_hashes_are_deterministic(self) -> None:
+        """Same inputs produce the same per-layer hashes."""
+        from terok.lib.orchestration.image import (
+            l0_content_hash,
+            l1_content_hash,
+            l2_content_hash,
+        )
+
+        rendered = {
+            "L0.Dockerfile": "FROM ubuntu:24.04",
+            "L1.cli.Dockerfile": "FROM terok-l0:ubuntu-24-04",
+            "L2.Dockerfile": "FROM terok-l1-cli:ubuntu-24-04",
+        }
+        assert l0_content_hash("ubuntu:24.04", rendered) == l0_content_hash(
+            "ubuntu:24.04", rendered
+        )
+        assert l1_content_hash(rendered) == l1_content_hash(rendered)
+        assert l2_content_hash(rendered) == l2_content_hash(rendered)
+
+    def test_l0_changes_dont_affect_l1_hash(self) -> None:
+        """Changing L0 Dockerfile does not change L1 hash."""
+        from terok.lib.orchestration.image import l0_content_hash, l1_content_hash
+
+        rendered_a = {
+            "L0.Dockerfile": "FROM ubuntu:24.04",
+            "L1.cli.Dockerfile": "FROM l0-tag",
+            "L2.Dockerfile": "FROM l1-tag",
+        }
+        rendered_b = {**rendered_a, "L0.Dockerfile": "FROM ubuntu:26.04"}
+
+        assert l0_content_hash("ubuntu:24.04", rendered_a) != l0_content_hash(
+            "ubuntu:26.04", rendered_b
+        )
+        assert l1_content_hash(rendered_a) == l1_content_hash(rendered_b)
+
+    def test_combined_hash_derives_from_per_layer(self) -> None:
+        """Combined hash changes when any per-layer hash changes."""
+        from terok.lib.orchestration.image import (
+            build_context_hash_from_rendered,
+        )
+
+        with image_project("proj_hash_comb"):
+            from terok.lib.core.projects import load_project
+            from terok.lib.orchestration.image import render_all_dockerfiles
+
+            project = load_project("proj_hash_comb")
+            rendered = render_all_dockerfiles(project)
+            h1 = build_context_hash_from_rendered(project, rendered)
+
+            # Tweak L2 only
+            rendered["L2.Dockerfile"] += "\nRUN echo hello"
+            h2 = build_context_hash_from_rendered(project, rendered)
+            assert h1 != h2
+
+
+# ---------- Build manifest ----------
+
+
+class TestBuildManifest:
+    """Verify manifest read/write round-tripping."""
+
+    def test_write_and_read_manifest(self) -> None:
+        """Manifest round-trips through JSON on disk."""
+        from terok.lib.orchestration.image import (
+            _write_build_manifest,
+            read_build_manifest,
+        )
+
+        manifest = {
+            "schema": 1,
+            "base_image": "ubuntu:24.04",
+            "l0": {"tag": "terok-l0:ubuntu-24-04", "content_hash": "aaa"},
+            "l1": {"tag": "terok-l1-cli:ubuntu-24-04", "content_hash": "bbb"},
+            "l2_cli": {"tag": "test:l2-cli", "content_hash": "ccc"},
+            "combined_hash": "ddd",
+        }
+        with image_project("proj_manifest"):
+            generate_dockerfiles("proj_manifest")
+            _write_build_manifest("proj_manifest", manifest)
+            loaded = read_build_manifest("proj_manifest")
+
+        assert loaded == manifest
+
+    def test_missing_manifest_returns_none(self) -> None:
+        """read_build_manifest returns None when no manifest exists."""
+        from terok.lib.orchestration.image import read_build_manifest
+
+        with image_project("proj_no_manifest"):
+            assert read_build_manifest("proj_no_manifest") is None
+
+    def test_corrupt_manifest_returns_none(self) -> None:
+        """Corrupt JSON manifest returns None."""
+        from terok.lib.orchestration.image import _manifest_path, read_build_manifest
+
+        with image_project("proj_corrupt"):
+            generate_dockerfiles("proj_corrupt")
+            path = _manifest_path("proj_corrupt")
+            path.write_text("not json", encoding="utf-8")
+            assert read_build_manifest("proj_corrupt") is None
+
+    def test_build_images_writes_manifest(self) -> None:
+        """build_images writes a build manifest after successful build."""
+        from terok.lib.orchestration.image import read_build_manifest
+
+        with image_project("proj_build_manifest"):
+            generate_dockerfiles("proj_build_manifest")
+            build_commands("proj_build_manifest", rebuild_agents=True)
+            manifest = read_build_manifest("proj_build_manifest")
+
+        assert manifest is not None
+        assert manifest["schema"] == 1
+        assert "l0" in manifest and "l1" in manifest and "l2_cli" in manifest
+        assert all(manifest[k]["content_hash"] for k in ("l0", "l1"))
+
+    def test_skipped_base_carries_forward_manifest_hashes(self) -> None:
+        """When L0/L1 are skipped, manifest preserves previous hashes."""
+        from terok.lib.orchestration.image import (
+            _write_build_manifest,
+            read_build_manifest,
+        )
+
+        with image_project("proj_skip"):
+            generate_dockerfiles("proj_skip")
+            # Simulate a previous build with known L0/L1 hashes
+            _write_build_manifest(
+                "proj_skip",
+                {
+                    "schema": 1,
+                    "base_image": "ubuntu:24.04",
+                    "l0": {"tag": "terok-l0:ubuntu-24-04", "content_hash": "old-l0"},
+                    "l1": {"tag": "terok-l1-cli:ubuntu-24-04", "content_hash": "old-l1"},
+                    "l2_cli": {"tag": "proj_skip:l2-cli", "content_hash": "old-l2"},
+                    "combined_hash": "old-combined",
+                },
+            )
+            # Default build (rebuild_agents=False) → L0/L1 skipped
+            build_commands("proj_skip")
+            manifest = read_build_manifest("proj_skip")
+
+        assert manifest is not None
+        # L0/L1 hashes carried forward from previous manifest
+        assert manifest["l0"]["content_hash"] == "old-l0"
+        assert manifest["l1"]["content_hash"] == "old-l1"
+        # L2 hash is freshly computed (not "old-l2")
+        assert manifest["l2_cli"]["content_hash"] != "old-l2"

--- a/tests/unit/lib/test_projects.py
+++ b/tests/unit/lib/test_projects.py
@@ -280,6 +280,7 @@ class TestProject:
             "dockerfiles_old": True,
             "images": True,
             "images_old": True,
+            "stale_layers": ["l0", "l1", "l2"],
             "ssh": True,
             "gate": True,
             "gate_last_commit": None,

--- a/tests/unit/lib/test_staleness_detection.py
+++ b/tests/unit/lib/test_staleness_detection.py
@@ -120,6 +120,169 @@ class TestDetectStaleLayers:
             stale = _detect_stale_layers(project, rendered)
             assert stale == ["l0", "l2"]
 
+    def test_malformed_manifest_entry_marks_layer_stale(self) -> None:
+        """Manifest with non-dict layer entry → that layer is stale."""
+        from terok.lib.domain.project_state import _detect_stale_layers
+
+        project = Mock(id="p1", base_image="ubuntu:24.04")
+        rendered = {"L0.Dockerfile": "x", "L1.cli.Dockerfile": "y", "L2.Dockerfile": "z"}
+
+        # l1 entry is a string instead of a dict
+        manifest = self._make_manifest("h0", "h1", "h2")
+        manifest["l1"] = "not-a-dict"
+
+        with (
+            patch("terok.lib.orchestration.image.l0_content_hash", return_value="h0"),
+            patch("terok.lib.orchestration.image.l1_content_hash", return_value="h1"),
+            patch("terok.lib.orchestration.image.l2_content_hash", return_value="h2"),
+            patch(
+                "terok.lib.orchestration.image.read_build_manifest",
+                return_value=manifest,
+            ),
+        ):
+            stale = _detect_stale_layers(project, rendered)
+            assert "l1" in stale
+            assert "l0" not in stale  # l0 matches, still current
+
+    def test_missing_manifest_key_marks_layer_stale(self) -> None:
+        """Manifest missing a layer key entirely → that layer is stale."""
+        from terok.lib.domain.project_state import _detect_stale_layers
+
+        project = Mock(id="p1", base_image="ubuntu:24.04")
+        rendered = {"L0.Dockerfile": "x", "L1.cli.Dockerfile": "y", "L2.Dockerfile": "z"}
+
+        manifest = self._make_manifest("h0", "h1", "h2")
+        del manifest["l0"]
+
+        with (
+            patch("terok.lib.orchestration.image.l0_content_hash", return_value="h0"),
+            patch("terok.lib.orchestration.image.l1_content_hash", return_value="h1"),
+            patch("terok.lib.orchestration.image.l2_content_hash", return_value="h2"),
+            patch(
+                "terok.lib.orchestration.image.read_build_manifest",
+                return_value=manifest,
+            ),
+        ):
+            stale = _detect_stale_layers(project, rendered)
+            assert stale == ["l0"]  # only l0 is stale (missing from manifest)
+
+    def test_import_error_falls_back_to_all_stale(self) -> None:
+        """ImportError during hash computation → all layers stale."""
+        from terok.lib.domain.project_state import _detect_stale_layers
+
+        project = Mock(id="p1", base_image="ubuntu:24.04")
+        rendered = {"L0.Dockerfile": "x", "L1.cli.Dockerfile": "y", "L2.Dockerfile": "z"}
+
+        with patch(
+            "terok.lib.orchestration.image.l0_content_hash",
+            side_effect=ImportError("missing"),
+        ):
+            assert _detect_stale_layers(project, rendered) == ["l0", "l1", "l2"]
+
+
+class TestIsTaskImageOld:
+    """Verify is_task_image_old return values."""
+
+    def test_returns_false_when_all_current(self) -> None:
+        """Running task with current manifest → False."""
+        from terok.lib.domain.project_state import is_task_image_old
+
+        task = Mock(mode="cli", task_id="42")
+        container_inspect = Mock(returncode=0, stdout="true\tsha256:abc123")
+
+        with (
+            patch("terok.lib.domain.project_state.subprocess.run", return_value=container_inspect),
+            patch("terok.lib.domain.project_state._container_name", return_value="c1"),
+            patch(
+                "terok.lib.orchestration.image.render_all_dockerfiles",
+                return_value={"L0.Dockerfile": "x", "L1.cli.Dockerfile": "y", "L2.Dockerfile": "z"},
+            ),
+            patch(
+                "terok.lib.domain.project_state.load_project",
+                return_value=Mock(base_image="ubuntu:24.04"),
+            ),
+            patch(
+                "terok.lib.domain.project_state._detect_stale_layers",
+                return_value=[],
+            ),
+        ):
+            result = is_task_image_old("proj1", task)
+
+        assert result is False
+
+    def test_returns_true_when_stale(self) -> None:
+        """Running task with stale L1 → True."""
+        from terok.lib.domain.project_state import is_task_image_old
+
+        task = Mock(mode="cli", task_id="42")
+        container_inspect = Mock(returncode=0, stdout="true\tsha256:abc123")
+
+        with (
+            patch("terok.lib.domain.project_state.subprocess.run", return_value=container_inspect),
+            patch("terok.lib.domain.project_state._container_name", return_value="c1"),
+            patch(
+                "terok.lib.orchestration.image.render_all_dockerfiles",
+                return_value={"L0.Dockerfile": "x", "L1.cli.Dockerfile": "y", "L2.Dockerfile": "z"},
+            ),
+            patch(
+                "terok.lib.domain.project_state.load_project",
+                return_value=Mock(base_image="ubuntu:24.04"),
+            ),
+            patch(
+                "terok.lib.domain.project_state._detect_stale_layers",
+                return_value=["l1"],
+            ),
+        ):
+            result = is_task_image_old("proj1", task)
+
+        assert result is True
+
+    def test_returns_none_for_non_cli_task(self) -> None:
+        """Non-CLI task mode → None (not applicable)."""
+        from terok.lib.domain.project_state import is_task_image_old
+
+        task = Mock(mode="web", task_id="42")
+        assert is_task_image_old("proj1", task) is None
+
+    def test_returns_none_for_none_project(self) -> None:
+        """None project_id → None."""
+        from terok.lib.domain.project_state import is_task_image_old
+
+        task = Mock(mode="cli", task_id="42")
+        assert is_task_image_old(None, task) is None
+
+    def test_falls_back_to_label_check_on_exception(self) -> None:
+        """When manifest approach fails, falls back to L2 label comparison."""
+        from datetime import UTC, datetime
+
+        from terok.lib.domain.project_state import is_task_image_old
+
+        task = Mock(mode="cli", task_id="42")
+        container_inspect = Mock(returncode=0, stdout="true\tsha256:abc123")
+
+        with (
+            patch("terok.lib.domain.project_state.subprocess.run", return_value=container_inspect),
+            patch("terok.lib.domain.project_state._container_name", return_value="c1"),
+            # Make manifest approach fail at load_project (inside is_task_image_old)
+            patch(
+                "terok.lib.domain.project_state.load_project",
+                side_effect=RuntimeError("boom"),
+            ),
+            # Fallback: build_context_hash succeeds
+            patch(
+                "terok.lib.orchestration.image.build_context_hash",
+                return_value="current-hash",
+            ),
+            # Label on image doesn't match → stale
+            patch(
+                "terok.lib.domain.project_state._get_image_metadata",
+                return_value=(datetime.now(UTC), "old-hash"),
+            ),
+        ):
+            result = is_task_image_old("proj1", task)
+
+        assert result is True  # "old-hash" != "current-hash"
+
 
 class TestStaleLayerHint:
     """Verify TUI hint selection for stale layers."""

--- a/tests/unit/lib/test_staleness_detection.py
+++ b/tests/unit/lib/test_staleness_detection.py
@@ -1,0 +1,149 @@
+# SPDX-FileCopyrightText: 2026 Jiri Vyskocil
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for per-layer image staleness detection via build manifests."""
+
+from __future__ import annotations
+
+from unittest.mock import Mock, patch
+
+
+class TestDetectStaleLayers:
+    """Verify _detect_stale_layers identifies per-layer staleness."""
+
+    @staticmethod
+    def _make_manifest(l0_hash: str, l1_hash: str, l2_hash: str) -> dict:
+        return {
+            "schema": 1,
+            "base_image": "ubuntu:24.04",
+            "l0": {"tag": "terok-l0:ubuntu-24-04", "content_hash": l0_hash},
+            "l1": {"tag": "terok-l1-cli:ubuntu-24-04", "content_hash": l1_hash},
+            "l2_cli": {"tag": "test:l2-cli", "content_hash": l2_hash},
+            "combined_hash": "irrelevant",
+        }
+
+    def test_all_current_returns_empty(self) -> None:
+        """All layers current → empty stale list."""
+        from terok.lib.domain.project_state import _detect_stale_layers
+
+        project = Mock(id="p1", base_image="ubuntu:24.04")
+        rendered = {
+            "L0.Dockerfile": "FROM ubuntu:24.04",
+            "L1.cli.Dockerfile": "FROM l0",
+            "L2.Dockerfile": "FROM l1",
+        }
+
+        with (
+            patch("terok.lib.orchestration.image.l0_content_hash", return_value="h0"),
+            patch("terok.lib.orchestration.image.l1_content_hash", return_value="h1"),
+            patch("terok.lib.orchestration.image.l2_content_hash", return_value="h2"),
+            patch(
+                "terok.lib.orchestration.image.read_build_manifest",
+                return_value=self._make_manifest("h0", "h1", "h2"),
+            ),
+        ):
+            assert _detect_stale_layers(project, rendered) == []
+
+    def test_l1_stale_detected(self) -> None:
+        """L1 hash mismatch → ["l1"] returned."""
+        from terok.lib.domain.project_state import _detect_stale_layers
+
+        project = Mock(id="p1", base_image="ubuntu:24.04")
+        rendered = {
+            "L0.Dockerfile": "FROM ubuntu:24.04",
+            "L1.cli.Dockerfile": "FROM l0 CHANGED",
+            "L2.Dockerfile": "FROM l1",
+        }
+
+        with (
+            patch("terok.lib.orchestration.image.l0_content_hash", return_value="h0"),
+            patch(
+                "terok.lib.orchestration.image.l1_content_hash",
+                return_value="h1-new",
+            ),
+            patch("terok.lib.orchestration.image.l2_content_hash", return_value="h2"),
+            patch(
+                "terok.lib.orchestration.image.read_build_manifest",
+                return_value=self._make_manifest("h0", "h1-old", "h2"),
+            ),
+        ):
+            stale = _detect_stale_layers(project, rendered)
+            assert stale == ["l1"]
+
+    def test_missing_manifest_marks_all_stale(self) -> None:
+        """No manifest → all layers stale."""
+        from terok.lib.domain.project_state import _detect_stale_layers
+
+        project = Mock(id="p1", base_image="ubuntu:24.04")
+        rendered = {"L0.Dockerfile": "x", "L1.cli.Dockerfile": "y", "L2.Dockerfile": "z"}
+
+        with (
+            patch("terok.lib.orchestration.image.l0_content_hash", return_value="h0"),
+            patch("terok.lib.orchestration.image.l1_content_hash", return_value="h1"),
+            patch("terok.lib.orchestration.image.l2_content_hash", return_value="h2"),
+            patch(
+                "terok.lib.orchestration.image.read_build_manifest",
+                return_value=None,
+            ),
+        ):
+            assert _detect_stale_layers(project, rendered) == ["l0", "l1", "l2"]
+
+    def test_no_rendered_marks_all_stale(self) -> None:
+        """None rendered dict → all layers stale."""
+        from terok.lib.domain.project_state import _detect_stale_layers
+
+        project = Mock(id="p1", base_image="ubuntu:24.04")
+        assert _detect_stale_layers(project, None) == ["l0", "l1", "l2"]
+
+    def test_multiple_stale_layers(self) -> None:
+        """L0 + L2 stale, L1 current → ["l0", "l2"]."""
+        from terok.lib.domain.project_state import _detect_stale_layers
+
+        project = Mock(id="p1", base_image="ubuntu:24.04")
+        rendered = {"L0.Dockerfile": "x", "L1.cli.Dockerfile": "y", "L2.Dockerfile": "z"}
+
+        with (
+            patch(
+                "terok.lib.orchestration.image.l0_content_hash",
+                return_value="h0-new",
+            ),
+            patch("terok.lib.orchestration.image.l1_content_hash", return_value="h1"),
+            patch(
+                "terok.lib.orchestration.image.l2_content_hash",
+                return_value="h2-new",
+            ),
+            patch(
+                "terok.lib.orchestration.image.read_build_manifest",
+                return_value=self._make_manifest("h0-old", "h1", "h2-old"),
+            ),
+        ):
+            stale = _detect_stale_layers(project, rendered)
+            assert stale == ["l0", "l2"]
+
+
+class TestStaleLayerHint:
+    """Verify TUI hint selection for stale layers."""
+
+    def test_l0_stale_suggests_full_rebuild(self) -> None:
+        """L0 stale → deepest layer hint is --full-rebuild."""
+        from terok.tui.widgets.project_state import _stale_layer_hint
+
+        assert _stale_layer_hint(["l0", "l1", "l2"]) == "build --full-rebuild"
+
+    def test_l1_only_suggests_agents(self) -> None:
+        """L1-only stale → --agents hint."""
+        from terok.tui.widgets.project_state import _stale_layer_hint
+
+        assert _stale_layer_hint(["l1"]) == "build --agents"
+
+    def test_l2_only_suggests_build(self) -> None:
+        """L2-only stale → plain build hint."""
+        from terok.tui.widgets.project_state import _stale_layer_hint
+
+        assert _stale_layer_hint(["l2"]) == "build"
+
+    def test_empty_returns_empty(self) -> None:
+        """No stale layers → empty hint."""
+        from terok.tui.widgets.project_state import _stale_layer_hint
+
+        assert _stale_layer_hint([]) == ""

--- a/tests/unit/lib/test_staleness_detection.py
+++ b/tests/unit/lib/test_staleness_detection.py
@@ -124,32 +124,32 @@ class TestDetectStaleLayers:
 class TestStaleLayerHint:
     """Verify TUI hint selection for stale layers."""
 
-    def test_all_stale_shows_l0_command(self) -> None:
-        """All layers stale → shows L0/L1/L2 with deepest rebuild command."""
+    def test_all_stale(self) -> None:
+        """All layers stale → L0/L1/L2."""
         from terok.tui.widgets.project_state import _stale_layer_hint
 
-        assert _stale_layer_hint(["l0", "l1", "l2"]) == "L0/L1/L2 (build --full-rebuild)"
+        assert _stale_layer_hint(["l0", "l1", "l2"]) == "L0/L1/L2"
 
-    def test_l1_only_shows_agents(self) -> None:
-        """L1-only stale → L1 with --agents hint."""
+    def test_l1_only(self) -> None:
+        """L1-only stale → L1."""
         from terok.tui.widgets.project_state import _stale_layer_hint
 
-        assert _stale_layer_hint(["l1"]) == "L1 (build --agents)"
+        assert _stale_layer_hint(["l1"]) == "L1"
 
-    def test_l2_only_shows_build(self) -> None:
-        """L2-only stale → L2 with plain build hint."""
+    def test_l2_only(self) -> None:
+        """L2-only stale → L2."""
         from terok.tui.widgets.project_state import _stale_layer_hint
 
-        assert _stale_layer_hint(["l2"]) == "L2 (build)"
+        assert _stale_layer_hint(["l2"]) == "L2"
 
-    def test_l0_and_l2_shows_both_labels(self) -> None:
-        """L0+L2 stale → L0/L2 with --full-rebuild (deepest)."""
+    def test_l0_and_l2(self) -> None:
+        """L0+L2 stale → L0/L2."""
         from terok.tui.widgets.project_state import _stale_layer_hint
 
-        assert _stale_layer_hint(["l0", "l2"]) == "L0/L2 (build --full-rebuild)"
+        assert _stale_layer_hint(["l0", "l2"]) == "L0/L2"
 
     def test_empty_returns_empty(self) -> None:
-        """No stale layers → empty hint."""
+        """No stale layers → empty string."""
         from terok.tui.widgets.project_state import _stale_layer_hint
 
         assert _stale_layer_hint([]) == ""

--- a/tests/unit/lib/test_staleness_detection.py
+++ b/tests/unit/lib/test_staleness_detection.py
@@ -124,23 +124,29 @@ class TestDetectStaleLayers:
 class TestStaleLayerHint:
     """Verify TUI hint selection for stale layers."""
 
-    def test_l0_stale_suggests_full_rebuild(self) -> None:
-        """L0 stale → deepest layer hint is --full-rebuild."""
+    def test_all_stale_shows_l0_command(self) -> None:
+        """All layers stale → shows L0/L1/L2 with deepest rebuild command."""
         from terok.tui.widgets.project_state import _stale_layer_hint
 
-        assert _stale_layer_hint(["l0", "l1", "l2"]) == "build --full-rebuild"
+        assert _stale_layer_hint(["l0", "l1", "l2"]) == "L0/L1/L2 (build --full-rebuild)"
 
-    def test_l1_only_suggests_agents(self) -> None:
-        """L1-only stale → --agents hint."""
+    def test_l1_only_shows_agents(self) -> None:
+        """L1-only stale → L1 with --agents hint."""
         from terok.tui.widgets.project_state import _stale_layer_hint
 
-        assert _stale_layer_hint(["l1"]) == "build --agents"
+        assert _stale_layer_hint(["l1"]) == "L1 (build --agents)"
 
-    def test_l2_only_suggests_build(self) -> None:
-        """L2-only stale → plain build hint."""
+    def test_l2_only_shows_build(self) -> None:
+        """L2-only stale → L2 with plain build hint."""
         from terok.tui.widgets.project_state import _stale_layer_hint
 
-        assert _stale_layer_hint(["l2"]) == "build"
+        assert _stale_layer_hint(["l2"]) == "L2 (build)"
+
+    def test_l0_and_l2_shows_both_labels(self) -> None:
+        """L0+L2 stale → L0/L2 with --full-rebuild (deepest)."""
+        from terok.tui.widgets.project_state import _stale_layer_hint
+
+        assert _stale_layer_hint(["l0", "l2"]) == "L0/L2 (build --full-rebuild)"
 
     def test_empty_returns_empty(self) -> None:
         """No stale layers → empty hint."""


### PR DESCRIPTION
Fixes #382

## Summary
- Replace broken single-hash staleness check with per-layer content hashes (`l0_content_hash`, `l1_content_hash`, `l2_content_hash`) and a `build_manifest.json` that records what each layer was actually built from
- When `build_base_images(rebuild=False)` skips L0/L1, the manifest carries forward previous hashes — so staleness detection correctly identifies that L1 is stale even after L2 is rebuilt
- Missing manifest = all layers stale (forces `--agents` rebuild on first use post-upgrade)
- TUI shows actionable hint: `old (build --agents)` instead of just `old`

## The bug
A single `build_context_hash` mixed L0+L1+L2 inputs but was only stored on L2. After upgrading terok (new L1 Dockerfile), running `terok build` rebuilt L2 with a new hash, masking that L1 was never rebuilt. Users got cryptic bash errors in containers (`command not found`).

## Test plan
- [x] 18 new tests: per-layer hashing, manifest round-trip, stale layer detection, TUI hints
- [x] 1642 tests pass, `make check` green
- [ ] Manual: upgrade executor wheel → `terok build myproject` → TUI shows L1 stale
- [ ] Manual: `terok build myproject --agents` → TUI shows all current

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-layer staleness detection and persisted build manifest to track L0/L1/L2.
  * UI shows compact stale-layer hints (e.g., "L0/L2") in image status.

* **Bug Fixes**
  * More accurate image/project staleness reporting via explicit stale_layers with a safe fallback when manifest checks fail.

* **Tests**
  * New unit tests covering per-layer hashing, manifest read/write, staleness detection, and hint formatting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->