### PR TITLE
fix: point TUI entry points at terok-tui after CLI rename

### DIFF
--- a/docs/login-design.md
+++ b/docs/login-design.md
@@ -95,7 +95,7 @@ The user gets a real terminal in the new tab while the TUI remains in the origin
 
 ### `--tmux` opt-in wrapper (R3, R5)
 
-`terok --tmux` wraps the TUI in a managed tmux session with the host config
+`terok-tui --tmux` wraps the TUI in a managed tmux session with the host config
 (blue status bar, usage hints). Login sessions become additional tmux windows.
 This is opt-in — without the flag, the TUI runs directly in the terminal as before.
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -160,7 +160,7 @@ install.  The steps below show the equivalent CLI workflow.
 
 - Podman installed and working
 - OpenSSH client tools (ssh, ssh-keygen) for private Git over SSH
-- tmux (optional, for `terok --tmux` and persistent container sessions)
+- tmux (optional, for `terok-tui --tmux` and persistent container sessions)
 
 ### Step 1: Create Project Directory
 
@@ -341,7 +341,7 @@ method automatically:
 #### Running the TUI under tmux (recommended)
 
 ```bash
-terok --tmux
+terok-tui --tmux
 ```
 
 This wraps the TUI in a managed tmux session with a blue status bar showing

--- a/src/terok/resources/tmux/host-tmux.conf
+++ b/src/terok/resources/tmux/host-tmux.conf
@@ -1,5 +1,5 @@
 # terok host tmux — prefix is ^b (default)
-# Launched by: terok --tmux
+# Launched by: terok-tui --tmux
 # Blue status bar distinguishes host from container tmux.
 
 set -g status on

--- a/src/terok/tui/app.py
+++ b/src/terok/tui/app.py
@@ -1238,7 +1238,7 @@ if _HAS_TEXTUAL:
             print(
                 "Error: tmux is not installed.\n"
                 "Install it (e.g. 'apt install tmux' or 'brew install tmux') "
-                "and try again,\nor run 'terok' without --tmux.",
+                "and try again,\nor run 'terok-tui' without --tmux.",
                 file=sys.stderr,
             )
             sys.exit(1)
@@ -1260,7 +1260,7 @@ if _HAS_TEXTUAL:
                     "new-session",
                     "-s",
                     "terok",
-                    "terok",
+                    "terok-tui",
                 ],
             )
 

--- a/src/terok/tui/serve.py
+++ b/src/terok/tui/serve.py
@@ -66,7 +66,7 @@ def main() -> None:
     )
     args = parser.parse_args()
 
-    server = Server("terok", host=args.host, port=args.port, public_url=args.public_url)
+    server = Server("terok-tui", host=args.host, port=args.port, public_url=args.public_url)
     server.serve()
 
 

--- a/tests/unit/tui/test_serve.py
+++ b/tests/unit/tui/test_serve.py
@@ -66,7 +66,7 @@ class TestMain:
         main()
 
         mock_server_cls.assert_called_once_with(
-            "terok", host="localhost", port=8566, public_url=None
+            "terok-tui", host="localhost", port=8566, public_url=None
         )
         mock_server_instance.serve.assert_called_once()
 
@@ -84,5 +84,7 @@ class TestMain:
 
         main()
 
-        mock_server_cls.assert_called_once_with("terok", host="0.0.0.0", port=9000, public_url=None)
+        mock_server_cls.assert_called_once_with(
+            "terok-tui", host="0.0.0.0", port=9000, public_url=None
+        )
         mock_server_instance.serve.assert_called_once()


### PR DESCRIPTION
## Summary

- `terok-tui --tmux` was killing its own tmux session instantly: the wrapper ran `terok` as the session command, but `terok` is now the CLI and exits immediately on a missing subcommand, so tmux tore the session down before the error was readable.
- Same bug in `terok-web` (textual-serve): `Server("terok", ...)` spawned the CLI for every connection and died on the required subcommand.
- Fix both call sites to spawn `terok-tui`. Update stale user-facing strings (error message, tmux config banner, docs) to match.

## Test plan

- [x] `make lint` — clean
- [x] `pytest tests/unit/tui/test_serve.py` — 14/14 pass (assertions updated to `terok-tui`)
- [ ] Manual: `terok-tui --tmux` from a plain terminal launches the managed tmux session
- [ ] Manual: `terok-web` serves the TUI over HTTP

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated tmux integration documentation and guidance to use the correct `terok-tui --tmux` command for interactive terminal usage
  * Updated error messages to reference the proper command name when tmux prerequisites are unavailable

<!-- end of auto-generated comment: release notes by coderabbit.ai -->