### PR TITLE
feat: run.nested_containers for podman-in-podman under SELinux

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -20,6 +20,7 @@ provisioning.
 - **Security Modes**: Online and gatekeeping modes for different trust levels
 - **Container Layers**: Efficient three-layer container image architecture (L0/L1/L2)
 - **Distro-Agnostic Base Images**: Ubuntu/Debian (apt) and Fedora/RPM (dnf) base images supported out of the box; `image.family` override for anything outside the allowlist
+- **Nested Containers**: `run.nested_containers: true` declares projects that run podman/docker inside their container — terok adds the SELinux `label=nested` type and `/dev/fuse` device, keeping the outer container's SELinux boundary intact
 - **Hardened Runtime**: Defence-in-depth via [terok-sandbox](https://github.com/terok-ai/terok-sandbox) — egress firewall, gated git access, SSH isolation, GPU passthrough, socket-based credential and SSH transport with SELinux support
 - **Agent Instructions**: Layered, inheritable instruction system delivered to every task
 - **Interactive TUI**: Full-featured Textual interface with project/task management, log viewing, and login sessions

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -998,6 +998,45 @@ When enabled, terok adds:
 
 ---
 
+## Running Containers Inside Your Container
+
+Projects that run `podman` or `docker` inside their terok container (for example, projects developing container tooling, or those needing `fuse-overlayfs`) need the outer container launched with two extra flags. Declare this once in `project.yml`:
+
+```yaml
+run:
+  nested_containers: true
+```
+
+When set, terok appends to the outer `podman run`:
+
+- `--security-opt label=nested` — the SELinux type that confines the outer container but permits nested container operations (devpts mount, rootless overlay setup). This is *not* `label=disable` — SELinux stays enforced.
+- `--device /dev/fuse` — required by rootless podman's `fuse-overlayfs` storage driver.
+
+Verify inside the container:
+
+```console
+$ podman run alpine echo hello
+hello
+```
+
+### Requirements
+
+- Podman ≥ v4.5.0 on the **host** (introduced `label=nested`, April 2023 — every current distro ships 4.5+).
+- A base image with podman preinstalled; the bundled `online-podman` / `gatekeeping-podman` presets point at `quay.io/podman/stable:latest` (Fedora-based, rootless-ready).
+- On SELinux-enforcing hosts: `container-selinux` package (usually already installed on Fedora/RHEL).
+
+If the image doesn't have podman preinstalled, `nested_containers: true` still sets the capabilities — your project's user snippet can install the runtime:
+
+```yaml
+image:
+  base_image: fedora:43
+  user_snippet_inline: RUN dnf install -y podman fuse-overlayfs
+run:
+  nested_containers: true
+```
+
+---
+
 ## Tips
 
 - **Show resolved paths:** `terok config`

--- a/src/terok/lib/core/project_model.py
+++ b/src/terok/lib/core/project_model.py
@@ -61,6 +61,8 @@ class ProjectConfig(BaseModel):
     """Podman ``--memory`` limit from ``run.memory`` in project.yml."""
     cpu_limit: str | None = None
     """Podman ``--cpus`` limit from ``run.cpus`` in project.yml."""
+    nested_containers: bool = False
+    """Project runs podman/docker inside its container (see ``run.nested_containers``)."""
     task_name_categories: list[str] | None = None
     shield_drop_on_task_run: bool = True
     shield_on_task_restart: str = "retain"

--- a/src/terok/lib/core/projects.py
+++ b/src/terok/lib/core/projects.py
@@ -208,6 +208,7 @@ def _build_project_config(
         shutdown_timeout=raw.run.shutdown_timeout,
         memory_limit=raw.run.memory,
         cpu_limit=raw.run.cpus,
+        nested_containers=raw.run.nested_containers,
         task_name_categories=raw.tasks.name_categories,
         shield_drop_on_task_run=shield_drop,
         shield_on_task_restart=shield_restart,

--- a/src/terok/lib/core/yaml_schema.py
+++ b/src/terok/lib/core/yaml_schema.py
@@ -268,6 +268,15 @@ class RawRunSection(BaseModel):
     )
     memory: str | None = None
     cpus: str | None = None
+    nested_containers: bool = Field(
+        default=False,
+        description=(
+            "Declares that the project runs podman/docker inside its container. "
+            "When true, the outer container is launched with ``--security-opt "
+            "label=nested`` and ``--device /dev/fuse`` so rootless nested "
+            "containers work under SELinux without disabling labels wholesale."
+        ),
+    )
     hooks: RawHooksSection = Field(default_factory=RawHooksSection)
 
     @field_validator("memory", "cpus", mode="before")

--- a/src/terok/lib/orchestration/task_runners.py
+++ b/src/terok/lib/orchestration/task_runners.py
@@ -343,6 +343,7 @@ def _run_container(
         command: Optional command + args appended after the image name.
         hooks: Optional lifecycle callbacks fired around the launch.
     """
+    merged_args = list(extra_args or ()) + _project_runtime_flags(project)
     spec = RunSpec(
         container_name=cname,
         image=image,
@@ -353,7 +354,7 @@ def _run_container(
         gpu_enabled=has_gpu(project),
         memory_limit=project.memory_limit,
         cpu_limit=project.cpu_limit,
-        extra_args=tuple(extra_args or ()),
+        extra_args=tuple(merged_args),
         unrestricted="TEROK_UNRESTRICTED" in env,
         sealed=project.is_sealed,
     )
@@ -367,6 +368,23 @@ def _run_container(
 def _sandbox() -> Sandbox:
     """Return a :class:`Sandbox` with terok's bridged config."""
     return Sandbox(make_sandbox_config())
+
+
+def _project_runtime_flags(project: ProjectConfig) -> list[str]:
+    """Return extra ``podman run`` flags derived from project-level capabilities.
+
+    ``run.nested_containers`` → ``--security-opt label=nested`` plus
+    ``--device /dev/fuse``.  ``label=nested`` confines the outer container
+    to the SELinux type that permits nested container operations
+    (devpts mount, rootless overlay setup) without disabling labelling;
+    ``/dev/fuse`` is required by rootless podman's fuse-overlayfs driver.
+    Available on podman v4.5.0+ (April 2023); older podmans error with
+    "unknown label option: nested" and the user is expected to upgrade.
+    """
+    flags: list[str] = []
+    if project.nested_containers:
+        flags += ["--security-opt", "label=nested", "--device", "/dev/fuse"]
+    return flags
 
 
 def task_run_cli(

--- a/tests/unit/lib/test_task_runner_internals.py
+++ b/tests/unit/lib/test_task_runner_internals.py
@@ -350,6 +350,7 @@ class TestRunContainer:
         p.is_sealed = False
         p.memory_limit = None
         p.cpu_limit = None
+        p.nested_containers = False
         return p
 
     def test_builds_runspec_and_delegates(self) -> None:
@@ -601,6 +602,53 @@ class TestRunContainer:
 
         spec = sandbox_factory.return_value.run.call_args[0][0]
         assert spec.sealed is False
+
+    def test_nested_containers_adds_selinux_and_fuse_flags(self) -> None:
+        """run.nested_containers=true appends label=nested + /dev/fuse."""
+        project = self._make_project()
+        project.nested_containers = True
+        with (
+            patch("terok.lib.orchestration.task_runners._sandbox") as sandbox_factory,
+            patch("terok.lib.orchestration.task_runners.has_gpu", return_value=False),
+        ):
+            _run_container(
+                cname="nested-ctr",
+                image="alpine:latest",
+                env={},
+                volumes=[],
+                project=project,
+                task_dir=MOCK_TASK_DIR,
+                extra_args=["-p", "127.0.0.1:8080:8080"],
+            )
+
+        spec = sandbox_factory.return_value.run.call_args[0][0]
+        # Caller-supplied flags come first, project-derived flags append.
+        assert "--security-opt" in spec.extra_args
+        assert "label=nested" in spec.extra_args
+        assert "--device" in spec.extra_args
+        assert "/dev/fuse" in spec.extra_args
+        assert "-p" in spec.extra_args
+        assert "127.0.0.1:8080:8080" in spec.extra_args
+
+    def test_nested_containers_default_adds_nothing(self) -> None:
+        """run.nested_containers=false (default) leaves extra_args untouched."""
+        project = self._make_project()  # nested_containers defaults False
+        with (
+            patch("terok.lib.orchestration.task_runners._sandbox") as sandbox_factory,
+            patch("terok.lib.orchestration.task_runners.has_gpu", return_value=False),
+        ):
+            _run_container(
+                cname="plain-ctr",
+                image="alpine:latest",
+                env={},
+                volumes=[],
+                project=project,
+                task_dir=MOCK_TASK_DIR,
+            )
+
+        spec = sandbox_factory.return_value.run.call_args[0][0]
+        assert "label=nested" not in spec.extra_args
+        assert "/dev/fuse" not in spec.extra_args
 
 
 # ── _apply_unrestricted_env ───────────────────────────────


### PR DESCRIPTION
## Summary

Projects that run podman or docker inside their terok container can now declare it once in \`project.yml\`:

\`\`\`yaml
run:
  nested_containers: true
\`\`\`

When set, the outer \`podman run\` gets two extra flags:

- \`--security-opt label=nested\` — the SELinux type that confines the outer container but permits nested container operations (devpts mount, rootless overlay setup).  **This is not \`label=disable\`** — SELinux stays enforced end-to-end; only the type adjusts to the one designed for this scenario.
- \`--device /dev/fuse\` — rootless podman's \`fuse-overlayfs\` storage driver needs it.

Without this knob, nested podman inside a terok container fails with SELinux AVC denials on Fedora / RHEL hosts (\`crun: mount devpts to dev/pts: Permission denied\`).

## Why a boolean, not a raw flag list

- **Domain vocabulary**: \`nested_containers\` declares what the project *does*.  A raw \`podman_args: [...]\` escape hatch leaks implementation detail and ages badly as the flag set evolves.
- **Minimal surface**: one field, one translation.  If a future podman version tightens or loosens the required set, the translation changes — callers don't.
- **Default false** preserves today's behaviour for every project.

## Why no version probe

\`label=nested\` was introduced in podman **v4.5.0 (April 2023)**.  Every currently-supported distro's podman has it (RHEL 9.x: 4.9+, Fedora 38+: 4.5+, Ubuntu 24.04: 4.9, Debian 12 backports: 4.x).  Pre-4.5 podmans emit a clear \"unknown label option: nested\" error and the fix is \"upgrade podman\".

## Mechanics

- \`RawRunSection\` gains \`nested_containers: bool\` (\`Field(default=False, description=...)\`, so the config reference regenerates automatically).
- \`ProjectConfig\` plumbs it through \`_build_project_config\`.
- \`task_runners._project_runtime_flags()\` translates the boolean.  \`_run_container\` merges them after any caller-supplied \`extra_args\` so port mappings / toad args stay first.

## Test plan

- [x] \`make lint\`, \`tach\`, \`lint-imports\`, \`docstrings\`, \`reuse\` — all clean
- [x] \`make test\` — 1755 passed (1 pre-existing sandbox flake unrelated), including two new \`TestRunContainer\` cases:
  - \`test_nested_containers_adds_selinux_and_fuse_flags\`: flags appear alongside caller-supplied \`-p\` args
  - \`test_nested_containers_default_adds_nothing\`: default False leaves \`extra_args\` untouched
- [ ] Manual: \`terok build\` a podman-preset project with \`nested_containers: true\`, confirm \`podman run alpine echo hello\` succeeds inside (downstream test — needs Fedora/RHEL host with SELinux enforcing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for running containers inside project containers via a new run.nested_containers config flag; when enabled, the runtime preserves SELinux boundaries and exposes FUSE to the inner container.

* **Documentation**
  * Added usage docs detailing configuration, host/base-image requirements, examples, and verification steps.

* **Tests**
  * Added unit tests covering nested-containers behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->