### PR TITLE
fix(tui): panic button armed label now reads as an instruction

### DIFF
--- a/src/terok/tui/widgets/panic_button.py
+++ b/src/terok/tui/widgets/panic_button.py
@@ -12,7 +12,7 @@ from textual.message import Message
 from textual.widgets import Static
 
 _LABEL_IDLE = "PANIC"
-_LABEL_ARMED = "!! CONFIRM PANIC !!"
+_LABEL_ARMED = "PRESS AGAIN TO PANIC"
 _DISARM_SECONDS = 5.0
 
 

--- a/tests/unit/tui/test_panic_button.py
+++ b/tests/unit/tui/test_panic_button.py
@@ -71,7 +71,7 @@ class TestArm:
     def test_updates_label(self, button):
         """arm() changes the label to the armed prompt."""
         button.arm()
-        button.update.assert_called_with("!! CONFIRM PANIC !!")
+        button.update.assert_called_with("PRESS AGAIN TO PANIC")
 
     def test_starts_disarm_timer(self, button):
         """arm() starts a 5-second auto-disarm timer."""


### PR DESCRIPTION
## Summary

\`"!! CONFIRM PANIC !!"\` on the armed state was a command imperative
that could be read either direction — users weren't sure whether the
button was *asking* for confirmation or *claiming* a confirmed state.

The armed label is now \`"PRESS AGAIN TO PANIC"\`: a complete English
sentence naming both the action and the consequence, so the next
input is unambiguous for mouse and keyboard users alike.  The red
background + bold-reverse styling still carries the visual urgency,
so dropping the \`!! ... !!\` decoration is safe.

## Test plan

- [x] \`make lint\` clean
- [x] \`pytest tests/unit/tui/test_panic_button.py\` — 19 pass
- [ ] Manual: launch \`terok-tui\`, press P (or click the button),
      confirm armed label reads as intended

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Panic button armed-state label text has been updated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->