### PR TITLE
fix(tui): show .postN commits-past-tag in title bar

### DIFF
--- a/src/terok/lib/core/version.py
+++ b/src/terok/lib/core/version.py
@@ -202,21 +202,25 @@ def base_version(version: str) -> str:
 def short_version(version: str) -> str:
     """Return a human-friendly short version for display.
 
-    At a tagged release the base version is returned as-is (e.g. ``"0.4.0"``).
-    When the full version string contains post/dev/local suffixes — indicating
-    that HEAD is past the last release tag — a trailing ``"+"`` is appended
-    (e.g. ``"0.4.0+"``).
+    Keeps at most four dot-separated segments (``X.Y.Z.SUFFIX``) and
+    drops the ``+local`` git-hash segment.  Anything past the first
+    suffix — typically ``poetry-dynamic-versioning``'s redundant
+    ``.dev0`` tacked onto a ``.postN`` — is dropped.  No hard-coded
+    knowledge of which suffixes are meaningful, just "first thing
+    after the release triple, if there is one."
 
-    Args:
-        version: Full PEP 440 version string.
+    Examples::
 
-    Returns:
-        Short display version like ``"0.4.0"`` or ``"0.4.0+"``.
+        >>> short_version("0.4.0")
+        '0.4.0'
+        >>> short_version("0.7.4.post4.dev0+549a07a")
+        '0.7.4.post4'
+        >>> short_version("1.0.0.dev1")
+        '1.0.0.dev1'
+        >>> short_version("1.2.3rc1")
+        '1.2.3rc1'
     """
-    base = base_version(version)
-    if version != base:
-        return f"{base}+"
-    return base
+    return ".".join(version.split(".", 4)[:4]).split("+", 1)[0]
 
 
 def format_version_string(version: str, branch: str | None) -> str:

--- a/tests/unit/tui/test_version_branch_detection.py
+++ b/tests/unit/tui/test_version_branch_detection.py
@@ -49,13 +49,16 @@ def test_base_version(value: str, expected: str) -> None:
     ("value", "expected"),
     [
         pytest.param("0.4.0", "0.4.0", id="release"),
-        pytest.param("0.4.0.post3.dev0+gabcdef", "0.4.0+", id="past-release"),
-        pytest.param("1.0.0.dev1", "1.0.0+", id="dev-version"),
+        pytest.param("0.7.4.post4.dev0+549a07a", "0.7.4.post4", id="dynver-post-release"),
+        pytest.param("0.4.0.post3+gabcdef", "0.4.0.post3", id="post-without-dev"),
+        pytest.param("1.0.0.dev1", "1.0.0.dev1", id="dev-preserved"),
+        pytest.param("1.0.0.dev1+gabcdef", "1.0.0.dev1", id="dev-with-local-stripped"),
+        pytest.param("1.2.3rc1", "1.2.3rc1", id="rc-preserved"),
         pytest.param("unknown", "unknown", id="unknown"),
     ],
 )
 def test_short_version(value: str, expected: str) -> None:
-    """``short_version`` preserves releases and adds ``+`` past them."""
+    """``short_version`` strips only the git-hash local segment and the redundant ``.devN`` that dynver appends to ``.postN``."""
     from terok.lib.core.version import short_version
 
     assert short_version(value) == expected


### PR DESCRIPTION
## Summary

The TUI title showed `Terok TUI v0.7.4+` on any post-release build,
dropping the useful `.postN` counter that `poetry-dynamic-versioning`
emits.  The CLI's `--version` already surfaces the full
`0.7.4.post4.dev0+549a07a`; this brings the TUI into line for the dev
who's actively watching how far past the last tag they are.

`short_version` now strips only two things: the `+local` segment
(just a git hash, not useful in a title bar) and the redundant `.devN`
that dynver always appends to `.postN` (the post counter already tells
you how far past).  Everything else is preserved as-is.

Examples:

| input                              | output          |
| ---------------------------------- | --------------- |
| `0.4.0`                            | `0.4.0`         |
| `0.7.4.post4.dev0+549a07a`         | `0.7.4.post4`   |
| `0.4.0.post3+gabcdef`              | `0.4.0.post3`   |
| `1.0.0.dev1`                       | `1.0.0.dev1`    |
| `1.2.3rc1`                         | `1.2.3rc1`      |

## Test plan

- [x] `make lint tach` clean
- [x] `pytest tests/unit/tui/test_version_branch_detection.py` — 44 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved shortening of version strings: local (+hash) segments are removed; ".postN.devN" appended by tooling is collapsed to ".postN"; development (".devN") and pre-release (rc) markers are preserved when appropriate, yielding more accurate displayed versions.

* **Tests**
  * Updated tests to reflect the revised shortening behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->