### PR TITLE
feat: default services.mode to socket (0.7.3)

### DIFF
--- a/docs/selinux.md
+++ b/docs/selinux.md
@@ -1,0 +1,94 @@
+# SELinux & the socket transport
+
+Since 0.7.3, terok defaults to **`services.mode: socket`** — Unix-socket
+IPC between host services (gate, vault, SSH-agent) and task containers.
+No TCP ports are claimed for terok's own services.
+
+This page explains what that means on your distro, and how to opt out.
+
+## What changes per distro
+
+### Non-SELinux distros (Ubuntu, Debian, Arch, Alpine, …)
+
+Nothing extra.  `terok setup` installs socket-mode units, services bind
+Unix sockets, containers mount the sockets with `:z`, and everything
+works.  You will never see a SELinux block in the setup output and you
+never need `sudo`.
+
+### SELinux distros in permissive mode
+
+Same as above.  Sockets bind normally, the default container-SELinux
+policy covers the flow, `terok setup` skips the SELinux block.
+
+### SELinux distros in enforcing mode (Fedora, RHEL, …)
+
+By default SELinux blocks `container_t → unconfined_t` `connectto` on
+Unix sockets (see [Dan Walsh][1] / [Podman #23972][2]).  To let rootless
+Podman containers reach terok's host-side sockets, we ship a narrowly
+targeted policy module (`terok_socket_t`) that carves out this single
+exception.  Installing it is a one-time `sudo` operation per host.
+
+`terok setup` on an enforcing host will print:
+
+```text
+SELinux:
+  terok_socket_t   WARN (policy NOT installed)
+                   Containers cannot connect to service sockets.
+                   Fix (pick one):
+                     install policy: sudo bash /path/to/install_policy.sh
+                     or opt out:     add `services: {mode: tcp}` to ~/.config/terok/config.yml
+```
+
+The installer script is short, auditable, and sits next to the `.te`
+policy source in the terok-sandbox package.  `cat` it before running.
+It compiles `terok_socket.te` with `checkmodule` / `semodule_package`
+and loads it with `semodule -i`.
+
+After running it, `terok setup` shows `ok (policy installed)` and task
+containers can connect to the gate / vault / SSH-agent sockets.
+
+#### Removing the policy
+
+```bash
+sudo semodule -r terok_socket
+```
+
+## Opting out: the TCP transport
+
+If you can't or don't want to install the policy — shared host where
+you don't have root, locked-down distro image, container build where
+`sudo` isn't practical — set:
+
+```yaml
+# ~/.config/terok/config.yml
+services:
+  mode: tcp
+```
+
+This falls back to the previous TCP-loopback transport.  terok claims
+three auto-allocated TCP ports per user (gate, vault, ssh-agent) and
+containers reach them via `host.containers.internal` / slirp4netns.
+Works on any distro, SELinux or not, zero extra setup.
+
+The TCP transport is **not** deprecated — it's a supported opt-out.
+Some caveats:
+
+- Three ports per user are visible on the host via `ss -tlnp`
+  (127.0.0.1 only).  They don't leak off-loopback, but on multi-user
+  hosts another user could see that *something* is listening.
+- Port-allocation edge cases (collisions with other services that
+  bind in the 18700-32700 range) surface as terok setup failures with
+  clear messages.
+
+## Background
+
+The socket story is an intermediate step toward a longer-term **bridge
+mode** where task containers and terok service containers sit on a
+shared rootless Podman bridge — container↔container connections don't
+cross the SELinux host boundary, automatic MCS categories provide
+per-task isolation, and no custom policy module is needed at all.
+Bridge mode is tracked separately and depends on
+[terok-shield](https://github.com/terok-ai/terok-shield) support.
+
+[1]: https://danwalsh.livejournal.com/78643.html
+[2]: https://github.com/containers/podman/discussions/23972

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -101,6 +101,7 @@ nav:
     - Security Modes: git-gate-and-security-modes.md
     - Shield Security: shield-security.md
     - Kernel Keyring: kernel-keyring.md
+    - SELinux & Socket Transport: selinux.md
     - Login Design: login-design.md
 
   - Developer Guide:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "poetry_dynamic_versioning.backend"
 
 [tool.poetry]
 name = "terok"
-version = "0.7.2"
+version = "0.7.3"
 description = "Manage containerized projects and per-run tasks with Podman"
 readme = "README.md"
 license = "Apache-2.0"

--- a/src/terok/cli/commands/setup.py
+++ b/src/terok/cli/commands/setup.py
@@ -18,8 +18,10 @@ import sys
 
 from terok_executor import AUTH_PROVIDERS
 
+from ...lib.core.config import global_config_path
 from ...lib.core.images import require_agent_installed
 from ...lib.core.projects import load_project
+from ...lib.core.yaml_schema import SERVICES_TCP_OPTOUT_YAML
 from ...lib.domain.facade import (
     authenticate,
     build_images,
@@ -433,17 +435,23 @@ def _check_selinux_policy(*, color: bool) -> bool:
     match result.status:
         case SelinuxStatus.POLICY_MISSING:
             print(f"  terok_socket_t   {_warn_label(color)} (policy NOT installed)")
+            print("                   Containers cannot connect to service sockets.")
+            print("                   Fix (pick one):")
             if result.missing_policy_tools:
                 tools = ", ".join(result.missing_policy_tools)
                 print(f"                   Policy tools missing: {tools}")
                 print(
-                    f"                   Fix: "
+                    f"                     install policy: "
                     f"{bold('sudo dnf install selinux-policy-devel policycoreutils', color)}, "
                     f"then {bold(install_cmd, color)}"
                 )
             else:
-                print("                   Containers cannot connect to service sockets.")
-                print(f"                   Fix: {bold(install_cmd, color)}")
+                print(f"                     install policy: {bold(install_cmd, color)}")
+            print(
+                f"                     or opt out:     add "
+                f"{bold(SERVICES_TCP_OPTOUT_YAML, color)}"
+                f" to {global_config_path()}"
+            )
             print()
             return False
         case SelinuxStatus.LIBSELINUX_MISSING:

--- a/src/terok/cli/commands/sickbay.py
+++ b/src/terok/cli/commands/sickbay.py
@@ -36,9 +36,10 @@ from terok_sandbox import (
     is_vault_systemd_available,
 )
 
-from ...lib.core.config import get_services_mode, make_sandbox_config
+from ...lib.core.config import get_services_mode, global_config_path, make_sandbox_config
 from ...lib.core.project_model import ProjectConfig
 from ...lib.core.projects import list_projects, load_project
+from ...lib.core.yaml_schema import SERVICES_TCP_OPTOUT_YAML
 from ...lib.orchestration.container_doctor import run_container_doctor
 from ...lib.orchestration.hooks import run_hook
 from ...lib.orchestration.tasks import container_name, tasks_meta_dir
@@ -421,20 +422,21 @@ def _check_selinux_policy() -> _CheckResult:
             return ("ok", label, "not needed (SELinux not enforcing)")
         case SelinuxStatus.POLICY_MISSING:
             install_cmd = selinux_install_command()
+            opt_out = f"or opt out: {SERVICES_TCP_OPTOUT_YAML} in {global_config_path()}"
             if result.missing_policy_tools:
                 tools = ", ".join(result.missing_policy_tools)
                 return (
                     "warn",
                     label,
                     f"terok_socket_t NOT installed; policy tools missing ({tools}). "
-                    "Fix: sudo dnf install selinux-policy-devel policycoreutils, "
-                    f"then {install_cmd}",
+                    "Fix (pick one): sudo dnf install selinux-policy-devel policycoreutils, "
+                    f"then {install_cmd}; {opt_out}",
                 )
             return (
                 "warn",
                 label,
                 "terok_socket_t NOT installed — containers cannot connect to sockets. "
-                f"Fix: {install_cmd}",
+                f"Fix (pick one): {install_cmd}; {opt_out}",
             )
         case SelinuxStatus.LIBSELINUX_MISSING:
             return (

--- a/src/terok/lib/core/yaml_schema.py
+++ b/src/terok/lib/core/yaml_schema.py
@@ -488,12 +488,19 @@ class RawShieldGlobalSection(BaseModel):
     on_task_restart: Literal["retain", "up"] = "retain"
 
 
+SERVICES_TCP_OPTOUT_YAML = "services: {mode: tcp}"
+"""User-facing opt-out snippet shown in SELinux hints — keep in one place
+so setup, sickbay, tests and docs stay in sync."""
+
+
 class RawServicesSection(BaseModel):
     """Global ``services:`` section — transport mode for host ↔ container IPC."""
 
     model_config = ConfigDict(extra="forbid")
 
-    mode: Literal["tcp", "socket"] = "tcp"
+    mode: Literal["tcp", "socket"] = "socket"
+    """Transport for host↔container IPC.  Default ``socket`` since 0.7.3;
+    set to ``tcp`` to opt out.  See ``docs/selinux.md``."""
 
 
 class RawVaultSection(BaseModel):

--- a/tests/unit/cli/test_cli_setup_global.py
+++ b/tests/unit/cli/test_cli_setup_global.py
@@ -503,16 +503,18 @@ class TestSelinuxPrereqPrint:
         assert ok is True
 
     def test_warns_when_policy_missing(self, capsys: pytest.CaptureFixture) -> None:
-        """Policy-missing prints the sudo-bash fix hint and returns False."""
+        """Policy-missing prints two-option fix hint (install or opt out) and returns False."""
 
         ok, out = _run_selinux_check(capsys, SelinuxCheckResult(SelinuxStatus.POLICY_MISSING))
         assert "SELinux:" in out
         assert "policy NOT installed" in out
+        # Both remedies surfaced — install the policy *or* opt out to tcp.
         assert "install_policy.sh" in out
+        assert "services: {mode: tcp}" in out
         assert ok is False
 
     def test_warns_with_missing_tools_hint(self, capsys: pytest.CaptureFixture) -> None:
-        """Missing tools → include the dnf install prerequisite, return False."""
+        """Missing tools → dnf prerequisite plus both remedies, return False."""
 
         ok, out = _run_selinux_check(
             capsys,
@@ -521,6 +523,7 @@ class TestSelinuxPrereqPrint:
         assert "Policy tools missing: checkmodule" in out
         assert "selinux-policy-devel" in out
         assert "install_policy.sh" in out
+        assert "services: {mode: tcp}" in out
         assert ok is False
 
     def test_warns_when_libselinux_unloadable(self, capsys: pytest.CaptureFixture) -> None:

--- a/tests/unit/cli/test_cli_sickbay.py
+++ b/tests/unit/cli/test_cli_sickbay.py
@@ -11,6 +11,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 from terok_sandbox import GateServerStatus
 
+from terok.cli.commands import sickbay as _sickbay_module
 from terok.cli.commands.sickbay import (
     _check_keyring,
     _check_shield,
@@ -112,7 +113,19 @@ def test_cmd_sickbay_reports_health(
     mock_ec = MagicMock(health="ok", hooks="per-container", dns_tier="dnsmasq")
     mock_cfg = MagicMock()
     mock_cfg.return_value.ssh_keys_json_path = ssh_keys
+
+    # _check_vault_migration hits the real filesystem via namespace_state_dir;
+    # swap just that entry in _GLOBAL_CHECKS for a stub so the test stays
+    # hermetic without masking unrelated lookups.
+    def _stub_vault_migration() -> tuple[str, str, str]:
+        return ("ok", "Vault migration", "no legacy directory")
+
+    patched_checks = [
+        _stub_vault_migration if fn.__name__ == "_check_vault_migration" else fn
+        for fn in _sickbay_module._GLOBAL_CHECKS
+    ]
     with (
+        patch("terok.cli.commands.sickbay._GLOBAL_CHECKS", patched_checks),
         patch("terok.cli.commands.sickbay.get_server_status", return_value=status),
         patch("terok.cli.commands.sickbay.check_units_outdated", return_value=outdated),
         patch("terok.cli.commands.sickbay.is_systemd_available", return_value=systemd_available),
@@ -297,6 +310,14 @@ def test_check_vault_states(
         patch(
             "terok.cli.commands.sickbay.is_vault_socket_active",
             return_value=False,
+        ),
+        # Pin services.mode to match the fixture's default ``transport=tcp``
+        # so the running-branch mismatch check doesn't fire.  These
+        # parametrised cases are about reachability / systemd state, not
+        # transport-config consistency.
+        patch(
+            "terok.cli.commands.sickbay.get_services_mode",
+            return_value="tcp",
         ),
     ):
         status, label, detail = _check_vault()

--- a/tests/unit/cli/test_sickbay.py
+++ b/tests/unit/cli/test_sickbay.py
@@ -500,16 +500,18 @@ class TestCheckSelinuxPolicy:
         assert "not enforcing" in detail
 
     def test_warn_when_policy_missing(self) -> None:
-        """Policy-missing renders as warn with install hint."""
+        """Policy-missing renders both remedies (install-or-opt-out)."""
 
         sev, _, detail = self._run(SelinuxCheckResult(SelinuxStatus.POLICY_MISSING))
         assert sev == "warn"
         assert "terok_socket_t NOT installed" in detail
         assert "sudo bash" in detail
         assert "install_policy.sh" in detail
+        # Opt-out must be surfaced — the user may not have root.
+        assert "services: {mode: tcp}" in detail
 
     def test_warn_also_names_missing_tools(self) -> None:
-        """Policy-missing + missing tools renders the dnf-install prerequisite."""
+        """Policy-missing + missing tools renders the dnf prerequisite plus both remedies."""
 
         sev, _, detail = self._run(
             SelinuxCheckResult(
@@ -521,6 +523,7 @@ class TestCheckSelinuxPolicy:
         assert "policy tools missing" in detail
         assert "checkmodule" in detail
         assert "selinux-policy-devel" in detail
+        assert "services: {mode: tcp}" in detail
 
     def test_warn_when_libselinux_unloadable(self) -> None:
         """Libselinux-missing renders as warn naming the silent-fail vector."""

--- a/tests/unit/lib/test_tasks.py
+++ b/tests/unit/lib/test_tasks.py
@@ -39,12 +39,18 @@ from tests.test_utils import (
     write_project,
 )
 from tests.testfs import CONTAINER_SSH_DIR
-from tests.testnet import CONTAINER_HOSTNAME, GATE_PORT
+from tests.testnet import GATE_PORT
 
 
 def _gate_repo_fragment(project_id: str, *, port: int = GATE_PORT) -> str:
-    """Return the host-side gate URL fragment embedded in task env vars."""
-    return f"@{CONTAINER_HOSTNAME}:{port}/{project_id}.git"
+    """Return the gate URL fragment embedded in task env vars.
+
+    Intentionally mode-agnostic: socket transport builds URLs with
+    ``localhost:9418`` (container-local socat bridge), tcp transport
+    with ``host.containers.internal:<port>``.  We only assert on the
+    repo path so these tests pass regardless of ``services.mode``.
+    """
+    return f":{port}/{project_id}.git"
 
 
 class TestTask:

--- a/tests/unit/lib/test_yaml_schema.py
+++ b/tests/unit/lib/test_yaml_schema.py
@@ -235,6 +235,16 @@ class RawGlobalConfigTests(unittest.TestCase):
         self.assertIsNone(cfg.default_agent)
         self.assertFalse(cfg.experimental)
 
+    def test_services_mode_default_is_socket(self) -> None:
+        """Default transport is ``socket`` (since 0.7.3)."""
+        cfg = RawGlobalConfig.model_validate({})
+        self.assertEqual(cfg.services.mode, "socket")
+
+    def test_services_mode_tcp_opt_out(self) -> None:
+        """``services: {mode: tcp}`` is a supported opt-out."""
+        cfg = RawGlobalConfig.model_validate({"services": {"mode": "tcp"}})
+        self.assertEqual(cfg.services.mode, "tcp")
+
     def test_experimental_flag(self) -> None:
         """``experimental: true`` is accepted as a top-level bool."""
         cfg = RawGlobalConfig.model_validate({"experimental": True})


### PR DESCRIPTION
## Summary

- Flip the default transport from `tcp` → `socket`.  No more claiming
  three ports per user by default.  Non-SELinux and permissive-SELinux
  hosts see zero extra work; enforcing SELinux hosts get a one-time
  `sudo bash install_policy.sh` prompt with a clear opt-out path to
  `services: {mode: tcp}`.
- SELinux-missing hint in `terok setup` and `terok sickbay` now surfaces
  both remedies side-by-side — users without root still have a working
  option.  Both hints interpolate `global_config_path()` so the message
  tracks `TEROK_CONFIG_FILE` / `XDG_CONFIG_HOME` overrides.
- New `docs/selinux.md` documents the three distro scenarios and the
  transitional nature of the current policy (bridge mode is the
  longer-term goal).
- Centralises the opt-out YAML snippet as `SERVICES_TCP_OPTOUT_YAML` so
  setup, sickbay, docs and tests all reference the same string.

## Why 0.7.3

0.7.1 shipped the socket transport as an opt-in; 0.7.2 was the vault
rename (unrelated).  0.7.3 is the pure default flip, which makes it
trivial to bisect or roll back if a distro surprises us. 

## Test plan

- [x] `make lint tach docstrings reuse security` clean
- [x] `pytest` — all 220 tests in changed files pass; full suite clean
      apart from pre-existing failures on master (vault rename
      leftovers + host port conflict, unrelated to this PR)
- [ ] Fedora enforcing: `terok setup` shows two-option hint, installing
      policy unblocks the flow, opt-out path exits cleanly
- [ ] Ubuntu: `terok setup` completes with no SELinux section, task
      containers reach gate/vault/SSH-agent via sockets

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a "SELinux & Socket Transport" guide explaining behavior, troubleshooting, a narrow SELinux policy installer, verification/removal, and a TCP opt-out; added to the User Guide.

* **New Features**
  * Socket transport is now the default for services.
  * CLI remediation now presents two clear options: install the SELinux policy or opt out to TCP (add the provided services: {mode: tcp} snippet).

* **Tests**
  * Updated unit tests to reflect the new default, CLI hints, and more deterministic stubs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->