### PR TITLE
fix: surface errors in release chain script

### DIFF
--- a/tools/terok-release-chain.py
+++ b/tools/terok-release-chain.py
@@ -32,9 +32,12 @@ from typing import Any, Never
 
 import click
 import tomlkit
-from pydantic import BaseModel, Field
+from pydantic import VERSION as _pydantic_ver, BaseModel, Field
 from rich.console import Console
 from rich.table import Table
+
+if int(_pydantic_ver.split(".")[0]) < 2:
+    raise SystemExit(f"pydantic >= 2 required (found {_pydantic_ver}): pip install 'pydantic>=2'")
 
 console = Console(stderr=True)
 
@@ -197,8 +200,16 @@ class Ctx:
 def sh(
     *args: str, cwd: Path | None = None, capture: bool = False, check: bool = True
 ) -> subprocess.CompletedProcess[str]:
-    """Run a subprocess."""
-    return subprocess.run(args, cwd=cwd, capture_output=capture, text=True, check=check)
+    """Run a subprocess — always surfaces output on failure."""
+    r = subprocess.run(args, cwd=cwd, capture_output=capture, text=True, check=False)
+    if check and r.returncode:
+        detail = (r.stderr or r.stdout or "").strip() if capture else ""
+        cmd = " ".join(args)
+        msg = f"Command failed (exit {r.returncode}): {cmd}"
+        if detail:
+            msg += f"\n{detail}"
+        die(msg)
+    return r
 
 
 # ── TOML ops ──────────────────────────────────────────────────────────────
@@ -355,7 +366,8 @@ def wait_for_checks(pr_url: str, gh_repo: str, ctx: Ctx) -> str:
             if elapsed < grace:
                 time.sleep(poll)
                 continue
-            die(f"gh pr checks failed (exit {r.returncode})")
+            detail = (r.stderr or r.stdout or "").strip()
+            die(f"gh pr checks failed (exit {r.returncode}): {detail}")
 
         checks = json.loads(r.stdout) if r.stdout.strip() else []
         if not checks:


### PR DESCRIPTION
## Summary
- Add pydantic v2 version guard so running outside poetry venv gives a clear message instead of a cryptic `AttributeError` mid-execution
- Rewrite `sh()` helper to capture and display stderr/stdout on failure instead of raising bare `CalledProcessError` that hides command output
- Include stderr/stdout in `wait_for_checks` error message when `gh pr checks` fails

## Test plan
- [ ] Run `./tools/terok-release-chain.py` with system python (pydantic v1) — should get clear version error
- [ ] Run `poetry run ./tools/terok-release-chain.py quick` with a failing CI check — should see actual error output

🤖 Generated with [Claude Code](https://claude.com/claude-code)