### PR TITLE
feat: migrate exec/start/stop to terok-sandbox API (Phase 1, Groups 1+2)

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -439,153 +439,153 @@ files = [
 
 [[package]]
 name = "charset-normalizer"
-version = "3.4.6"
+version = "3.4.7"
 description = "The Real First Universal Charset Detector. Open, modern and actively maintained alternative to Chardet."
 optional = false
 python-versions = ">=3.7"
 groups = ["main", "dev", "docs"]
 files = [
-    {file = "charset_normalizer-3.4.6-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:2e1d8ca8611099001949d1cdfaefc510cf0f212484fe7c565f735b68c78c3c95"},
-    {file = "charset_normalizer-3.4.6-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e25369dc110d58ddf29b949377a93e0716d72a24f62bad72b2b39f155949c1fd"},
-    {file = "charset_normalizer-3.4.6-cp310-cp310-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:259695e2ccc253feb2a016303543d691825e920917e31f894ca1a687982b1de4"},
-    {file = "charset_normalizer-3.4.6-cp310-cp310-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:dda86aba335c902b6149a02a55b38e96287157e609200811837678214ba2b1db"},
-    {file = "charset_normalizer-3.4.6-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:51fb3c322c81d20567019778cb5a4a6f2dc1c200b886bc0d636238e364848c89"},
-    {file = "charset_normalizer-3.4.6-cp310-cp310-manylinux_2_31_armv7l.whl", hash = "sha256:4482481cb0572180b6fd976a4d5c72a30263e98564da68b86ec91f0fe35e8565"},
-    {file = "charset_normalizer-3.4.6-cp310-cp310-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:39f5068d35621da2881271e5c3205125cc456f54e9030d3f723288c873a71bf9"},
-    {file = "charset_normalizer-3.4.6-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:8bea55c4eef25b0b19a0337dc4e3f9a15b00d569c77211fa8cde38684f234fb7"},
-    {file = "charset_normalizer-3.4.6-cp310-cp310-musllinux_1_2_armv7l.whl", hash = "sha256:f0cdaecd4c953bfae0b6bb64910aaaca5a424ad9c72d85cb88417bb9814f7550"},
-    {file = "charset_normalizer-3.4.6-cp310-cp310-musllinux_1_2_ppc64le.whl", hash = "sha256:150b8ce8e830eb7ccb029ec9ca36022f756986aaaa7956aad6d9ec90089338c0"},
-    {file = "charset_normalizer-3.4.6-cp310-cp310-musllinux_1_2_riscv64.whl", hash = "sha256:e68c14b04827dd76dcbd1aeea9e604e3e4b78322d8faf2f8132c7138efa340a8"},
-    {file = "charset_normalizer-3.4.6-cp310-cp310-musllinux_1_2_s390x.whl", hash = "sha256:3778fd7d7cd04ae8f54651f4a7a0bd6e39a0cf20f801720a4c21d80e9b7ad6b0"},
-    {file = "charset_normalizer-3.4.6-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:dad6e0f2e481fffdcf776d10ebee25e0ef89f16d691f1e5dee4b586375fdc64b"},
-    {file = "charset_normalizer-3.4.6-cp310-cp310-win32.whl", hash = "sha256:74a2e659c7ecbc73562e2a15e05039f1e22c75b7c7618b4b574a3ea9118d1557"},
-    {file = "charset_normalizer-3.4.6-cp310-cp310-win_amd64.whl", hash = "sha256:aa9cccf4a44b9b62d8ba8b4dd06c649ba683e4bf04eea606d2e94cfc2d6ff4d6"},
-    {file = "charset_normalizer-3.4.6-cp310-cp310-win_arm64.whl", hash = "sha256:e985a16ff513596f217cee86c21371b8cd011c0f6f056d0920aa2d926c544058"},
-    {file = "charset_normalizer-3.4.6-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:82060f995ab5003a2d6e0f4ad29065b7672b6593c8c63559beefe5b443242c3e"},
-    {file = "charset_normalizer-3.4.6-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:60c74963d8350241a79cb8feea80e54d518f72c26db618862a8f53e5023deaf9"},
-    {file = "charset_normalizer-3.4.6-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:f6e4333fb15c83f7d1482a76d45a0818897b3d33f00efd215528ff7c51b8e35d"},
-    {file = "charset_normalizer-3.4.6-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:bc72863f4d9aba2e8fd9085e63548a324ba706d2ea2c83b260da08a59b9482de"},
-    {file = "charset_normalizer-3.4.6-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9cc4fc6c196d6a8b76629a70ddfcd4635a6898756e2d9cac5565cf0654605d73"},
-    {file = "charset_normalizer-3.4.6-cp311-cp311-manylinux_2_31_armv7l.whl", hash = "sha256:0c173ce3a681f309f31b87125fecec7a5d1347261ea11ebbb856fa6006b23c8c"},
-    {file = "charset_normalizer-3.4.6-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:c907cdc8109f6c619e6254212e794d6548373cc40e1ec75e6e3823d9135d29cc"},
-    {file = "charset_normalizer-3.4.6-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:404a1e552cf5b675a87f0651f8b79f5f1e6fd100ee88dc612f89aa16abd4486f"},
-    {file = "charset_normalizer-3.4.6-cp311-cp311-musllinux_1_2_armv7l.whl", hash = "sha256:e3c701e954abf6fc03a49f7c579cc80c2c6cc52525340ca3186c41d3f33482ef"},
-    {file = "charset_normalizer-3.4.6-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:7a6967aaf043bceabab5412ed6bd6bd26603dae84d5cb75bf8d9a74a4959d398"},
-    {file = "charset_normalizer-3.4.6-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:5feb91325bbceade6afab43eb3b508c63ee53579fe896c77137ded51c6b6958e"},
-    {file = "charset_normalizer-3.4.6-cp311-cp311-musllinux_1_2_s390x.whl", hash = "sha256:f820f24b09e3e779fe84c3c456cb4108a7aa639b0d1f02c28046e11bfcd088ed"},
-    {file = "charset_normalizer-3.4.6-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:b35b200d6a71b9839a46b9b7fff66b6638bb52fc9658aa58796b0326595d3021"},
-    {file = "charset_normalizer-3.4.6-cp311-cp311-win32.whl", hash = "sha256:9ca4c0b502ab399ef89248a2c84c54954f77a070f28e546a85e91da627d1301e"},
-    {file = "charset_normalizer-3.4.6-cp311-cp311-win_amd64.whl", hash = "sha256:a9e68c9d88823b274cf1e72f28cb5dc89c990edf430b0bfd3e2fb0785bfeabf4"},
-    {file = "charset_normalizer-3.4.6-cp311-cp311-win_arm64.whl", hash = "sha256:97d0235baafca5f2b09cf332cc275f021e694e8362c6bb9c96fc9a0eb74fc316"},
-    {file = "charset_normalizer-3.4.6-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:2ef7fedc7a6ecbe99969cd09632516738a97eeb8bd7258bf8a0f23114c057dab"},
-    {file = "charset_normalizer-3.4.6-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a4ea868bc28109052790eb2b52a9ab33f3aa7adc02f96673526ff47419490e21"},
-    {file = "charset_normalizer-3.4.6-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:836ab36280f21fc1a03c99cd05c6b7af70d2697e374c7af0b61ed271401a72a2"},
-    {file = "charset_normalizer-3.4.6-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:f1ce721c8a7dfec21fcbdfe04e8f68174183cf4e8188e0645e92aa23985c57ff"},
-    {file = "charset_normalizer-3.4.6-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0e28d62a8fc7a1fa411c43bd65e346f3bce9716dc51b897fbe930c5987b402d5"},
-    {file = "charset_normalizer-3.4.6-cp312-cp312-manylinux_2_31_armv7l.whl", hash = "sha256:530d548084c4a9f7a16ed4a294d459b4f229db50df689bfe92027452452943a0"},
-    {file = "charset_normalizer-3.4.6-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:30f445ae60aad5e1f8bdbb3108e39f6fbc09f4ea16c815c66578878325f8f15a"},
-    {file = "charset_normalizer-3.4.6-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:ac2393c73378fea4e52aa56285a3d64be50f1a12395afef9cce47772f60334c2"},
-    {file = "charset_normalizer-3.4.6-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:90ca27cd8da8118b18a52d5f547859cc1f8354a00cd1e8e5120df3e30d6279e5"},
-    {file = "charset_normalizer-3.4.6-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:8e5a94886bedca0f9b78fecd6afb6629142fd2605aa70a125d49f4edc6037ee6"},
-    {file = "charset_normalizer-3.4.6-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:695f5c2823691a25f17bc5d5ffe79fa90972cc34b002ac6c843bb8a1720e950d"},
-    {file = "charset_normalizer-3.4.6-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:231d4da14bcd9301310faf492051bee27df11f2bc7549bc0bb41fef11b82daa2"},
-    {file = "charset_normalizer-3.4.6-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:a056d1ad2633548ca18ffa2f85c202cfb48b68615129143915b8dc72a806a923"},
-    {file = "charset_normalizer-3.4.6-cp312-cp312-win32.whl", hash = "sha256:c2274ca724536f173122f36c98ce188fd24ce3dad886ec2b7af859518ce008a4"},
-    {file = "charset_normalizer-3.4.6-cp312-cp312-win_amd64.whl", hash = "sha256:c8ae56368f8cc97c7e40a7ee18e1cedaf8e780cd8bc5ed5ac8b81f238614facb"},
-    {file = "charset_normalizer-3.4.6-cp312-cp312-win_arm64.whl", hash = "sha256:899d28f422116b08be5118ef350c292b36fc15ec2daeb9ea987c89281c7bb5c4"},
-    {file = "charset_normalizer-3.4.6-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:11afb56037cbc4b1555a34dd69151e8e069bee82e613a73bef6e714ce733585f"},
-    {file = "charset_normalizer-3.4.6-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:423fb7e748a08f854a08a222b983f4df1912b1daedce51a72bd24fe8f26a1843"},
-    {file = "charset_normalizer-3.4.6-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:d73beaac5e90173ac3deb9928a74763a6d230f494e4bfb422c217a0ad8e629bf"},
-    {file = "charset_normalizer-3.4.6-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:d60377dce4511655582e300dc1e5a5f24ba0cb229005a1d5c8d0cb72bb758ab8"},
-    {file = "charset_normalizer-3.4.6-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:530e8cebeea0d76bdcf93357aa5e41336f48c3dc709ac52da2bb167c5b8271d9"},
-    {file = "charset_normalizer-3.4.6-cp313-cp313-manylinux_2_31_armv7l.whl", hash = "sha256:a26611d9987b230566f24a0a125f17fe0de6a6aff9f25c9f564aaa2721a5fb88"},
-    {file = "charset_normalizer-3.4.6-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:34315ff4fc374b285ad7f4a0bf7dcbfe769e1b104230d40f49f700d4ab6bbd84"},
-    {file = "charset_normalizer-3.4.6-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:5f8ddd609f9e1af8c7bd6e2aca279c931aefecd148a14402d4e368f3171769fd"},
-    {file = "charset_normalizer-3.4.6-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:80d0a5615143c0b3225e5e3ef22c8d5d51f3f72ce0ea6fb84c943546c7b25b6c"},
-    {file = "charset_normalizer-3.4.6-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:92734d4d8d187a354a556626c221cd1a892a4e0802ccb2af432a1d85ec012194"},
-    {file = "charset_normalizer-3.4.6-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:613f19aa6e082cf96e17e3ffd89383343d0d589abda756b7764cf78361fd41dc"},
-    {file = "charset_normalizer-3.4.6-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:2b1a63e8224e401cafe7739f77efd3f9e7f5f2026bda4aead8e59afab537784f"},
-    {file = "charset_normalizer-3.4.6-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:6cceb5473417d28edd20c6c984ab6fee6c6267d38d906823ebfe20b03d607dc2"},
-    {file = "charset_normalizer-3.4.6-cp313-cp313-win32.whl", hash = "sha256:d7de2637729c67d67cf87614b566626057e95c303bc0a55ffe391f5205e7003d"},
-    {file = "charset_normalizer-3.4.6-cp313-cp313-win_amd64.whl", hash = "sha256:572d7c822caf521f0525ba1bce1a622a0b85cf47ffbdae6c9c19e3b5ac3c4389"},
-    {file = "charset_normalizer-3.4.6-cp313-cp313-win_arm64.whl", hash = "sha256:a4474d924a47185a06411e0064b803c68be044be2d60e50e8bddcc2649957c1f"},
-    {file = "charset_normalizer-3.4.6-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:9cc6e6d9e571d2f863fa77700701dae73ed5f78881efc8b3f9a4398772ff53e8"},
-    {file = "charset_normalizer-3.4.6-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ef5960d965e67165d75b7c7ffc60a83ec5abfc5c11b764ec13ea54fbef8b4421"},
-    {file = "charset_normalizer-3.4.6-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:b3694e3f87f8ac7ce279d4355645b3c878d24d1424581b46282f24b92f5a4ae2"},
-    {file = "charset_normalizer-3.4.6-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:5d11595abf8dd942a77883a39d81433739b287b6aa71620f15164f8096221b30"},
-    {file = "charset_normalizer-3.4.6-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7bda6eebafd42133efdca535b04ccb338ab29467b3f7bf79569883676fc628db"},
-    {file = "charset_normalizer-3.4.6-cp314-cp314-manylinux_2_31_armv7l.whl", hash = "sha256:bbc8c8650c6e51041ad1be191742b8b421d05bbd3410f43fa2a00c8db87678e8"},
-    {file = "charset_normalizer-3.4.6-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:22c6f0c2fbc31e76c3b8a86fba1a56eda6166e238c29cdd3d14befdb4a4e4815"},
-    {file = "charset_normalizer-3.4.6-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:7edbed096e4a4798710ed6bc75dcaa2a21b68b6c356553ac4823c3658d53743a"},
-    {file = "charset_normalizer-3.4.6-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:7f9019c9cb613f084481bd6a100b12e1547cf2efe362d873c2e31e4035a6fa43"},
-    {file = "charset_normalizer-3.4.6-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:58c948d0d086229efc484fe2f30c2d382c86720f55cd9bc33591774348ad44e0"},
-    {file = "charset_normalizer-3.4.6-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:419a9d91bd238052642a51938af8ac05da5b3343becde08d5cdeab9046df9ee1"},
-    {file = "charset_normalizer-3.4.6-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:5273b9f0b5835ff0350c0828faea623c68bfa65b792720c453e22b25cc72930f"},
-    {file = "charset_normalizer-3.4.6-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:0e901eb1049fdb80f5bd11ed5ea1e498ec423102f7a9b9e4645d5b8204ff2815"},
-    {file = "charset_normalizer-3.4.6-cp314-cp314-win32.whl", hash = "sha256:b4ff1d35e8c5bd078be89349b6f3a845128e685e751b6ea1169cf2160b344c4d"},
-    {file = "charset_normalizer-3.4.6-cp314-cp314-win_amd64.whl", hash = "sha256:74119174722c4349af9708993118581686f343adc1c8c9c007d59be90d077f3f"},
-    {file = "charset_normalizer-3.4.6-cp314-cp314-win_arm64.whl", hash = "sha256:e5bcc1a1ae744e0bb59641171ae53743760130600da8db48cbb6e4918e186e4e"},
-    {file = "charset_normalizer-3.4.6-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:ad8faf8df23f0378c6d527d8b0b15ea4a2e23c89376877c598c4870d1b2c7866"},
-    {file = "charset_normalizer-3.4.6-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f5ea69428fa1b49573eef0cc44a1d43bebd45ad0c611eb7d7eac760c7ae771bc"},
-    {file = "charset_normalizer-3.4.6-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:06a7e86163334edfc5d20fe104db92fcd666e5a5df0977cb5680a506fe26cc8e"},
-    {file = "charset_normalizer-3.4.6-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:e1f6e2f00a6b8edb562826e4632e26d063ac10307e80f7461f7de3ad8ef3f077"},
-    {file = "charset_normalizer-3.4.6-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:95b52c68d64c1878818687a473a10547b3292e82b6f6fe483808fb1468e2f52f"},
-    {file = "charset_normalizer-3.4.6-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:7504e9b7dc05f99a9bbb4525c67a2c155073b44d720470a148b34166a69c054e"},
-    {file = "charset_normalizer-3.4.6-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:172985e4ff804a7ad08eebec0a1640ece87ba5041d565fff23c8f99c1f389484"},
-    {file = "charset_normalizer-3.4.6-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:4be9f4830ba8741527693848403e2c457c16e499100963ec711b1c6f2049b7c7"},
-    {file = "charset_normalizer-3.4.6-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:79090741d842f564b1b2827c0b82d846405b744d31e84f18d7a7b41c20e473ff"},
-    {file = "charset_normalizer-3.4.6-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:87725cfb1a4f1f8c2fc9890ae2f42094120f4b44db9360be5d99a4c6b0e03a9e"},
-    {file = "charset_normalizer-3.4.6-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:fcce033e4021347d80ed9c66dcf1e7b1546319834b74445f561d2e2221de5659"},
-    {file = "charset_normalizer-3.4.6-cp314-cp314t-musllinux_1_2_s390x.whl", hash = "sha256:ca0276464d148c72defa8bb4390cce01b4a0e425f3b50d1435aa6d7a18107602"},
-    {file = "charset_normalizer-3.4.6-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:197c1a244a274bb016dd8b79204850144ef77fe81c5b797dc389327adb552407"},
-    {file = "charset_normalizer-3.4.6-cp314-cp314t-win32.whl", hash = "sha256:2a24157fa36980478dd1770b585c0f30d19e18f4fb0c47c13aa568f871718579"},
-    {file = "charset_normalizer-3.4.6-cp314-cp314t-win_amd64.whl", hash = "sha256:cd5e2801c89992ed8c0a3f0293ae83c159a60d9a5d685005383ef4caca77f2c4"},
-    {file = "charset_normalizer-3.4.6-cp314-cp314t-win_arm64.whl", hash = "sha256:47955475ac79cc504ef2704b192364e51d0d473ad452caedd0002605f780101c"},
-    {file = "charset_normalizer-3.4.6-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:659a1e1b500fac8f2779dd9e1570464e012f43e580371470b45277a27baa7532"},
-    {file = "charset_normalizer-3.4.6-cp38-cp38-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f61aa92e4aad0be58eb6eb4e0c21acf32cf8065f4b2cae5665da756c4ceef982"},
-    {file = "charset_normalizer-3.4.6-cp38-cp38-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:f50498891691e0864dc3da965f340fada0771f6142a378083dc4608f4ea513e2"},
-    {file = "charset_normalizer-3.4.6-cp38-cp38-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:bf625105bb9eef28a56a943fec8c8a98aeb80e7d7db99bd3c388137e6eb2d237"},
-    {file = "charset_normalizer-3.4.6-cp38-cp38-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2bd9d128ef93637a5d7a6af25363cf5dec3fa21cf80e68055aad627f280e8afa"},
-    {file = "charset_normalizer-3.4.6-cp38-cp38-manylinux_2_31_armv7l.whl", hash = "sha256:d08ec48f0a1c48d75d0356cea971921848fb620fdeba805b28f937e90691209f"},
-    {file = "charset_normalizer-3.4.6-cp38-cp38-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:1ed80ff870ca6de33f4d953fda4d55654b9a2b340ff39ab32fa3adbcd718f264"},
-    {file = "charset_normalizer-3.4.6-cp38-cp38-musllinux_1_2_aarch64.whl", hash = "sha256:f98059e4fcd3e3e4e2d632b7cf81c2faae96c43c60b569e9c621468082f1d104"},
-    {file = "charset_normalizer-3.4.6-cp38-cp38-musllinux_1_2_armv7l.whl", hash = "sha256:ab30e5e3e706e3063bc6de96b118688cb10396b70bb9864a430f67df98c61ecc"},
-    {file = "charset_normalizer-3.4.6-cp38-cp38-musllinux_1_2_ppc64le.whl", hash = "sha256:d5f5d1e9def3405f60e3ca8232d56f35c98fb7bf581efcc60051ebf53cb8b611"},
-    {file = "charset_normalizer-3.4.6-cp38-cp38-musllinux_1_2_riscv64.whl", hash = "sha256:461598cd852bfa5a61b09cae2b1c02e2efcd166ee5516e243d540ac24bfa68a7"},
-    {file = "charset_normalizer-3.4.6-cp38-cp38-musllinux_1_2_s390x.whl", hash = "sha256:71be7e0e01753a89cf024abf7ecb6bca2c81738ead80d43004d9b5e3f1244e64"},
-    {file = "charset_normalizer-3.4.6-cp38-cp38-musllinux_1_2_x86_64.whl", hash = "sha256:df01808ee470038c3f8dc4f48620df7225c49c2d6639e38f96e6d6ac6e6f7b0e"},
-    {file = "charset_normalizer-3.4.6-cp38-cp38-win32.whl", hash = "sha256:69dd852c2f0ad631b8b60cfbe25a28c0058a894de5abb566619c205ce0550eae"},
-    {file = "charset_normalizer-3.4.6-cp38-cp38-win_amd64.whl", hash = "sha256:517ad0e93394ac532745129ceabdf2696b609ec9f87863d337140317ebce1c14"},
-    {file = "charset_normalizer-3.4.6-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:31215157227939b4fb3d740cd23fe27be0439afef67b785a1eb78a3ae69cba9e"},
-    {file = "charset_normalizer-3.4.6-cp39-cp39-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ecbbd45615a6885fe3240eb9db73b9e62518b611850fdf8ab08bd56de7ad2b17"},
-    {file = "charset_normalizer-3.4.6-cp39-cp39-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:c45a03a4c69820a399f1dda9e1d8fbf3562eda46e7720458180302021b08f778"},
-    {file = "charset_normalizer-3.4.6-cp39-cp39-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:e8aeb10fcbe92767f0fa69ad5a72deca50d0dca07fbde97848997d778a50c9fe"},
-    {file = "charset_normalizer-3.4.6-cp39-cp39-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:54fae94be3d75f3e573c9a1b5402dc593de19377013c9a0e4285e3d402dd3a2a"},
-    {file = "charset_normalizer-3.4.6-cp39-cp39-manylinux_2_31_armv7l.whl", hash = "sha256:2f7fdd9b6e6c529d6a2501a2d36b240109e78a8ceaef5687cfcfa2bbe671d297"},
-    {file = "charset_normalizer-3.4.6-cp39-cp39-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:4d1d02209e06550bdaef34af58e041ad71b88e624f5d825519da3a3308e22687"},
-    {file = "charset_normalizer-3.4.6-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:8bc5f0687d796c05b1e28ab0d38a50e6309906ee09375dd3aff6a9c09dd6e8f4"},
-    {file = "charset_normalizer-3.4.6-cp39-cp39-musllinux_1_2_armv7l.whl", hash = "sha256:ee4ec14bc1680d6b0afab9aea2ef27e26d2024f18b24a2d7155a52b60da7e833"},
-    {file = "charset_normalizer-3.4.6-cp39-cp39-musllinux_1_2_ppc64le.whl", hash = "sha256:d1a2ee9c1499fc8f86f4521f27a973c914b211ffa87322f4ee33bb35392da2c5"},
-    {file = "charset_normalizer-3.4.6-cp39-cp39-musllinux_1_2_riscv64.whl", hash = "sha256:48696db7f18afb80a068821504296eb0787d9ce239b91ca15059d1d3eaacf13b"},
-    {file = "charset_normalizer-3.4.6-cp39-cp39-musllinux_1_2_s390x.whl", hash = "sha256:4f41da960b196ea355357285ad1316a00099f22d0929fe168343b99b254729c9"},
-    {file = "charset_normalizer-3.4.6-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:802168e03fba8bbc5ce0d866d589e4b1ca751d06edee69f7f3a19c5a9fe6b597"},
-    {file = "charset_normalizer-3.4.6-cp39-cp39-win32.whl", hash = "sha256:8761ac29b6c81574724322a554605608a9960769ea83d2c73e396f3df896ad54"},
-    {file = "charset_normalizer-3.4.6-cp39-cp39-win_amd64.whl", hash = "sha256:1cf0a70018692f85172348fe06d3a4b63f94ecb055e13a00c644d368eb82e5b8"},
-    {file = "charset_normalizer-3.4.6-cp39-cp39-win_arm64.whl", hash = "sha256:3516bbb8d42169de9e61b8520cbeeeb716f12f4ecfe3fd30a9919aa16c806ca8"},
-    {file = "charset_normalizer-3.4.6-py3-none-any.whl", hash = "sha256:947cf925bc916d90adba35a64c82aace04fa39b46b52d4630ece166655905a69"},
-    {file = "charset_normalizer-3.4.6.tar.gz", hash = "sha256:1ae6b62897110aa7c79ea2f5dd38d1abca6db663687c0b1ad9aed6f6bae3d9d6"},
+    {file = "charset_normalizer-3.4.7-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:cdd68a1fb318e290a2077696b7eb7a21a49163c455979c639bf5a5dcdc46617d"},
+    {file = "charset_normalizer-3.4.7-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e17b8d5d6a8c47c85e68ca8379def1303fd360c3e22093a807cd34a71cd082b8"},
+    {file = "charset_normalizer-3.4.7-cp310-cp310-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:511ef87c8aec0783e08ac18565a16d435372bc1ac25a91e6ac7f5ef2b0bff790"},
+    {file = "charset_normalizer-3.4.7-cp310-cp310-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:007d05ec7321d12a40227aae9e2bc6dca73f3cb21058999a1df9e193555a9dcc"},
+    {file = "charset_normalizer-3.4.7-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:cf29836da5119f3c8a8a70667b0ef5fdca3bb12f80fd06487cfa575b3909b393"},
+    {file = "charset_normalizer-3.4.7-cp310-cp310-manylinux_2_31_armv7l.whl", hash = "sha256:12d8baf840cc7889b37c7c770f478adea7adce3dcb3944d02ec87508e2dcf153"},
+    {file = "charset_normalizer-3.4.7-cp310-cp310-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:d560742f3c0d62afaccf9f41fe485ed69bd7661a241f86a3ef0f0fb8b1a397af"},
+    {file = "charset_normalizer-3.4.7-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:b14b2d9dac08e28bb8046a1a0434b1750eb221c8f5b87a68f4fa11a6f97b5e34"},
+    {file = "charset_normalizer-3.4.7-cp310-cp310-musllinux_1_2_armv7l.whl", hash = "sha256:bc17a677b21b3502a21f66a8cc64f5bfad4df8a0b8434d661666f8ce90ac3af1"},
+    {file = "charset_normalizer-3.4.7-cp310-cp310-musllinux_1_2_ppc64le.whl", hash = "sha256:750e02e074872a3fad7f233b47734166440af3cdea0add3e95163110816d6752"},
+    {file = "charset_normalizer-3.4.7-cp310-cp310-musllinux_1_2_riscv64.whl", hash = "sha256:4e5163c14bffd570ef2affbfdd77bba66383890797df43dc8b4cc7d6f500bf53"},
+    {file = "charset_normalizer-3.4.7-cp310-cp310-musllinux_1_2_s390x.whl", hash = "sha256:6ed74185b2db44f41ef35fd1617c5888e59792da9bbc9190d6c7300617182616"},
+    {file = "charset_normalizer-3.4.7-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:94e1885b270625a9a828c9793b4d52a64445299baa1fea5a173bf1d3dd9a1a5a"},
+    {file = "charset_normalizer-3.4.7-cp310-cp310-win32.whl", hash = "sha256:6785f414ae0f3c733c437e0f3929197934f526d19dfaa75e18fdb4f94c6fb374"},
+    {file = "charset_normalizer-3.4.7-cp310-cp310-win_amd64.whl", hash = "sha256:6696b7688f54f5af4462118f0bfa7c1621eeb87154f77fa04b9295ce7a8f2943"},
+    {file = "charset_normalizer-3.4.7-cp310-cp310-win_arm64.whl", hash = "sha256:66671f93accb62ed07da56613636f3641f1a12c13046ce91ffc923721f23c008"},
+    {file = "charset_normalizer-3.4.7-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:7641bb8895e77f921102f72833904dcd9901df5d6d72a2ab8f31d04b7e51e4e7"},
+    {file = "charset_normalizer-3.4.7-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:202389074300232baeb53ae2569a60901f7efadd4245cf3a3bf0617d60b439d7"},
+    {file = "charset_normalizer-3.4.7-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:30b8d1d8c52a48c2c5690e152c169b673487a2a58de1ec7393196753063fcd5e"},
+    {file = "charset_normalizer-3.4.7-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:532bc9bf33a68613fd7d65e4b1c71a6a38d7d42604ecf239c77392e9b4e8998c"},
+    {file = "charset_normalizer-3.4.7-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2fe249cb4651fd12605b7288b24751d8bfd46d35f12a20b1ba33dea122e690df"},
+    {file = "charset_normalizer-3.4.7-cp311-cp311-manylinux_2_31_armv7l.whl", hash = "sha256:65bcd23054beab4d166035cabbc868a09c1a49d1efe458fe8e4361215df40265"},
+    {file = "charset_normalizer-3.4.7-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:08e721811161356f97b4059a9ba7bafb23ea5ee2255402c42881c214e173c6b4"},
+    {file = "charset_normalizer-3.4.7-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:e060d01aec0a910bdccb8be71faf34e7799ce36950f8294c8bf612cba65a2c9e"},
+    {file = "charset_normalizer-3.4.7-cp311-cp311-musllinux_1_2_armv7l.whl", hash = "sha256:38c0109396c4cfc574d502df99742a45c72c08eff0a36158b6f04000043dbf38"},
+    {file = "charset_normalizer-3.4.7-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:1c2a768fdd44ee4a9339a9b0b130049139b8ce3c01d2ce09f67f5a68048d477c"},
+    {file = "charset_normalizer-3.4.7-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:1a87ca9d5df6fe460483d9a5bbf2b18f620cbed41b432e2bddb686228282d10b"},
+    {file = "charset_normalizer-3.4.7-cp311-cp311-musllinux_1_2_s390x.whl", hash = "sha256:d635aab80466bc95771bb78d5370e74d36d1fe31467b6b29b8b57b2a3cd7d22c"},
+    {file = "charset_normalizer-3.4.7-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:ae196f021b5e7c78e918242d217db021ed2a6ace2bc6ae94c0fc596221c7f58d"},
+    {file = "charset_normalizer-3.4.7-cp311-cp311-win32.whl", hash = "sha256:adb2597b428735679446b46c8badf467b4ca5f5056aae4d51a19f9570301b1ad"},
+    {file = "charset_normalizer-3.4.7-cp311-cp311-win_amd64.whl", hash = "sha256:8e385e4267ab76874ae30db04c627faaaf0b509e1ccc11a95b3fc3e83f855c00"},
+    {file = "charset_normalizer-3.4.7-cp311-cp311-win_arm64.whl", hash = "sha256:d4a48e5b3c2a489fae013b7589308a40146ee081f6f509e047e0e096084ceca1"},
+    {file = "charset_normalizer-3.4.7-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:eca9705049ad3c7345d574e3510665cb2cf844c2f2dcfe675332677f081cbd46"},
+    {file = "charset_normalizer-3.4.7-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6178f72c5508bfc5fd446a5905e698c6212932f25bcdd4b47a757a50605a90e2"},
+    {file = "charset_normalizer-3.4.7-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:e1421b502d83040e6d7fb2fb18dff63957f720da3d77b2fbd3187ceb63755d7b"},
+    {file = "charset_normalizer-3.4.7-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:edac0f1ab77644605be2cbba52e6b7f630731fc42b34cb0f634be1a6eface56a"},
+    {file = "charset_normalizer-3.4.7-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5649fd1c7bade02f320a462fdefd0b4bd3ce036065836d4f42e0de958038e116"},
+    {file = "charset_normalizer-3.4.7-cp312-cp312-manylinux_2_31_armv7l.whl", hash = "sha256:203104ed3e428044fd943bc4bf45fa73c0730391f9621e37fe39ecf477b128cb"},
+    {file = "charset_normalizer-3.4.7-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:298930cec56029e05497a76988377cbd7457ba864beeea92ad7e844fe74cd1f1"},
+    {file = "charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:708838739abf24b2ceb208d0e22403dd018faeef86ddac04319a62ae884c4f15"},
+    {file = "charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:0f7eb884681e3938906ed0434f20c63046eacd0111c4ba96f27b76084cd679f5"},
+    {file = "charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:4dc1e73c36828f982bfe79fadf5919923f8a6f4df2860804db9a98c48824ce8d"},
+    {file = "charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:aed52fea0513bac0ccde438c188c8a471c4e0f457c2dd20cdbf6ea7a450046c7"},
+    {file = "charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:fea24543955a6a729c45a73fe90e08c743f0b3334bbf3201e6c4bc1b0c7fa464"},
+    {file = "charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:bb6d88045545b26da47aa879dd4a89a71d1dce0f0e549b1abcb31dfe4a8eac49"},
+    {file = "charset_normalizer-3.4.7-cp312-cp312-win32.whl", hash = "sha256:2257141f39fe65a3fdf38aeccae4b953e5f3b3324f4ff0daf9f15b8518666a2c"},
+    {file = "charset_normalizer-3.4.7-cp312-cp312-win_amd64.whl", hash = "sha256:5ed6ab538499c8644b8a3e18debabcd7ce684f3fa91cf867521a7a0279cab2d6"},
+    {file = "charset_normalizer-3.4.7-cp312-cp312-win_arm64.whl", hash = "sha256:56be790f86bfb2c98fb742ce566dfb4816e5a83384616ab59c49e0604d49c51d"},
+    {file = "charset_normalizer-3.4.7-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:f496c9c3cc02230093d8330875c4c3cdfc3b73612a5fd921c65d39cbcef08063"},
+    {file = "charset_normalizer-3.4.7-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0ea948db76d31190bf08bd371623927ee1339d5f2a0b4b1b4a4439a65298703c"},
+    {file = "charset_normalizer-3.4.7-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:a277ab8928b9f299723bc1a2dabb1265911b1a76341f90a510368ca44ad9ab66"},
+    {file = "charset_normalizer-3.4.7-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:3bec022aec2c514d9cf199522a802bd007cd588ab17ab2525f20f9c34d067c18"},
+    {file = "charset_normalizer-3.4.7-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e044c39e41b92c845bc815e5ae4230804e8e7bc29e399b0437d64222d92809dd"},
+    {file = "charset_normalizer-3.4.7-cp313-cp313-manylinux_2_31_armv7l.whl", hash = "sha256:f495a1652cf3fbab2eb0639776dad966c2fb874d79d87ca07f9d5f059b8bd215"},
+    {file = "charset_normalizer-3.4.7-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:e712b419df8ba5e42b226c510472b37bd57b38e897d3eca5e8cfd410a29fa859"},
+    {file = "charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:7804338df6fcc08105c7745f1502ba68d900f45fd770d5bdd5288ddccb8a42d8"},
+    {file = "charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:481551899c856c704d58119b5025793fa6730adda3571971af568f66d2424bb5"},
+    {file = "charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:f59099f9b66f0d7145115e6f80dd8b1d847176df89b234a5a6b3f00437aa0832"},
+    {file = "charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:f59ad4c0e8f6bba240a9bb85504faa1ab438237199d4cce5f622761507b8f6a6"},
+    {file = "charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:3dedcc22d73ec993f42055eff4fcfed9318d1eeb9a6606c55892a26964964e48"},
+    {file = "charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:64f02c6841d7d83f832cd97ccf8eb8a906d06eb95d5276069175c696b024b60a"},
+    {file = "charset_normalizer-3.4.7-cp313-cp313-win32.whl", hash = "sha256:4042d5c8f957e15221d423ba781e85d553722fc4113f523f2feb7b188cc34c5e"},
+    {file = "charset_normalizer-3.4.7-cp313-cp313-win_amd64.whl", hash = "sha256:3946fa46a0cf3e4c8cb1cc52f56bb536310d34f25f01ca9b6c16afa767dab110"},
+    {file = "charset_normalizer-3.4.7-cp313-cp313-win_arm64.whl", hash = "sha256:80d04837f55fc81da168b98de4f4b797ef007fc8a79ab71c6ec9bc4dd662b15b"},
+    {file = "charset_normalizer-3.4.7-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:c36c333c39be2dbca264d7803333c896ab8fa7d4d6f0ab7edb7dfd7aea6e98c0"},
+    {file = "charset_normalizer-3.4.7-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1c2aed2e5e41f24ea8ef1590b8e848a79b56f3a5564a65ceec43c9d692dc7d8a"},
+    {file = "charset_normalizer-3.4.7-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:54523e136b8948060c0fa0bc7b1b50c32c186f2fceee897a495406bb6e311d2b"},
+    {file = "charset_normalizer-3.4.7-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:715479b9a2802ecac752a3b0efa2b0b60285cf962ee38414211abdfccc233b41"},
+    {file = "charset_normalizer-3.4.7-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:bd6c2a1c7573c64738d716488d2cdd3c00e340e4835707d8fdb8dc1a66ef164e"},
+    {file = "charset_normalizer-3.4.7-cp314-cp314-manylinux_2_31_armv7l.whl", hash = "sha256:c45e9440fb78f8ddabcf714b68f936737a121355bf59f3907f4e17721b9d1aae"},
+    {file = "charset_normalizer-3.4.7-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:3534e7dcbdcf757da6b85a0bbf5b6868786d5982dd959b065e65481644817a18"},
+    {file = "charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:e8ac484bf18ce6975760921bb6148041faa8fef0547200386ea0b52b5d27bf7b"},
+    {file = "charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:a5fe03b42827c13cdccd08e6c0247b6a6d4b5e3cdc53fd1749f5896adcdc2356"},
+    {file = "charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:2d6eb928e13016cea4f1f21d1e10c1cebd5a421bc57ddf5b1142ae3f86824fab"},
+    {file = "charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:e74327fb75de8986940def6e8dee4f127cc9752bee7355bb323cc5b2659b6d46"},
+    {file = "charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:d6038d37043bced98a66e68d3aa2b6a35505dc01328cd65217cefe82f25def44"},
+    {file = "charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:7579e913a5339fb8fa133f6bbcfd8e6749696206cf05acdbdca71a1b436d8e72"},
+    {file = "charset_normalizer-3.4.7-cp314-cp314-win32.whl", hash = "sha256:5b77459df20e08151cd6f8b9ef8ef1f961ef73d85c21a555c7eed5b79410ec10"},
+    {file = "charset_normalizer-3.4.7-cp314-cp314-win_amd64.whl", hash = "sha256:92a0a01ead5e668468e952e4238cccd7c537364eb7d851ab144ab6627dbbe12f"},
+    {file = "charset_normalizer-3.4.7-cp314-cp314-win_arm64.whl", hash = "sha256:67f6279d125ca0046a7fd386d01b311c6363844deac3e5b069b514ba3e63c246"},
+    {file = "charset_normalizer-3.4.7-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:effc3f449787117233702311a1b7d8f59cba9ced946ba727bdc329ec69028e24"},
+    {file = "charset_normalizer-3.4.7-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:fbccdc05410c9ee21bbf16a35f4c1d16123dcdeb8a1d38f33654fa21d0234f79"},
+    {file = "charset_normalizer-3.4.7-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:733784b6d6def852c814bce5f318d25da2ee65dd4839a0718641c696e09a2960"},
+    {file = "charset_normalizer-3.4.7-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a89c23ef8d2c6b27fd200a42aa4ac72786e7c60d40efdc76e6011260b6e949c4"},
+    {file = "charset_normalizer-3.4.7-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6c114670c45346afedc0d947faf3c7f701051d2518b943679c8ff88befe14f8e"},
+    {file = "charset_normalizer-3.4.7-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:a180c5e59792af262bf263b21a3c49353f25945d8d9f70628e73de370d55e1e1"},
+    {file = "charset_normalizer-3.4.7-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:3c9a494bc5ec77d43cea229c4f6db1e4d8fe7e1bbffa8b6f0f0032430ff8ab44"},
+    {file = "charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:8d828b6667a32a728a1ad1d93957cdf37489c57b97ae6c4de2860fa749b8fc1e"},
+    {file = "charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:cf1493cd8607bec4d8a7b9b004e699fcf8f9103a9284cc94962cb73d20f9d4a3"},
+    {file = "charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:0c96c3b819b5c3e9e165495db84d41914d6894d55181d2d108cc1a69bfc9cce0"},
+    {file = "charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:752a45dc4a6934060b3b0dab47e04edc3326575f82be64bc4fc293914566503e"},
+    {file = "charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_s390x.whl", hash = "sha256:8778f0c7a52e56f75d12dae53ae320fae900a8b9b4164b981b9c5ce059cd1fcb"},
+    {file = "charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:ce3412fbe1e31eb81ea42f4169ed94861c56e643189e1e75f0041f3fe7020abe"},
+    {file = "charset_normalizer-3.4.7-cp314-cp314t-win32.whl", hash = "sha256:c03a41a8784091e67a39648f70c5f97b5b6a37f216896d44d2cdcb82615339a0"},
+    {file = "charset_normalizer-3.4.7-cp314-cp314t-win_amd64.whl", hash = "sha256:03853ed82eeebbce3c2abfdbc98c96dc205f32a79627688ac9a27370ea61a49c"},
+    {file = "charset_normalizer-3.4.7-cp314-cp314t-win_arm64.whl", hash = "sha256:c35abb8bfff0185efac5878da64c45dafd2b37fb0383add1be155a763c1f083d"},
+    {file = "charset_normalizer-3.4.7-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:e5f4d355f0a2b1a31bc3edec6795b46324349c9cb25eed068049e4f472fb4259"},
+    {file = "charset_normalizer-3.4.7-cp38-cp38-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:16d971e29578a5e97d7117866d15889a4a07befe0e87e703ed63cd90cb348c01"},
+    {file = "charset_normalizer-3.4.7-cp38-cp38-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:dca4bbc466a95ba9c0234ef56d7dd9509f63da22274589ebd4ed7f1f4d4c54e3"},
+    {file = "charset_normalizer-3.4.7-cp38-cp38-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:e80c8378d8f3d83cd3164da1ad2df9e37a666cdde7b1cb2298ed0b558064be30"},
+    {file = "charset_normalizer-3.4.7-cp38-cp38-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:36836d6ff945a00b88ba1e4572d721e60b5b8c98c155d465f56ad19d68f23734"},
+    {file = "charset_normalizer-3.4.7-cp38-cp38-manylinux_2_31_armv7l.whl", hash = "sha256:bd9b23791fe793e4968dba0c447e12f78e425c59fc0e3b97f6450f4781f3ee60"},
+    {file = "charset_normalizer-3.4.7-cp38-cp38-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:aef65cd602a6d0e0ff6f9930fcb1c8fec60dd2cfcb6facaf4bdb0e5873042db0"},
+    {file = "charset_normalizer-3.4.7-cp38-cp38-musllinux_1_2_aarch64.whl", hash = "sha256:82b271f5137d07749f7bf32f70b17ab6eaabedd297e75dce75081a24f76eb545"},
+    {file = "charset_normalizer-3.4.7-cp38-cp38-musllinux_1_2_armv7l.whl", hash = "sha256:1efde3cae86c8c273f1eb3b287be7d8499420cf2fe7585c41d370d3e790054a5"},
+    {file = "charset_normalizer-3.4.7-cp38-cp38-musllinux_1_2_ppc64le.whl", hash = "sha256:c593052c465475e64bbfe5dbd81680f64a67fdc752c56d7a0ae205dc8aeefe0f"},
+    {file = "charset_normalizer-3.4.7-cp38-cp38-musllinux_1_2_riscv64.whl", hash = "sha256:af21eb4409a119e365397b2adbaca4c9ccab56543a65d5dbd9f920d6ac29f686"},
+    {file = "charset_normalizer-3.4.7-cp38-cp38-musllinux_1_2_s390x.whl", hash = "sha256:84c018e49c3bf790f9c2771c45e9313a08c2c2a6342b162cd650258b57817706"},
+    {file = "charset_normalizer-3.4.7-cp38-cp38-musllinux_1_2_x86_64.whl", hash = "sha256:dd915403e231e6b1809fe9b6d9fc55cf8fb5e02765ac625d9cd623342a7905d7"},
+    {file = "charset_normalizer-3.4.7-cp38-cp38-win32.whl", hash = "sha256:320ade88cfb846b8cd6b4ddf5ee9e80ee0c1f52401f2456b84ae1ae6a1a5f207"},
+    {file = "charset_normalizer-3.4.7-cp38-cp38-win_amd64.whl", hash = "sha256:1dc8b0ea451d6e69735094606991f32867807881400f808a106ee1d963c46a83"},
+    {file = "charset_normalizer-3.4.7-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:177a0ba5f0211d488e295aaf82707237e331c24788d8d76c96c5a41594723217"},
+    {file = "charset_normalizer-3.4.7-cp39-cp39-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6e0d51f618228538a3e8f46bd246f87a6cd030565e015803691603f55e12afb5"},
+    {file = "charset_normalizer-3.4.7-cp39-cp39-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:14265bfe1f09498b9d8ec91e9ec9fa52775edf90fcbde092b25f4a33d444fea9"},
+    {file = "charset_normalizer-3.4.7-cp39-cp39-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:87fad7d9ba98c86bcb41b2dc8dbb326619be2562af1f8ff50776a39e55721c5a"},
+    {file = "charset_normalizer-3.4.7-cp39-cp39-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f22dec1690b584cea26fade98b2435c132c1b5f68e39f5a0b7627cd7ae31f1dc"},
+    {file = "charset_normalizer-3.4.7-cp39-cp39-manylinux_2_31_armv7l.whl", hash = "sha256:d61f00a0869d77422d9b2aba989e2d24afa6ffd552af442e0e58de4f35ea6d00"},
+    {file = "charset_normalizer-3.4.7-cp39-cp39-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:6370e8686f662e6a3941ee48ed4742317cafbe5707e36406e9df792cdb535776"},
+    {file = "charset_normalizer-3.4.7-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:a6c5863edfbe888d9eff9c8b8087354e27618d9da76425c119293f11712a6319"},
+    {file = "charset_normalizer-3.4.7-cp39-cp39-musllinux_1_2_armv7l.whl", hash = "sha256:ed065083d0898c9d5b4bbec7b026fd755ff7454e6e8b73a67f8c744b13986e24"},
+    {file = "charset_normalizer-3.4.7-cp39-cp39-musllinux_1_2_ppc64le.whl", hash = "sha256:2cd4a60d0e2fb04537162c62bbbb4182f53541fe0ede35cdf270a1c1e723cc42"},
+    {file = "charset_normalizer-3.4.7-cp39-cp39-musllinux_1_2_riscv64.whl", hash = "sha256:813c0e0132266c08eb87469a642cb30aaff57c5f426255419572aaeceeaa7bf4"},
+    {file = "charset_normalizer-3.4.7-cp39-cp39-musllinux_1_2_s390x.whl", hash = "sha256:07d9e39b01743c3717745f4c530a6349eadbfa043c7577eef86c502c15df2c67"},
+    {file = "charset_normalizer-3.4.7-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:c0f081d69a6e58272819b70288d3221a6ee64b98df852631c80f293514d3b274"},
+    {file = "charset_normalizer-3.4.7-cp39-cp39-win32.whl", hash = "sha256:8751d2787c9131302398b11e6c8068053dcb55d5a8964e114b6e196cf16cb366"},
+    {file = "charset_normalizer-3.4.7-cp39-cp39-win_amd64.whl", hash = "sha256:12a6fff75f6bc66711b73a2f0addfc4c8c15a20e805146a02d147a318962c444"},
+    {file = "charset_normalizer-3.4.7-cp39-cp39-win_arm64.whl", hash = "sha256:bb8cc7534f51d9a017b93e3e85b260924f909601c3df002bcdb58ddb4dc41a5c"},
+    {file = "charset_normalizer-3.4.7-py3-none-any.whl", hash = "sha256:3dce51d0f5e7951f8bb4900c257dad282f49190fdbebecd4ba99bcc41fef404d"},
+    {file = "charset_normalizer-3.4.7.tar.gz", hash = "sha256:ae89db9e5f98a11a4bf50407d4363e7b09b31e55bc117b4f7d80aab97ba009e5"},
 ]
 
 [[package]]
 name = "click"
-version = "8.3.1"
+version = "8.3.2"
 description = "Composable command line interface toolkit"
 optional = false
 python-versions = ">=3.10"
 groups = ["dev", "docs"]
 files = [
-    {file = "click-8.3.1-py3-none-any.whl", hash = "sha256:981153a64e25f12d547d3426c367a4857371575ee7ad18df2a6183ab0545b2a6"},
-    {file = "click-8.3.1.tar.gz", hash = "sha256:12ff4785d337a1bb490bb7e9c2b1ee5da3112e94a8622f26a6c77f5d2fc6842a"},
+    {file = "click-8.3.2-py3-none-any.whl", hash = "sha256:1924d2c27c5653561cd2cae4548d1406039cb79b858b747cfea24924bbc1616d"},
+    {file = "click-8.3.2.tar.gz", hash = "sha256:14162b8b3b3550a7d479eafa77dfd3c38d9dc8951f6f69c78913a8f9a7540fd5"},
 ]
 
 [package.dependencies]
@@ -2101,14 +2101,14 @@ files = [
 
 [[package]]
 name = "packaging"
-version = "26.0"
+version = "26.1"
 description = "Core utilities for Python packages"
 optional = false
 python-versions = ">=3.8"
 groups = ["docs", "test"]
 files = [
-    {file = "packaging-26.0-py3-none-any.whl", hash = "sha256:b36f1fef9334a5588b4166f8bcd26a14e521f2b55e6b9de3aaa80d3ff7a37529"},
-    {file = "packaging-26.0.tar.gz", hash = "sha256:00243ae351a257117b6a241061796684b084ed1c516a08c48a3f7e147a9d80b4"},
+    {file = "packaging-26.1-py3-none-any.whl", hash = "sha256:5d9c0669c6285e491e0ced2eee587eaf67b670d94a19e94e3984a481aba6802f"},
+    {file = "packaging-26.1.tar.gz", hash = "sha256:f042152b681c4bfac5cae2742a55e103d27ab2ec0f3d88037136b6bfe7c9c5de"},
 ]
 
 [[package]]
@@ -3062,34 +3062,34 @@ url = "https://github.com/terok-ai/terok-dbus/releases/download/v0.5.6/terok_dbu
 
 [[package]]
 name = "terok-executor"
-version = "0.0.76"
+version = "0.0.77"
 description = "Single-agent task runner for hardened Podman containers"
 optional = false
 python-versions = ">=3.12,<4.0"
 groups = ["main"]
 files = [
-    {file = "terok_executor-0.0.76-py3-none-any.whl", hash = "sha256:36222298684ad6fe7eecafa33ca9e4e430ff7b76390d566c527204f69352522a"},
+    {file = "terok_executor-0.0.77-py3-none-any.whl", hash = "sha256:7924deb2afe0c752851c7025f7a7e34db287b7fa0ad4e17c1160d934765c9ac3"},
 ]
 
 [package.dependencies]
 Jinja2 = ">=3.1"
 "ruamel.yaml" = ">=0.18"
-terok_sandbox = {url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.0.66/terok_sandbox-0.0.66-py3-none-any.whl"}
+terok_sandbox = {url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.0.67/terok_sandbox-0.0.67-py3-none-any.whl"}
 tomli-w = ">=1.0"
 
 [package.source]
 type = "url"
-url = "https://github.com/terok-ai/terok-executor/releases/download/v0.0.76/terok_executor-0.0.76-py3-none-any.whl"
+url = "https://github.com/terok-ai/terok-executor/releases/download/v0.0.77/terok_executor-0.0.77-py3-none-any.whl"
 
 [[package]]
 name = "terok-sandbox"
-version = "0.0.66"
+version = "0.0.67"
 description = "Hardened Podman container runner with gate server and shield integration"
 optional = false
 python-versions = ">=3.12,<4.0"
 groups = ["main"]
 files = [
-    {file = "terok_sandbox-0.0.66-py3-none-any.whl", hash = "sha256:33b723108bdc45039de98fe1356a4ec1523553466ae70f0482472e89afe53e82"},
+    {file = "terok_sandbox-0.0.67-py3-none-any.whl", hash = "sha256:8699ca449a009ef0f5b098ff15a92649a69b7cfdef043fe14ae8e877e032cbb6"},
 ]
 
 [package.dependencies]
@@ -3100,7 +3100,7 @@ terok_shield = {url = "https://github.com/terok-ai/terok-shield/releases/downloa
 
 [package.source]
 type = "url"
-url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.0.66/terok_sandbox-0.0.66-py3-none-any.whl"
+url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.0.67/terok_sandbox-0.0.67-py3-none-any.whl"
 
 [[package]]
 name = "terok-shield"
@@ -3379,21 +3379,21 @@ zstd = ["backports-zstd (>=1.0.0) ; python_version < \"3.14\""]
 
 [[package]]
 name = "virtualenv"
-version = "21.2.0"
+version = "21.2.3"
 description = "Virtual Python Environment builder"
 optional = false
 python-versions = ">=3.8"
 groups = ["dev"]
 files = [
-    {file = "virtualenv-21.2.0-py3-none-any.whl", hash = "sha256:1bd755b504931164a5a496d217c014d098426cddc79363ad66ac78125f9d908f"},
-    {file = "virtualenv-21.2.0.tar.gz", hash = "sha256:1720dc3a62ef5b443092e3f499228599045d7fea4c79199770499df8becf9098"},
+    {file = "virtualenv-21.2.3-py3-none-any.whl", hash = "sha256:486652347ea8526d91e9807c0274583cb7ba31dd4942ff10fb5621402f0fe0d8"},
+    {file = "virtualenv-21.2.3.tar.gz", hash = "sha256:9bb6d1414ab55ca624371e30c7719c32f183ef44da544ef8aa44a456de7ac191"},
 ]
 
 [package.dependencies]
 distlib = ">=0.3.7,<1"
 filelock = {version = ">=3.24.2,<4", markers = "python_version >= \"3.10\""}
 platformdirs = ">=3.9.1,<5"
-python-discovery = ">=1"
+python-discovery = ">=1.2.2"
 
 [[package]]
 name = "vulture"
@@ -3608,4 +3608,4 @@ propcache = ">=0.2.1"
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.12,<4.0"
-content-hash = "90e08a73036ac327726e194b27036582c23aff0450e7b82f303fd837252ba341"
+content-hash = "8a0b79474be4c1a7127e4e7699f8e44a44f64751f39ada4333e146d5e37d29cc"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,8 +44,8 @@ rich = ">=13.0"
 platformdirs = ">=4.5.1"
 unique-namer = ">=1.3"
 textual-serve = ">=1.1.0"
-terok-executor = {url = "https://github.com/terok-ai/terok-executor/releases/download/v0.0.76/terok_executor-0.0.76-py3-none-any.whl"}
-terok-sandbox = {url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.0.66/terok_sandbox-0.0.66-py3-none-any.whl"}
+terok-executor = {url = "https://github.com/terok-ai/terok-executor/releases/download/v0.0.77/terok_executor-0.0.77-py3-none-any.whl"}
+terok-sandbox = {url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.0.67/terok_sandbox-0.0.67-py3-none-any.whl"}
 terok-dbus = {url = "https://github.com/terok-ai/terok-dbus/releases/download/v0.5.6/terok_dbus-0.5.6-py3-none-any.whl"}
 
 [tool.poetry.group.dev.dependencies]

--- a/src/terok/lib/orchestration/container_doctor.py
+++ b/src/terok/lib/orchestration/container_doctor.py
@@ -19,7 +19,13 @@ from pathlib import Path
 from urllib.parse import urlparse
 
 from terok_executor import agent_doctor_checks, get_roster
-from terok_sandbox import get_container_state, get_proxy_port, get_ssh_agent_port, make_shield
+from terok_sandbox import (
+    get_container_state,
+    get_proxy_port,
+    get_ssh_agent_port,
+    make_shield,
+    sandbox_exec,
+)
 from terok_sandbox.doctor import CheckVerdict, DoctorCheck, sandbox_doctor_checks
 
 from ..core.config import make_sandbox_config
@@ -46,13 +52,8 @@ def _exec_in_container(
     *,
     timeout: int = 10,
 ) -> subprocess.CompletedProcess[str]:
-    """Run *cmd* inside *cname* via ``podman exec`` and return the result."""
-    return subprocess.run(
-        ["podman", "exec", cname, *cmd],
-        capture_output=True,
-        text=True,
-        timeout=timeout,
-    )
+    """Run *cmd* inside *cname* via the sandbox exec API."""
+    return sandbox_exec(cname, cmd, timeout=timeout)
 
 
 # ---------------------------------------------------------------------------

--- a/src/terok/lib/orchestration/container_exec.py
+++ b/src/terok/lib/orchestration/container_exec.py
@@ -3,14 +3,14 @@
 
 """Container-based command execution for agent workspaces.
 
-Runs git (and other commands) **inside** task containers via ``podman exec``
-instead of on the host, eliminating the risk of poisoned git hooks or
-scripts executing with host privileges.
+Runs git (and other commands) **inside** task containers via the
+terok-sandbox ``sandbox_exec`` API instead of on the host, eliminating
+the risk of poisoned git hooks or scripts executing with host privileges.
 """
 
-import subprocess
+from subprocess import TimeoutExpired
 
-from terok_sandbox import get_container_state
+from terok_sandbox import container_start, container_stop, get_container_state, sandbox_exec
 
 from ..core.task_display import container_name as _container_name
 from ..util.logging_utils import _log_debug
@@ -19,14 +19,12 @@ from ..util.logging_utils import _log_debug
 def _podman_start(cname: str) -> bool:
     """Start a stopped container, returning ``True`` on success."""
     try:
-        subprocess.run(
-            ["podman", "start", cname],
-            check=True,
-            stdout=subprocess.DEVNULL,
-            stderr=subprocess.DEVNULL,
-        )
-    except (FileNotFoundError, subprocess.CalledProcessError) as exc:
-        _log_debug(f"container_exec._podman_start({cname}): {exc}")
+        result = container_start(cname)
+    except FileNotFoundError:
+        _log_debug(f"container_exec._podman_start({cname}): podman not found")
+        return False
+    if result.returncode != 0:
+        _log_debug(f"container_exec._podman_start({cname}): rc={result.returncode}")
         return False
     return True
 
@@ -34,12 +32,7 @@ def _podman_start(cname: str) -> bool:
 def _podman_stop(cname: str, timeout: int = 10) -> None:
     """Stop a container best-effort."""
     try:
-        subprocess.run(
-            ["podman", "stop", "--time", str(timeout), cname],
-            check=False,
-            stdout=subprocess.DEVNULL,
-            stderr=subprocess.DEVNULL,
-        )
+        container_stop(cname, timeout=timeout)
     except FileNotFoundError:
         pass
 
@@ -89,13 +82,12 @@ def container_git_diff(
         restarted = True
 
     try:
-        cmd = ["podman", "exec", cname, "git", "-C", "/workspace", "diff", *args]
-        result = subprocess.run(cmd, capture_output=True, text=True, timeout=timeout)
+        result = sandbox_exec(cname, ["git", "-C", "/workspace", "diff", *args], timeout=timeout)
         if result.returncode != 0:
             _log_debug(f"container_git_diff: git diff failed rc={result.returncode}")
             return None
         return result.stdout
-    except (FileNotFoundError, subprocess.TimeoutExpired) as exc:
+    except (FileNotFoundError, TimeoutExpired) as exc:
         _log_debug(f"container_git_diff: {exc}")
         return None
     finally:

--- a/src/terok/lib/orchestration/task_runners.py
+++ b/src/terok/lib/orchestration/task_runners.py
@@ -5,7 +5,7 @@
 
 from __future__ import annotations
 
-import subprocess
+import shlex
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from pathlib import Path
@@ -24,9 +24,12 @@ from terok_sandbox import (
     Sandbox,
     Sharing,
     VolumeSpec,
+    container_start,
+    container_stop,
     down as _shield_down_impl,
     get_container_state,
     is_container_running,
+    login_command as _sandbox_login_command,
     stream_initial_logs,
     wait_for_exit,
 )
@@ -169,17 +172,16 @@ def _prepare_agent_config(
 def _podman_start(cname: str) -> None:
     """Start an existing container, raising SystemExit on failure."""
     try:
-        subprocess.run(
-            ["podman", "start", cname],
-            check=True,
-            stdout=subprocess.DEVNULL,
-            stderr=subprocess.PIPE,
-        )
+        result = container_start(cname)
     except FileNotFoundError:
         raise SystemExit("podman not found; please install podman")
-    except subprocess.CalledProcessError as exc:
-        stderr = (exc.stderr or b"").decode(errors="replace")
-        msg = f"Failed to start container:\n{stderr.strip()}" if stderr else str(exc)
+    if result.returncode != 0:
+        stderr = result.stderr.strip() if result.stderr else ""
+        msg = (
+            f"Failed to start container:\n{stderr}"
+            if stderr
+            else f"podman start failed (rc={result.returncode})"
+        )
         raise SystemExit(msg)
 
 
@@ -196,7 +198,7 @@ def _assert_running(cname: str) -> None:
 def _print_login_instructions(project_id: str, task_id: str, cname: str, color: bool) -> None:
     """Print how to log into a CLI container."""
     login_cmd = f"terok login {project_id} {task_id}"
-    raw_cmd = f"podman exec -it {cname} bash"
+    raw_cmd = shlex.join(_sandbox_login_command(cname, command=("bash",)))
     print(f"Login with: {_blue(login_cmd, color)}")
     print(f"  (or:      {_blue(raw_cmd, color)})")
 
@@ -1052,16 +1054,14 @@ def task_restart(project_id: str, task_id: str) -> None:
     if container_state == "running":
         # Container is running - stop it first, then start it again
         try:
-            subprocess.run(
-                ["podman", "stop", "--time", str(project.shutdown_timeout), cname],
-                check=True,
-                stdout=subprocess.DEVNULL,
-                stderr=subprocess.DEVNULL,
-            )
+            result = container_stop(cname, timeout=project.shutdown_timeout)
         except FileNotFoundError:
             raise SystemExit("podman not found; please install podman")
-        except subprocess.CalledProcessError as e:
-            raise SystemExit(f"Failed to stop container: {e}")
+        if result.returncode != 0:
+            stderr = (result.stderr or "").strip()
+            raise SystemExit(
+                f"Failed to stop container: {stderr or f'exit code {result.returncode}'}"
+            )
         run_hook(
             "post_stop",
             project.hook_post_stop,

--- a/src/terok/lib/orchestration/tasks.py
+++ b/src/terok/lib/orchestration/tasks.py
@@ -21,8 +21,10 @@ from dataclasses import dataclass
 from pathlib import Path
 
 from terok_sandbox import (
+    container_stop,
     get_container_state,
     get_container_states,
+    login_command,
     stop_task_containers,
 )
 
@@ -869,19 +871,9 @@ def _validate_login(project: ProjectConfig, task_id: str) -> tuple[str, str]:
 
 
 def _get_login_command(project: ProjectConfig, task_id: str) -> list[str]:
-    """Return the podman exec command to log into a task container."""
+    """Return the command to interactively log into a task container."""
     cname, _mode = _validate_login(project, task_id)
-    return [
-        "podman",
-        "exec",
-        "-it",
-        cname,
-        "tmux",
-        "new-session",
-        "-A",
-        "-s",
-        "main",
-    ]
+    return login_command(cname)
 
 
 def _task_login(project: ProjectConfig, task_id: str) -> None:
@@ -917,16 +909,12 @@ def _task_stop(project: ProjectConfig, task_id: str, *, timeout: int | None = No
         raise SystemExit(f"Task {task_id} container is not stoppable (state: {state})")
 
     try:
-        subprocess.run(
-            ["podman", "stop", "--time", str(effective_timeout), cname],
-            check=True,
-            stdout=subprocess.DEVNULL,
-            stderr=subprocess.DEVNULL,
-        )
+        result = container_stop(cname, timeout=effective_timeout)
     except FileNotFoundError:
         raise SystemExit("podman not found; please install podman")
-    except subprocess.CalledProcessError as e:
-        raise SystemExit(f"Failed to stop container: {e}")
+    if result.returncode != 0:
+        stderr = (result.stderr or "").strip()
+        raise SystemExit(f"Failed to stop container: {stderr or f'exit code {result.returncode}'}")
 
     try:
         from .ports import release_web_port

--- a/tests/unit/lib/test_autopilot.py
+++ b/tests/unit/lib/test_autopilot.py
@@ -200,7 +200,7 @@ def run_followup_request(
     ):
         with (
             mock_git_config(),
-            unittest.mock.patch("terok.lib.orchestration.task_runners.subprocess.run") as run_mock,
+            unittest.mock.patch("terok.lib.orchestration.task_runners.container_start") as run_mock,
             unittest.mock.patch(
                 "terok.lib.orchestration.task_runners.get_container_state",
                 side_effect=container_state if isinstance(container_state, list) else None,
@@ -211,7 +211,7 @@ def run_followup_request(
             ) as wait_mock,
             unittest.mock.patch("terok.lib.orchestration.task_runners._print_run_summary"),
         ):
-            run_mock.return_value = subprocess.CompletedProcess([], 0)
+            run_mock.return_value = subprocess.CompletedProcess([], 0, stderr="")
             buffer = StringIO()
             with redirect_stdout(buffer):
                 task_followup_headless(project_id, task_id, prompt, follow=follow)
@@ -541,17 +541,17 @@ class TestTaskFollowupHeadless:
             assert "initial prompt" in history
             assert "---" in history
 
-    def test_followup_uses_podman_start(self) -> None:
-        """Follow-up uses podman start, not podman run."""
+    def test_followup_uses_container_start(self) -> None:
+        """Follow-up uses container_start, not sandbox.run."""
         with tempfile.TemporaryDirectory() as td:
             base = Path(td)
             task_id = self._create_completed_task(base, "proj_start")
             result = run_followup_request(
                 base, "proj_start", task_id, "continue", container_state=["exited", "running"]
             )
-            cmd = result.run_mock.call_args[0][0]
-            assert cmd[0] == "podman"
-            assert cmd[1] == "start"
+            result.run_mock.assert_called_once()
+            cname = result.run_mock.call_args[0][0]
+            assert cname == f"proj_start-run-{task_id}"
 
     def test_followup_rejects_non_run_mode(self) -> None:
         """Follow-up rejects tasks that aren't headless (mode != 'run')."""
@@ -693,14 +693,14 @@ class TestTaskFollowupHeadless:
                 with (
                     mock_git_config(),
                     unittest.mock.patch(
-                        "terok.lib.orchestration.task_runners.subprocess.run"
+                        "terok.lib.orchestration.task_runners.container_start"
                     ) as run_mock,
                     unittest.mock.patch(
                         "terok.lib.orchestration.task_runners.get_container_state",
                         side_effect=["exited", "exited"],
                     ),
                 ):
-                    run_mock.return_value = subprocess.CompletedProcess([], 0)
+                    run_mock.return_value = subprocess.CompletedProcess([], 0, stderr="")
                     with pytest.raises(SystemExit) as ctx:
                         task_followup_headless("proj_startfail", task_id, "test")
                     assert "failed to start" in str(ctx.value)
@@ -729,7 +729,7 @@ class TestTaskFollowupHeadless:
                 with (
                     mock_git_config(),
                     unittest.mock.patch(
-                        "terok.lib.orchestration.task_runners.subprocess.run"
+                        "terok.lib.orchestration.task_runners.container_start"
                     ) as run_mock,
                     unittest.mock.patch(
                         "terok.lib.orchestration.task_runners.get_container_state",
@@ -741,7 +741,7 @@ class TestTaskFollowupHeadless:
                     unittest.mock.patch("terok.lib.orchestration.task_runners._print_run_summary"),
                     unittest.mock.patch("terok_sandbox.Sandbox") as mock_sandbox_cls,
                 ):
-                    run_mock.return_value = subprocess.CompletedProcess([], 0)
+                    run_mock.return_value = subprocess.CompletedProcess([], 0, stderr="")
                     buffer = StringIO()
                     with redirect_stdout(buffer):
                         task_followup_headless("proj_sealed", task_id, "sealed follow-up")

--- a/tests/unit/lib/test_container_doctor.py
+++ b/tests/unit/lib/test_container_doctor.py
@@ -25,17 +25,16 @@ MOCK_TASK_DIR = MOCK_BASE / "projects" / "proj" / "tasks" / "42"
 
 
 class TestExecInContainer:
-    """Low-level podman exec helper."""
+    """Low-level sandbox exec helper."""
 
-    def test_calls_podman_exec(self) -> None:
-        with patch("terok.lib.orchestration.container_doctor.subprocess.run") as mock_run:
-            mock_run.return_value = subprocess.CompletedProcess(
+    def test_delegates_to_sandbox_exec(self) -> None:
+        with patch("terok.lib.orchestration.container_doctor.sandbox_exec") as mock_exec:
+            mock_exec.return_value = subprocess.CompletedProcess(
                 args=[], returncode=0, stdout="ok\n", stderr=""
             )
             result = _exec_in_container("proj-cli-42", ["echo", "hello"])
             assert result.returncode == 0
-            cmd = mock_run.call_args[0][0]
-            assert cmd == ["podman", "exec", "proj-cli-42", "echo", "hello"]
+            mock_exec.assert_called_once_with("proj-cli-42", ["echo", "hello"], timeout=10)
 
 
 class TestGitIdentityCheck:

--- a/tests/unit/lib/test_container_exec.py
+++ b/tests/unit/lib/test_container_exec.py
@@ -8,6 +8,8 @@ import unittest.mock
 
 from terok.lib.orchestration.container_exec import container_git_diff
 
+_MOD = "terok.lib.orchestration.container_exec"
+
 
 class TestContainerGitDiff:
     """Tests for container_git_diff."""
@@ -15,137 +17,79 @@ class TestContainerGitDiff:
     def test_running_container_returns_diff(self) -> None:
         """Diff output returned when the container is already running."""
         expected = "diff --git a/f.txt b/f.txt\n+hello\n"
+        exec_result = subprocess.CompletedProcess(args=[], returncode=0, stdout=expected, stderr="")
         with (
-            unittest.mock.patch(
-                "terok.lib.orchestration.container_exec.get_container_state",
-                return_value="running",
-            ),
-            unittest.mock.patch(
-                "terok.lib.orchestration.container_exec.subprocess.run"
-            ) as mock_run,
+            unittest.mock.patch(f"{_MOD}.get_container_state", return_value="running"),
+            unittest.mock.patch(f"{_MOD}.sandbox_exec", return_value=exec_result) as mock_exec,
+            unittest.mock.patch(f"{_MOD}.container_start") as mock_start,
         ):
-            mock_result = unittest.mock.Mock()
-            mock_result.returncode = 0
-            mock_result.stdout = expected
-            mock_run.return_value = mock_result
-
             result = container_git_diff("proj", "1", "cli", "HEAD")
             assert result == expected
-
-            # Should NOT have called podman start
-            calls = [c[0][0] for c in mock_run.call_args_list]
-            assert all("start" not in cmd for cmd in calls)
+            mock_exec.assert_called_once()
+            mock_start.assert_not_called()
 
     def test_stopped_container_restarts_and_stops(self) -> None:
         """Stopped CLI container is started, exec'd, and stopped again."""
         expected = " 1 file changed\n"
+        start_result = subprocess.CompletedProcess(args=[], returncode=0, stderr="")
+        exec_result = subprocess.CompletedProcess(args=[], returncode=0, stdout=expected, stderr="")
+        stop_result = subprocess.CompletedProcess(args=[], returncode=0, stderr="")
         with (
-            unittest.mock.patch(
-                "terok.lib.orchestration.container_exec.get_container_state",
-                return_value="exited",
-            ),
-            unittest.mock.patch(
-                "terok.lib.orchestration.container_exec.subprocess.run"
-            ) as mock_run,
+            unittest.mock.patch(f"{_MOD}.get_container_state", return_value="exited"),
+            unittest.mock.patch(f"{_MOD}.container_start", return_value=start_result) as mock_start,
+            unittest.mock.patch(f"{_MOD}.sandbox_exec", return_value=exec_result) as mock_exec,
+            unittest.mock.patch(f"{_MOD}.container_stop", return_value=stop_result) as mock_stop,
         ):
-            # First call: podman start (success)
-            # Second call: podman exec git diff (success)
-            # Third call: podman stop (cleanup)
-            start_result = unittest.mock.Mock()
-            start_result.returncode = 0
-            exec_result = unittest.mock.Mock()
-            exec_result.returncode = 0
-            exec_result.stdout = expected
-            stop_result = unittest.mock.Mock()
-            mock_run.side_effect = [start_result, exec_result, stop_result]
-
             result = container_git_diff("proj", "2", "cli", "--stat", "HEAD@{1}..HEAD")
             assert result == expected
-            assert mock_run.call_count == 3
 
-            # Verify start was called
-            start_cmd = mock_run.call_args_list[0][0][0]
-            assert start_cmd == ["podman", "start", "proj-cli-2"]
-
-            # Verify exec was called with correct git args
-            exec_cmd = mock_run.call_args_list[1][0][0]
-            assert exec_cmd == [
-                "podman",
-                "exec",
+            mock_start.assert_called_once_with("proj-cli-2")
+            mock_exec.assert_called_once_with(
                 "proj-cli-2",
-                "git",
-                "-C",
-                "/workspace",
-                "diff",
-                "--stat",
-                "HEAD@{1}..HEAD",
-            ]
-
-            # Verify stop was called with correct container name
-            stop_cmd = mock_run.call_args_list[2][0][0]
-            assert stop_cmd[:2] == ["podman", "stop"]
-            assert "proj-cli-2" in stop_cmd
+                ["git", "-C", "/workspace", "diff", "--stat", "HEAD@{1}..HEAD"],
+                timeout=30,
+            )
+            mock_stop.assert_called_once_with("proj-cli-2", timeout=10)
 
     def test_exited_headless_container_not_restarted(self) -> None:
         """Exited headless (run mode) containers must not be restarted."""
-        with unittest.mock.patch(
-            "terok.lib.orchestration.container_exec.get_container_state",
-            return_value="exited",
-        ):
+        with unittest.mock.patch(f"{_MOD}.get_container_state", return_value="exited"):
             result = container_git_diff("proj", "1", "run", "--stat", "HEAD@{1}..HEAD")
             assert result is None
 
     def test_no_container_returns_none(self) -> None:
         """Return None when the container does not exist."""
-        with unittest.mock.patch(
-            "terok.lib.orchestration.container_exec.get_container_state",
-            return_value=None,
-        ):
+        with unittest.mock.patch(f"{_MOD}.get_container_state", return_value=None):
             result = container_git_diff("proj", "99", "cli")
             assert result is None
 
     def test_podman_exec_failure_returns_none(self) -> None:
         """Return None when git diff fails inside the container."""
+        exec_result = subprocess.CompletedProcess(args=[], returncode=128, stdout="", stderr="")
         with (
-            unittest.mock.patch(
-                "terok.lib.orchestration.container_exec.get_container_state",
-                return_value="running",
-            ),
-            unittest.mock.patch(
-                "terok.lib.orchestration.container_exec.subprocess.run"
-            ) as mock_run,
+            unittest.mock.patch(f"{_MOD}.get_container_state", return_value="running"),
+            unittest.mock.patch(f"{_MOD}.sandbox_exec", return_value=exec_result),
         ):
-            mock_result = unittest.mock.Mock()
-            mock_result.returncode = 128
-            mock_run.return_value = mock_result
-
             result = container_git_diff("proj", "1", "cli", "HEAD")
             assert result is None
 
     def test_start_failure_returns_none(self) -> None:
-        """Return None when podman start fails on a stopped container."""
+        """Return None when container start fails on a stopped container."""
+        start_result = subprocess.CompletedProcess(args=[], returncode=125, stderr="Error")
         with (
-            unittest.mock.patch(
-                "terok.lib.orchestration.container_exec.get_container_state",
-                return_value="exited",
-            ),
-            unittest.mock.patch(
-                "terok.lib.orchestration.container_exec.subprocess.run",
-                side_effect=subprocess.CalledProcessError(1, "podman start"),
-            ),
+            unittest.mock.patch(f"{_MOD}.get_container_state", return_value="exited"),
+            unittest.mock.patch(f"{_MOD}.container_start", return_value=start_result),
         ):
-            result = container_git_diff("proj", "1", "run")
+            # "run" mode refuses to restart, so use "cli" to hit the start path
+            result = container_git_diff("proj", "1", "cli")
             assert result is None
 
     def test_timeout_returns_none(self) -> None:
-        """Return None on subprocess timeout."""
+        """Return None on sandbox_exec timeout."""
         with (
+            unittest.mock.patch(f"{_MOD}.get_container_state", return_value="running"),
             unittest.mock.patch(
-                "terok.lib.orchestration.container_exec.get_container_state",
-                return_value="running",
-            ),
-            unittest.mock.patch(
-                "terok.lib.orchestration.container_exec.subprocess.run",
+                f"{_MOD}.sandbox_exec",
                 side_effect=subprocess.TimeoutExpired("podman", 30),
             ),
         ):

--- a/tests/unit/lib/test_container_lifecycle.py
+++ b/tests/unit/lib/test_container_lifecycle.py
@@ -111,12 +111,14 @@ def test_task_stop_uses_expected_timeout(
     ) as ctx:
         task_id = create_task_with_mode(ctx, project_id)
 
+        stop_result = subprocess.CompletedProcess(args=[], returncode=0, stderr="")
         with (
             mock_git_config(),
             patch("terok.lib.orchestration.tasks.get_container_state", return_value="running"),
-            patch("terok.lib.orchestration.tasks.subprocess.run") as run_mock,
+            patch(
+                "terok.lib.orchestration.tasks.container_stop", return_value=stop_result
+            ) as mock_stop,
         ):
-            run_mock.return_value = completed_process()
             capture_stdout(
                 task_stop,
                 project_id,
@@ -124,13 +126,9 @@ def test_task_stop_uses_expected_timeout(
                 **({"timeout": timeout_override} if timeout_override is not None else {}),
             )
 
-        assert run_podman_args(run_mock) == [
-            "podman",
-            "stop",
-            "--time",
-            expected_timeout,
-            f"{project_id}-cli-{task_id}",
-        ]
+        mock_stop.assert_called_once_with(
+            f"{project_id}-cli-{task_id}", timeout=int(expected_timeout)
+        )
 
 
 def test_task_stop_unknown_task_raises_system_exit() -> None:
@@ -142,24 +140,28 @@ def test_task_stop_unknown_task_raises_system_exit() -> None:
 
 
 def test_task_restart_starts_exited_container() -> None:
-    """Restarting an exited task uses ``podman start``."""
+    """Restarting an exited task uses container_start."""
     project_id = "proj_restart"
     with project_env(project_config(project_id), project_id=project_id) as ctx:
         task_id = create_task_with_mode(ctx, project_id)
         container_name = f"{project_id}-cli-{task_id}"
 
+        start_result = completed_process()
+        start_result.stderr = ""
         with (
             mock_git_config(),
             patch(
                 "terok.lib.orchestration.task_runners.get_container_state",
                 side_effect=["exited", "running"],
             ),
-            patch("terok.lib.orchestration.task_runners.subprocess.run") as run_mock,
+            patch(
+                "terok.lib.orchestration.task_runners.container_start",
+                return_value=start_result,
+            ) as mock_start,
         ):
-            run_mock.return_value = completed_process()
             capture_stdout(task_restart, project_id, task_id)
 
-        assert run_podman_args(run_mock) == ["podman", "start", container_name]
+        mock_start.assert_called_once_with(container_name)
 
 
 def test_task_restart_running_container_stops_then_starts() -> None:
@@ -169,25 +171,27 @@ def test_task_restart_running_container_stops_then_starts() -> None:
         task_id = create_task_with_mode(ctx, project_id)
         container_name = f"{project_id}-cli-{task_id}"
 
+        stop_result = subprocess.CompletedProcess(args=[], returncode=0, stderr="")
+        start_result = subprocess.CompletedProcess(args=[], returncode=0, stderr="")
         with (
             mock_git_config(),
             patch(
                 "terok.lib.orchestration.task_runners.get_container_state",
                 side_effect=["running", "running"],
             ),
-            patch("terok.lib.orchestration.task_runners.subprocess.run") as run_mock,
+            patch(
+                "terok.lib.orchestration.task_runners.container_stop",
+                return_value=stop_result,
+            ) as mock_stop,
+            patch(
+                "terok.lib.orchestration.task_runners.container_start",
+                return_value=start_result,
+            ) as mock_start,
         ):
-            run_mock.return_value = completed_process()
             output = capture_stdout(task_restart, project_id, task_id)
 
-        assert run_podman_args(run_mock, call_index=0) == [
-            "podman",
-            "stop",
-            "--time",
-            "10",
-            container_name,
-        ]
-        assert run_podman_args(run_mock, call_index=1) == ["podman", "start", container_name]
+        mock_stop.assert_called_once_with(container_name, timeout=10)
+        mock_start.assert_called_once_with(container_name)
         assert "Restarted" in output
 
 

--- a/tests/unit/lib/test_task_runner_internals.py
+++ b/tests/unit/lib/test_task_runner_internals.py
@@ -74,36 +74,36 @@ class TestStrToBool:
 class TestPodmanStart:
     """Verify _podman_start error handling."""
 
+    _PATCH = "terok.lib.orchestration.task_runners.container_start"
+
     def test_raises_on_missing_podman(self) -> None:
         """FileNotFoundError becomes SystemExit with install hint."""
         from terok.lib.orchestration.task_runners import _podman_start
 
         with (
-            patch("subprocess.run", side_effect=FileNotFoundError),
+            patch(self._PATCH, side_effect=FileNotFoundError),
             pytest.raises(SystemExit, match="podman not found"),
         ):
             _podman_start("test-ctr")
 
     def test_raises_on_start_failure(self) -> None:
-        """CalledProcessError becomes SystemExit with stderr message."""
+        """Non-zero returncode with stderr becomes SystemExit."""
         from terok.lib.orchestration.task_runners import _podman_start
 
-        exc = subprocess.CalledProcessError(1, ["podman", "start"])
-        exc.stderr = b"container not found"
+        result = subprocess.CompletedProcess(args=[], returncode=1, stderr="container not found")
         with (
-            patch("subprocess.run", side_effect=exc),
+            patch(self._PATCH, return_value=result),
             pytest.raises(SystemExit, match="container not found"),
         ):
             _podman_start("test-ctr")
 
     def test_raises_on_start_failure_empty_stderr(self) -> None:
-        """CalledProcessError with empty stderr still raises SystemExit."""
+        """Non-zero returncode with empty stderr still raises SystemExit."""
         from terok.lib.orchestration.task_runners import _podman_start
 
-        exc = subprocess.CalledProcessError(125, ["podman", "start"])
-        exc.stderr = b""
+        result = subprocess.CompletedProcess(args=[], returncode=125, stderr="")
         with (
-            patch("subprocess.run", side_effect=exc),
+            patch(self._PATCH, return_value=result),
             pytest.raises(SystemExit),
         ):
             _podman_start("test-ctr")

--- a/tests/unit/lib/test_tasks.py
+++ b/tests/unit/lib/test_tasks.py
@@ -420,14 +420,10 @@ class TestTask:
                     side_effect=[None, "running"],  # No existing container, then alive
                 ),
                 unittest.mock.patch(
-                    "terok.lib.orchestration.task_runners.subprocess.run"
-                ) as run_mock,
-                unittest.mock.patch(
                     "terok.lib.orchestration.task_runners._supports_color",
                     return_value=True,
                 ),
             ):
-                run_mock.return_value = subprocess.CompletedProcess([], 0)
                 buffer = StringIO()
                 with redirect_stdout(buffer):
                     task_run_cli(project_id, tid)
@@ -464,11 +460,7 @@ class TestTask:
                     "terok.lib.orchestration.task_runners.get_container_state",
                     side_effect=[None, "running"],
                 ),
-                unittest.mock.patch(
-                    "terok.lib.orchestration.task_runners.subprocess.run"
-                ) as run_mock,
             ):
-                run_mock.return_value = subprocess.CompletedProcess([], 0)
                 task_run_cli(project_id, tid)
 
             assert sorted(p.name for p in workspace_dir.iterdir()) == [".new-task-marker"]
@@ -579,16 +571,10 @@ class TestTask:
                     "terok.lib.orchestration.task_runners.get_container_state",
                     return_value="running",
                 ),
-                unittest.mock.patch(
-                    "terok.lib.orchestration.task_runners.subprocess.run"
-                ) as run_mock,
             ):
                 buffer = StringIO()
                 with redirect_stdout(buffer):
                     task_run_cli(project_id, tid)
-
-                # Verify no podman run was called
-                run_mock.assert_not_called()
 
                 # Verify message indicates already running
                 output = buffer.getvalue()
@@ -610,6 +596,8 @@ class TestTask:
             meta["mode"] = "cli"
             meta_path.write_text(yaml_dump(meta))
 
+            cname = f"{project_id}-cli-{tid}"
+            start_result = subprocess.CompletedProcess(args=[], returncode=0, stderr="")
             with (
                 mock_git_config(),
                 unittest.mock.patch(
@@ -617,18 +605,16 @@ class TestTask:
                     side_effect=["exited", "running"],  # Stopped, then alive after start
                 ),
                 unittest.mock.patch(
-                    "terok.lib.orchestration.task_runners.subprocess.run"
-                ) as run_mock,
+                    "terok.lib.orchestration.task_runners.container_start",
+                    return_value=start_result,
+                ) as mock_start,
             ):
-                run_mock.return_value = subprocess.CompletedProcess(args=[], returncode=0)
                 buffer = StringIO()
                 with redirect_stdout(buffer):
                     task_run_cli(project_id, tid)
 
-                # Verify podman start was called
-                run_mock.assert_called_once()
-                call_args = run_mock.call_args[0][0]
-                assert call_args[:2] == ["podman", "start"]
+                # Verify container_start was called with the correct name
+                mock_start.assert_called_once_with(cname)
 
                 # Verify metadata mode is preserved
                 meta = yaml_load(meta_path.read_text())


### PR DESCRIPTION
## Summary

- Replace all direct `podman exec/start/stop` subprocess calls in 4 orchestration modules with terok-sandbox's new `sandbox_exec()`, `container_start()`, `container_stop()`, and `login_command()` functions
- Remove `import subprocess` from `container_exec.py` and `task_runners.py` — these modules no longer touch podman directly
- Update all test mocks to target the new sandbox function imports instead of `subprocess.run`
- Net reduction: -85 lines (145 added, 230 removed)

Phase 1, Groups 1+2 of the runtime abstraction. Seals the Podman boundary for exec/start/stop operations so future backends (microVM/libkrun) only need to implement the sandbox API.

### PR chain

1. **terok-ai/terok-sandbox#155** — adds `sandbox_exec`, `login_command`, `container_start`, `container_stop`
2. **terok-ai/terok-executor#167** — chains sandbox dep to sandbox PR branch tip
3. **This PR** — chains both deps to PR branch tips, migrates callers

After merge: replace git branch pins with release wheel URLs.

### Migrated call sites

| File | Before | After |
|------|--------|-------|
| `container_doctor.py` | `subprocess.run(["podman", "exec", ...])` | `sandbox_exec(cname, cmd)` |
| `container_exec.py` | `subprocess.run(["podman", "start/stop/exec", ...])` | `container_start/stop()` + `sandbox_exec()` |
| `task_runners.py` | `subprocess.run(["podman", "start/stop", ...])` | `container_start/stop()` |
| `tasks.py` | `["podman", "exec", "-it", ...]` + `subprocess.run(["podman", "stop", ...])` | `login_command()` + `container_stop()` |

## Test plan

- [x] `make lint` passes
- [x] 1612 unit tests pass locally (2 pre-existing gate test failures excluded — broken by sandbox#149 OO refactor, not this PR)
- [x] Zero `["podman", "exec/start/stop"` calls remain in migrated files
- [x] `import subprocess` removed from `container_exec.py` and `task_runners.py`
- [ ] CI green (deps chained to PR branch tips)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Switched container start/stop and in-container command execution to the sandbox-based API, standardizing lifecycle and exec behavior.
  * Updated two internal package dependency versions to newer releases.
* **Tests**
  * Updated unit tests to mock and assert the new sandbox helpers and updated container lifecycle calls.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->