### PR TITLE
feat: sort TUI task list by creation time, newest first

### DIFF
--- a/src/terok/lib/orchestration/tasks.py
+++ b/src/terok/lib/orchestration/tasks.py
@@ -266,6 +266,7 @@ def get_task_meta(project_id: str, task_id: str) -> TaskMeta:
         unrestricted=raw.get("unrestricted"),
         work_status=ws_status,
         work_message=ws_message,
+        created_at=raw.get("created_at"),
     )
 
 
@@ -1001,6 +1002,7 @@ def task_status(project_id: str, task_id: str) -> None:
         name=meta["name"],
         provider=meta.get("provider"),
         unrestricted=meta.get("unrestricted"),
+        created_at=meta.get("created_at"),
     )
     status = effective_status(task)
     info = STATUS_DISPLAY.get(status, STATUS_DISPLAY["created"])

--- a/src/terok/lib/orchestration/tasks.py
+++ b/src/terok/lib/orchestration/tasks.py
@@ -18,6 +18,7 @@ import secrets
 import shutil
 import subprocess
 from dataclasses import dataclass
+from datetime import UTC, datetime
 from pathlib import Path
 
 from terok_sandbox import (
@@ -122,6 +123,7 @@ class TaskMeta(TaskState):
     work_status: str | None = None
     work_message: str | None = None
     shield_state: str | None = None
+    created_at: str | None = None
 
     @property
     def status(self) -> str:
@@ -402,6 +404,7 @@ def _task_new(project: ProjectConfig, *, name: str | None = None) -> str:
         "mode": None,
         "workspace": str(ws),
         "web_port": None,
+        "created_at": datetime.now(tz=UTC).isoformat(),
     }
     (meta_dir / f"{next_id}.yml").write_text(_yaml_dump(meta))
     print(f"Created task {next_id} ({task_name}) in {ws}")
@@ -509,6 +512,7 @@ def _get_tasks(project_id: str, reverse: bool = False) -> list[TaskMeta]:
                     unrestricted=meta.get("unrestricted"),
                     work_status=ws_status,
                     work_message=ws_message,
+                    created_at=meta.get("created_at"),
                 )
             )
         except Exception as exc:

--- a/src/terok/tui/widgets/task_list.py
+++ b/src/terok/tui/widgets/task_list.py
@@ -88,7 +88,7 @@ class TaskList(ListView):
         return label
 
     def set_tasks(self, project_id: str, tasks_meta: list[TaskMeta]) -> None:
-        """Populate the list from ``TaskMeta`` instances."""
+        """Populate the list from ``TaskMeta`` instances, newest first."""
         existing_states: dict[str, str | None] = {}
         if self.project_id == project_id:
             for task in self.tasks:
@@ -99,7 +99,7 @@ class TaskList(ListView):
         self._generation += 1
         self.clear()
 
-        for tm in tasks_meta:
+        for tm in sorted(tasks_meta, key=lambda t: t.created_at or "", reverse=True):
             if tm.task_id in existing_states:
                 tm.container_state = existing_states[tm.task_id]
             self.tasks.append(tm)

--- a/tests/unit/lib/test_tasks.py
+++ b/tests/unit/lib/test_tasks.py
@@ -8,7 +8,7 @@ import re
 import subprocess
 import unittest.mock
 from contextlib import redirect_stdout
-from datetime import datetime
+from datetime import datetime, timedelta
 from io import StringIO
 from pathlib import Path
 
@@ -129,7 +129,9 @@ class TestTask:
             meta = yaml_load(meta_path.read_text())
 
             assert "created_at" in meta
-            datetime.fromisoformat(meta["created_at"])  # parses → valid ISO 8601
+            parsed = datetime.fromisoformat(meta["created_at"])
+            assert parsed.tzinfo is not None, "created_at must be timezone-aware"
+            assert parsed.utcoffset() == timedelta(0), "created_at must be UTC"
 
             [task] = [t for t in get_tasks(project_id) if t.task_id == tid]
             assert task.created_at == meta["created_at"]

--- a/tests/unit/lib/test_tasks.py
+++ b/tests/unit/lib/test_tasks.py
@@ -8,6 +8,7 @@ import re
 import subprocess
 import unittest.mock
 from contextlib import redirect_stdout
+from datetime import datetime
 from io import StringIO
 from pathlib import Path
 
@@ -19,6 +20,7 @@ from terok.lib.orchestration.environment import build_task_env_and_volumes
 from terok.lib.orchestration.task_runners import task_run_cli, task_run_toad
 from terok.lib.orchestration.tasks import (
     TaskDeleteResult,
+    get_tasks,
     get_workspace_git_diff,
     task_delete,
     task_list,
@@ -110,6 +112,27 @@ class TestTask:
             assert isinstance(result, TaskDeleteResult)
             assert not meta_path.exists()
             assert not workspace.exists()
+
+    def test_task_new_records_created_at(self) -> None:
+        """task_new writes an ISO 8601 created_at timestamp that round-trips via get_tasks.
+
+        The TUI uses this field to sort tasks newest-first; task_id is random hex
+        and carries no temporal information.
+        """
+        project_id = "proj_created_at"
+        with project_env(
+            f"project:\n  id: {project_id}\n",
+            project_id=project_id,
+        ) as ctx:
+            tid = task_new(project_id)
+            meta_path = ctx.state_dir / "projects" / project_id / "tasks" / f"{tid}.yml"
+            meta = yaml_load(meta_path.read_text())
+
+            assert "created_at" in meta
+            datetime.fromisoformat(meta["created_at"])  # parses → valid ISO 8601
+
+            [task] = [t for t in get_tasks(project_id) if t.task_id == tid]
+            assert task.created_at == meta["created_at"]
 
     def test_task_new_creates_marker_file(self) -> None:
         """Verify that task_new() creates the .new-task-marker file.


### PR DESCRIPTION
## Summary

- Task IDs are random hex with no temporal information, so the TUI list order has been effectively arbitrary.
- Record `created_at` (ISO 8601 UTC) on the task metadata YAML at creation time, thread it through `TaskMeta`, and sort the TUI task list descending by it so the most recently created task is at the top.
- Pre-existing tasks with no `created_at` field sort to the bottom; they'll keep relative order among themselves until a migration or natural churn replaces them.

## Test plan

- [x] `ruff check` / `ruff format --check` clean
- [x] `tach check` clean
- [x] `docstr-coverage` 99.3%
- [x] `bandit` — no new medium/high findings
- [x] 1709 unit tests pass (one pre-existing failure in `test_cli_config.py` unrelated — port 9418 bound in local env; reproduces on clean master)
- [x] New unit test `test_task_new_records_created_at` round-trips the field through the YAML and `get_tasks`
- [ ] Smoke test in the TUI against a project with multiple tasks of varying age

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Tasks now record a creation timestamp (ISO-8601, UTC) when created.
  * Task lists are sorted by creation time so newest tasks appear first.

* **Tests**
  * Added tests to verify task creation timestamps are recorded and surfaced correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->