### PR TITLE
refactor: move config field descriptions into Pydantic models

### DIFF
--- a/docs/gen_config_reference.py
+++ b/docs/gen_config_reference.py
@@ -10,9 +10,10 @@ Runs during ``mkdocs build`` via the mkdocs-gen-files plugin.  Introspects
 - Per-section Markdown tables with field name, type, default, and description
 - A full annotated YAML example for each config file
 
-The Pydantic models are the **single source of truth** — if a field exists in
-the schema, it appears in the docs automatically.  Table and YAML rendering
-is delegated to ``mkdocs_terok.config_reference``.
+Every ``Field(description=...)`` in the Pydantic models is the **single source
+of truth** — if a field exists in the schema, it appears in the docs
+automatically.  Table and YAML rendering is delegated to
+``mkdocs_terok.config_reference``.
 """
 
 from __future__ import annotations
@@ -30,81 +31,6 @@ from terok.lib.core.yaml_schema import RawGlobalConfig, RawProjectYaml
 
 _MD_RULE = "---\n\n"
 """Markdown horizontal rule with trailing blank line."""
-
-# ---------------------------------------------------------------------------
-# Human-friendly descriptions for fields that lack Field(description=...).
-# Key format: "section.field" (dot-separated YAML path).
-# ---------------------------------------------------------------------------
-
-_FIELD_DOCS: dict[str, str] = {
-    # project.yml — project section
-    "project.id": "Unique project identifier (lowercase, ``[a-z0-9_-]``)",
-    "project.name": "Human-readable project name (display only)",
-    "project.security_class": "Security mode: ``online`` (direct push) or ``gatekeeping`` (gated mirror)",
-    # git
-    "git.upstream_url": "Repository URL to clone into task containers",
-    "git.default_branch": "Default branch name (e.g. ``main``)",
-    "git.human_name": "Human name for git committer identity",
-    "git.human_email": "Human email for git committer identity",
-    "git.authorship": "How agent/human map to git author/committer. Values: ``agent-human``, ``human-agent``, ``agent``, ``human``",
-    # ssh
-    "ssh.key_name": "SSH key filename (default: ``id_ed25519_<project_id>``)",
-    "ssh.host_dir": "Host directory for SSH key storage (keys served via SSH agent proxy, not mounted)",
-    "ssh.config_template": "Path to an SSH config template file (supports ``{{IDENTITY_FILE}}``, ``{{KEY_NAME}}``, ``{{PROJECT_ID}}``)",
-    "ssh.allow_host_keys": "Allow fallback to ``~/.ssh`` host keys for gate operations (default: ``false``)",
-    # tasks
-    "tasks.root": "Override task workspace root directory",
-    "tasks.name_categories": "Word categories for auto-generated task names (string or list of strings)",
-    # gate
-    "gate.path": "Override git gate (mirror) path",
-    # gatekeeping
-    "gatekeeping.staging_root": "Staging directory for gatekeeping builds",
-    "gatekeeping.expose_external_remote": "Add upstream URL as ``external`` remote in gatekeeping containers",
-    "gatekeeping.upstream_polling.enabled": "Poll upstream for new commits",
-    "gatekeeping.upstream_polling.interval_minutes": "Polling interval in minutes",
-    "gatekeeping.auto_sync.enabled": "Auto-sync branches from upstream to gate",
-    "gatekeeping.auto_sync.branches": "Branch names to auto-sync",
-    # run
-    "run.shutdown_timeout": "Seconds to wait before SIGKILL on container stop",
-    "run.gpus": 'GPU passthrough: ``true``, ``"all"``, or omit to disable',
-    # shield
-    "shield.drop_on_task_run": "Drop shield (bypass firewall) when task container is created",
-    "shield.on_task_restart": "Shield policy on container restart: ``retain`` or ``up``",
-    # image
-    "image.base_image": "Base container image for builds",
-    "image.user_snippet_inline": "Inline Dockerfile snippet injected into the project image",
-    "image.user_snippet_file": "Path to a file containing a Dockerfile snippet",
-    # shared dir
-    "shared_dir": "Shared directory for multi-agent IPC (``true`` = auto-create under tasks root, or absolute path)",
-    # top-level
-    "default_agent": "Default agent provider (e.g. ``claude``, ``codex``)",
-    "agent": "Agent configuration dict (model, subagents, MCP servers, etc.)",
-    # global config — ui
-    "ui.base_port": "Base port for Toad and other browser-accessible task containers",
-    # credentials
-    "credentials.dir": "Shared credentials directory (proxy DB, agent config mounts)",
-    # paths
-    "paths.root": "Namespace state root shared by all ecosystem packages "
-    "(Podman model — one config, multiple readers)",
-    "paths.sandbox_live_dir": "Container-writable runtime data (tasks, agent mounts). "
-    "For hardened installs, mount the target with ``noexec,nosuid,nodev``",
-    "paths.build_dir": "Build artifacts directory (generated Dockerfiles)",
-    "paths.user_projects_dir": "User projects directory (per-user project configs)",
-    "paths.user_presets_dir": "User presets directory (per-user preset configs)",
-    # tui
-    "tui.default_tmux": "Default to tmux mode when launching the TUI",
-    # logs
-    "logs.partial_streaming": "Enable typewriter-effect streaming for log viewing",
-    # shield (global)
-    "shield.bypass_firewall_no_protection": "**Dangerous**: disable egress firewall entirely",
-    "shield.profiles": "Named shield profiles for per-project firewall rules",
-    "shield.audit": "Enable shield audit logging",
-    # gate_server
-    "gate_server.port": "Gate server listen port",
-    "gate_server.repos_dir": "Override gate repo directory (default: ``state_dir/gate``)",
-    "gate_server.suppress_systemd_warning": "Suppress the systemd unit installation suggestion",
-}
-
 
 # ---------------------------------------------------------------------------
 # Main: assemble the page
@@ -139,11 +65,11 @@ def _generate() -> str:
         "in config.yml) or the system config root.\n\n"
     )
 
-    buf.write(render_model_tables(RawProjectYaml, field_docs=_FIELD_DOCS))
+    buf.write(render_model_tables(RawProjectYaml))
 
     buf.write("### Full example\n\n")
     buf.write('```yaml title="project.yml"\n')
-    buf.write(render_yaml_example(RawProjectYaml, field_docs=_FIELD_DOCS))
+    buf.write(render_yaml_example(RawProjectYaml))
     buf.write("```\n\n")
 
     # --- config.yml ---
@@ -161,11 +87,11 @@ def _generate() -> str:
         "4. `/etc/terok/config.yml`\n\n"
     )
 
-    buf.write(render_model_tables(RawGlobalConfig, field_docs=_FIELD_DOCS))
+    buf.write(render_model_tables(RawGlobalConfig))
 
     buf.write("### Full example\n\n")
     buf.write('```yaml title="config.yml"\n')
-    buf.write(render_yaml_example(RawGlobalConfig, field_docs=_FIELD_DOCS))
+    buf.write(render_yaml_example(RawGlobalConfig))
     buf.write("```\n\n")
 
     # --- Validation ---

--- a/poetry.lock
+++ b/poetry.lock
@@ -1776,13 +1776,13 @@ properdocs = ">=1.6.5"
 
 [[package]]
 name = "mkdocs-terok"
-version = "0.3.0"
+version = "0.4.1"
 description = "Shared MkDocs documentation generators for terok projects"
 optional = false
 python-versions = ">=3.12,<4.0"
 groups = ["docs"]
 files = [
-    {file = "mkdocs_terok-0.3.0-py3-none-any.whl", hash = "sha256:a395aa569f05a5da1e1c3ab3c83a915f2c70bfb19c4d78686888d0ec3c3da329"},
+    {file = "mkdocs_terok-0.4.1-py3-none-any.whl", hash = "sha256:cbd7fdc18169227ab59b1fba5432b801c484854a482b15a3c2af160306133ef9"},
 ]
 
 [package.dependencies]
@@ -1791,7 +1791,7 @@ PyYAML = ">=6.0"
 
 [package.source]
 type = "url"
-url = "https://github.com/terok-ai/mkdocs-terok/releases/download/v0.3.0/mkdocs_terok-0.3.0-py3-none-any.whl"
+url = "https://github.com/terok-ai/mkdocs-terok/releases/download/v0.4.1/mkdocs_terok-0.4.1-py3-none-any.whl"
 
 [[package]]
 name = "mkdocstrings"
@@ -3608,4 +3608,4 @@ propcache = ">=0.2.1"
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.12,<4.0"
-content-hash = "52f3d7c173a99786847111accee0cf634f7da16ad2ca6336e4e8abda66ca017b"
+content-hash = "e8e43619526648f9a49b83d4be4be1f8112f233c5428cdecdcd0c58a26102e48"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,7 +75,7 @@ mkdocstrings = {extras = ["python"], version = ">=0.24"}
 mkdocs-gen-files = ">=0.5"
 mkdocs-literate-nav = ">=0.6"
 mkdocs-section-index = ">=0.3"
-mkdocs-terok = {url = "https://github.com/terok-ai/mkdocs-terok/releases/download/v0.3.0/mkdocs_terok-0.3.0-py3-none-any.whl"}
+mkdocs-terok = {url = "https://github.com/terok-ai/mkdocs-terok/releases/download/v0.4.1/mkdocs_terok-0.4.1-py3-none-any.whl"}
 
 [tool.pytest.ini_options]
 testpaths = ["tests/unit", "tests/integration"]

--- a/src/terok/lib/core/yaml_schema.py
+++ b/src/terok/lib/core/yaml_schema.py
@@ -63,9 +63,14 @@ class RawProjectSection(BaseModel):
 
     model_config = ConfigDict(extra="forbid")
 
-    id: str | None = None
-    name: str | None = Field(default=None, description="Human-readable project name")
-    security_class: str = Field(default="online", description="online or gatekeeping")
+    id: str | None = Field(
+        default=None, description="Unique project identifier (lowercase, ``[a-z0-9_-]``)"
+    )
+    name: str | None = Field(default=None, description="Human-readable project name (display only)")
+    security_class: str = Field(
+        default="online",
+        description="Security mode: ``online`` (direct push) or ``gatekeeping`` (gated mirror)",
+    )
     isolation: str = Field(
         default="shared", description="shared (bind mounts) or sealed (no mounts)"
     )
@@ -108,11 +113,25 @@ class RawGitSection(BaseModel):
 
     model_config = ConfigDict(extra="forbid")
 
-    upstream_url: str | None = None
-    default_branch: str | None = None
-    human_name: str | None = None
-    human_email: str | None = None
-    authorship: str | None = None
+    upstream_url: str | None = Field(
+        default=None, description="Repository URL to clone into task containers"
+    )
+    default_branch: str | None = Field(
+        default=None, description="Default branch name (e.g. ``main``)"
+    )
+    human_name: str | None = Field(
+        default=None, description="Human name for git committer identity"
+    )
+    human_email: str | None = Field(
+        default=None, description="Human email for git committer identity"
+    )
+    authorship: str | None = Field(
+        default=None,
+        description=(
+            "How agent/human map to git author/committer."
+            " Values: ``agent-human``, ``human-agent``, ``agent``, ``human``"
+        ),
+    )
 
 
 class RawGlobalGitSection(BaseModel):
@@ -120,9 +139,19 @@ class RawGlobalGitSection(BaseModel):
 
     model_config = ConfigDict(extra="forbid")
 
-    human_name: str | None = None
-    human_email: str | None = None
-    authorship: str | None = None
+    human_name: str | None = Field(
+        default=None, description="Human name for git committer identity"
+    )
+    human_email: str | None = Field(
+        default=None, description="Human email for git committer identity"
+    )
+    authorship: str | None = Field(
+        default=None,
+        description=(
+            "How agent/human map to git author/committer."
+            " Values: ``agent-human``, ``human-agent``, ``agent``, ``human``"
+        ),
+    )
 
 
 class RawSSHSection(BaseModel):
@@ -130,9 +159,20 @@ class RawSSHSection(BaseModel):
 
     model_config = ConfigDict(extra="forbid")
 
-    key_name: str | None = None
-    host_dir: str | None = Field(default=None, description="Host-side SSH directory")
-    config_template: str | None = None
+    key_name: str | None = Field(
+        default=None, description="SSH key filename (default: ``id_ed25519_<project_id>``)"
+    )
+    host_dir: str | None = Field(
+        default=None,
+        description="Host directory for SSH key storage (keys served via SSH agent proxy, not mounted)",
+    )
+    config_template: str | None = Field(
+        default=None,
+        description=(
+            "Path to an SSH config template file"
+            " (supports ``{{IDENTITY_FILE}}``, ``{{KEY_NAME}}``, ``{{PROJECT_ID}}``)"
+        ),
+    )
     allow_host_keys: bool = Field(
         default=False,
         description="Allow fallback to ~/.ssh host keys for gate operations",
@@ -144,8 +184,11 @@ class RawTasksSection(BaseModel):
 
     model_config = ConfigDict(extra="forbid")
 
-    root: str | None = None
-    name_categories: NameCategories = None
+    root: str | None = Field(default=None, description="Override task workspace root directory")
+    name_categories: NameCategories = Field(
+        default=None,
+        description="Word categories for auto-generated task names (string or list of strings)",
+    )
 
 
 class RawGateSection(BaseModel):
@@ -153,7 +196,7 @@ class RawGateSection(BaseModel):
 
     model_config = ConfigDict(extra="forbid")
 
-    path: str | None = None
+    path: str | None = Field(default=None, description="Override git gate (mirror) path")
 
 
 class RawUpstreamPolling(BaseModel):
@@ -161,8 +204,8 @@ class RawUpstreamPolling(BaseModel):
 
     model_config = ConfigDict(extra="forbid")
 
-    enabled: bool = True
-    interval_minutes: int = 5
+    enabled: bool = Field(default=True, description="Poll upstream for new commits")
+    interval_minutes: int = Field(default=5, description="Polling interval in minutes")
 
 
 class RawAutoSync(BaseModel):
@@ -170,8 +213,8 @@ class RawAutoSync(BaseModel):
 
     model_config = ConfigDict(extra="forbid")
 
-    enabled: bool = False
-    branches: list[str] = Field(default_factory=list)
+    enabled: bool = Field(default=False, description="Auto-sync branches from upstream to gate")
+    branches: list[str] = Field(default_factory=list, description="Branch names to auto-sync")
 
 
 class RawGatekeepingSection(BaseModel):
@@ -179,8 +222,13 @@ class RawGatekeepingSection(BaseModel):
 
     model_config = ConfigDict(extra="forbid")
 
-    staging_root: str | None = None
-    expose_external_remote: bool = False
+    staging_root: str | None = Field(
+        default=None, description="Staging directory for gatekeeping builds"
+    )
+    expose_external_remote: bool = Field(
+        default=False,
+        description="Add upstream URL as ``external`` remote in gatekeeping containers",
+    )
     upstream_polling: RawUpstreamPolling = Field(default_factory=RawUpstreamPolling)
     auto_sync: RawAutoSync = Field(default_factory=RawAutoSync)
 
@@ -211,8 +259,13 @@ class RawRunSection(BaseModel):
 
     model_config = ConfigDict(extra="forbid")
 
-    shutdown_timeout: int = 10
-    gpus: str | bool | None = None
+    shutdown_timeout: int = Field(
+        default=10, description="Seconds to wait before SIGKILL on container stop"
+    )
+    gpus: str | bool | None = Field(
+        default=None,
+        description='GPU passthrough: ``true``, ``"all"``, or omit to disable',
+    )
     memory: str | None = None
     cpus: str | None = None
     hooks: RawHooksSection = Field(default_factory=RawHooksSection)
@@ -244,8 +297,14 @@ class RawShieldProjectSection(BaseModel):
 
     model_config = ConfigDict(extra="forbid")
 
-    drop_on_task_run: bool | None = None
-    on_task_restart: Literal["retain", "up"] | None = None
+    drop_on_task_run: bool | None = Field(
+        default=None,
+        description="Drop shield (bypass firewall) when task container is created",
+    )
+    on_task_restart: Literal["retain", "up"] | None = Field(
+        default=None,
+        description="Shield policy on container restart: ``retain`` or ``up``",
+    )
 
 
 class RawImageSection(BaseModel):
@@ -253,9 +312,13 @@ class RawImageSection(BaseModel):
 
     model_config = ConfigDict(extra="forbid")
 
-    base_image: str = "ubuntu:24.04"
-    user_snippet_inline: str | None = None
-    user_snippet_file: str | None = None
+    base_image: str = Field(default="ubuntu:24.04", description="Base container image for builds")
+    user_snippet_inline: str | None = Field(
+        default=None, description="Inline Dockerfile snippet injected into the project image"
+    )
+    user_snippet_file: str | None = Field(
+        default=None, description="Path to a file containing a Dockerfile snippet"
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -277,13 +340,18 @@ class RawProjectYaml(BaseModel):
     run: RawRunSection = Field(default_factory=RawRunSection)
     shield: RawShieldProjectSection = Field(default_factory=RawShieldProjectSection)
     image: RawImageSection = Field(default_factory=RawImageSection)
-    default_agent: str | None = None
+    default_agent: str | None = Field(
+        default=None, description="Default agent provider (e.g. ``claude``, ``codex``)"
+    )
     default_login: str | None = None
     shared_dir: bool | str | None = Field(
         default=None,
-        description="Shared directory for multi-agent IPC (true = auto, or absolute path)",
+        description="Shared directory for multi-agent IPC (``true`` = auto-create under tasks root, or absolute path)",
     )
-    agent: dict[str, Any] = Field(default_factory=dict)
+    agent: dict[str, Any] = Field(
+        default_factory=dict,
+        description="Agent configuration dict (model, subagents, MCP servers, etc.)",
+    )
 
     _SECTION_KEYS: ClassVar[frozenset[str]] = frozenset(
         {
@@ -317,7 +385,10 @@ class RawUISection(BaseModel):
 
     model_config = ConfigDict(extra="forbid")
 
-    base_port: int = 7860
+    base_port: int = Field(
+        default=7860,
+        description="Base port for Toad and other browser-accessible task containers",
+    )
 
 
 class RawCredentialsSection(BaseModel):
@@ -325,7 +396,10 @@ class RawCredentialsSection(BaseModel):
 
     model_config = ConfigDict(extra="forbid")
 
-    dir: str | None = None
+    dir: str | None = Field(
+        default=None,
+        description="Shared credentials directory (proxy DB, agent config mounts)",
+    )
 
 
 class RawPathsSection(BaseModel):
@@ -337,11 +411,29 @@ class RawPathsSection(BaseModel):
 
     model_config = ConfigDict(extra="forbid")
 
-    root: str | None = None
-    build_dir: str | None = None
-    sandbox_live_dir: str | None = None
-    user_projects_dir: str | None = None
-    user_presets_dir: str | None = None
+    root: str | None = Field(
+        default=None,
+        description=(
+            "Namespace state root shared by all ecosystem packages"
+            " (Podman model — one config, multiple readers)"
+        ),
+    )
+    build_dir: str | None = Field(
+        default=None, description="Build artifacts directory (generated Dockerfiles)"
+    )
+    sandbox_live_dir: str | None = Field(
+        default=None,
+        description=(
+            "Container-writable runtime data (tasks, agent mounts)."
+            " For hardened installs, mount the target with ``noexec,nosuid,nodev``"
+        ),
+    )
+    user_projects_dir: str | None = Field(
+        default=None, description="User projects directory (per-user project configs)"
+    )
+    user_presets_dir: str | None = Field(
+        default=None, description="User presets directory (per-user preset configs)"
+    )
 
 
 class RawTUISection(BaseModel):
@@ -349,7 +441,9 @@ class RawTUISection(BaseModel):
 
     model_config = ConfigDict(extra="forbid")
 
-    default_tmux: bool = False
+    default_tmux: bool = Field(
+        default=False, description="Default to tmux mode when launching the TUI"
+    )
 
 
 class RawLogsSection(BaseModel):
@@ -357,7 +451,9 @@ class RawLogsSection(BaseModel):
 
     model_config = ConfigDict(extra="forbid")
 
-    partial_streaming: bool = True
+    partial_streaming: bool = Field(
+        default=True, description="Enable typewriter-effect streaming for log viewing"
+    )
 
 
 class RawShieldGlobalSection(BaseModel):
@@ -365,9 +461,13 @@ class RawShieldGlobalSection(BaseModel):
 
     model_config = ConfigDict(extra="forbid")
 
-    bypass_firewall_no_protection: bool = False
-    profiles: dict[str, Any] | None = None
-    audit: bool = True
+    bypass_firewall_no_protection: bool = Field(
+        default=False, description="**Dangerous**: disable egress firewall entirely"
+    )
+    profiles: dict[str, Any] | None = Field(
+        default=None, description="Named shield profiles for per-project firewall rules"
+    )
+    audit: bool = Field(default=True, description="Enable shield audit logging")
     drop_on_task_run: bool = True
     on_task_restart: Literal["retain", "up"] = "retain"
 
@@ -386,9 +486,14 @@ class RawGateServerSection(BaseModel):
 
     model_config = ConfigDict(extra="forbid")
 
-    port: int = 9418
-    repos_dir: str | None = None
-    suppress_systemd_warning: bool = False
+    port: int = Field(default=9418, description="Gate server listen port")
+    repos_dir: str | None = Field(
+        default=None,
+        description="Override gate repo directory (default: ``state_dir/gate``)",
+    )
+    suppress_systemd_warning: bool = Field(
+        default=False, description="Suppress the systemd unit installation suggestion"
+    )
 
 
 class RawTasksGlobalSection(BaseModel):
@@ -396,7 +501,10 @@ class RawTasksGlobalSection(BaseModel):
 
     model_config = ConfigDict(extra="forbid")
 
-    name_categories: NameCategories = None
+    name_categories: NameCategories = Field(
+        default=None,
+        description="Word categories for auto-generated task names (string or list of strings)",
+    )
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- **Single source of truth**: moved all ~40 field descriptions from the `_FIELD_DOCS` dict in `docs/gen_config_reference.py` into `Field(description=...)` on the Pydantic models in `yaml_schema.py` — the rendering engine already reads `fi.description`, so the manual override layer was redundant
- **Deleted `_FIELD_DOCS`** and all `field_docs=` arguments from `gen_config_reference.py` (−70 lines of duplication)
- **Bumped `mkdocs-terok`** from v0.3.0 → v0.4.1

## Test plan

- [x] `make lint` — passes
- [x] `make test` — 1630 tests pass
- [x] `make tach` — module boundaries clean
- [x] `make docstrings` — 99.5% coverage
- [ ] `mkdocs build` — verify generated config-reference.md still renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)