### PR TITLE
Propagate sys.path for creation of Python subprocesses

### DIFF
--- a/src/terok/tui/project_actions.py
+++ b/src/terok/tui/project_actions.py
@@ -446,6 +446,7 @@ class ProjectActionsMixin:
     async def action_new_project_wizard(self) -> None:
         """Launch the CLI project wizard in a suspended terminal."""
         with self.suspend():
+            old_argv = sys.argv[:]
             try:
                 sys.argv = ["terok.cli.main", "project-wizard"]
                 runpy.run_module("terok.cli.main", run_name="__main__")
@@ -454,6 +455,8 @@ class ProjectActionsMixin:
                     print(f"Wizard exited with code {e.code}")
             except Exception as e:
                 print(f"Error: {e}")
+            finally:
+                sys.argv = old_argv
             input("\n[Press Enter to return to TerokTUI] ")
         await self.refresh_projects()
         self.notify("Project list refreshed.")

--- a/src/terok/tui/project_actions.py
+++ b/src/terok/tui/project_actions.py
@@ -445,10 +445,7 @@ class ProjectActionsMixin:
     async def action_new_project_wizard(self) -> None:
         """Launch the CLI project wizard in a suspended terminal."""
         with self.suspend():
-            import os
-            import sys
-            env = os.environ.copy()
-            env["PYTHONPATH"] = os.pathsep.join(sys.path)
+            env = {**os.environ, "PYTHONPATH": os.pathsep.join(sys.path)}
             try:
                 result = subprocess.run(
                     [sys.executable, "-m", "terok.cli.main", "project-wizard"],

--- a/src/terok/tui/project_actions.py
+++ b/src/terok/tui/project_actions.py
@@ -445,10 +445,15 @@ class ProjectActionsMixin:
     async def action_new_project_wizard(self) -> None:
         """Launch the CLI project wizard in a suspended terminal."""
         with self.suspend():
+            import os
+            import sys
+            env = os.environ.copy()
+            env["PYTHONPATH"] = os.pathsep.join(sys.path)
             try:
                 result = subprocess.run(
                     [sys.executable, "-m", "terok.cli.main", "project-wizard"],
                     check=False,
+                    env=env,
                 )
                 if result.returncode != 0:
                     print(f"Wizard exited with code {result.returncode}")

--- a/src/terok/tui/project_actions.py
+++ b/src/terok/tui/project_actions.py
@@ -9,6 +9,7 @@ project and task actions.
 """
 
 import os
+import runpy
 import shlex
 import subprocess
 import sys
@@ -446,12 +447,11 @@ class ProjectActionsMixin:
         """Launch the CLI project wizard in a suspended terminal."""
         with self.suspend():
             try:
-                result = subprocess.run(
-                    [sys.executable, "-m", "terok.cli.main", "project-wizard"],
-                    check=False,
-                )
-                if result.returncode != 0:
-                    print(f"Wizard exited with code {result.returncode}")
+                sys.argv = ["terok.cli.main", "project-wizard"]
+                runpy.run_module("terok.cli.main", run_name="__main__")
+            except SystemExit as e:
+                if e.code != 0:
+                    print(f"Wizard exited with code {e.code}")
             except Exception as e:
                 print(f"Error: {e}")
             input("\n[Press Enter to return to TerokTUI] ")

--- a/src/terok/tui/project_actions.py
+++ b/src/terok/tui/project_actions.py
@@ -9,7 +9,6 @@ project and task actions.
 """
 
 import os
-import runpy
 import shlex
 import subprocess
 import sys
@@ -447,11 +446,12 @@ class ProjectActionsMixin:
         """Launch the CLI project wizard in a suspended terminal."""
         with self.suspend():
             try:
-                sys.argv = ["terok.cli.main", "project-wizard"]
-                runpy.run_module("terok.cli.main", run_name="__main__")
-            except SystemExit as e:
-                if e.code != 0:
-                    print(f"Wizard exited with code {e.code}")
+                result = subprocess.run(
+                    [sys.executable, "-m", "terok.cli.main", "project-wizard"],
+                    check=False,
+                )
+                if result.returncode != 0:
+                    print(f"Wizard exited with code {result.returncode}")
             except Exception as e:
                 print(f"Error: {e}")
             input("\n[Press Enter to return to TerokTUI] ")

--- a/src/terok/tui/project_actions.py
+++ b/src/terok/tui/project_actions.py
@@ -446,7 +446,6 @@ class ProjectActionsMixin:
     async def action_new_project_wizard(self) -> None:
         """Launch the CLI project wizard in a suspended terminal."""
         with self.suspend():
-            old_argv = sys.argv[:]
             try:
                 sys.argv = ["terok.cli.main", "project-wizard"]
                 runpy.run_module("terok.cli.main", run_name="__main__")
@@ -455,8 +454,6 @@ class ProjectActionsMixin:
                     print(f"Wizard exited with code {e.code}")
             except Exception as e:
                 print(f"Error: {e}")
-            finally:
-                sys.argv = old_argv
             input("\n[Press Enter to return to TerokTUI] ")
         await self.refresh_projects()
         self.notify("Project list refreshed.")


### PR DESCRIPTION
With version 0.7.0, Terok has begun launching itself via subprocess for a number of TUI actions. This discards the current Python environment, leading to trouble in some setups. Fixed by using runpy instead, to stay within the same environment.

For the moment, this seems to fix the issues that I had, but there might be more places where this fix needs to be applied. Currently testing 0.7.0, so I'll see if I keep running into similar troubles.

Up for discussion:

- [x] ~~This no longer creates new processes, but instead reuses the same processes for sub-tasks. This might have other unintended downsides for stability, meaning that I would rather have to fix this in my packaging.~~ Changed the PR such that processes are still created

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Project wizard launches more reliably across environments while preserving TUI state.
  * Clearer reporting when the wizard exits with an error and simpler generic error messages.
  * After the wizard finishes or errors, the project list refreshes and the user is notified.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->