### PR TITLE
chore: add merge-queue guard against git-source deps

### DIFF
--- a/.github/workflows/no-git-deps.yml
+++ b/.github/workflows/no-git-deps.yml
@@ -1,5 +1,10 @@
 name: no-git-deps
 
+# Inert until merge queue is enabled on `master` and `no-git-deps` is
+# listed as a required status check in the master ruleset.
+# Settings → Rules → Rulesets → (master ruleset): add "Require merge queue"
+# and add `no-git-deps` under "Require status checks to pass".
+
 on:
   merge_group:
 
@@ -7,7 +12,7 @@ jobs:
   no-git-deps:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Scan pyproject.toml for git sources
         run: |
           python3 <<'PY'
@@ -16,16 +21,17 @@ jobs:
           data = tomllib.loads(pathlib.Path("pyproject.toml").read_text())
           offenders = []
 
+          def scan(label, deps):
+              for name, spec in deps.items():
+                  if isinstance(spec, dict) and "git" in spec:
+                      ref = spec.get("branch") or spec.get("rev") or spec.get("tag") or "?"
+                      offenders.append(f"{label}.{name} -> {spec['git']}@{ref}")
+
           poetry = data.get("tool", {}).get("poetry", {})
           for key in ("dependencies", "dev-dependencies"):
-              for name, spec in poetry.get(key, {}).items():
-                  if isinstance(spec, dict) and "git" in spec:
-                      ref = spec.get("branch") or spec.get("rev") or spec.get("tag")
-                      offenders.append(f"{key}.{name} -> {spec.get('git')}@{ref}")
+              scan(key, poetry.get(key, {}))
           for gname, g in poetry.get("group", {}).items():
-              for name, spec in g.get("dependencies", {}).items():
-                  if isinstance(spec, dict) and "git" in spec:
-                      offenders.append(f"group.{gname}.{name} -> {spec.get('git')}")
+              scan(f"group.{gname}", g.get("dependencies", {}))
 
           project = data.get("project", {})
           for dep in project.get("dependencies", []):

--- a/.github/workflows/no-git-deps.yml
+++ b/.github/workflows/no-git-deps.yml
@@ -1,0 +1,46 @@
+name: no-git-deps
+
+on:
+  merge_group:
+
+jobs:
+  no-git-deps:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Scan pyproject.toml for git sources
+        run: |
+          python3 <<'PY'
+          import sys, tomllib, pathlib
+
+          data = tomllib.loads(pathlib.Path("pyproject.toml").read_text())
+          offenders = []
+
+          poetry = data.get("tool", {}).get("poetry", {})
+          for key in ("dependencies", "dev-dependencies"):
+              for name, spec in poetry.get(key, {}).items():
+                  if isinstance(spec, dict) and "git" in spec:
+                      ref = spec.get("branch") or spec.get("rev") or spec.get("tag")
+                      offenders.append(f"{key}.{name} -> {spec.get('git')}@{ref}")
+          for gname, g in poetry.get("group", {}).items():
+              for name, spec in g.get("dependencies", {}).items():
+                  if isinstance(spec, dict) and "git" in spec:
+                      offenders.append(f"group.{gname}.{name} -> {spec.get('git')}")
+
+          project = data.get("project", {})
+          for dep in project.get("dependencies", []):
+              if "git+" in dep:
+                  offenders.append(dep)
+          for gname, deps in project.get("optional-dependencies", {}).items():
+              for dep in deps:
+                  if "git+" in dep:
+                      offenders.append(f"{gname}: {dep}")
+
+          if offenders:
+              print("Git sources found in pyproject.toml:")
+              for o in offenders:
+                  print(f"  - {o}")
+              print("\nSwap to released wheels before merging.")
+              sys.exit(1)
+          print("No git sources - OK.")
+          PY


### PR DESCRIPTION
## Summary

Adds a `merge_group`-triggered workflow that fails if any dependency in `pyproject.toml` still points at a git source (branch, rev, or tag). Catches the case where a PR-chain branch ref is forgotten in a submitted PR — both an honest mistake and a supply-chain hazard.

The workflow is invisible during normal PR life (no `pull_request` trigger), so chain-testing flows stay green. It only runs when the PR enters the merge queue.

## Follow-up (not in this PR)

To enforce, we also need to:
1. Enable merge queue on `master` for this repo (Settings → Rules → Rulesets).
2. Mark `no-git-deps` as a required status check in the ruleset.
3. Replicate the workflow + ruleset across the sibling repos (`terok-executor`, `terok-sandbox`, `terok-shield`, `terok-mkdocs`, `terok-jetbrains`).

Org-level rulesets would have been one-shot, but they require a Team plan — per-repo is the free-tier path.

## Test plan

- [ ] Dry-run the scan locally against current `pyproject.toml` (no git sources) — passes.
- [ ] After merge, add a throwaway git-source dep in a test PR and verify the merge queue rejects it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI now scans declared Python dependencies for direct VCS/git references and fails merge checks if any are found, prompting replacement with released packages.
  * Prevents merging changes that rely on unreleased git-based dependencies to improve release stability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->