### PR TITLE
feat: project-derive shares git gate and SSH key with source

### DIFF
--- a/src/terok/cli/commands/project.py
+++ b/src/terok/cli/commands/project.py
@@ -7,9 +7,9 @@ from __future__ import annotations
 
 import argparse
 
-from ...lib.core.projects import derive_project, list_presets, list_projects, load_project
-from ...lib.domain.facade import delete_project, find_projects_sharing_gate
-from ...lib.domain.wizards.new_project import run_wizard
+from ...lib.core.projects import list_presets, list_projects, load_project
+from ...lib.domain.facade import delete_project, derive_project, find_projects_sharing_gate
+from ...lib.domain.wizards.new_project import offer_edit_then_init, run_wizard
 from ._completers import complete_project_ids as _complete_project_ids, set_completer
 from .setup import cmd_project_init
 
@@ -73,12 +73,14 @@ def dispatch(args: argparse.Namespace) -> bool:
                 )
         return True
     if args.cmd == "project-derive":
-        target = derive_project(args.source_id, args.new_id)
-        print(f"Derived project '{args.new_id}' from '{args.source_id}' at {target}")
-        print("Next steps:")
-        print(f"  1. Edit {target / 'project.yml'} (customize agent: section)")
-        print(f"  2. Initialize: terok project-init {args.new_id}")
-        print("  Tip: global presets are shared across projects (see terok config)")
+        project = derive_project(args.source_id, args.new_id)
+        config_path = project.config.root / "project.yml"
+        print(
+            f"Derived project '{args.new_id}' from '{args.source_id}' — "
+            f"shares git gate and SSH key with source.\n"
+            f"Config: {config_path}"
+        )
+        offer_edit_then_init(config_path, args.new_id, init_fn=cmd_project_init)
         return True
     if args.cmd == "project-delete":
         _cmd_project_delete(args.project_id, force=args.force)

--- a/src/terok/lib/core/projects.py
+++ b/src/terok/lib/core/projects.py
@@ -24,6 +24,7 @@ from .config import (
     get_global_section,
     get_shield_drop_on_task_run,
     get_shield_on_task_restart,
+    make_sandbox_config,
     projects_dir,
     sandbox_live_dir,
     user_presets_dir,
@@ -279,11 +280,15 @@ def load_preset(project_id: str, preset_name: str) -> tuple[dict[str, Any], Path
 
 
 def derive_project(source_id: str, new_id: str) -> Path:
-    """Create a new project config derived from an existing one.
+    """Create a new project config that *shares infrastructure* with an existing one.
 
-    Copies the source ``project.yml``, preserving ``git``, ``ssh``, and ``gate``
-    sections while resetting ``project.id`` and clearing the ``agent:`` section
-    for customization.  Returns the new project root directory.
+    The derived project points at the same git-gate mirror and the same SSH
+    keypair as the source — only ``project.id`` and the ``agent:`` section
+    differ.  This is the "sibling project" use case: rerun the same repo
+    through a different image or agent without re-provisioning keys or
+    re-cloning the mirror.
+
+    Returns the new project's root directory.
 
     Raises SystemExit if the source project is not found or the target already exists.
     """
@@ -301,13 +306,9 @@ def derive_project(source_id: str, new_id: str) -> Path:
 
     source_cfg = _yaml_load((source.root / _PROJECT_YML).read_text(encoding="utf-8")) or {}
 
-    # Update project ID
-    if "project" not in source_cfg:
-        source_cfg["project"] = {}
-    source_cfg["project"]["id"] = new_id
-
-    # Clear agent section for customization
+    source_cfg.setdefault("project", {})["id"] = new_id
     source_cfg.pop("agent", None)
+    _pin_shared_infra(source_cfg, source)
 
     target_root.mkdir(parents=True, exist_ok=True)
     (target_root / _PROJECT_YML).write_text(
@@ -316,6 +317,27 @@ def derive_project(source_id: str, new_id: str) -> Path:
     )
 
     return target_root
+
+
+def _pin_shared_infra(cfg: dict, source: ProjectConfig) -> None:
+    """Pin *source*'s resolved gate and SSH paths into *cfg*.
+
+    Makes the sibling project's infrastructure sharing explicit in the
+    written YAML, decoupled from terok's default-path conventions.
+    """
+    cfg.setdefault("gate", {})["path"] = str(source.gate_path)
+    ssh_section = cfg.setdefault("ssh", {})
+    ssh_section["host_dir"] = str(resolve_ssh_host_dir(source))
+    ssh_section["key_name"] = effective_ssh_key_name(source)
+
+
+def resolve_ssh_host_dir(project: ProjectConfig) -> Path:
+    """On-disk directory holding *project*'s SSH keypair and config.
+
+    Project-level ``ssh.host_dir`` wins; otherwise falls back to the managed
+    default ``<sandbox state>/ssh-keys/<project_id>``.
+    """
+    return project.ssh_host_dir or (make_sandbox_config().ssh_keys_dir / project.id)
 
 
 def _find_project_root(project_id: str) -> Path:

--- a/src/terok/lib/domain/facade.py
+++ b/src/terok/lib/domain/facade.py
@@ -29,12 +29,14 @@ used by CLI commands that operate on ``project_id`` strings directly.
 
 from __future__ import annotations
 
+import json
+
 from terok_executor import (
     authenticate as _authenticate_raw,
 )
 
 from ..core.images import project_cli_image
-from ..core.projects import load_project
+from ..core.projects import derive_project as _derive_project, load_project
 from ..orchestration.image import build_images, generate_dockerfiles
 from ..orchestration.task_runners import (  # noqa: F401 — re-exported public API
     HeadlessRunRequest,
@@ -92,11 +94,47 @@ def list_projects() -> list[Project]:
 
 
 def derive_project(source_id: str, new_id: str) -> Project:
-    """Derive a new project from an existing one and return it."""
-    from ..core.projects import derive_project as _derive_project
+    """Derive a new project from an existing one and return it.
 
+    The derived project shares the source's git-gate mirror and SSH keypair.
+    If the source already has an ``ssh-keys.json`` entry, the same key files
+    are registered under the new scope so the credential proxy can serve the
+    derived project without further setup.
+    """
     _derive_project(source_id, new_id)
+    _share_ssh_key_registration(source_id, new_id)
     return Project(load_project(new_id))
+
+
+def _share_ssh_key_registration(source_id: str, new_id: str) -> None:
+    """Register the source's SSH key under *new_id* in ``ssh-keys.json``.
+
+    Silent no-op when the source has no registered key yet — ``project-init``
+    on the derived project will populate both scopes once the key exists on
+    disk.  For sources with multiple keys the first is shared; that is enough
+    for the common single-remote sibling use case.
+    """
+    from ..core.config import make_sandbox_config
+
+    try:
+        mapping = json.loads(make_sandbox_config().ssh_keys_json_path.read_text(encoding="utf-8"))
+    except (FileNotFoundError, json.JSONDecodeError):
+        return
+
+    raw = mapping.get(source_id)
+    source_entries = raw if isinstance(raw, list) else [raw]
+    shareable_key = next(
+        (
+            k
+            for k in source_entries
+            if isinstance(k, dict) and {"private_key", "public_key"} <= k.keys()
+        ),
+        None,
+    )
+    if shareable_key is None:
+        return
+
+    register_ssh_key(new_id, shareable_key)
 
 
 # ---------------------------------------------------------------------------

--- a/src/terok/lib/domain/project.py
+++ b/src/terok/lib/domain/project.py
@@ -62,7 +62,7 @@ from ..core.config import (
     user_projects_dir,
 )
 from ..core.project_model import ProjectConfig
-from ..core.projects import list_presets, load_project
+from ..core.projects import list_presets, load_project, resolve_ssh_host_dir
 from ..orchestration.agent_config import resolve_agent_config
 from ..orchestration.image import build_images, generate_dockerfiles
 from ..orchestration.task_runners import HeadlessRunRequest, task_run_headless
@@ -183,27 +183,24 @@ def make_git_gate(config: ProjectConfig) -> GitGate:
     Resolves *ssh_host_dir* via :func:`make_sandbox_config` so the gate looks
     in terok's state directory, not sandbox's standalone default.
     """
-    cfg = make_sandbox_config()
-    ssh_dir = config.ssh_host_dir or (cfg.ssh_keys_dir / config.id)
     return GitGate(
         scope=config.id,
         gate_path=config.gate_path,
         upstream_url=config.upstream_url,
         default_branch=config.default_branch,
-        ssh_host_dir=ssh_dir,
+        ssh_host_dir=resolve_ssh_host_dir(config),
         ssh_key_name=config.ssh_key_name,
         allow_host_keys=config.ssh_allow_host_keys,
         validate_gate_fn=validate_gate_upstream_match,
-        clone_cache_base=cfg.clone_cache_base_path,
+        clone_cache_base=make_sandbox_config().clone_cache_base_path,
     )
 
 
 def make_ssh_manager(config: ProjectConfig) -> SSHManager:
     """Construct an :class:`SSHManager` from a :class:`ProjectConfig` (adapter factory)."""
-    ssh_dir = config.ssh_host_dir or (make_sandbox_config().ssh_keys_dir / config.id)
     return SSHManager(
         scope=config.id,
-        ssh_host_dir=ssh_dir,
+        ssh_host_dir=resolve_ssh_host_dir(config),
         ssh_key_name=config.ssh_key_name,
         ssh_config_template=config.ssh_config_template,
     )
@@ -346,8 +343,7 @@ def delete_project(project_id: str) -> DeleteProjectResult:
             deleted.append(str(d))
 
     # 5. SSH credentials (may be user-configured path)
-    ssh_dir = project.ssh_host_dir or (make_sandbox_config().ssh_keys_dir / pid)
-    _rmtree_managed(ssh_dir, "SSH dir", deleted, skipped)
+    _rmtree_managed(resolve_ssh_host_dir(project), "SSH dir", deleted, skipped)
 
     # 6. Git gate (skip if shared with other projects)
     sharing = find_projects_sharing_gate(project.gate_path, exclude_project=pid)

--- a/src/terok/lib/domain/project_state.py
+++ b/src/terok/lib/domain/project_state.py
@@ -11,12 +11,11 @@ for overview displays.
 import subprocess
 from collections.abc import Callable
 from datetime import datetime
-from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
-from ..core.config import build_dir, make_sandbox_config
+from ..core.config import build_dir
 from ..core.images import project_cli_image
-from ..core.projects import load_project
+from ..core.projects import load_project, resolve_ssh_host_dir
 from ..core.task_display import container_name as _container_name
 
 if TYPE_CHECKING:
@@ -111,8 +110,7 @@ def get_project_state(
 
     # SSH: consider SSH "ready" when the key directory and its config file exist.
     # Falls back to the managed ssh-keys store (same as SSHManager / git gate).
-    ssh_dir = project.ssh_host_dir or (make_sandbox_config().ssh_keys_dir / project.id)
-    ssh_dir = Path(ssh_dir).expanduser().resolve()
+    ssh_dir = resolve_ssh_host_dir(project).expanduser().resolve()
     has_ssh = ssh_dir.is_dir() and (ssh_dir / "config").is_file()
 
     # Gate: a mirror bare repo initialized by sync_project_gate(). We

--- a/src/terok/lib/domain/wizards/new_project.py
+++ b/src/terok/lib/domain/wizards/new_project.py
@@ -217,6 +217,38 @@ def generate_config(values: dict) -> Path:
     return config_path
 
 
+def offer_edit_then_init(
+    config_path: Path,
+    project_id: str,
+    init_fn: Callable[[str], None] | None,
+) -> None:
+    """Interactively review and commission a newly-created project configuration.
+
+    Opens the config in the user's editor (skippable), then offers to run the
+    initialisation routine.  On ``KeyboardInterrupt`` or ``EOFError`` the
+    half-finished sequence is abandoned cleanly — the config file is kept
+    and a manual next-step hint is printed so the user can resume later.
+    """
+    try:
+        edit_answer = input("Edit configuration file before setup? [Y/n]: ").strip().lower()
+        if edit_answer not in ("n", "no") and not open_in_editor(config_path):
+            print(
+                f"Warning: could not open editor — edit file manually: {config_path}",
+                file=sys.stderr,
+            )
+
+        if init_fn is not None:
+            init_answer = input("Run project initialization? [Y/n]: ").strip().lower()
+            if init_answer not in ("n", "no"):
+                init_fn(project_id)
+                print(f"\nProject '{project_id}' is ready.")
+                return
+
+        print(f"Next step: terok project-init {project_id}")
+    except (KeyboardInterrupt, EOFError):
+        print(f"\nSkipped. Run manually: terok project-init {project_id}")
+
+
 def run_wizard(init_fn: Callable[[str], None] | None = None) -> Path | None:
     """Top-level wizard entry point called by the CLI.
 
@@ -235,26 +267,5 @@ def run_wizard(init_fn: Callable[[str], None] | None = None) -> Path | None:
     project_id = values["project_id"]
     print(f"\nProject configuration created: {config_path}")
 
-    try:
-        # Offer to edit the generated config before setup
-        edit_answer = input("Edit configuration file before setup? [Y/n]: ").strip().lower()
-        if edit_answer not in ("n", "no"):
-            if not open_in_editor(config_path):
-                print(
-                    f"Warning: could not open editor — edit file manually: {config_path}",
-                    file=sys.stderr,
-                )
-
-        # Offer to run project-init if a handler was provided
-        if init_fn is not None:
-            init_answer = input("Run project initialization? [Y/n]: ").strip().lower()
-            if init_answer not in ("n", "no"):
-                init_fn(project_id)
-                print(f"\nProject '{project_id}' is ready.")
-                return config_path
-
-        print(f"Next step: terok project-init {project_id}")
-    except (KeyboardInterrupt, EOFError):
-        print(f"\nSkipped. Run manually: terok project-init {project_id}")
-
+    offer_edit_then_init(config_path, project_id, init_fn)
     return config_path

--- a/src/terok/tui/project_actions.py
+++ b/src/terok/tui/project_actions.py
@@ -25,7 +25,7 @@ from terok_sandbox import (
     uninstall_systemd_units,
 )
 
-from ..lib.core.projects import effective_ssh_key_name, load_project
+from ..lib.core.projects import effective_ssh_key_name, load_project, resolve_ssh_host_dir
 from ..lib.domain.facade import (
     authenticate,
     build_images,
@@ -61,11 +61,8 @@ class ProjectActionsMixin:
         if not (upstream.startswith("git@") or upstream.startswith("ssh://")):
             return
 
-        from ..lib.core.config import make_sandbox_config
-
-        ssh_dir = project.ssh_host_dir or (make_sandbox_config().ssh_keys_dir / project.id)
         key_name = effective_ssh_key_name(project, key_type="ed25519")
-        pub_key_path = ssh_dir / f"{key_name}.pub"
+        pub_key_path = resolve_ssh_host_dir(project) / f"{key_name}.pub"
 
         print("\nHint: this project uses an SSH upstream.")
         print(

--- a/tach.toml
+++ b/tach.toml
@@ -478,6 +478,7 @@ expose = [
     "list_presets",
     "derive_project",
     "effective_ssh_key_name",
+    "resolve_ssh_host_dir",
     "validate_project_id",
 ]
 from = ["terok.lib.core.projects"]
@@ -679,7 +680,7 @@ expose = ["wait_for_container_exit", "follow_container_logs_cmd"]
 from = ["terok.lib.orchestration.autopilot"]
 
 [[interfaces]]
-expose = ["run_wizard", "collect_wizard_inputs", "generate_config"]
+expose = ["run_wizard", "offer_edit_then_init", "collect_wizard_inputs", "generate_config"]
 from = ["terok.lib.domain.wizards.new_project"]
 
 # Facade interface (stable boundary for presentation layer)

--- a/tests/integration/projects/test_projects.py
+++ b/tests/integration/projects/test_projects.py
@@ -79,19 +79,26 @@ class TestProjects:
     def test_project_derive_preserves_infra_and_clears_agent(
         self, terok_env: TerokIntegrationEnv
     ) -> None:
-        """``project-derive`` copies infra config but clears ``agent:``."""
+        """``project-derive`` pins shared gate+SSH paths and clears ``agent:``."""
         terok_env.write_project("alpha", SOURCE_PROJECT)
 
         result = terok_env.run_cli("project-derive", "alpha", "beta")
 
         target = terok_env.project_root("beta") / "project.yml"
         assert "Derived project 'beta' from 'alpha'" in result.stdout
+        assert "shares git gate and SSH key with source" in result.stdout
         assert target.is_file()
 
         derived = yaml_load(target.read_text(encoding="utf-8"))
         assert derived["project"]["id"] == "beta"
         assert "agent" not in derived
         assert derived["git"]["upstream_url"] == TEST_UPSTREAM_URL
+
+        # Shared infra is pinned to source's resolved paths so the derived
+        # project points at the same gate mirror and SSH keypair.
+        assert derived["gate"]["path"] == str(terok_env.gate_path("alpha"))
+        expected_ssh_dir = terok_env.sandbox_state_root / "ssh-keys" / "alpha"
+        assert derived["ssh"]["host_dir"] == str(expected_ssh_dir)
         assert derived["ssh"]["key_name"] == "id_alpha"
 
         listed = terok_env.run_cli("projects")
@@ -134,6 +141,7 @@ class TestProjects:
         assert re.search(r"(?m)^\s*agent\s*:", raw) is None
         assert re.search(r"(?m)^\s*#.*\bagent\b", raw) is None
 
-        # Key order matches the source file (not alphabetically sorted)
+        # Original section order is preserved (not alphabetically sorted).
+        # ``gate`` is appended by derive to pin the shared gate mirror path.
         keys = [m.group(1) for m in re.finditer(r"(?m)^(\w+)\s*:", raw)]
-        assert keys == ["project", "git", "ssh"]
+        assert keys == ["project", "git", "ssh", "gate"]

--- a/tests/unit/lib/test_projects.py
+++ b/tests/unit/lib/test_projects.py
@@ -303,7 +303,7 @@ class TestProject:
                     "terok.lib.core.projects._get_global_git_config", return_value=None
                 ),
                 unittest.mock.patch(
-                    "terok.lib.domain.project_state.make_sandbox_config",
+                    "terok.lib.core.projects.make_sandbox_config",
                     return_value=mock_sandbox_cfg,
                 ),
             ):
@@ -321,3 +321,80 @@ class TestProject:
             "gate": True,
             "gate_last_commit": None,
         }
+
+
+class TestShareSshKeyRegistration:
+    """Source's key paths are aliased under the derived scope, not copied."""
+
+    def _patch_sandbox_config(self, keys_path: Path) -> unittest.mock._patch:
+        """Return a patch that routes ``make_sandbox_config().ssh_keys_json_path`` to *keys_path*."""
+        mock_cfg = unittest.mock.MagicMock()
+        mock_cfg.ssh_keys_json_path = keys_path
+        return unittest.mock.patch(
+            "terok.lib.core.config.make_sandbox_config", return_value=mock_cfg
+        )
+
+    def test_copies_dict_entry_to_new_scope(self, tmp_path: Path) -> None:
+        """Source's single-key dict entry is copied under the new scope."""
+        import json
+
+        from terok.lib.domain.facade import _share_ssh_key_registration
+
+        keys_path = tmp_path / "ssh-keys.json"
+        keys_path.write_text(
+            json.dumps({"alpha": {"private_key": "/k/alpha/id", "public_key": "/k/alpha/id.pub"}})
+        )
+        with self._patch_sandbox_config(keys_path):
+            _share_ssh_key_registration("alpha", "beta")
+
+        mapping = json.loads(keys_path.read_text())
+        # ``update_ssh_keys_json`` normalises entries to a list per scope.
+        assert mapping["beta"] == [{"private_key": "/k/alpha/id", "public_key": "/k/alpha/id.pub"}]
+        assert mapping["alpha"]["private_key"] == "/k/alpha/id"
+
+    def test_missing_file_is_noop(self, tmp_path: Path) -> None:
+        """Absent ``ssh-keys.json`` — silent no-op (handled later by project-init)."""
+        from terok.lib.domain.facade import _share_ssh_key_registration
+
+        keys_path = tmp_path / "ssh-keys.json"
+        with self._patch_sandbox_config(keys_path):
+            _share_ssh_key_registration("alpha", "beta")
+        assert not keys_path.exists()
+
+    def test_missing_source_entry_is_noop(self, tmp_path: Path) -> None:
+        """No entry for *source_id* — derived project is left unregistered."""
+        import json
+
+        from terok.lib.domain.facade import _share_ssh_key_registration
+
+        keys_path = tmp_path / "ssh-keys.json"
+        keys_path.write_text(
+            json.dumps({"gamma": {"private_key": "/k/g", "public_key": "/k/g.pub"}})
+        )
+        with self._patch_sandbox_config(keys_path):
+            _share_ssh_key_registration("alpha", "beta")
+
+        assert "beta" not in json.loads(keys_path.read_text())
+
+    def test_list_entry_copies_first_key(self, tmp_path: Path) -> None:
+        """When source has multiple keys, the first is shared with the new scope."""
+        import json
+
+        from terok.lib.domain.facade import _share_ssh_key_registration
+
+        keys_path = tmp_path / "ssh-keys.json"
+        keys_path.write_text(
+            json.dumps(
+                {
+                    "alpha": [
+                        {"private_key": "/k/a1", "public_key": "/k/a1.pub"},
+                        {"private_key": "/k/a2", "public_key": "/k/a2.pub"},
+                    ]
+                }
+            )
+        )
+        with self._patch_sandbox_config(keys_path):
+            _share_ssh_key_registration("alpha", "beta")
+
+        mapping = json.loads(keys_path.read_text())
+        assert mapping["beta"] == [{"private_key": "/k/a1", "public_key": "/k/a1.pub"}]

--- a/tests/unit/test_error_surfacing.py
+++ b/tests/unit/test_error_surfacing.py
@@ -335,7 +335,7 @@ class TestProjectStateWarnings:
             ),
             patch("subprocess.run", side_effect=FileNotFoundError("no podman")),
             patch("terok.lib.util.logging_utils.log_warning") as mock_warn,
-            patch("terok.lib.domain.project_state.make_sandbox_config") as mock_sbx,
+            patch("terok.lib.core.projects.make_sandbox_config") as mock_sbx,
         ):
             mock_sbx.return_value.ssh_keys_dir = tmp_path / "ssh-keys"
             get_project_state("test-proj")
@@ -362,7 +362,7 @@ class TestProjectStateWarnings:
             patch("terok.lib.domain.project_state.build_dir", return_value=tmp_path / "build"),
             patch("subprocess.run", side_effect=FileNotFoundError("no podman")),
             patch("terok.lib.util.logging_utils.log_warning") as mock_warn,
-            patch("terok.lib.domain.project_state.make_sandbox_config") as mock_sbx,
+            patch("terok.lib.core.projects.make_sandbox_config") as mock_sbx,
         ):
             mock_sbx.return_value.ssh_keys_dir = tmp_path / "ssh-keys"
             get_project_state("test-proj", gate_commit_provider=broken_commit)


### PR DESCRIPTION
## Summary

Makes `terok project-derive` produce a genuine **sibling** project that shares the source's git-gate mirror and SSH keypair, instead of merely copying config and then re-provisioning fresh infrastructure on `project-init`.

**Mental model after this change:**
- `project-wizard` → fresh, independent project.
- `project-derive` → sibling, shares infrastructure with source.

## What changes

- **Shared infra pinned in derived `project.yml`.** `gate.path`, `ssh.host_dir`, and `ssh.key_name` are written with the source's resolved values so sharing is stable even if terok's default-path conventions change later.
- **SSH key auto-registered for the new scope.** If the source has an `ssh-keys.json` entry, the same private/public key paths are registered under the derived `project_id`, so the credential proxy can serve the sibling without a new `ssh-init` + deploy-key dance.
- **`$EDITOR` flow after derive.** The CLI now opens the new `project.yml` in the user's editor (skippable), then offers to run `project-init` — the same post-create interaction the wizard already had. Extracted into `offer_edit_then_init` and reused from both entry points.
- **Opportunistic reuse.** Extracted `resolve_ssh_host_dir(project)` and migrated 6 copies of the `project.ssh_host_dir or (make_sandbox_config().ssh_keys_dir / project.id)` idiom.

Existing `find_projects_sharing_gate` already handles shared-gate lifecycle for delete, and `SSHManager.init()` is idempotent — so no sibling-repo changes are needed; sandbox's existing primitives do the right thing once the derived config points at the shared files.

## Test plan

- [x] `make lint`, `make tach`, `make lint-imports`, `make docstrings`, `make reuse`, `make security` — all green.
- [x] Full suite: 1798 passed, 32 skipped (one pre-existing port-conflict test deselected).
- [x] Integration test `test_project_derive_preserves_infra_and_clears_agent` extended to assert `gate.path` and `ssh.host_dir` are pinned to source's resolved values.
- [x] New unit tests for `_share_ssh_key_registration`: single-dict entry copied; missing file no-op; missing source no-op; list entry picks first usable key.
- [ ] Manual: run `terok project-derive alpha beta` on a real setup, verify `beta` reuses `alpha`'s gate mirror and SSH deploy key without re-registration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Derived projects now automatically inherit and share SSH key registration and infrastructure configuration from their source projects.
  * Improved project initialization workflow with streamlined interactive configuration and setup prompts.

* **Chores**
  * Refactored SSH directory resolution logic for consistency across the system.
  * Updated tests to validate enhanced infrastructure sharing during project derivation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->