### PR TITLE
feat: project-derive copies all source SSH keys, not just the first

### DIFF
--- a/src/terok/lib/domain/facade.py
+++ b/src/terok/lib/domain/facade.py
@@ -107,12 +107,12 @@ def derive_project(source_id: str, new_id: str) -> Project:
 
 
 def _share_ssh_key_registration(source_id: str, new_id: str) -> None:
-    """Register the source's SSH key under *new_id* in ``ssh-keys.json``.
+    """Register all of the source's SSH keys under *new_id* in ``ssh-keys.json``.
 
-    Silent no-op when the source has no registered key yet — ``project-init``
-    on the derived project will populate both scopes once the key exists on
-    disk.  For sources with multiple keys the first is shared; that is enough
-    for the common single-remote sibling use case.
+    Silent no-op when the source has no registered keys yet — ``project-init``
+    on the derived project will populate both scopes once the keys exist on
+    disk.  Every usable key (GitHub + GitLab + …) is shared so the sibling
+    can reach the same remotes as the source.
     """
     from ..core.config import make_sandbox_config
 
@@ -123,18 +123,9 @@ def _share_ssh_key_registration(source_id: str, new_id: str) -> None:
 
     raw = mapping.get(source_id)
     source_entries = raw if isinstance(raw, list) else [raw]
-    shareable_key = next(
-        (
-            k
-            for k in source_entries
-            if isinstance(k, dict) and {"private_key", "public_key"} <= k.keys()
-        ),
-        None,
-    )
-    if shareable_key is None:
-        return
-
-    register_ssh_key(new_id, shareable_key)
+    for key_entry in source_entries:
+        if isinstance(key_entry, dict) and {"private_key", "public_key"} <= key_entry.keys():
+            register_ssh_key(new_id, key_entry)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/lib/test_projects.py
+++ b/tests/unit/lib/test_projects.py
@@ -376,8 +376,26 @@ class TestShareSshKeyRegistration:
 
         assert "beta" not in json.loads(keys_path.read_text())
 
-    def test_list_entry_copies_first_key(self, tmp_path: Path) -> None:
-        """When source has multiple keys, the first is shared with the new scope."""
+    def test_list_entry_copies_all_keys(self, tmp_path: Path) -> None:
+        """All of source's keys (GitHub + GitLab, etc.) are shared with the new scope."""
+        import json
+
+        from terok.lib.domain.facade import _share_ssh_key_registration
+
+        keys_path = tmp_path / "ssh-keys.json"
+        source_keys = [
+            {"private_key": "/k/a1", "public_key": "/k/a1.pub"},
+            {"private_key": "/k/a2", "public_key": "/k/a2.pub"},
+        ]
+        keys_path.write_text(json.dumps({"alpha": source_keys}))
+        with self._patch_sandbox_config(keys_path):
+            _share_ssh_key_registration("alpha", "beta")
+
+        mapping = json.loads(keys_path.read_text())
+        assert mapping["beta"] == source_keys
+
+    def test_list_entry_skips_malformed_keys(self, tmp_path: Path) -> None:
+        """Entries missing ``private_key``/``public_key`` are skipped; valid ones still share."""
         import json
 
         from terok.lib.domain.facade import _share_ssh_key_registration
@@ -388,7 +406,9 @@ class TestShareSshKeyRegistration:
                 {
                     "alpha": [
                         {"private_key": "/k/a1", "public_key": "/k/a1.pub"},
-                        {"private_key": "/k/a2", "public_key": "/k/a2.pub"},
+                        {"private_key": "/k/a2"},  # missing public_key
+                        "not-a-dict",
+                        {"private_key": "/k/a3", "public_key": "/k/a3.pub"},
                     ]
                 }
             )
@@ -397,4 +417,7 @@ class TestShareSshKeyRegistration:
             _share_ssh_key_registration("alpha", "beta")
 
         mapping = json.loads(keys_path.read_text())
-        assert mapping["beta"] == [{"private_key": "/k/a1", "public_key": "/k/a1.pub"}]
+        assert mapping["beta"] == [
+            {"private_key": "/k/a1", "public_key": "/k/a1.pub"},
+            {"private_key": "/k/a3", "public_key": "/k/a3.pub"},
+        ]


### PR DESCRIPTION
## Summary

Follow-up to #728 — when a project has multiple SSH keys registered (e.g. GitHub + GitLab, or multiple deploy keys for sub-repos), `project-derive` now shares **all** of them with the sibling, not just the first usable entry.

**Stacks on #728** — the first commit here is #728's change, which must land first. Review the second commit.

## What changes

- `_share_ssh_key_registration` iterates over every well-formed entry in the source's `ssh-keys.json` list and registers each one under the new scope, instead of `next(...)`-picking one.
- Malformed entries (wrong shape, missing `private_key`/`public_key`) are skipped; the rest are still shared.

## Test plan

- [x] `make lint`, `make tach`, `make lint-imports`, `make docstrings`, `make reuse`, `make security` — all green.
- [x] Renamed `test_list_entry_copies_first_key` → `test_list_entry_copies_all_keys` and added `test_list_entry_skips_malformed_keys`.
- [x] Full suite: 1799 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved SSH key registration during project derivation to include all available SSH keys instead of only the first one. This enhancement enables better support for configurations with multiple Git hosting platforms.

* **Tests**
  * Expanded test coverage to verify proper handling of multiple SSH keys and graceful skipping of malformed key entries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->