### PR TITLE
fix: show transport in terok setup's Vault/Gate status lines

### DIFF
--- a/src/terok/cli/commands/setup.py
+++ b/src/terok/cli/commands/setup.py
@@ -286,8 +286,12 @@ def _ensure_vault(*, check_only: bool, color: bool) -> bool:
         # Check-only: just probe reachability
         try:
             ensure_vault_reachable(cfg)
-            mode = get_vault_status().mode or "active"
-            print(f"  Vault            {_status_label(True, color)} ({mode}, reachable)")
+            status = get_vault_status()
+            mode = status.mode or "active"
+            transport = status.transport or "tcp"
+            print(
+                f"  Vault            {_status_label(True, color)} ({mode}, {transport}, reachable)"
+            )
             return True
         except (VaultUnreachableError, SystemExit):
             installed = is_vault_socket_active()
@@ -321,8 +325,13 @@ def _ensure_vault(*, check_only: bool, color: bool) -> bool:
     # Verify actual TCP reachability (triggers systemd start)
     try:
         ensure_vault_reachable(cfg)
-        mode = get_vault_status().mode or "active"
-        print(f"  Vault            {_status_label(True, color)} ({mode}, reachable)")
+        status = get_vault_status()
+        mode = status.mode or "active"
+        transport_label = status.transport or "tcp"
+        print(
+            f"  Vault            {_status_label(True, color)} "
+            f"({mode}, {transport_label}, reachable)"
+        )
         return True
     except (VaultUnreachableError, SystemExit) as exc:
         print(f"  Vault            {_status_label(False, color)} (installed but NOT reachable)")
@@ -352,7 +361,11 @@ def _ensure_gate(*, check_only: bool, color: bool) -> bool:
             # Unit exists (running or socket-activated) — probe TCP to be sure
             try:
                 ensure_server_reachable(cfg)
-                print(f"  Gate server      {_status_label(True, color)} ({status.mode}, reachable)")
+                transport = status.transport or "tcp"
+                print(
+                    f"  Gate server      {_status_label(True, color)} "
+                    f"({status.mode}, {transport}, reachable)"
+                )
                 return True
             except SystemExit:
                 print(
@@ -389,7 +402,7 @@ def _ensure_gate(*, check_only: bool, color: bool) -> bool:
     # Verify reachability (triggers socket activation)
     try:
         ensure_server_reachable(cfg)
-        print(f"  Gate server      {_status_label(True, color)} (systemd, reachable)")
+        print(f"  Gate server      {_status_label(True, color)} (systemd, {transport}, reachable)")
         return True
     except SystemExit as exc:
         print(f"  Gate server      {_status_label(False, color)} (installed but NOT reachable)")


### PR DESCRIPTION
## Summary

\`terok sickbay\` prints \`(systemd, tcp)\` / \`(systemd, socket)\` for
the services.  \`terok setup\` hid the transport and just said
\`(systemd, reachable)\` — on a machine with surprising behaviour
the operator reaches for \`terok setup\` first, so the ambiguity
actively misleads.

Both Vault and Gate status lines — in both check-only and post-install
paths — now surface \`status.transport\` (falling back to \`tcp\` when
the service isn't running yet, mirroring sickbay's idiom).

## Test plan

- [x] \`make lint tach\` clean
- [x] \`pytest\` — 1837 pass; 14 pre-existing vault-rename ImportErrors
      on master (unrelated)
- [ ] Manual: \`terok setup --check\` on both TCP and socket-mode hosts;
      confirm output reads \`(systemd, tcp, reachable)\` /
      \`(systemd, socket, reachable)\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Setup command now displays transport mode information in vault and gate status output, providing more detailed diagnostic information during verification and check operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->