### PR TITLE
fix: `terok setup` must verify service health, not just installation

### DIFF
--- a/src/terok/cli/commands/setup.py
+++ b/src/terok/cli/commands/setup.py
@@ -328,14 +328,11 @@ def _ensure_gate(*, check_only: bool, color: bool) -> bool:
 
     if check_only:
         status = get_server_status(cfg)
-        if status.running:
-            print(f"  Gate server      {_status_label(True, color)} ({status.mode}, running)")
-            return True
-        if status.mode == "systemd":
-            # Socket installed but not yet activated — try to reach it
+        if status.running or status.mode == "systemd":
+            # Unit exists (running or socket-activated) — probe TCP to be sure
             try:
                 ensure_server_reachable(cfg)
-                print(f"  Gate server      {_status_label(True, color)} (systemd, reachable)")
+                print(f"  Gate server      {_status_label(True, color)} ({status.mode}, reachable)")
                 return True
             except SystemExit:
                 print(

--- a/src/terok/cli/commands/setup.py
+++ b/src/terok/cli/commands/setup.py
@@ -221,7 +221,7 @@ def _ensure_shield(*, check_only: bool, color: bool) -> bool:
 
     ec = check_environment()
     if ec.health == "ok":
-        print(f"  Shield hooks     {_status_label(True, color)} (already installed)")
+        print(f"  Shield hooks     {_status_label(True, color)} (active)")
         return True
     if ec.health == "bypass":
         print(f"  Shield hooks     {_warn_label(color)} (bypass_firewall_no_protection is active)")
@@ -231,75 +231,149 @@ def _ensure_shield(*, check_only: bool, color: bool) -> bool:
         print(f"  Shield hooks     {_status_label(False, color)} ({hint})")
         return False
 
+    # Force-reinstall to ensure hooks match the current package version
     try:
         setup_hooks_direct(root=False)
     except Exception as exc:  # noqa: BLE001 — best-effort
         print(f"  Shield hooks     {_status_label(False, color)} ({exc})")
         return False
 
-    print(f"  Shield hooks     {_status_label(True, color)} (installed)")
-    return True
+    # Verify installation took effect
+    ec = check_environment()
+    if ec.health == "ok":
+        print(f"  Shield hooks     {_status_label(True, color)} (installed)")
+        return True
+
+    print(
+        f"  Shield hooks     {_status_label(False, color)} (install succeeded but health: {ec.health})"
+    )
+    return False
 
 
 def _ensure_proxy(*, check_only: bool, color: bool) -> bool:
-    """Install credential proxy via systemd socket activation.  Returns True on success."""
+    """Install credential proxy and verify it is reachable.  Returns True on success."""
     from terok_sandbox import (
+        ProxyUnreachableError,
+        ensure_proxy_reachable,
         get_proxy_status,
         install_proxy_systemd,
         is_proxy_socket_active,
+        stop_proxy,
+        uninstall_proxy_systemd,
     )
 
     from ...lib.core.config import make_sandbox_config
 
-    status = get_proxy_status()
-    if status.running or is_proxy_socket_active():
-        mode = status.mode or "active"
-        print(f"  Credential proxy {_status_label(True, color)} ({mode})")
-        return True
+    cfg = make_sandbox_config()
+
     if check_only:
-        print(f"  Credential proxy {_status_label(False, color)} (not installed)")
-        return False
+        # Check-only: just probe reachability
+        try:
+            ensure_proxy_reachable(cfg)
+            mode = get_proxy_status().mode or "active"
+            print(f"  Credential proxy {_status_label(True, color)} ({mode}, reachable)")
+            return True
+        except (ProxyUnreachableError, SystemExit):
+            installed = is_proxy_socket_active()
+            state = "installed but NOT reachable" if installed else "not installed"
+            print(f"  Credential proxy {_status_label(False, color)} ({state})")
+            return False
+
+    # Clean reinstall: stop → uninstall → install → verify reachability
+    try:
+        stop_proxy(cfg=cfg)
+    except Exception:  # noqa: BLE001 — best-effort, may not be running
+        pass
+    try:
+        uninstall_proxy_systemd(cfg=cfg)
+    except Exception:  # noqa: BLE001 — best-effort, may not be installed
+        pass
 
     try:
         from terok_executor import ensure_proxy_routes
 
-        cfg = make_sandbox_config()
         ensure_proxy_routes(cfg=cfg)
         install_proxy_systemd(cfg=cfg)
     except Exception as exc:  # noqa: BLE001 — best-effort
-        print(f"  Credential proxy {_status_label(False, color)} ({exc})")
+        print(f"  Credential proxy {_status_label(False, color)} (install failed: {exc})")
         return False
 
-    print(f"  Credential proxy {_status_label(True, color)} (installed)")
-    return True
+    # Verify actual TCP reachability (triggers systemd start)
+    try:
+        ensure_proxy_reachable(cfg)
+        mode = get_proxy_status().mode or "active"
+        print(f"  Credential proxy {_status_label(True, color)} ({mode}, reachable)")
+        return True
+    except (ProxyUnreachableError, SystemExit) as exc:
+        print(f"  Credential proxy {_status_label(False, color)} (installed but NOT reachable)")
+        print(f"                   {exc}")
+        print("                   Check: journalctl --user -u terok-credential-proxy")
+        return False
 
 
 def _ensure_gate(*, check_only: bool, color: bool) -> bool:
     """Install gate server via systemd socket activation.  Returns True on success."""
-    from terok_sandbox import get_server_status, install_systemd_units, is_systemd_available
+    from terok_sandbox import (
+        ensure_server_reachable,
+        get_server_status,
+        install_systemd_units,
+        is_systemd_available,
+        stop_daemon,
+        uninstall_systemd_units,
+    )
 
     from ...lib.core.config import make_sandbox_config
 
     cfg = make_sandbox_config()
-    status = get_server_status(cfg)
-    if status.running or status.mode == "systemd":
-        print(f"  Gate server      {_status_label(True, color)} ({status.mode})")
-        return True
+
     if check_only:
+        status = get_server_status(cfg)
+        if status.running:
+            print(f"  Gate server      {_status_label(True, color)} ({status.mode}, running)")
+            return True
+        if status.mode == "systemd":
+            # Socket installed but not yet activated — try to reach it
+            try:
+                ensure_server_reachable(cfg)
+                print(f"  Gate server      {_status_label(True, color)} (systemd, reachable)")
+                return True
+            except SystemExit:
+                print(
+                    f"  Gate server      {_status_label(False, color)} (installed but NOT reachable)"
+                )
+                return False
         print(f"  Gate server      {_status_label(False, color)} (not installed)")
         return False
+
     if not is_systemd_available():
         print(f"  Gate server      {_warn_label(color)} (systemd not available, skipping)")
         return True
 
+    # Clean reinstall: stop → uninstall → install → verify
+    try:
+        stop_daemon(cfg=cfg)
+    except Exception:  # noqa: BLE001
+        pass
+    try:
+        uninstall_systemd_units(cfg=cfg)
+    except Exception:  # noqa: BLE001
+        pass
+
     try:
         install_systemd_units(cfg=cfg)
     except Exception as exc:  # noqa: BLE001 — best-effort
-        print(f"  Gate server      {_status_label(False, color)} ({exc})")
+        print(f"  Gate server      {_status_label(False, color)} (install failed: {exc})")
         return False
 
-    print(f"  Gate server      {_status_label(True, color)} (installed)")
-    return True
+    # Verify reachability (triggers socket activation)
+    try:
+        ensure_server_reachable(cfg)
+        print(f"  Gate server      {_status_label(True, color)} (systemd, reachable)")
+        return True
+    except SystemExit as exc:
+        print(f"  Gate server      {_status_label(False, color)} (installed but NOT reachable)")
+        print(f"                   {exc}")
+        return False
 
 
 def cmd_setup(*, check_only: bool = False) -> None:

--- a/tests/unit/cli/test_cli_setup_global.py
+++ b/tests/unit/cli/test_cli_setup_global.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 from unittest.mock import MagicMock, patch
 
 import pytest
+from terok_sandbox import ProxyUnreachableError
 
 from terok.cli.commands.setup import (
     _check_host_binaries,
@@ -16,7 +17,11 @@ from terok.cli.commands.setup import (
     _ensure_shield,
     cmd_setup,
 )
+from tests.testfs import FAKE_CREDENTIALS_DIR, MOCK_BASE
 from tests.testgate import make_gate_server_status
+
+MOCK_PROXY_SOCKET = MOCK_BASE / "run" / "credential-proxy.sock"
+MOCK_PROXY_DB = FAKE_CREDENTIALS_DIR / "credentials.db"
 
 # ── Host binary checks ──────────────────────────────────────────────────
 
@@ -82,7 +87,6 @@ def test_shield_install_and_verify(
     mock_env: MagicMock, mock_setup: MagicMock, capsys: pytest.CaptureFixture
 ) -> None:
     """Shield missing → install → verify health = ok."""
-    # First call: setup-needed; second call (verify): ok
     mock_env.side_effect = [
         MagicMock(health="setup-needed", issues=[], setup_hint=""),
         MagicMock(health="ok"),
@@ -91,6 +95,33 @@ def test_shield_install_and_verify(
     mock_setup.assert_called_once_with(root=False)
     out = capsys.readouterr().out
     assert "installed" in out
+
+
+@patch("terok_sandbox.setup_hooks_direct")
+@patch("terok_sandbox.check_environment")
+def test_shield_install_verify_still_unhealthy(
+    mock_env: MagicMock, _setup: MagicMock, capsys: pytest.CaptureFixture
+) -> None:
+    """Shield install succeeds but post-verify health is not ok → False."""
+    mock_env.side_effect = [
+        MagicMock(health="setup-needed", issues=[], setup_hint=""),
+        MagicMock(health="stale-hooks"),
+    ]
+    assert _ensure_shield(check_only=False, color=False) is False
+    out = capsys.readouterr().out
+    assert "stale-hooks" in out
+
+
+@patch("terok_sandbox.setup_hooks_direct", side_effect=RuntimeError("hook install boom"))
+@patch("terok_sandbox.check_environment")
+def test_shield_install_exception(
+    mock_env: MagicMock, _setup: MagicMock, capsys: pytest.CaptureFixture
+) -> None:
+    """Shield install raises → caught, returns False."""
+    mock_env.return_value = MagicMock(health="setup-needed", issues=[], setup_hint="")
+    assert _ensure_shield(check_only=False, color=False) is False
+    out = capsys.readouterr().out
+    assert "FAIL" in out
 
 
 @patch("terok_sandbox.check_environment")
@@ -125,7 +156,10 @@ def test_proxy_check_reachable(
     assert "reachable" in out
 
 
-@patch("terok_sandbox.ensure_proxy_reachable", side_effect=SystemExit("unreachable"))
+@patch(
+    "terok_sandbox.ensure_proxy_reachable",
+    side_effect=ProxyUnreachableError(socket_path=MOCK_PROXY_SOCKET, db_path=MOCK_PROXY_DB),
+)
 @patch("terok_sandbox.is_proxy_socket_active", return_value=True)
 def test_proxy_check_unreachable(
     _sock: MagicMock, _reach: MagicMock, capsys: pytest.CaptureFixture
@@ -134,6 +168,20 @@ def test_proxy_check_unreachable(
     assert _ensure_proxy(check_only=True, color=False) is False
     out = capsys.readouterr().out
     assert "NOT reachable" in out
+
+
+@patch(
+    "terok_sandbox.ensure_proxy_reachable",
+    side_effect=ProxyUnreachableError(socket_path=MOCK_PROXY_SOCKET, db_path=MOCK_PROXY_DB),
+)
+@patch("terok_sandbox.is_proxy_socket_active", return_value=False)
+def test_proxy_check_not_installed(
+    _sock: MagicMock, _reach: MagicMock, capsys: pytest.CaptureFixture
+) -> None:
+    """check_only mode: proxy not even installed → reports 'not installed'."""
+    assert _ensure_proxy(check_only=True, color=False) is False
+    out = capsys.readouterr().out
+    assert "not installed" in out
 
 
 @patch("terok_sandbox.get_proxy_status")
@@ -161,20 +209,115 @@ def test_proxy_reinstall_and_verify(
     _reach.assert_called_once()
 
 
+@patch("terok_sandbox.install_proxy_systemd", side_effect=RuntimeError("install boom"))
+@patch("terok_executor.ensure_proxy_routes")
+@patch("terok.lib.core.config.make_sandbox_config")
+@patch("terok_sandbox.uninstall_proxy_systemd")
+@patch("terok_sandbox.stop_proxy")
+def test_proxy_install_fails(
+    _stop: MagicMock,
+    _uninstall: MagicMock,
+    _cfg: MagicMock,
+    _routes: MagicMock,
+    _install: MagicMock,
+    capsys: pytest.CaptureFixture,
+) -> None:
+    """Install mode: install raises → returns False."""
+    assert _ensure_proxy(check_only=False, color=False) is False
+    out = capsys.readouterr().out
+    assert "install failed" in out
+
+
+@patch(
+    "terok_sandbox.ensure_proxy_reachable",
+    side_effect=ProxyUnreachableError(socket_path=MOCK_PROXY_SOCKET, db_path=MOCK_PROXY_DB),
+)
+@patch("terok_sandbox.install_proxy_systemd")
+@patch("terok_executor.ensure_proxy_routes")
+@patch("terok.lib.core.config.make_sandbox_config")
+@patch("terok_sandbox.uninstall_proxy_systemd")
+@patch("terok_sandbox.stop_proxy")
+def test_proxy_installed_but_unreachable(
+    _stop: MagicMock,
+    _uninstall: MagicMock,
+    _cfg: MagicMock,
+    _routes: MagicMock,
+    _install: MagicMock,
+    _reach: MagicMock,
+    capsys: pytest.CaptureFixture,
+) -> None:
+    """Install mode: installed ok but TCP probe fails → returns False with journal hint."""
+    assert _ensure_proxy(check_only=False, color=False) is False
+    out = capsys.readouterr().out
+    assert "NOT reachable" in out
+    assert "journalctl" in out
+
+
 # ── Gate server ──────────────────────────────────────────────────────────
 
 
 @patch("terok_sandbox.ensure_server_reachable")
 @patch("terok.lib.core.config.make_sandbox_config")
 @patch("terok_sandbox.get_server_status")
-def test_gate_check_running(
-    mock_status: MagicMock, _cfg: MagicMock, _reach: MagicMock, capsys: pytest.CaptureFixture
+def test_gate_check_running_and_reachable(
+    mock_status: MagicMock,
+    _cfg: MagicMock,
+    mock_reach: MagicMock,
+    capsys: pytest.CaptureFixture,
 ) -> None:
-    """check_only: gate running → ok."""
+    """check_only: gate running + reachable → ok."""
     mock_status.return_value = make_gate_server_status("systemd", running=True)
     assert _ensure_gate(check_only=True, color=False) is True
+    mock_reach.assert_called_once()
     out = capsys.readouterr().out
-    assert "running" in out
+    assert "reachable" in out
+
+
+@patch("terok_sandbox.ensure_server_reachable", side_effect=SystemExit("stale"))
+@patch("terok.lib.core.config.make_sandbox_config")
+@patch("terok_sandbox.get_server_status")
+def test_gate_check_running_but_unreachable(
+    mock_status: MagicMock,
+    _cfg: MagicMock,
+    _reach: MagicMock,
+    capsys: pytest.CaptureFixture,
+) -> None:
+    """check_only: gate process exists but TCP unreachable → FAIL."""
+    mock_status.return_value = make_gate_server_status("systemd", running=True)
+    assert _ensure_gate(check_only=True, color=False) is False
+    out = capsys.readouterr().out
+    assert "NOT reachable" in out
+
+
+@patch("terok_sandbox.ensure_server_reachable")
+@patch("terok.lib.core.config.make_sandbox_config")
+@patch("terok_sandbox.get_server_status")
+def test_gate_check_systemd_socket_reachable(
+    mock_status: MagicMock,
+    _cfg: MagicMock,
+    mock_reach: MagicMock,
+    capsys: pytest.CaptureFixture,
+) -> None:
+    """check_only: gate socket installed (not running) + reachable after activation → ok."""
+    mock_status.return_value = make_gate_server_status("systemd", running=False)
+    assert _ensure_gate(check_only=True, color=False) is True
+    mock_reach.assert_called_once()
+
+
+@patch("terok_sandbox.ensure_server_reachable", side_effect=SystemExit("down"))
+@patch("terok.lib.core.config.make_sandbox_config")
+@patch("terok_sandbox.get_server_status")
+def test_gate_check_systemd_unreachable(
+    mock_status: MagicMock,
+    _cfg: MagicMock,
+    _reach: MagicMock,
+    capsys: pytest.CaptureFixture,
+) -> None:
+    """check_only: gate socket installed but service won't start → FAIL."""
+    mock_status.return_value = make_gate_server_status("systemd", running=False)
+    assert _ensure_gate(check_only=True, color=False) is False
+    out = capsys.readouterr().out
+    assert "NOT reachable" in out
 
 
 @patch("terok.lib.core.config.make_sandbox_config")
@@ -213,6 +356,52 @@ def test_gate_reinstall_and_verify(
     _uninstall.assert_called_once()
     _install.assert_called_once()
     _reach.assert_called_once()
+
+
+@patch("terok_sandbox.install_systemd_units", side_effect=RuntimeError("unit boom"))
+@patch("terok_sandbox.uninstall_systemd_units")
+@patch("terok_sandbox.stop_daemon")
+@patch("terok_sandbox.is_systemd_available", return_value=True)
+@patch("terok.lib.core.config.make_sandbox_config")
+@patch("terok_sandbox.get_server_status")
+def test_gate_install_fails(
+    mock_status: MagicMock,
+    _cfg: MagicMock,
+    _systemd: MagicMock,
+    _stop: MagicMock,
+    _uninstall: MagicMock,
+    _install: MagicMock,
+    capsys: pytest.CaptureFixture,
+) -> None:
+    """Install mode: install raises → returns False."""
+    mock_status.return_value = make_gate_server_status("none")
+    assert _ensure_gate(check_only=False, color=False) is False
+    out = capsys.readouterr().out
+    assert "install failed" in out
+
+
+@patch("terok_sandbox.ensure_server_reachable", side_effect=SystemExit("port dead"))
+@patch("terok_sandbox.install_systemd_units")
+@patch("terok_sandbox.uninstall_systemd_units")
+@patch("terok_sandbox.stop_daemon")
+@patch("terok_sandbox.is_systemd_available", return_value=True)
+@patch("terok.lib.core.config.make_sandbox_config")
+@patch("terok_sandbox.get_server_status")
+def test_gate_installed_but_unreachable(
+    mock_status: MagicMock,
+    _cfg: MagicMock,
+    _systemd: MagicMock,
+    _stop: MagicMock,
+    _uninstall: MagicMock,
+    _install: MagicMock,
+    _reach: MagicMock,
+    capsys: pytest.CaptureFixture,
+) -> None:
+    """Install mode: installed ok but TCP probe fails → returns False."""
+    mock_status.return_value = make_gate_server_status("none")
+    assert _ensure_gate(check_only=False, color=False) is False
+    out = capsys.readouterr().out
+    assert "NOT reachable" in out
 
 
 @patch("terok_sandbox.is_systemd_available", return_value=False)

--- a/tests/unit/cli/test_cli_setup_global.py
+++ b/tests/unit/cli/test_cli_setup_global.py
@@ -62,7 +62,7 @@ def test_shield_already_installed(mock_env: MagicMock, capsys: pytest.CaptureFix
     mock_env.return_value = MagicMock(health="ok")
     assert _ensure_shield(check_only=False, color=False) is True
     out = capsys.readouterr().out
-    assert "already installed" in out
+    assert "active" in out
 
 
 @patch("terok_sandbox.check_environment")
@@ -78,11 +78,15 @@ def test_shield_check_only_missing(mock_env: MagicMock, capsys: pytest.CaptureFi
 
 @patch("terok_sandbox.setup_hooks_direct")
 @patch("terok_sandbox.check_environment")
-def test_shield_install_success(
+def test_shield_install_and_verify(
     mock_env: MagicMock, mock_setup: MagicMock, capsys: pytest.CaptureFixture
 ) -> None:
-    """Shield missing → install succeeds."""
-    mock_env.return_value = MagicMock(health="setup-needed", issues=[], setup_hint="")
+    """Shield missing → install → verify health = ok."""
+    # First call: setup-needed; second call (verify): ok
+    mock_env.side_effect = [
+        MagicMock(health="setup-needed", issues=[], setup_hint=""),
+        MagicMock(health="ok"),
+    ]
     assert _ensure_shield(check_only=False, color=False) is True
     mock_setup.assert_called_once_with(root=False)
     out = capsys.readouterr().out
@@ -108,88 +112,107 @@ def _make_proxy_status(*, running: bool = True, mode: str = "systemd") -> MagicM
     return s
 
 
-@patch("terok_sandbox.is_proxy_socket_active", return_value=False)
 @patch("terok_sandbox.get_proxy_status")
-def test_proxy_already_running(
-    mock_status: MagicMock, _sock: MagicMock, capsys: pytest.CaptureFixture
+@patch("terok_sandbox.ensure_proxy_reachable")
+@patch("terok_sandbox.is_proxy_socket_active", return_value=True)
+def test_proxy_check_reachable(
+    _sock: MagicMock, _reach: MagicMock, mock_status: MagicMock, capsys: pytest.CaptureFixture
 ) -> None:
-    """Proxy running → skip."""
+    """check_only mode: proxy reachable → ok."""
     mock_status.return_value = _make_proxy_status(running=True)
-    assert _ensure_proxy(check_only=False, color=False) is True
+    assert _ensure_proxy(check_only=True, color=False) is True
+    out = capsys.readouterr().out
+    assert "reachable" in out
 
 
-@patch("terok_sandbox.is_proxy_socket_active", return_value=False)
-@patch("terok_sandbox.get_proxy_status")
-def test_proxy_check_only_missing(
-    mock_status: MagicMock, _sock: MagicMock, capsys: pytest.CaptureFixture
+@patch("terok_sandbox.ensure_proxy_reachable", side_effect=SystemExit("unreachable"))
+@patch("terok_sandbox.is_proxy_socket_active", return_value=True)
+def test_proxy_check_unreachable(
+    _sock: MagicMock, _reach: MagicMock, capsys: pytest.CaptureFixture
 ) -> None:
-    """Proxy not running + check_only → report False."""
-    mock_status.return_value = _make_proxy_status(running=False, mode="none")
+    """check_only mode: proxy installed but unreachable → FAIL."""
     assert _ensure_proxy(check_only=True, color=False) is False
     out = capsys.readouterr().out
-    assert "FAIL" in out
+    assert "NOT reachable" in out
 
 
+@patch("terok_sandbox.get_proxy_status")
+@patch("terok_sandbox.ensure_proxy_reachable")
 @patch("terok_sandbox.install_proxy_systemd")
 @patch("terok_executor.ensure_proxy_routes")
 @patch("terok.lib.core.config.make_sandbox_config")
-@patch("terok_sandbox.is_proxy_socket_active", return_value=False)
-@patch("terok_sandbox.get_proxy_status")
-def test_proxy_install_success(
-    mock_status: MagicMock,
-    _sock: MagicMock,
+@patch("terok_sandbox.uninstall_proxy_systemd")
+@patch("terok_sandbox.stop_proxy")
+def test_proxy_reinstall_and_verify(
+    _stop: MagicMock,
+    _uninstall: MagicMock,
     _cfg: MagicMock,
-    mock_routes: MagicMock,
-    mock_install: MagicMock,
+    _routes: MagicMock,
+    _install: MagicMock,
+    _reach: MagicMock,
+    mock_status: MagicMock,
 ) -> None:
-    """Proxy missing → install succeeds."""
-    mock_status.return_value = _make_proxy_status(running=False, mode="none")
+    """Install mode: clean reinstall → verify reachable → ok."""
+    mock_status.return_value = _make_proxy_status(running=True)
     assert _ensure_proxy(check_only=False, color=False) is True
-    mock_routes.assert_called_once()
-    mock_install.assert_called_once()
+    _stop.assert_called_once()
+    _uninstall.assert_called_once()
+    _install.assert_called_once()
+    _reach.assert_called_once()
 
 
 # ── Gate server ──────────────────────────────────────────────────────────
 
 
+@patch("terok_sandbox.ensure_server_reachable")
 @patch("terok.lib.core.config.make_sandbox_config")
 @patch("terok_sandbox.get_server_status")
-def test_gate_already_installed(
-    mock_status: MagicMock, _cfg: MagicMock, capsys: pytest.CaptureFixture
+def test_gate_check_running(
+    mock_status: MagicMock, _cfg: MagicMock, _reach: MagicMock, capsys: pytest.CaptureFixture
 ) -> None:
-    """Gate running → skip."""
+    """check_only: gate running → ok."""
     mock_status.return_value = make_gate_server_status("systemd", running=True)
-    assert _ensure_gate(check_only=False, color=False) is True
+    assert _ensure_gate(check_only=True, color=False) is True
     out = capsys.readouterr().out
-    assert "systemd" in out
+    assert "running" in out
 
 
 @patch("terok.lib.core.config.make_sandbox_config")
 @patch("terok_sandbox.get_server_status")
-def test_gate_check_only_missing(
+def test_gate_check_not_installed(
     mock_status: MagicMock, _cfg: MagicMock, capsys: pytest.CaptureFixture
 ) -> None:
-    """Gate not installed + check_only → report False."""
+    """check_only: gate not installed → FAIL."""
     mock_status.return_value = make_gate_server_status("none")
     assert _ensure_gate(check_only=True, color=False) is False
     out = capsys.readouterr().out
-    assert "FAIL" in out
+    assert "not installed" in out
 
 
+@patch("terok_sandbox.ensure_server_reachable")
 @patch("terok_sandbox.install_systemd_units")
+@patch("terok_sandbox.uninstall_systemd_units")
+@patch("terok_sandbox.stop_daemon")
 @patch("terok_sandbox.is_systemd_available", return_value=True)
 @patch("terok.lib.core.config.make_sandbox_config")
 @patch("terok_sandbox.get_server_status")
-def test_gate_install_success(
+def test_gate_reinstall_and_verify(
     mock_status: MagicMock,
     _cfg: MagicMock,
     _systemd: MagicMock,
-    mock_install: MagicMock,
+    _stop: MagicMock,
+    _uninstall: MagicMock,
+    _install: MagicMock,
+    _reach: MagicMock,
+    capsys: pytest.CaptureFixture,
 ) -> None:
-    """Gate missing + systemd available → install succeeds."""
+    """Install mode: clean reinstall → verify reachable → ok."""
     mock_status.return_value = make_gate_server_status("none")
     assert _ensure_gate(check_only=False, color=False) is True
-    mock_install.assert_called_once()
+    _stop.assert_called_once()
+    _uninstall.assert_called_once()
+    _install.assert_called_once()
+    _reach.assert_called_once()
 
 
 @patch("terok_sandbox.is_systemd_available", return_value=False)


### PR DESCRIPTION
## Summary

- `terok setup` was checking whether systemd units were *installed* but not whether the services were actually *reachable* on their TCP ports — reporting "ok" while `terok task start` would fail
- Now uses `ensure_proxy_reachable()` and `ensure_server_reachable()` to verify actual TCP connectivity
- Clean reinstall flow: stop → uninstall → install → verify for proxy and gate
- Shield: re-verifies `check_environment()` health after installation
- `--check` mode also probes reachability, not just unit presence
- Reports "installed but NOT reachable" with `journalctl` hint on failure

## Test plan

- [ ] `make check` passes
- [ ] Manual: `terok setup` on a system where proxy port is stale → reports FAIL with journal hint
- [ ] Manual: `terok setup` on clean system → installs + verifies reachability before reporting ok
- [ ] Manual: `terok setup --check` → probes real TCP connectivity

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added post-install reachability checks for shield, proxy, and gate services and clearer status labels (e.g., "active", "reachable", "NOT reachable").
  * Installer now attempts clean reinstall flows (stop/uninstall/install) when needed and reports install failures with actionable hints (including journalctl guidance).
* **Tests**
  * Updated unit tests to cover reachability verification, reinstall flows, and improved success/failure messaging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->