### PR TITLE
fix: point podman presets at quay.io/podman/stable

### DIFF
--- a/docs/container-layers.md
+++ b/docs/container-layers.md
@@ -17,7 +17,7 @@ terok builds project containers in three logical layers. L0 (dev) and L1 (agent)
 
 #### Base image families
 
-Officially tested base images: `ubuntu:24.04`, `fedora:43`, `quay.io/containers/podman`, `nvcr.io/nvidia/nvhpc`. The package-manager branch (`apt`/`dnf`) is auto-detected from the image name. For images outside the allowlist, set `image.family: deb` or `image.family: rpm` explicitly:
+Officially tested base images: `ubuntu:24.04`, `fedora:43`, `quay.io/podman/stable`, `nvcr.io/nvidia/nvhpc`. The package-manager branch (`apt`/`dnf`) is auto-detected from the image name. For images outside the allowlist, set `image.family: deb` or `image.family: rpm` explicitly:
 
 ```yaml
 image:

--- a/src/terok/resources/templates/projects/gatekeeping-podman.yml
+++ b/src/terok/resources/templates/projects/gatekeeping-podman.yml
@@ -12,7 +12,7 @@ git:
   default_branch: "{{DEFAULT_BRANCH}}"
 
 image:
-  base_image: "quay.io/containers/podman:latest"
+  base_image: "quay.io/podman/stable:latest"
   # Optional: extra Dockerfile commands injected into the project image.
   # Use user_snippet_file to point to an external .dockerinclude file.
   # Both can be set — file is included first, inline appended.

--- a/src/terok/resources/templates/projects/online-podman.yml
+++ b/src/terok/resources/templates/projects/online-podman.yml
@@ -11,7 +11,7 @@ git:
   default_branch: "{{DEFAULT_BRANCH}}"
 
 image:
-  base_image: "quay.io/containers/podman:latest"
+  base_image: "quay.io/podman/stable:latest"
   # Optional: extra Dockerfile commands injected into the project image.
   # Use user_snippet_file to point to an external .dockerinclude file.
   # Both can be set — file is included first, inline appended.

--- a/tests/unit/lib/test_wizard.py
+++ b/tests/unit/lib/test_wizard.py
@@ -224,7 +224,7 @@ def generate_into_tmp(values: dict[str, object]) -> tuple[str, str, str]:
                 project_id="podman-proj",
                 upstream_url="https://x.com/r.git",
             ),
-            ['base_image: "quay.io/containers/podman:latest"'],
+            ['base_image: "quay.io/podman/stable:latest"'],
             id="online-podman",
         ),
     ],


### PR DESCRIPTION
## Summary

The online/gatekeeping \"podman\" project templates and the tested-images note in \`docs/container-layers.md\` pointed at \`quay.io/containers/podman\`, which is a different image (unrelated to the Podman project).  The official upstream path is \`quay.io/podman/stable\`, which matches the allowlist fix landing in the companion terok-executor PR.

## What changed

- \`src/terok/resources/templates/projects/online-podman.yml\`: \`base_image\` corrected.
- \`src/terok/resources/templates/projects/gatekeeping-podman.yml\`: same.
- \`docs/container-layers.md\`: tested-bases list corrected.
- \`tests/unit/lib/test_wizard.py\`: preset-wizard parametrisation updated.

## Dependency chain

- Pairs with terok-ai/terok-executor#178 (detect_family allowlist). Once that's released in a wheel and terok bumps to it, this preset change will have its \`auto-detect family=rpm\` counterpart in place.  Standalone-mergeable either way — worst case is the wizard-generated project.yml needs an explicit \`image.family: rpm\` until the executor bump lands.

## Test plan

- [x] \`make lint\`, \`tach\` — clean
- [x] \`pytest tests/unit/lib/test_wizard.py\` — 36 passed
- [ ] Manual \`terok init\` of a podman-preset project on a host with the new executor wheel

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated officially tested base images allowlist for container configurations.

* **Chores**
  * Updated Podman project templates and corresponding tests to reference new base image source.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->