### PR TITLE
feat: project-derive copies source instructions.md

### DIFF
--- a/src/terok/lib/core/projects.py
+++ b/src/terok/lib/core/projects.py
@@ -5,6 +5,7 @@
 
 import logging
 import re
+import shutil
 import subprocess
 import sys
 from pathlib import Path
@@ -44,6 +45,7 @@ from .yaml_schema import RawGlobalGitSection, RawProjectYaml
 logger = logging.getLogger(__name__)
 
 _PROJECT_YML = "project.yml"
+_INSTRUCTIONS_MD = "instructions.md"
 
 
 def _get_global_git_config(key: str) -> str | None:
@@ -289,7 +291,9 @@ def derive_project(source_id: str, new_id: str) -> Path:
     keypair as the source — only ``project.id`` and the ``agent:`` section
     differ.  This is the "sibling project" use case: rerun the same repo
     through a different image or agent without re-provisioning keys or
-    re-cloning the mirror.
+    re-cloning the mirror.  The source's ``instructions.md``, if present, is
+    copied over so the derived project starts with the same user-provided
+    guidance.
 
     Returns the new project's root directory.
 
@@ -318,6 +322,10 @@ def derive_project(source_id: str, new_id: str) -> Path:
         _yaml_dump(source_cfg),
         encoding="utf-8",
     )
+
+    instructions_src = source.root / _INSTRUCTIONS_MD
+    if instructions_src.is_file():
+        shutil.copy2(instructions_src, target_root / _INSTRUCTIONS_MD)
 
     return target_root
 

--- a/tests/integration/projects/test_projects.py
+++ b/tests/integration/projects/test_projects.py
@@ -105,6 +105,27 @@ class TestProjects:
         assert "- alpha [online]" in listed.stdout
         assert "- beta [online]" in listed.stdout
 
+    def test_project_derive_copies_instructions_md(self, terok_env: TerokIntegrationEnv) -> None:
+        """``project-derive`` copies source ``instructions.md`` into the new project.
+
+        Absent on the source, the file must remain absent on the target — the
+        copy is best-effort, not a required invariant of every derivation.
+        """
+        source_root = terok_env.write_project("alpha", SOURCE_PROJECT)
+        instructions = "# Alpha house rules\n\nAlways run `make lint` first.\n"
+        (source_root / "instructions.md").write_text(instructions, encoding="utf-8")
+
+        terok_env.run_cli("project-derive", "alpha", "beta")
+
+        derived_instructions = terok_env.project_root("beta") / "instructions.md"
+        assert derived_instructions.is_file()
+        assert derived_instructions.read_text(encoding="utf-8") == instructions
+
+        # Sibling without source instructions.md stays clean.
+        terok_env.write_project("gamma", SOURCE_PROJECT.replace("id: alpha", "id: gamma"))
+        terok_env.run_cli("project-derive", "gamma", "delta")
+        assert not (terok_env.project_root("delta") / "instructions.md").exists()
+
     def test_project_derive_preserves_yaml_comments(self, terok_env: TerokIntegrationEnv) -> None:
         """``project-derive`` preserves user comments via ruamel.yaml round-trip.
 


### PR DESCRIPTION
## Summary

- `terok project-derive` now copies the source project's `instructions.md` into the new project root, so sibling projects start with the same user-authored guidance the source had carefully tuned.
- Silent no-op when the source has no `instructions.md` — matches the best-effort style of the existing SSH-share logic (#731) and gate-share logic (#728).

## Motivation

Derive already propagates gate, SSH keys, and YAML config. The per-project instructions file — mounted into the container alongside agent config — was the last piece still missing; derived projects would start with an empty instruction set even when the source had carefully tuned house rules, which defeats the "sibling project" use case.

## Test plan

- [x] `poetry run pytest tests/integration/projects/test_projects.py` — 4/4 passing, including new `test_project_derive_copies_instructions_md` covering both the present-source and absent-source paths.
- [x] `make lint`, `make tach`, `make reuse`, `make security` — all green.
- [x] `poetry run pytest tests/unit/lib/test_projects.py` — 23/23 still passing (no regressions in the existing share-SSH-keys tests).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * `instructions.md` files are now automatically copied from source projects to derived projects, ensuring project-specific guidance and documentation persist across project derivations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->