### PR TITLE
fix: derive vault.transport from services.mode (new tasks get SSH again)

### DIFF
--- a/src/terok/lib/core/config.py
+++ b/src/terok/lib/core/config.py
@@ -491,12 +491,13 @@ def get_services_mode() -> ServicesMode:
 def get_vault_transport() -> str:
     """Return the vault transport mode (``"direct"`` or ``"socket"``).
 
-    Global config (config.yml)::
-
-        vault:
-          transport: socket   # or "direct"
+    Derived from ``services.mode``: ``socket`` → ``"socket"`` (containers
+    read the mounted Unix socket), anything else → ``"direct"``
+    (containers connect to the broker's TCP port).  One knob, two
+    vocabularies — kept aligned so the listener and the container-side
+    routing cannot disagree.
     """
-    return _load_validated().vault.transport
+    return "socket" if _load_validated().services.mode == "socket" else "direct"
 
 
 def get_vault_token_broker_port() -> int | None:

--- a/src/terok/lib/core/yaml_schema.py
+++ b/src/terok/lib/core/yaml_schema.py
@@ -504,12 +504,18 @@ class RawServicesSection(BaseModel):
 
 
 class RawVaultSection(BaseModel):
-    """Global ``vault:`` section (token broker + SSH signer)."""
+    """Global ``vault:`` section (token broker + SSH signer).
+
+    The container-side transport was previously configured via
+    ``vault.transport``; since 0.7.4 it is derived from
+    ``services.mode`` so the two knobs stay in lockstep (tcp listener
+    ↔ direct routing, socket listener ↔ socket routing).  Any prior
+    ``vault.transport:`` line in ``config.yml`` must be removed.
+    """
 
     model_config = ConfigDict(extra="forbid")
 
     bypass_no_secret_protection: bool = False
-    transport: Literal["direct", "socket"] = "direct"
     port: int | None = Field(default=None, ge=1, le=65535)
     ssh_signer_port: int | None = Field(default=None, ge=1, le=65535)
 

--- a/tests/unit/lib/test_config.py
+++ b/tests/unit/lib/test_config.py
@@ -631,6 +631,22 @@ def test_is_experimental_cli_flag_wins(monkeypatch: pytest.MonkeyPatch, tmp_path
 # ---------- Claude agent config getters ----------
 
 
+def test_vault_transport_defaults_to_socket(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Empty config → ``services.mode=socket`` → vault transport ``"socket"``."""
+    monkeypatch.setenv("TEROK_CONFIG_FILE", str(write_config(tmp_path, "")))
+    assert cfg.get_vault_transport() == "socket"
+
+
+def test_vault_transport_follows_services_mode_tcp(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """``services.mode=tcp`` → vault transport ``"direct"`` (container connects via TCP)."""
+    monkeypatch.setenv("TEROK_CONFIG_FILE", str(write_config(tmp_path, "services:\n  mode: tcp\n")))
+    assert cfg.get_vault_transport() == "direct"
+
+
 def test_claude_allow_oauth_default(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     """``get_claude_allow_oauth()`` defaults to False."""
     monkeypatch.setenv("TEROK_CONFIG_FILE", str(write_config(tmp_path, "")))

--- a/tests/unit/lib/test_yaml_schema.py
+++ b/tests/unit/lib/test_yaml_schema.py
@@ -245,6 +245,11 @@ class RawGlobalConfigTests(unittest.TestCase):
         cfg = RawGlobalConfig.model_validate({"services": {"mode": "tcp"}})
         self.assertEqual(cfg.services.mode, "tcp")
 
+    def test_vault_transport_field_rejected(self) -> None:
+        """``vault.transport`` is no longer a config key — it's derived from ``services.mode``."""
+        with self.assertRaises(ValidationError):
+            RawGlobalConfig.model_validate({"vault": {"transport": "socket"}})
+
     def test_experimental_flag(self) -> None:
         """``experimental: true`` is accepted as a top-level bool."""
         cfg = RawGlobalConfig.model_validate({"experimental": True})


### PR DESCRIPTION
## Summary

On a 0.7.3/0.7.4 host, new tasks failed to reach their git remote:

\`\`\`
-e TEROK_SSH_SIGNER_PORT=None ...
git@github.com: Permission denied (publickey).
\`\`\`

Root cause: two config keys managing one concept.

- \`services.mode\` — where services listen (tcp vs socket).
  Flipped to \`socket\` in 0.7.3.
- \`vault.transport\` — how containers reach the vault.  Still defaulted
  to \`direct\`.

Vault bound Unix sockets, but terok-executor's env injection
(\`container/env.py:466-471\`) read \`vault.transport\` and took the TCP
branch — emitting the literal string \`"None"\` as
\`TEROK_SSH_SIGNER_PORT\`.  Inside the task, \`ssh-agent-bridge.sh:31\`
rejected the non-numeric value, no SSH bridge was established.

Running tasks kept working because their bridges were established
inside the live container and never re-exec the script.

## Fix

Collapse the two into one.  \`get_vault_transport()\` now derives from
\`services.mode\` (\`socket\` → \`"socket"\`, otherwise \`"direct"\`), and
the \`vault.transport\` field is removed from \`RawVaultSection\`.  Any
existing \`transport:\` line in \`config.yml\` becomes a pydantic
validation error, surfacing the required cleanup.

Bridge mode eventually retires the whole tcp/socket dichotomy, so the
deeper fix (typed transport objects) is deferred per earlier scoping
discussion.

## Test plan

- [x] \`make lint tach docstrings reuse\` clean
- [x] \`pytest\` — 143 config/schema tests pass; added derivation test
      + validation-error test; existing 14 unrelated vault-rename
      ImportError failures untouched
- [ ] Manual: on the Fedora box, \`terok task start terok\` — expect
      \`TEROK_SSH_SIGNER_SOCKET=/run/terok/ssh-agent.sock\` (not
      \`TEROK_SSH_SIGNER_PORT=None\`) in the podman command, and
      successful \`git clone\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated vault transport configuration: transport mode is now derived from the `services.mode` setting instead of a separate configuration option. Remove any `vault.transport:` entries from your configuration files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->