### PR TITLE
feat: add terokctl scriptable surface, launch TUI on bare terok

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -95,6 +95,7 @@ asyncio_mode = "auto"
 
 [tool.poetry.scripts]
 terok = "terok.cli.main:main"
+terokctl = "terok.cli.main:terokctl_main"
 terok-tui = "terok.tui.app:main"
 terok-web = "terok.tui.serve:main"
 terok-clearance = "terok.tui.clearance_screen:main"

--- a/src/terok/cli/commands/completions.py
+++ b/src/terok/cli/commands/completions.py
@@ -13,14 +13,28 @@ from argcomplete import shellcode
 
 _SHELLS = ("bash", "zsh", "fish")
 
+# Both binaries share the same command tree today, so we install completions
+# for each — users who wire up scripts via terokctl still want tab-completion.
+_PROGS = ("terok", "terokctl")
+
 _XDG_DATA_HOME = Path(os.environ.get("XDG_DATA_HOME") or (Path.home() / ".local" / "share"))
 _XDG_CONFIG_HOME = Path(os.environ.get("XDG_CONFIG_HOME") or (Path.home() / ".config"))
 
-_INSTALL_TARGETS: dict[str, Path] = {
-    "bash": _XDG_DATA_HOME / "bash-completion" / "completions" / "terok",
-    "zsh": _XDG_DATA_HOME / "zsh" / "site-functions" / "_terok",
-    "fish": _XDG_CONFIG_HOME / "fish" / "completions" / "terok.fish",
-}
+
+def _target_for(shell: str, prog: str) -> Path:
+    """Return the auto-load path for *prog* completions under *shell*."""
+    if shell == "bash":
+        return _XDG_DATA_HOME / "bash-completion" / "completions" / prog
+    if shell == "zsh":
+        return _XDG_DATA_HOME / "zsh" / "site-functions" / f"_{prog}"
+    if shell == "fish":
+        return _XDG_CONFIG_HOME / "fish" / "completions" / f"{prog}.fish"
+    raise ValueError(f"unsupported shell: {shell!r}")
+
+
+# Retained for documentation (``--help`` text): the ``terok`` install paths
+# are the ones most users will recognise; ``terokctl`` installs alongside.
+_INSTALL_TARGETS: dict[str, Path] = {shell: _target_for(shell, "terok") for shell in _SHELLS}
 
 _BASH_COMPLETION_DIRS = (
     _XDG_DATA_HOME / "bash-completion" / "completions",
@@ -41,6 +55,7 @@ _SHELL_RC_FILES = (
 _RC_MARKERS = (
     "terok completions",
     "register-python-argcomplete terok",
+    "register-python-argcomplete terokctl",
 )
 
 
@@ -60,16 +75,17 @@ def _detect_shell() -> str:
 
 
 def _install_completions(shell: str | None) -> None:
-    """Write the completion script to the auto-load directory for *shell*."""
+    """Write completion scripts for *shell* to each binary's auto-load path."""
     if shell is None:
         shell = _detect_shell()
-    target = _INSTALL_TARGETS[shell]
-    target.parent.mkdir(parents=True, exist_ok=True)
-    target.write_text(
-        shellcode(["terok"], shell=shell, use_defaults=True) + "\n",  # nosec B604
-        encoding="utf-8",
-    )
-    print(f"Installed {shell} completions to {target}")
+    for prog in _PROGS:
+        target = _target_for(shell, prog)
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(
+            shellcode([prog], shell=shell, use_defaults=True) + "\n",  # nosec B604
+            encoding="utf-8",
+        )
+        print(f"Installed {shell} completions for {prog} to {target}")
     print("Restart your shell or open a new terminal to activate.")
 
 
@@ -108,18 +124,20 @@ def dispatch(args: argparse.Namespace) -> bool:
     if args.action == "install":
         _install_completions(getattr(args, "shell", None))
     else:
-        print(shellcode(["terok"], shell=args.action, use_defaults=True))  # nosec B604
+        for prog in _PROGS:
+            print(shellcode([prog], shell=args.action, use_defaults=True))  # nosec B604
     return True
 
 
 def is_completion_installed() -> bool:
     """Check whether terok completions are set up (file or rc-file marker)."""
-    if any((d / "terok").is_file() for d in _BASH_COMPLETION_DIRS):
-        return True
-    if any((d / "_terok").is_file() for d in _ZSH_COMPLETION_DIRS):
-        return True
-    if any((d / "terok.fish").is_file() for d in _FISH_COMPLETION_DIRS):
-        return True
+    for prog in _PROGS:
+        if any((d / prog).is_file() for d in _BASH_COMPLETION_DIRS):
+            return True
+        if any((d / f"_{prog}").is_file() for d in _ZSH_COMPLETION_DIRS):
+            return True
+        if any((d / f"{prog}.fish").is_file() for d in _FISH_COMPLETION_DIRS):
+            return True
     for rc in _SHELL_RC_FILES:
         try:
             content = rc.read_text(encoding="utf-8")

--- a/src/terok/cli/main.py
+++ b/src/terok/cli/main.py
@@ -75,11 +75,17 @@ def main(prog: str = "terok") -> None:
     # Fast-path: bare ``terok`` in a terminal launches the TUI.  Scripts
     # piping ``terok`` get the argparse usage error instead — the TTY
     # check keeps the convenience shortcut from surprising automation.
+    # If ``terok-tui`` isn't on PATH (partial install, exotic layout), fall
+    # through to argparse so the user sees a usage error rather than a
+    # traceback from ``execlp``.
     if prog == "terok" and len(sys.argv) == 1 and sys.stdin.isatty() and sys.stdout.isatty():
         import os
 
-        os.execlp("terok-tui", "terok-tui")
-        return  # pragma: no cover — execlp never returns
+        try:
+            os.execlp("terok-tui", "terok-tui")
+            return  # pragma: no cover — execlp never returns on success
+        except FileNotFoundError:
+            pass
 
     # Get version info for --version flag
     version, branch = get_version_info()

--- a/src/terok/cli/main.py
+++ b/src/terok/cli/main.py
@@ -58,35 +58,56 @@ _DISPATCHERS = [
 ]
 
 
-def main() -> None:
-    """Parse CLI arguments and dispatch to the appropriate command handler."""
+def main(prog: str = "terok") -> None:
+    """Parse CLI arguments and dispatch to the appropriate command handler.
+
+    ``prog`` selects which surface this invocation presents:
+
+    * ``"terok"`` — human-friendly entry point.  Bare ``terok`` in an
+      interactive terminal execs ``terok-tui`` instead of printing the
+      usage error.
+    * ``"terokctl"`` — scriptable surface.  Always parses arguments, so
+      no-args produces the argparse ``required subcommand`` error (stable,
+      predictable exit code).  The command tree is identical today; the
+      split exists so ``terok`` can evolve richer UX while ``terokctl``
+      preserves backwards compatibility.
+    """
+    # Fast-path: bare ``terok`` in a terminal launches the TUI.  Scripts
+    # piping ``terok`` get the argparse usage error instead — the TTY
+    # check keeps the convenience shortcut from surprising automation.
+    if prog == "terok" and len(sys.argv) == 1 and sys.stdin.isatty() and sys.stdout.isatty():
+        import os
+
+        os.execlp("terok-tui", "terok-tui")
+        return  # pragma: no cover — execlp never returns
+
     # Get version info for --version flag
     version, branch = get_version_info()
     version_string = format_version_string(version, branch)
 
     parser = argparse.ArgumentParser(
-        prog="terok",
+        prog=prog,
         description="terok – generate/build images and run per-project task containers",
         formatter_class=argparse.RawDescriptionHelpFormatter,
         epilog=(
             "Quick start:\n"
-            "  1. Bootstrap:  terok setup                        (install host services)\n"
-            "  2. Project:    terok project-wizard                (create a project)\n"
-            "  3. Auth:       terok auth claude <project>         (authenticate agents)\n"
-            "  4. Work:       terok task start <project_id>       (new CLI task)\n"
-            "  5. Login:      terok login <project_id> <task_id>\n"
+            f"  1. Bootstrap:  {prog} setup                        (install host services)\n"
+            f"  2. Project:    {prog} project-wizard                (create a project)\n"
+            f"  3. Auth:       {prog} auth claude <project>         (authenticate agents)\n"
+            f"  4. Work:       {prog} task start <project_id>       (new CLI task)\n"
+            f"  5. Login:      {prog} login <project_id> <task_id>\n"
             "\n"
             "Standalone agent (no project):\n"
-            "  terok executor run claude .          (headless against cwd)\n"
-            "  terok executor run claude . -p 'fix' (with prompt)\n"
+            f"  {prog} executor run claude .          (headless against cwd)\n"
+            f"  {prog} executor run claude . -p 'fix' (with prompt)\n"
             "\n"
-            "Tip: enable tab completion with: terok completions install\n"
+            f"Tip: enable tab completion with: {prog} completions install\n"
         ),
     )
     parser.add_argument(
         "--version",
         action="version",
-        version=f"terok {version_string}\nLicense: Apache-2.0\nCopyright: 2025 Jiri Vyskocil",
+        version=f"{prog} {version_string}\nLicense: Apache-2.0\nCopyright: 2025 Jiri Vyskocil",
     )
     parser.add_argument(
         "--experimental",
@@ -187,6 +208,16 @@ def main() -> None:
             return
 
     parser.error("Unknown command")
+
+
+def terokctl_main() -> None:
+    """Entry point for the ``terokctl`` scriptable surface.
+
+    Same command tree as ``terok``, but no-args prints the argparse
+    usage error instead of launching the TUI — the stable, predictable
+    behavior scripts and automation want.
+    """
+    main(prog="terokctl")
 
 
 if __name__ == "__main__":

--- a/tests/unit/cli/test_cli_completions.py
+++ b/tests/unit/cli/test_cli_completions.py
@@ -106,18 +106,20 @@ def test_install_completions_writes_to_selected_target(
     expected_shell: str,
     capsys: pytest.CaptureFixture[str],
 ) -> None:
-    """Completion install writes the generated script to the resolved target path."""
-    targets = install_targets(tmp_path)
-    monkeypatch.setattr(completions, "_INSTALL_TARGETS", targets)
+    """Install writes completion scripts for both ``terok`` and ``terokctl``."""
+    monkeypatch.setattr(completions, "_XDG_DATA_HOME", tmp_path / "data")
+    monkeypatch.setattr(completions, "_XDG_CONFIG_HOME", tmp_path / "config")
     if detected_shell is not None:
         monkeypatch.setattr(completions, "_detect_shell", lambda: detected_shell)
 
     completions._install_completions(requested_shell)
 
-    target = targets[expected_shell]
-    assert target.is_file()
-    assert "# completion" in target.read_text(encoding="utf-8")
-    assert str(target) in capsys.readouterr().out
+    output = capsys.readouterr().out
+    for prog in completions._PROGS:
+        target = completions._target_for(expected_shell, prog)
+        assert target.is_file(), f"{prog} completion not written"
+        assert "# completion" in target.read_text(encoding="utf-8")
+        assert str(target) in output
 
 
 def test_is_completion_installed_returns_false_when_nothing_found(
@@ -189,15 +191,18 @@ def test_dispatch_install_calls_install_helper() -> None:
 
 @patch("terok.cli.commands.completions.shellcode", return_value="# completion")
 def test_dispatch_prints_shellcode_for_selected_shell(
-    _mock_shellcode: MagicMock,
+    mock_shellcode: MagicMock,
     capsys: pytest.CaptureFixture[str],
 ) -> None:
-    """Dispatch prints generated shellcode for direct shell subcommands."""
+    """Dispatch emits shellcode for each managed binary (terok, terokctl)."""
     args = argparse.Namespace(cmd="completions", action="bash")
 
     assert completions.dispatch(args)
 
-    assert "# completion" in capsys.readouterr().out
+    output = capsys.readouterr().out
+    assert output.count("# completion") == len(completions._PROGS)
+    called_progs = [call.args[0] for call in mock_shellcode.call_args_list]
+    assert called_progs == [[p] for p in completions._PROGS]
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/cli/test_cli_completions.py
+++ b/tests/unit/cli/test_cli_completions.py
@@ -201,8 +201,14 @@ def test_dispatch_prints_shellcode_for_selected_shell(
 
     output = capsys.readouterr().out
     assert output.count("# completion") == len(completions._PROGS)
-    called_progs = [call.args[0] for call in mock_shellcode.call_args_list]
-    assert called_progs == [[p] for p in completions._PROGS]
+    # Every managed binary gets shellcode emitted — but don't constrain the
+    # call shape (one call per prog vs one call with a list are both valid).
+    requested_progs = {
+        prog
+        for call in mock_shellcode.call_args_list
+        for prog in (call.args[0] if call.args else call.kwargs.get("progs", []))
+    }
+    assert set(completions._PROGS) <= requested_progs
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/cli/test_cli_main.py
+++ b/tests/unit/cli/test_cli_main.py
@@ -187,7 +187,24 @@ class TestTuiOnNoArgs:
 
             main()
 
-            mock_exec.assert_not_called()
+        # Assert outside the ``with`` — pytest.raises short-circuits the block
+        # the moment SystemExit fires, so anything above this line never ran.
+        mock_exec.assert_not_called()
+
+    def test_missing_terok_tui_falls_through_to_argparse(self) -> None:
+        """If ``terok-tui`` isn't on PATH, argparse's usage error is the fallback."""
+        with (
+            patch("os.execlp", side_effect=FileNotFoundError) as mock_exec,
+            patch("sys.argv", ["terok"]),
+            patch("sys.stdin.isatty", return_value=True),
+            patch("sys.stdout.isatty", return_value=True),
+            pytest.raises(SystemExit),
+        ):
+            from terok.cli.main import main
+
+            main()
+
+        mock_exec.assert_called_once_with("terok-tui", "terok-tui")
 
     def test_terokctl_no_args_never_launches_tui(self) -> None:
         """``terokctl`` is the stable surface — no-args always prints usage."""
@@ -202,4 +219,4 @@ class TestTuiOnNoArgs:
 
             terokctl_main()
 
-            mock_exec.assert_not_called()
+        mock_exec.assert_not_called()

--- a/tests/unit/cli/test_cli_main.py
+++ b/tests/unit/cli/test_cli_main.py
@@ -112,3 +112,94 @@ def test_known_subcommands_appear_in_help(subcmd: str) -> None:
     """Core subcommands are listed in ``terok --help``."""
     result = _run_cli("--help")
     assert subcmd in result.stdout
+
+
+def _run_terokctl(*args: str) -> subprocess.CompletedProcess[str]:
+    """Run the CLI as ``terokctl`` by invoking the dedicated entry point."""
+    return subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            "from terok.cli.main import terokctl_main; terokctl_main()",
+            *args,
+        ],
+        capture_output=True,
+        text=True,
+        timeout=10,
+    )
+
+
+class TestTerokctlSurface:
+    """``terokctl`` is the scriptable surface — same tree, different branding."""
+
+    def test_help_shows_terokctl(self) -> None:
+        """``terokctl --help`` uses ``terokctl`` as the program name."""
+        result = _run_terokctl("--help")
+        assert result.returncode == 0
+        assert "terokctl" in result.stdout
+
+    def test_version_shows_terokctl(self) -> None:
+        """``terokctl --version`` starts with ``terokctl``."""
+        result = _run_terokctl("--version")
+        assert result.returncode == 0
+        assert result.stdout.startswith("terokctl ")
+
+    def test_epilog_uses_terokctl_prog(self) -> None:
+        """Quick-start examples in the epilog reference ``terokctl``, not ``terok``."""
+        result = _run_terokctl("--help")
+        assert "terokctl setup" in result.stdout
+        assert "terokctl completions install" in result.stdout
+
+    def test_known_subcommands_appear(self) -> None:
+        """Core subcommands are listed — command tree is identical to ``terok``."""
+        result = _run_terokctl("--help")
+        for subcmd in ("task", "project", "config", "sickbay", "tui"):
+            assert subcmd in result.stdout
+
+
+class TestTuiOnNoArgs:
+    """Bare ``terok`` in a terminal execs ``terok-tui``; scripts get help."""
+
+    def test_tty_no_args_execs_terok_tui(self) -> None:
+        """``terok`` with no args and a TTY on stdin/stdout execs the TUI."""
+        with (
+            patch("os.execlp") as mock_exec,
+            patch("sys.argv", ["terok"]),
+            patch("sys.stdin.isatty", return_value=True),
+            patch("sys.stdout.isatty", return_value=True),
+        ):
+            from terok.cli.main import main
+
+            main()
+
+            mock_exec.assert_called_once_with("terok-tui", "terok-tui")
+
+    def test_non_tty_no_args_falls_through_to_argparse(self) -> None:
+        """Without a TTY, bare ``terok`` errors out — automation-safe default."""
+        with (
+            patch("os.execlp") as mock_exec,
+            patch("sys.argv", ["terok"]),
+            patch("sys.stdin.isatty", return_value=False),
+            patch("sys.stdout.isatty", return_value=False),
+            pytest.raises(SystemExit),
+        ):
+            from terok.cli.main import main
+
+            main()
+
+            mock_exec.assert_not_called()
+
+    def test_terokctl_no_args_never_launches_tui(self) -> None:
+        """``terokctl`` is the stable surface — no-args always prints usage."""
+        with (
+            patch("os.execlp") as mock_exec,
+            patch("sys.argv", ["terokctl"]),
+            patch("sys.stdin.isatty", return_value=True),
+            patch("sys.stdout.isatty", return_value=True),
+            pytest.raises(SystemExit),
+        ):
+            from terok.cli.main import terokctl_main
+
+            terokctl_main()
+
+            mock_exec.assert_not_called()


### PR DESCRIPTION
## Summary

First step in the gradual `terok`/`terokctl` split — surface-only, command tree unchanged.

- **New entry point `terokctl`** resolving to the same Python `main()` with `prog="terokctl"`. Today it's functionally identical to `terok`; the split plants the flag for future divergence (apt vs. apt-get model). `terok` stays free to evolve richer UX; `terokctl` becomes the stable target for scripts and automation.
- **Bare `terok` in a terminal execs `terok-tui`.** A TTY guard on stdin *and* stdout keeps the shortcut from surprising pipes/scripts (`terok | grep ...` still argparse-errors cleanly). `terokctl` never takes the fast-path — no-args there always argparse-errors, regardless of TTY.
- **Tab completions installed for both binaries.** Single `completions install` now writes `~/.local/share/bash-completion/completions/terok` *and* `.../terokctl` (plus the zsh/fish equivalents), so scripts pinned to `terokctl` get interactive completion too.

Epilog quick-start examples now interpolate the invoked binary name so `terokctl --help` reads `terokctl setup`, `terokctl completions install`, etc.

## Non-goals

- No restructuring of the ~17 top-level commands (agreed to defer).
- No output-format divergence, no shortcut verbs, no deprecation warnings on `terok`.
- No stability contract on `terokctl` beyond "same tree as today" — the promise is aspirational until we start diverging `terok`.

## Test plan

- [x] `make lint` — clean
- [x] `make tach` / `make lint-imports` / `make docstrings` (99.4%) / `make reuse` / `make security` — all green
- [x] 1789 unit tests pass (one pre-existing failure unrelated: `test_config_command_color_output` fails on master too in this container because port 9418 is held by the gate bridge)
- [x] `terok --version` → `terok 0.7.1`, `terokctl --version` → `terokctl 0.7.1`
- [x] `terok --help` and `terokctl --help` show the expected program name throughout; epilog examples use the invoked binary
- [x] New tests added:
  - `TestTerokctlSurface` — branding, epilog, subcommand listing
  - `TestTuiOnNoArgs` — TTY path execs `terok-tui`, non-TTY falls through to argparse, `terokctl` never execs
  - `test_install_completions_writes_to_selected_target` — verifies both `terok` and `terokctl` files get written
- [ ] Manual: bare `terok` in a real terminal launches the TUI
- [ ] Manual: `completions install` writes both files and both `terok<tab>` and `terokctl<tab>` work

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new CLI entry point: terokctl.
  * terok auto-launches the interactive TUI when run with no arguments in a terminal.
  * Shell completion now installs and prints completions for both terok and terokctl across supported shells.

* **Tests**
  * Added tests covering terokctl branding/help/version, TUI no-arg behavior, and multi-program completion install/dispatch.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->