### PR TITLE
feat: token-gated toad ingress + basic-auth on terok serve

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -3070,19 +3070,20 @@ description = "Single-agent task runner for hardened Podman containers"
 optional = false
 python-versions = ">=3.12,<4.0"
 groups = ["main"]
-files = [
-    {file = "terok_executor-0.0.92-py3-none-any.whl", hash = "sha256:b958dd4ce6484e10aba21b58f468d406ae2e33d4a2f65f2003c078c87f683ecf"},
-]
+files = []
+develop = false
 
 [package.dependencies]
 Jinja2 = ">=3.1"
 "ruamel.yaml" = ">=0.18"
-terok_sandbox = {url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.0.77/terok_sandbox-0.0.77-py3-none-any.whl"}
+terok-sandbox = {url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.0.77/terok_sandbox-0.0.77-py3-none-any.whl"}
 tomli-w = ">=1.0"
 
 [package.source]
-type = "url"
-url = "https://github.com/terok-ai/terok-executor/releases/download/v0.0.92/terok_executor-0.0.92-py3-none-any.whl"
+type = "git"
+url = "https://github.com/sliwowitz/terok-executor.git"
+reference = "feat/caddy-roster"
+resolved_reference = "2b3e7a327baba1640647f49abc39cb54b02b4148"
 
 [[package]]
 name = "terok-sandbox"
@@ -3611,4 +3612,4 @@ propcache = ">=0.2.1"
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.12,<4.0"
-content-hash = "19d07702aea39b87bc991fc7de952a284a74ceab129c433ee191e30ad67e48ca"
+content-hash = "be22bbf29c88787d174d459fe83238f51fb12b2fced19b28c442dc446f69f8e3"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ rich = ">=13.0"
 platformdirs = ">=4.5.1"
 unique-namer = ">=1.3"
 textual-serve = ">=1.1.0"
-terok-executor = {url = "https://github.com/terok-ai/terok-executor/releases/download/v0.0.92/terok_executor-0.0.92-py3-none-any.whl"}
+terok-executor = {git = "https://github.com/sliwowitz/terok-executor.git", branch = "feat/caddy-roster"}
 terok-sandbox = {url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.0.77/terok_sandbox-0.0.77-py3-none-any.whl"}
 terok-dbus = {url = "https://github.com/terok-ai/terok-dbus/releases/download/v0.5.6/terok_dbus-0.5.6-py3-none-any.whl"}
 

--- a/src/terok/lib/orchestration/task_runners.py
+++ b/src/terok/lib/orchestration/task_runners.py
@@ -105,19 +105,12 @@ def _apply_unrestricted_env(env: dict[str, str]) -> None:
 
 
 def _ensure_toad_token(agent_config_dir: Path, existing: str | None = None) -> str:
-    """Write the toad auth token into *agent_config_dir* (0600) and return it.
+    """Per-task auth token for Caddy, written 0600 to ``toad.token`` and returned.
 
-    When *existing* is given (e.g. loaded from task metadata on restart),
-    the same token is rehydrated into the file; otherwise a fresh 32-byte
-    urlsafe token is minted.  The token is the shared secret that Caddy
-    inside the container validates before forwarding to ``textual-serve``;
-    it also ends up in the URL query string for the first browser hit
-    that seeds the auth cookie.
-
-    The write refuses to follow a pre-existing symlink (``O_NOFOLLOW``) —
-    ``agent-config`` is a bind mount, so a stopped container that points
-    ``toad.token`` at an arbitrary host path would otherwise get its
-    content clobbered by the next ``_ensure_toad_token`` call.
+    Reuses *existing* (restart path) or mints a fresh 32-byte urlsafe
+    string.  ``O_NOFOLLOW`` is load-bearing: ``agent-config`` is a bind
+    mount, so a stopped container could pre-stage a symlink at
+    ``toad.token`` to clobber a host path on the next rehydrate.
     """
     token = existing or secrets.token_urlsafe(32)
     dir_fd = os.open(agent_config_dir, os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW)
@@ -153,12 +146,10 @@ def _agent_config_dir(project: ProjectConfig, task_id: str) -> Path:
 
 
 def _rehydrate_toad_token(project: ProjectConfig, task_id: str, meta: dict, cname: str) -> str:
-    """Load the saved token from *meta* and refresh its file on disk.
+    """Saved toad token from *meta*, rewritten to ``agent-config/toad.token``.
 
-    Used by every code path that reuses an existing toad container
-    (resume, restart) — the agent-config dir may have been cleaned up
-    between runs, so the file is rewritten even when the token itself
-    is unchanged.
+    The file may have been cleaned up between runs even when the token
+    persists in metadata; rewriting on every reuse is cheap insurance.
     """
     saved_token = meta.get("web_token")
     if not isinstance(saved_token, str):
@@ -180,11 +171,7 @@ def _resume_toad_container(
     meta_path: Path,
     pub_host: str,
 ) -> None:
-    """Reuse (or start) an existing toad container, rehydrating its auth token.
-
-    Factored out of :func:`task_run_toad` to keep that function's cognitive
-    complexity down; it owns the fast-path for already-created containers.
-    """
+    """Fast-path for a toad task whose container already exists: rehydrate the token, start it if stopped, print the URL."""
     saved_port = meta.get("web_port")
     if not isinstance(saved_port, int):
         raise SystemExit(f"Existing toad container {cname} has no saved web_port in metadata.")

--- a/src/terok/lib/orchestration/task_runners.py
+++ b/src/terok/lib/orchestration/task_runners.py
@@ -5,6 +5,8 @@
 
 from __future__ import annotations
 
+import os
+import secrets
 import shlex
 from dataclasses import dataclass
 from datetime import UTC, datetime
@@ -69,7 +71,11 @@ if TYPE_CHECKING:
 
 _LOCALHOST = "127.0.0.1"
 _LOOPBACK_HOSTS = frozenset({"127.0.0.1", "localhost", "::1"})
-_TOAD_CONTAINER_PORT = 8080
+_TOAD_PUBLIC_PORT = 8080
+"""Port that Caddy binds inside the container — the one podman publishes."""
+_TOAD_INTERNAL_PORT = 8081
+"""Loopback port that toad binds inside the container — reached only via Caddy."""
+_TOAD_TOKEN_FILE_NAME = "toad.token"
 _ANTHROPIC_API_HOST = "api.anthropic.com"
 _FALSE_STRINGS = frozenset({"false", "0", "no", "off"})
 _CONTAINER_TEROK_CONFIG = "/home/dev/.terok"
@@ -96,6 +102,31 @@ def _apply_unrestricted_env(env: dict[str, str]) -> None:
 
     env["TEROK_UNRESTRICTED"] = "1"
     env.update(collect_all_auto_approve_env())
+
+
+def _ensure_toad_token(agent_config_dir: Path, existing: str | None = None) -> str:
+    """Write the toad auth token into *agent_config_dir* (0600) and return it.
+
+    When *existing* is given (e.g. loaded from task metadata on restart),
+    the same token is rehydrated into the file; otherwise a fresh 32-byte
+    urlsafe token is minted.  The token is the shared secret that Caddy
+    inside the container validates before forwarding to ``textual-serve``;
+    it also ends up in the URL query string for the first browser hit
+    that seeds the auth cookie.
+    """
+    token = existing or secrets.token_urlsafe(32)
+    token_path = agent_config_dir / _TOAD_TOKEN_FILE_NAME
+    fd = os.open(token_path, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+    try:
+        os.write(fd, token.encode())
+    finally:
+        os.close(fd)
+    return token
+
+
+def _toad_browser_url(public_host: str, port: int, token: str) -> str:
+    """Return the first-hit URL that seeds the Caddy-set auth cookie."""
+    return f"http://{public_host}:{port}/?token={token}"
 
 
 @dataclass(frozen=True)
@@ -562,8 +593,18 @@ def task_run_toad(
                 f"(got {actual}).  Re-create the task to use the new port."
             )
         ensure_vault()
+        saved_token = meta.get("web_token")
+        if not isinstance(saved_token, str):
+            raise SystemExit(
+                f"Existing toad container {cname} has no saved web_token in metadata "
+                f"(created before the Caddy auth gate landed).  Re-create the task."
+            )
+        # Token file may have been cleared by a host-side cleanup; re-write
+        # it so the in-container Caddy can read it on startup.
+        agent_config_dir = project.tasks_root / str(task_id) / "agent-config"
+        _ensure_toad_token(agent_config_dir, existing=saved_token)
         color_enabled = _supports_color()
-        url = f"http://{pub_host}:{saved_port}/"
+        url = _toad_browser_url(pub_host, saved_port, saved_token)
         if container_state == "running":
             print(f"Container {_green(cname, color_enabled)} is already running.")
             print(f"Toad: {_blue(url, color_enabled)}")
@@ -597,6 +638,15 @@ def task_run_toad(
     agent_config_dir = _prepare_agent_config(project, project_id, task_id, agents, preset)
     volumes.append(VolumeSpec(agent_config_dir, _CONTAINER_TEROK_CONFIG, sharing=Sharing.PRIVATE))
 
+    # Mint the auth token once per task; same value is reused on restart.
+    token = _ensure_toad_token(agent_config_dir)
+    meta["web_token"] = token
+
+    # Pin the caddy/toad port contract to the host-side constants so any
+    # future change here is picked up by the in-container supervisor.
+    env["TOAD_PUBLIC_PORT"] = str(_TOAD_PUBLIC_PORT)
+    env["TOAD_INTERNAL_PORT"] = str(_TOAD_INTERNAL_PORT)
+
     # Resolve unrestricted mode: CLI flag → config → default (True)
     if unrestricted is None:
         _effective = resolve_agent_config(
@@ -622,12 +672,11 @@ def task_run_toad(
     bind_addr = _LOCALHOST if pub_host in _LOOPBACK_HOSTS else "0.0.0.0"  # nosec B104
 
     task_dir = project.tasks_root / str(task_id)
-    toad_cmd = (
-        f"init-ssh-and-repo.sh"
-        f" && toad --serve -H 0.0.0.0 -p {_TOAD_CONTAINER_PORT}"
-        f" --public-url http://{pub_host}:{port}"
-        f" /workspace"
-    )
+    # ``terok-toad-entry`` (from the caddy/toad roster entries) owns the
+    # in-container choreography: it starts Caddy on ``_TOAD_PUBLIC_PORT``,
+    # launches toad on loopback ``_TOAD_INTERNAL_PORT``, waits for both to
+    # bind, and emits the ``TEROK_READY`` readiness marker.
+    toad_cmd = f"terok-toad-entry --public-url http://{pub_host}:{port} /workspace"
     run_hook(
         "pre_start",
         project.hook_pre_start,
@@ -646,7 +695,7 @@ def task_run_toad(
         volumes=volumes,
         project=project,
         task_dir=task_dir,
-        extra_args=["-p", f"{bind_addr}:{port}:{_TOAD_CONTAINER_PORT}"],
+        extra_args=["-p", f"{bind_addr}:{port}:{_TOAD_PUBLIC_PORT}"],
         command=["bash", "-lc", toad_cmd],
     )
     _apply_shield_policy(project, cname, task_dir, is_restart=False)
@@ -663,8 +712,8 @@ def task_run_toad(
     )
 
     def _toad_ready(line: str) -> bool:
-        """Return True when textual-serve reports it is serving."""
-        return "Serving " in line
+        """Return True when the supervisor wrapper reports both listeners are up."""
+        return "TEROK_READY" in line
 
     ready = stream_initial_logs(
         container_name=cname,
@@ -692,7 +741,7 @@ def task_run_toad(
     meta_path.write_text(_yaml_dump(meta))
 
     color_enabled = _supports_color()
-    url = f"http://{pub_host}:{port}/"
+    url = _toad_browser_url(pub_host, port, token)
     print(
         f"\n>> Toad is serving."
         f"\n- Name: {_green(cname, color_enabled)}"

--- a/src/terok/lib/orchestration/task_runners.py
+++ b/src/terok/lib/orchestration/task_runners.py
@@ -113,20 +113,38 @@ def _ensure_toad_token(agent_config_dir: Path, existing: str | None = None) -> s
     inside the container validates before forwarding to ``textual-serve``;
     it also ends up in the URL query string for the first browser hit
     that seeds the auth cookie.
+
+    The write refuses to follow a pre-existing symlink (``O_NOFOLLOW``) —
+    ``agent-config`` is a bind mount, so a stopped container that points
+    ``toad.token`` at an arbitrary host path would otherwise get its
+    content clobbered by the next ``_ensure_toad_token`` call.
     """
     token = existing or secrets.token_urlsafe(32)
-    token_path = agent_config_dir / _TOAD_TOKEN_FILE_NAME
-    fd = os.open(token_path, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+    dir_fd = os.open(agent_config_dir, os.O_RDONLY | os.O_DIRECTORY | os.O_NOFOLLOW)
     try:
-        os.write(fd, token.encode())
+        fd = os.open(
+            _TOAD_TOKEN_FILE_NAME,
+            os.O_WRONLY | os.O_CREAT | os.O_TRUNC | os.O_NOFOLLOW,
+            0o600,
+            dir_fd=dir_fd,
+        )
+        try:
+            os.write(fd, token.encode())
+        finally:
+            os.close(fd)
     finally:
-        os.close(fd)
+        os.close(dir_fd)
     return token
+
+
+def _url_host(host: str) -> str:
+    """Return *host* formatted for an HTTP URL authority (brackets IPv6 literals)."""
+    return f"[{host}]" if ":" in host and not host.startswith("[") else host
 
 
 def _toad_browser_url(public_host: str, port: int, token: str) -> str:
     """Return the first-hit URL that seeds the Caddy-set auth cookie."""
-    return f"http://{public_host}:{port}/?token={token}"
+    return f"http://{_url_host(public_host)}:{port}/?token={token}"
 
 
 def _resume_toad_container(
@@ -701,7 +719,7 @@ def task_run_toad(
     # in-container choreography: it starts Caddy on ``_TOAD_PUBLIC_PORT``,
     # launches toad on loopback ``_TOAD_INTERNAL_PORT``, waits for both to
     # bind, and emits the ``TEROK_READY`` readiness marker.
-    toad_cmd = f"terok-toad-entry --public-url http://{pub_host}:{port} /workspace"
+    toad_cmd = f"terok-toad-entry --public-url http://{_url_host(pub_host)}:{port} /workspace"
     run_hook(
         "pre_start",
         project.hook_pre_start,

--- a/src/terok/lib/orchestration/task_runners.py
+++ b/src/terok/lib/orchestration/task_runners.py
@@ -75,7 +75,7 @@ _TOAD_PUBLIC_PORT = 8080
 """Port that Caddy binds inside the container — the one podman publishes."""
 _TOAD_INTERNAL_PORT = 8081
 """Loopback port that toad binds inside the container — reached only via Caddy."""
-_TOAD_TOKEN_FILE_NAME = "toad.token"
+_TOAD_TOKEN_FILE_NAME = "toad.token"  # nosec B105 — filename, not a credential
 _ANTHROPIC_API_HOST = "api.anthropic.com"
 _FALSE_STRINGS = frozenset({"false", "0", "no", "off"})
 _CONTAINER_TEROK_CONFIG = "/home/dev/.terok"
@@ -127,6 +127,67 @@ def _ensure_toad_token(agent_config_dir: Path, existing: str | None = None) -> s
 def _toad_browser_url(public_host: str, port: int, token: str) -> str:
     """Return the first-hit URL that seeds the Caddy-set auth cookie."""
     return f"http://{public_host}:{port}/?token={token}"
+
+
+def _resume_toad_container(
+    *,
+    project: ProjectConfig,
+    task_id: str,
+    cname: str,
+    container_state: str,
+    meta: dict,
+    meta_path: Path,
+    pub_host: str,
+) -> None:
+    """Reuse (or start) an existing toad container, rehydrating its auth token.
+
+    Factored out of :func:`task_run_toad` to keep that function's cognitive
+    complexity down; it owns the fast-path for already-created containers.
+    """
+    saved_port = meta.get("web_port")
+    if not isinstance(saved_port, int):
+        raise SystemExit(f"Existing toad container {cname} has no saved web_port in metadata.")
+    actual = assign_web_port(project.id, task_id, preferred=saved_port)
+    if actual != saved_port:
+        raise SystemExit(
+            f"Port {saved_port} for {project.id}/{task_id} is no longer available "
+            f"(got {actual}).  Re-create the task to use the new port."
+        )
+    ensure_vault()
+    saved_token = meta.get("web_token")
+    if not isinstance(saved_token, str):
+        raise SystemExit(
+            f"Existing toad container {cname} has no saved web_token in metadata "
+            f"(created before the Caddy auth gate landed).  Re-create the task."
+        )
+    # Token file may have been cleared by a host-side cleanup; re-write
+    # it so the in-container Caddy can read it on startup.
+    agent_config_dir = project.tasks_root / str(task_id) / "agent-config"
+    _ensure_toad_token(agent_config_dir, existing=saved_token)
+    color_enabled = _supports_color()
+    url = _toad_browser_url(pub_host, saved_port, saved_token)
+    if container_state == "running":
+        print(f"Container {_green(cname, color_enabled)} is already running.")
+        print(f"Toad: {_blue(url, color_enabled)}")
+        return
+    print(f"Starting existing container {_green(cname, color_enabled)}...")
+    task_dir = project.tasks_root / str(task_id)
+    _podman_start(cname)
+    _assert_running(cname)
+    run_hook(
+        "post_start",
+        project.hook_post_start,
+        project_id=project.id,
+        task_id=task_id,
+        mode="toad",
+        cname=cname,
+        web_port=saved_port,
+        task_dir=task_dir,
+        meta_path=meta_path,
+    )
+    _apply_shield_policy(project, cname, task_dir, is_restart=True)
+    print("Container started.")
+    print(f"Toad: {_blue(url, color_enabled)}")
 
 
 @dataclass(frozen=True)
@@ -582,51 +643,15 @@ def task_run_toad(
     pub_host = get_public_host()
 
     if container_state is not None:
-        # Existing container — reuse its saved port (can't change the mapping).
-        saved_port = meta.get("web_port")
-        if not isinstance(saved_port, int):
-            raise SystemExit(f"Existing toad container {cname} has no saved web_port in metadata.")
-        actual = assign_web_port(project.id, task_id, preferred=saved_port)
-        if actual != saved_port:
-            raise SystemExit(
-                f"Port {saved_port} for {project.id}/{task_id} is no longer available "
-                f"(got {actual}).  Re-create the task to use the new port."
-            )
-        ensure_vault()
-        saved_token = meta.get("web_token")
-        if not isinstance(saved_token, str):
-            raise SystemExit(
-                f"Existing toad container {cname} has no saved web_token in metadata "
-                f"(created before the Caddy auth gate landed).  Re-create the task."
-            )
-        # Token file may have been cleared by a host-side cleanup; re-write
-        # it so the in-container Caddy can read it on startup.
-        agent_config_dir = project.tasks_root / str(task_id) / "agent-config"
-        _ensure_toad_token(agent_config_dir, existing=saved_token)
-        color_enabled = _supports_color()
-        url = _toad_browser_url(pub_host, saved_port, saved_token)
-        if container_state == "running":
-            print(f"Container {_green(cname, color_enabled)} is already running.")
-            print(f"Toad: {_blue(url, color_enabled)}")
-            return
-        print(f"Starting existing container {_green(cname, color_enabled)}...")
-        task_dir = project.tasks_root / str(task_id)
-        _podman_start(cname)
-        _assert_running(cname)
-        run_hook(
-            "post_start",
-            project.hook_post_start,
-            project_id=project.id,
+        _resume_toad_container(
+            project=project,
             task_id=task_id,
-            mode="toad",
             cname=cname,
-            web_port=saved_port,
-            task_dir=task_dir,
+            container_state=container_state,
+            meta=meta,
             meta_path=meta_path,
+            pub_host=pub_host,
         )
-        _apply_shield_policy(project, cname, task_dir, is_restart=True)
-        print("Container started.")
-        print(f"Toad: {_blue(url, color_enabled)}")
         return
 
     # New container — allocate a fresh port.
@@ -1145,6 +1170,16 @@ def task_restart(project_id: str, task_id: str) -> None:
                     f"(got {actual}).  Re-create the task to use the new port."
                 )
         task_dir = project.tasks_root / str(task_id)
+        if mode == "toad":
+            # Rehydrate the per-task auth token so Caddy can read it after
+            # restart — same guarantees task_run_toad's resume path offers.
+            saved_token = meta.get("web_token")
+            if not isinstance(saved_token, str):
+                raise SystemExit(
+                    f"Existing toad container {cname} has no saved web_token in metadata "
+                    f"(created before the Caddy auth gate landed).  Re-create the task."
+                )
+            _ensure_toad_token(task_dir / "agent-config", existing=saved_token)
         _podman_start(cname)
         _assert_running(cname)
         run_hook(
@@ -1165,8 +1200,9 @@ def task_restart(project_id: str, task_id: str) -> None:
             _print_login_instructions(project_id, task_id, cname, color_enabled)
         elif mode == "toad":
             port = meta.get("web_port")
-            if port:
-                print(f"Toad: http://{get_public_host()}:{port}/")
+            token = meta.get("web_token")
+            if isinstance(port, int) and isinstance(token, str):
+                print(f"Toad: {_toad_browser_url(get_public_host(), port, token)}")
     else:
         # Container is gone — restart can't recreate it.  User must start
         # a fresh task with ``task run``.

--- a/src/terok/lib/orchestration/task_runners.py
+++ b/src/terok/lib/orchestration/task_runners.py
@@ -147,6 +147,29 @@ def _toad_browser_url(public_host: str, port: int, token: str) -> str:
     return f"http://{_url_host(public_host)}:{port}/?token={token}"
 
 
+def _agent_config_dir(project: ProjectConfig, task_id: str) -> Path:
+    """Return the agent-config mount path for *task_id* under *project*."""
+    return project.tasks_root / str(task_id) / "agent-config"
+
+
+def _rehydrate_toad_token(project: ProjectConfig, task_id: str, meta: dict, cname: str) -> str:
+    """Load the saved token from *meta* and refresh its file on disk.
+
+    Used by every code path that reuses an existing toad container
+    (resume, restart) — the agent-config dir may have been cleaned up
+    between runs, so the file is rewritten even when the token itself
+    is unchanged.
+    """
+    saved_token = meta.get("web_token")
+    if not isinstance(saved_token, str):
+        raise SystemExit(
+            f"Existing toad container {cname} has no saved web_token in metadata "
+            f"(created before the Caddy auth gate landed).  Re-create the task."
+        )
+    _ensure_toad_token(_agent_config_dir(project, task_id), existing=saved_token)
+    return saved_token
+
+
 def _resume_toad_container(
     *,
     project: ProjectConfig,
@@ -172,16 +195,7 @@ def _resume_toad_container(
             f"(got {actual}).  Re-create the task to use the new port."
         )
     ensure_vault()
-    saved_token = meta.get("web_token")
-    if not isinstance(saved_token, str):
-        raise SystemExit(
-            f"Existing toad container {cname} has no saved web_token in metadata "
-            f"(created before the Caddy auth gate landed).  Re-create the task."
-        )
-    # Token file may have been cleared by a host-side cleanup; re-write
-    # it so the in-container Caddy can read it on startup.
-    agent_config_dir = project.tasks_root / str(task_id) / "agent-config"
-    _ensure_toad_token(agent_config_dir, existing=saved_token)
+    saved_token = _rehydrate_toad_token(project, task_id, meta, cname)
     color_enabled = _supports_color()
     url = _toad_browser_url(pub_host, saved_port, saved_token)
     if container_state == "running":
@@ -681,12 +695,9 @@ def task_run_toad(
     agent_config_dir = _prepare_agent_config(project, project_id, task_id, agents, preset)
     volumes.append(VolumeSpec(agent_config_dir, _CONTAINER_TEROK_CONFIG, sharing=Sharing.PRIVATE))
 
-    # Mint the auth token once per task; same value is reused on restart.
     token = _ensure_toad_token(agent_config_dir)
     meta["web_token"] = token
 
-    # Pin the caddy/toad port contract to the host-side constants so any
-    # future change here is picked up by the in-container supervisor.
     env["TOAD_PUBLIC_PORT"] = str(_TOAD_PUBLIC_PORT)
     env["TOAD_INTERNAL_PORT"] = str(_TOAD_INTERNAL_PORT)
 
@@ -1189,15 +1200,7 @@ def task_restart(project_id: str, task_id: str) -> None:
                 )
         task_dir = project.tasks_root / str(task_id)
         if mode == "toad":
-            # Rehydrate the per-task auth token so Caddy can read it after
-            # restart — same guarantees task_run_toad's resume path offers.
-            saved_token = meta.get("web_token")
-            if not isinstance(saved_token, str):
-                raise SystemExit(
-                    f"Existing toad container {cname} has no saved web_token in metadata "
-                    f"(created before the Caddy auth gate landed).  Re-create the task."
-                )
-            _ensure_toad_token(task_dir / "agent-config", existing=saved_token)
+            _rehydrate_toad_token(project, task_id, meta, cname)
         _podman_start(cname)
         _assert_running(cname)
         run_hook(

--- a/src/terok/lib/orchestration/tasks.py
+++ b/src/terok/lib/orchestration/tasks.py
@@ -115,6 +115,7 @@ class TaskMeta(TaskState):
     mode: str | None
     workspace: str
     web_port: int | None
+    web_token: str | None = None
     backend: str | None = None
     preset: str | None = None
     name: str = ""
@@ -255,6 +256,7 @@ def get_task_meta(project_id: str, task_id: str) -> TaskMeta:
         mode=mode,
         workspace=raw.get("workspace", ""),
         web_port=raw.get("web_port"),
+        web_token=raw.get("web_token"),
         backend=raw.get("backend"),
         container_state=live_state,
         exit_code=raw.get("exit_code"),
@@ -503,6 +505,7 @@ def _get_tasks(project_id: str, reverse: bool = False) -> list[TaskMeta]:
                     mode=mode,
                     workspace=meta.get("workspace", ""),
                     web_port=meta.get("web_port"),
+                    web_token=meta.get("web_token"),
                     backend=meta.get("backend"),
                     exit_code=meta.get("exit_code"),
                     deleting=bool(meta.get("deleting")),
@@ -981,6 +984,7 @@ def task_status(project_id: str, task_id: str) -> None:
         mode=mode,
         workspace=meta.get("workspace", ""),
         web_port=web_port,
+        web_token=meta.get("web_token"),
         backend=meta.get("backend"),
         exit_code=exit_code,
         deleting=bool(meta.get("deleting")),

--- a/src/terok/resources/instructions/default.md
+++ b/src/terok/resources/instructions/default.md
@@ -16,7 +16,7 @@ You are running inside an isolated Podman container managed by terok.
 
 ## Pre-installed tools
 
-git, gh (GitHub CLI), glab (GitLab CLI), rg (ripgrep), fd-find, jq, yq, ast-grep (structural code search/rewrite using AST patterns; `ast-grep run -p 'PATTERN' -l LANG` to search), toad (multi-agent TUI via ACP; `toad` to launch, `toad -a claude` to skip agent selection).
+git, gh (GitHub CLI), glab (GitLab CLI), rg (ripgrep), fd-find, jq, yq, ast-grep (structural code search/rewrite using AST patterns; `ast-grep run -p 'PATTERN' -l LANG` to search).
 
 Python 3 and Node.js are available. Use `sudo apt install` or `pip`/`npm` for anything else.
 

--- a/src/terok/tui/serve.py
+++ b/src/terok/tui/serve.py
@@ -1,5 +1,4 @@
 # SPDX-FileCopyrightText: 2025 Jiri Vyskocil
-# SPDX-FileCopyrightText: 2026 Jiri Vyskocil
 # SPDX-License-Identifier: Apache-2.0
 
 """Serve the Terok TUI as a web application via textual-serve."""
@@ -41,45 +40,80 @@ def _valid_port(value: str) -> int:
     return port
 
 
-def _password_path() -> Path:
-    """Return the ephemeral file path that stores the current session password.
+def _secure_runtime_dir() -> Path:
+    """Return a 0700 user-owned runtime dir for the password file.
 
-    ``$XDG_RUNTIME_DIR`` is a tmpfs cleared on reboot, so the password
-    naturally rotates each session without any on-disk state leaking.
-    Falls back to ``/tmp/terok-$UID`` when XDG_RUNTIME_DIR is unset.
+    ``$XDG_RUNTIME_DIR`` is a tmpfs cleared on reboot — ideal.  When it is
+    unset the fallback is ``/tmp/terok-$UID``, but since ``/tmp`` is shared
+    the directory is created with ``O_NOFOLLOW``-like semantics: we refuse
+    to reuse a path not owned by us or with looser permissions than 0700.
     """
     base = os.environ.get("XDG_RUNTIME_DIR")
     if base:
         root = Path(base) / "terok"
     else:
-        # Fallback when XDG_RUNTIME_DIR is unset: keep the password in a
-        # per-UID dir under /tmp so it is still isolated from other users.
         root = Path(f"/tmp/terok-{os.getuid()}")  # nosec B108  # noqa: S108
-    root.mkdir(parents=True, exist_ok=True)
-    return root / "serve.password"
+    try:
+        root.mkdir(mode=0o700, parents=True, exist_ok=False)
+    except FileExistsError:
+        st = root.lstat()
+        if not stat.S_ISDIR(st.st_mode) or stat.S_ISLNK(st.st_mode):
+            raise SystemExit(f"Refusing to use {root}: not a plain directory.")
+        if st.st_uid != os.getuid():
+            raise SystemExit(
+                f"Refusing to use {root}: owned by uid {st.st_uid}, not {os.getuid()}."
+            )
+        if stat.S_IMODE(st.st_mode) & 0o077:
+            raise SystemExit(
+                f"Refusing to use {root}: mode {oct(stat.S_IMODE(st.st_mode))}, expected 0700."
+            )
+    return root
+
+
+def _password_path() -> Path:
+    """Return the ephemeral file path that stores the current session password."""
+    return _secure_runtime_dir() / "serve.password"
 
 
 def _load_or_mint_password() -> str:
     """Read the current password from the runtime dir, or mint a fresh one.
 
     The file is created with mode 0600.  Existing files are refused if
-    they are world- or group-readable, to avoid another local user
-    sneaking a readable copy into the runtime dir between sessions.
+    they are world- or group-readable, if they are not owned by the
+    invoking user, or if the path is a symlink — these would let another
+    local user leak or overwrite credentials on shared hosts.
     """
     path = _password_path()
-    if path.exists():
-        mode = stat.S_IMODE(path.stat().st_mode)
-        if mode & 0o077:
-            raise SystemExit(
-                f"Refusing to read {path}: mode is {oct(mode)}, expected 0600. "
-                f"Delete it or fix the permissions."
-            )
-        value = path.read_text().strip()
-        if value:
-            return value
-    value = secrets.token_urlsafe(16)
-    fd = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
     try:
+        fd = os.open(path, os.O_RDONLY | os.O_NOFOLLOW)
+    except FileNotFoundError:
+        return _mint_password(path)
+    try:
+        st = os.fstat(fd)
+        if st.st_uid != os.getuid():
+            raise SystemExit(
+                f"Refusing to read {path}: owned by uid {st.st_uid}, not {os.getuid()}."
+            )
+        if stat.S_IMODE(st.st_mode) & 0o077:
+            raise SystemExit(
+                f"Refusing to read {path}: mode {oct(stat.S_IMODE(st.st_mode))}, expected 0600."
+            )
+        value = os.read(fd, 4096).decode().strip()
+    finally:
+        os.close(fd)
+    if value:
+        return value
+    return _mint_password(path)
+
+
+def _mint_password(path: Path) -> str:
+    """Write a fresh password into *path* (0600, no symlink follow) and return it."""
+    value = secrets.token_urlsafe(16)
+    fd = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_TRUNC | os.O_NOFOLLOW, 0o600)
+    try:
+        st = os.fstat(fd)
+        if st.st_uid != os.getuid():
+            raise SystemExit(f"Refusing to write {path}: not owned by current uid.")
         os.write(fd, value.encode())
     finally:
         os.close(fd)
@@ -201,9 +235,11 @@ def main() -> None:
     password = _load_or_mint_password()
     server = _build_server("terok-tui", args.host, args.port, args.public_url, password)
 
-    display_host = args.host if args.public_url is None else args.public_url
+    # When --public-url is given it's already a full URL; only assemble one
+    # ourselves when the caller left it unset.
+    display_url = args.public_url or f"http://{args.host}:{args.port}/"
     print(
-        f"terok-web: serving at http://{display_host}:{args.port}/ "
+        f"terok-web: serving at {display_url} "
         f"(user '{_AUTH_USER}', password in {_password_path()})",
         file=sys.stderr,
     )

--- a/src/terok/tui/serve.py
+++ b/src/terok/tui/serve.py
@@ -6,14 +6,18 @@
 from __future__ import annotations
 
 import argparse
+import getpass
+import hashlib
 import hmac
 import os
 import secrets
 import stat
 import sys
-from base64 import b64decode
+from base64 import b64decode, urlsafe_b64decode, urlsafe_b64encode
 from pathlib import Path
 from typing import TYPE_CHECKING
+
+from ..lib.core.paths import config_root
 
 if TYPE_CHECKING:
     from collections.abc import Awaitable, Callable
@@ -25,6 +29,15 @@ _DEFAULT_PORT = 8566
 _AUTH_USER = "terok"
 """Basic-auth username.  Constant so users only memorise the password."""
 _AUTH_REALM = "terok-tui"
+
+# scrypt KDF parameters.  N must be a power of 2; N=2**14 · r=8 · p=1 keeps
+# verify time around 30 ms on modern hardware — slow enough to frustrate
+# brute force yet fast enough for Basic auth re-prompts to stay snappy.
+_SCRYPT_N = 2**14
+_SCRYPT_R = 8
+_SCRYPT_P = 1
+_SCRYPT_DKLEN = 32
+_SCRYPT_PREFIX = "scrypt"
 
 
 def _valid_port(value: str) -> int:
@@ -40,54 +53,77 @@ def _valid_port(value: str) -> int:
     return port
 
 
-def _secure_runtime_dir() -> Path:
-    """Return a 0700 user-owned runtime dir for the password file.
-
-    ``$XDG_RUNTIME_DIR`` is a tmpfs cleared on reboot — ideal.  When it is
-    unset the fallback is ``/tmp/terok-$UID``, but since ``/tmp`` is shared
-    the directory is created with ``O_NOFOLLOW``-like semantics: we refuse
-    to reuse a path not owned by us or with looser permissions than 0700.
-    """
-    base = os.environ.get("XDG_RUNTIME_DIR")
-    if base:
-        root = Path(base) / "terok"
-    else:
-        root = Path(f"/tmp/terok-{os.getuid()}")  # nosec B108  # noqa: S108
-    try:
-        root.mkdir(mode=0o700, parents=True, exist_ok=False)
-    except FileExistsError:
-        st = root.lstat()
-        if not stat.S_ISDIR(st.st_mode) or stat.S_ISLNK(st.st_mode):
-            raise SystemExit(f"Refusing to use {root}: not a plain directory.")
-        if st.st_uid != os.getuid():
-            raise SystemExit(
-                f"Refusing to use {root}: owned by uid {st.st_uid}, not {os.getuid()}."
-            )
-        if stat.S_IMODE(st.st_mode) & 0o077:
-            raise SystemExit(
-                f"Refusing to use {root}: mode {oct(stat.S_IMODE(st.st_mode))}, expected 0700."
-            )
-    return root
-
-
 def _password_path() -> Path:
-    """Return the ephemeral file path that stores the current session password."""
-    return _secure_runtime_dir() / "serve.password"
+    """Return the persistent path that holds the scrypt-hashed serve password."""
+    root = config_root()
+    root.mkdir(mode=0o700, parents=True, exist_ok=True)
+    return root / "serve.password"
 
 
-def _load_or_mint_password() -> str:
-    """Read the current password from the runtime dir, or mint a fresh one.
+def _hash_password(password: str) -> str:
+    """Return a serialised scrypt record for *password*.
 
-    The file is created with mode 0600.  Existing files are refused if
-    they are world- or group-readable, if they are not owned by the
-    invoking user, or if the path is a symlink — these would let another
-    local user leak or overwrite credentials on shared hosts.
+    Format: ``scrypt$N$r$p$salt_b64$hash_b64`` — a single ASCII line,
+    self-describing so parameter changes can be detected on verify.
     """
-    path = _password_path()
+    salt = secrets.token_bytes(16)
+    hashed = hashlib.scrypt(
+        password.encode(),
+        salt=salt,
+        n=_SCRYPT_N,
+        r=_SCRYPT_R,
+        p=_SCRYPT_P,
+        dklen=_SCRYPT_DKLEN,
+    )
+    return "$".join(
+        (
+            _SCRYPT_PREFIX,
+            str(_SCRYPT_N),
+            str(_SCRYPT_R),
+            str(_SCRYPT_P),
+            urlsafe_b64encode(salt).decode().rstrip("="),
+            urlsafe_b64encode(hashed).decode().rstrip("="),
+        )
+    )
+
+
+def _verify_password(candidate: str, stored: str) -> bool:
+    """Return True when *candidate* re-hashes to the stored scrypt record."""
+    try:
+        prefix, n_s, r_s, p_s, salt_b64, hash_b64 = stored.split("$")
+    except ValueError:
+        return False
+    if prefix != _SCRYPT_PREFIX:
+        return False
+    try:
+        n, r, p = int(n_s), int(r_s), int(p_s)
+        salt = urlsafe_b64decode(salt_b64 + "=" * (-len(salt_b64) % 4))
+        expected = urlsafe_b64decode(hash_b64 + "=" * (-len(hash_b64) % 4))
+        got = hashlib.scrypt(candidate.encode(), salt=salt, n=n, r=r, p=p, dklen=len(expected))
+    except (ValueError, TypeError):
+        return False
+    return hmac.compare_digest(got, expected)
+
+
+def _write_password_hash(path: Path, password: str) -> None:
+    """Write the scrypt record for *password* to *path* (0600, no symlink follow)."""
+    record = _hash_password(password) + "\n"
+    fd = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_TRUNC | os.O_NOFOLLOW, 0o600)
+    try:
+        st = os.fstat(fd)
+        if st.st_uid != os.getuid():
+            raise SystemExit(f"Refusing to write {path}: not owned by current uid.")
+        os.write(fd, record.encode())
+    finally:
+        os.close(fd)
+
+
+def _read_password_hash(path: Path) -> str | None:
+    """Return the stored scrypt record, or ``None`` if the file does not exist."""
     try:
         fd = os.open(path, os.O_RDONLY | os.O_NOFOLLOW)
     except FileNotFoundError:
-        return _mint_password(path)
+        return None
     try:
         st = os.fstat(fd)
         if st.st_uid != os.getuid():
@@ -98,62 +134,62 @@ def _load_or_mint_password() -> str:
             raise SystemExit(
                 f"Refusing to read {path}: mode {oct(stat.S_IMODE(st.st_mode))}, expected 0600."
             )
-        value = os.read(fd, 4096).decode().strip()
+        return os.read(fd, 4096).decode().strip() or None
     finally:
         os.close(fd)
-    if value:
-        return value
-    return _mint_password(path)
 
 
-def _mint_password(path: Path) -> str:
-    """Write a fresh password into *path* (0600, no symlink follow) and return it."""
-    value = secrets.token_urlsafe(16)
-    fd = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_TRUNC | os.O_NOFOLLOW, 0o600)
-    try:
-        st = os.fstat(fd)
-        if st.st_uid != os.getuid():
-            raise SystemExit(f"Refusing to write {path}: not owned by current uid.")
-        os.write(fd, value.encode())
-    finally:
-        os.close(fd)
-    return value
+def _prompt_password(confirm: bool = True) -> str:
+    """Prompt for a password from stdin (hidden when TTY), confirming if asked."""
+    if sys.stdin.isatty():
+        pw = getpass.getpass("New terok-web password: ")
+        if not pw:
+            raise SystemExit("Password must not be empty.")
+        if confirm and getpass.getpass("Confirm: ") != pw:
+            raise SystemExit("Passwords did not match.")
+        return pw
+    pw = sys.stdin.readline().rstrip("\n")
+    if not pw:
+        raise SystemExit("Password must not be empty.")
+    return pw
 
 
-def _basic_auth_middleware(expected: str) -> Callable[..., Awaitable[web.StreamResponse]]:
+def _basic_auth_middleware(stored_hash: str) -> Callable[..., Awaitable[web.StreamResponse]]:
     """Build an aiohttp middleware that enforces Basic auth for every request.
 
-    The username is fixed (:data:`_AUTH_USER`); the password is compared
-    in constant time against *expected*.  On missing or wrong creds, a
-    401 with ``WWW-Authenticate: Basic`` is returned so browsers prompt
-    once per origin and cache the credentials for the tab lifetime.
+    The username is fixed (:data:`_AUTH_USER`); the password is verified
+    against *stored_hash* via scrypt.  On missing or wrong creds, a 401
+    with ``WWW-Authenticate: Basic`` is returned so browsers prompt once
+    per origin and cache the credentials for the tab lifetime.
     """
     from aiohttp import web
 
     challenge = {"WWW-Authenticate": f'Basic realm="{_AUTH_REALM}"'}
-    expected_token = f"{_AUTH_USER}:{expected}".encode()
+    user_prefix = f"{_AUTH_USER}:".encode()
 
     @web.middleware
     async def mw(
         request: web.Request,
         handler: Callable[[web.Request], Awaitable[web.StreamResponse]],
     ) -> web.StreamResponse:
-        """Pass through when creds match; otherwise respond with a 401 challenge."""
+        """Pass through when creds verify; otherwise respond with a 401 challenge."""
         header = request.headers.get("Authorization", "")
         scheme, _, payload = header.partition(" ")
         if scheme.lower() == "basic":
             try:
-                candidate = b64decode(payload.encode(), validate=True)
+                decoded = b64decode(payload.encode(), validate=True)
             except ValueError:
-                candidate = b""
-            if hmac.compare_digest(candidate, expected_token):
-                return await handler(request)
+                decoded = b""
+            if decoded.startswith(user_prefix):
+                candidate = decoded[len(user_prefix) :].decode("utf-8", errors="replace")
+                if _verify_password(candidate, stored_hash):
+                    return await handler(request)
         return web.Response(status=401, headers=challenge, text="Unauthorized")
 
     return mw
 
 
-def _build_server(command: str, host: str, port: int, public_url: str | None, password: str):
+def _build_server(command: str, host: str, port: int, public_url: str | None, stored_hash: str):
     """Construct a ``textual_serve`` Server with basic-auth middleware injected.
 
     Wraps ``Server._make_app`` on the instance so it returns the parent
@@ -164,7 +200,7 @@ def _build_server(command: str, host: str, port: int, public_url: str | None, pa
     """
     from textual_serve.server import Server
 
-    mw = _basic_auth_middleware(password)
+    mw = _basic_auth_middleware(stored_hash)
     server = Server(command, host=host, port=port, public_url=public_url)
     original_make_app = server._make_app
 
@@ -178,15 +214,38 @@ def _build_server(command: str, host: str, port: int, public_url: str | None, pa
     return server
 
 
+def _set_password_command(path: Path) -> None:
+    """Prompt for a new password, write its hash to *path*, and exit."""
+    pw = _prompt_password(confirm=True)
+    _write_password_hash(path, pw)
+    print(f"terok-web: password updated in {path}", file=sys.stderr)
+
+
+def _bootstrap_password_hash(path: Path) -> str:
+    """Load the stored hash, or mint + print a fresh random password on first run."""
+    existing = _read_password_hash(path)
+    if existing is not None:
+        return existing
+    fresh = secrets.token_urlsafe(16)
+    _write_password_hash(path, fresh)
+    print(
+        "terok-web: no password set — generated a random one.\n"
+        "           Copy it now; it will not be shown again.\n"
+        "           Run 'terok-web --set-password' to set your own.",
+        file=sys.stderr,
+    )
+    print(f"terok-web: password = {fresh}", file=sys.stderr)
+    return _read_password_hash(path) or ""
+
+
 def main() -> None:
     """Launch the Terok TUI as a web application.
 
-    Uses textual-serve to expose the TUI over HTTP/WebSocket so it can
-    be accessed from a browser.  Accepts ``--host`` and ``--port`` to
-    override the default listen address.  A random per-session password
-    gates the listener so other local users cannot reach it — the
-    password is printed to the launching terminal and also persisted
-    (0600) under ``$XDG_RUNTIME_DIR/terok/serve.password``.
+    Uses textual-serve to expose the TUI over HTTP/WebSocket so it can be
+    accessed from a browser.  A scrypt-hashed password at
+    ``~/.config/terok/serve.password`` (mode 0600) gates the listener.
+    On first launch a random password is minted and printed once; pass
+    ``--set-password`` to pick a memorable one instead.
     """
     try:
         from textual_serve.server import Server
@@ -230,20 +289,27 @@ def main() -> None:
         "(e.g. http://myhost:8566). Required when serving to LAN or "
         "behind a reverse proxy. If omitted, derived from --host and --port.",
     )
+    parser.add_argument(
+        "--set-password",
+        action="store_true",
+        help="Prompt for a new Basic-auth password, store its scrypt hash, and exit.",
+    )
     args = parser.parse_args()
 
-    password = _load_or_mint_password()
-    server = _build_server("terok-tui", args.host, args.port, args.public_url, password)
+    path = _password_path()
 
-    # When --public-url is given it's already a full URL; only assemble one
-    # ourselves when the caller left it unset.
+    if args.set_password:
+        _set_password_command(path)
+        return
+
+    stored_hash = _bootstrap_password_hash(path)
+    server = _build_server("terok-tui", args.host, args.port, args.public_url, stored_hash)
+
     display_url = args.public_url or f"http://{args.host}:{args.port}/"
     print(
-        f"terok-web: serving at {display_url} "
-        f"(user '{_AUTH_USER}', password in {_password_path()})",
+        f"terok-web: serving at {display_url} (user '{_AUTH_USER}', hash in {path})",
         file=sys.stderr,
     )
-    print(f"terok-web: password = {password}", file=sys.stderr)
     server.serve()
 
 

--- a/src/terok/tui/serve.py
+++ b/src/terok/tui/serve.py
@@ -1,13 +1,31 @@
 # SPDX-FileCopyrightText: 2025 Jiri Vyskocil
+# SPDX-FileCopyrightText: 2026 Jiri Vyskocil
 # SPDX-License-Identifier: Apache-2.0
 
 """Serve the Terok TUI as a web application via textual-serve."""
 
+from __future__ import annotations
+
 import argparse
+import hmac
+import os
+import secrets
+import stat
 import sys
+from base64 import b64decode
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from collections.abc import Awaitable, Callable
+
+    from aiohttp import web
 
 _DEFAULT_HOST = "localhost"
 _DEFAULT_PORT = 8566
+_AUTH_USER = "terok"
+"""Basic-auth username.  Constant so users only memorise the password."""
+_AUTH_REALM = "terok-tui"
 
 
 def _valid_port(value: str) -> int:
@@ -23,12 +41,118 @@ def _valid_port(value: str) -> int:
     return port
 
 
+def _password_path() -> Path:
+    """Return the ephemeral file path that stores the current session password.
+
+    ``$XDG_RUNTIME_DIR`` is a tmpfs cleared on reboot, so the password
+    naturally rotates each session without any on-disk state leaking.
+    Falls back to ``/tmp/terok-$UID`` when XDG_RUNTIME_DIR is unset.
+    """
+    base = os.environ.get("XDG_RUNTIME_DIR")
+    if base:
+        root = Path(base) / "terok"
+    else:
+        # Fallback when XDG_RUNTIME_DIR is unset: keep the password in a
+        # per-UID dir under /tmp so it is still isolated from other users.
+        root = Path(f"/tmp/terok-{os.getuid()}")  # nosec B108  # noqa: S108
+    root.mkdir(parents=True, exist_ok=True)
+    return root / "serve.password"
+
+
+def _load_or_mint_password() -> str:
+    """Read the current password from the runtime dir, or mint a fresh one.
+
+    The file is created with mode 0600.  Existing files are refused if
+    they are world- or group-readable, to avoid another local user
+    sneaking a readable copy into the runtime dir between sessions.
+    """
+    path = _password_path()
+    if path.exists():
+        mode = stat.S_IMODE(path.stat().st_mode)
+        if mode & 0o077:
+            raise SystemExit(
+                f"Refusing to read {path}: mode is {oct(mode)}, expected 0600. "
+                f"Delete it or fix the permissions."
+            )
+        value = path.read_text().strip()
+        if value:
+            return value
+    value = secrets.token_urlsafe(16)
+    fd = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+    try:
+        os.write(fd, value.encode())
+    finally:
+        os.close(fd)
+    return value
+
+
+def _basic_auth_middleware(expected: str) -> Callable[..., Awaitable[web.StreamResponse]]:
+    """Build an aiohttp middleware that enforces Basic auth for every request.
+
+    The username is fixed (:data:`_AUTH_USER`); the password is compared
+    in constant time against *expected*.  On missing or wrong creds, a
+    401 with ``WWW-Authenticate: Basic`` is returned so browsers prompt
+    once per origin and cache the credentials for the tab lifetime.
+    """
+    from aiohttp import web
+
+    challenge = {"WWW-Authenticate": f'Basic realm="{_AUTH_REALM}"'}
+    expected_token = f"{_AUTH_USER}:{expected}".encode()
+
+    @web.middleware
+    async def mw(
+        request: web.Request,
+        handler: Callable[[web.Request], Awaitable[web.StreamResponse]],
+    ) -> web.StreamResponse:
+        """Pass through when creds match; otherwise respond with a 401 challenge."""
+        header = request.headers.get("Authorization", "")
+        scheme, _, payload = header.partition(" ")
+        if scheme.lower() == "basic":
+            try:
+                candidate = b64decode(payload.encode(), validate=True)
+            except ValueError:
+                candidate = b""
+            if hmac.compare_digest(candidate, expected_token):
+                return await handler(request)
+        return web.Response(status=401, headers=challenge, text="Unauthorized")
+
+    return mw
+
+
+def _build_server(command: str, host: str, port: int, public_url: str | None, password: str):
+    """Construct a ``textual_serve`` Server with basic-auth middleware injected.
+
+    Wraps ``Server._make_app`` on the instance so it returns the parent
+    app with our auth middleware appended.  Using instance-level shadowing
+    (instead of subclassing) keeps the indirection to one line and leaves
+    the ``Server(...)`` call shape unchanged — it breaks only if textual-
+    serve renames ``_make_app`` (asserted at import time).
+    """
+    from textual_serve.server import Server
+
+    mw = _basic_auth_middleware(password)
+    server = Server(command, host=host, port=port, public_url=public_url)
+    original_make_app = server._make_app
+
+    async def _make_app_with_auth():
+        """Return the vanilla textual-serve app with our middleware appended."""
+        app = await original_make_app()
+        app.middlewares.append(mw)
+        return app
+
+    server._make_app = _make_app_with_auth
+    return server
+
+
 def main() -> None:
     """Launch the Terok TUI as a web application.
 
     Uses textual-serve to expose the TUI over HTTP/WebSocket so it can
     be accessed from a browser.  Accepts ``--host`` and ``--port`` to
-    override the default listen address.
+    override the default listen address.  A random per-session password
+    gates the listener so other local users cannot reach it — the
+    password is printed to the launching terminal and also persisted
+    (0600) under ``$XDG_RUNTIME_DIR/terok/serve.password``.
     """
     try:
         from textual_serve.server import Server
@@ -41,6 +165,14 @@ def main() -> None:
             )
             sys.exit(1)
         raise
+
+    if not hasattr(Server, "_make_app"):
+        print(
+            "Unsupported textual-serve version: Server._make_app is missing.  "
+            "terok pins the upstream seam used to inject basic-auth middleware.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
 
     parser = argparse.ArgumentParser(
         prog="terok-web",
@@ -66,7 +198,16 @@ def main() -> None:
     )
     args = parser.parse_args()
 
-    server = Server("terok-tui", host=args.host, port=args.port, public_url=args.public_url)
+    password = _load_or_mint_password()
+    server = _build_server("terok-tui", args.host, args.port, args.public_url, password)
+
+    display_host = args.host if args.public_url is None else args.public_url
+    print(
+        f"terok-web: serving at http://{display_host}:{args.port}/ "
+        f"(user '{_AUTH_USER}', password in {_password_path()})",
+        file=sys.stderr,
+    )
+    print(f"terok-web: password = {password}", file=sys.stderr)
     server.serve()
 
 

--- a/src/terok/tui/serve.py
+++ b/src/terok/tui/serve.py
@@ -1,7 +1,15 @@
 # SPDX-FileCopyrightText: 2025 Jiri Vyskocil
 # SPDX-License-Identifier: Apache-2.0
 
-"""Serve the Terok TUI as a web application via textual-serve."""
+"""HTTP gateway that serves terok-tui to the owning user's browser.
+
+An aiohttp Basic-auth middleware is injected into ``textual-serve``'s
+``Server._make_app`` so every route — including the WebSocket upgrade —
+is gated by a password the user picks and the browser remembers for the
+origin.  The password is persisted scrypt-hashed in
+``~/.config/terok/serve.password`` so it survives reboots; on first
+launch a random one is minted and printed once.
+"""
 
 from __future__ import annotations
 
@@ -25,15 +33,14 @@ if TYPE_CHECKING:
     from aiohttp import web
     from textual_serve.server import Server
 
+
 _DEFAULT_HOST = "localhost"
 _DEFAULT_PORT = 8566
 _AUTH_USER = "terok"
-"""Basic-auth username.  Constant so users only memorise the password."""
 _AUTH_REALM = "terok-tui"
 
-# scrypt KDF parameters.  N must be a power of 2; N=2**14 · r=8 · p=1 keeps
-# verify time around 30 ms on modern hardware — slow enough to frustrate
-# brute force yet fast enough for Basic auth re-prompts to stay snappy.
+# N=2**14 · r=8 · p=1 → ≈30 ms per verify on modern hardware; the KDF
+# cost *is* the online-guessing rate limit.
 _SCRYPT_N = 2**14
 _SCRYPT_R = 8
 _SCRYPT_P = 1
@@ -41,40 +48,127 @@ _SCRYPT_DKLEN = 32
 _SCRYPT_PREFIX = "scrypt"
 
 
-def _valid_port(value: str) -> int:
-    """Validate that *value* is a valid TCP port number (1–65535)."""
-    try:
-        port = int(value)
-    except ValueError:
-        raise argparse.ArgumentTypeError(f"invalid port value: {value!r} (must be an integer)")
-    if port < 1 or port > 65535:
-        raise argparse.ArgumentTypeError(
-            f"invalid port value: {value!r} (must be between 1 and 65535)"
-        )
-    return port
+# ── Entry point ─────────────────────────────────────────────────────────
 
 
-def _password_path() -> Path:
-    """Return the persistent path that holds the scrypt-hashed serve password."""
-    root = config_root()
-    root.mkdir(mode=0o700, parents=True, exist_ok=True)
-    return root / "serve.password"
+def main() -> None:
+    """Run the terok-web server, or update the stored password and exit."""
+    _require_textual_serve()
+    args = _argparser().parse_args()
+    path = _password_path()
+
+    if args.set_password:
+        _set_password(path)
+        return
+
+    stored_hash = _bootstrap_password(path)
+    server = _build_server("terok-tui", args.host, args.port, args.public_url, stored_hash)
+    display_url = args.public_url or f"http://{args.host}:{args.port}/"
+    print(
+        f"terok-web: serving at {display_url} (user '{_AUTH_USER}', hash in {path})",
+        file=sys.stderr,
+    )
+    server.serve()
+
+
+# ── Password lifecycle ──────────────────────────────────────────────────
+
+
+def _set_password(path: Path) -> None:
+    """Replace the stored password record with a user-chosen one."""
+    _save_password(path, _prompt_password())
+    print(f"terok-web: password updated in {path}", file=sys.stderr)
+
+
+def _bootstrap_password(path: Path) -> str:
+    """Stored scrypt record for the serve password, minting one on first run."""
+    existing = _load_password_record(path)
+    if existing is not None:
+        return existing
+    fresh = secrets.token_urlsafe(16)
+    record = _save_password(path, fresh)
+    print(
+        "terok-web: no password set — generated a random one.\n"
+        "           Copy it now; it will not be shown again.\n"
+        "           Run 'terok-web --set-password' to set your own.",
+        file=sys.stderr,
+    )
+    print(f"terok-web: password = {fresh}", file=sys.stderr)
+    return record
+
+
+# ── HTTP gate ───────────────────────────────────────────────────────────
+
+
+def _build_server(
+    command: str, host: str, port: int, public_url: str | None, stored_hash: str
+) -> Server:
+    """A textual-serve :class:`Server` with Basic-auth middleware already attached.
+
+    We monkey-patch ``_make_app`` on the instance rather than subclassing
+    so the upstream call shape stays unchanged.  Breaks only if
+    textual-serve renames that seam — guarded at import time.
+    """
+    from textual_serve.server import Server
+
+    mw = _basic_auth_middleware(stored_hash)
+    server = Server(command, host=host, port=port, public_url=public_url)
+    original_make_app = server._make_app
+
+    async def _make_app_with_auth() -> web.Application:
+        app = await original_make_app()
+        app.middlewares.append(mw)
+        return app
+
+    server._make_app = _make_app_with_auth
+    return server
+
+
+def _basic_auth_middleware(stored_hash: str) -> Callable[..., Awaitable[web.StreamResponse]]:
+    """Basic-auth gate that verifies the user's password against *stored_hash*.
+
+    Browsers cache Basic credentials for the origin, so the prompt fires
+    at most once per session.  Each request still pays a full scrypt
+    verify — deliberate rate limit against online guessing.
+    """
+    from aiohttp import web
+
+    challenge = {"WWW-Authenticate": f'Basic realm="{_AUTH_REALM}"'}
+    user_prefix = f"{_AUTH_USER}:".encode()
+
+    @web.middleware
+    async def mw(
+        request: web.Request,
+        handler: Callable[[web.Request], Awaitable[web.StreamResponse]],
+    ) -> web.StreamResponse:
+        header = request.headers.get("Authorization", "")
+        scheme, _, payload = header.partition(" ")
+        if scheme.lower() == "basic":
+            try:
+                decoded = b64decode(payload.encode(), validate=True)
+            except ValueError:
+                decoded = b""
+            if decoded.startswith(user_prefix):
+                candidate = decoded[len(user_prefix) :].decode("utf-8", errors="replace")
+                if _verify_password(candidate, stored_hash):
+                    return await handler(request)
+        return web.Response(status=401, headers=challenge, text="Unauthorized")
+
+    return mw
+
+
+# ── scrypt hashing ──────────────────────────────────────────────────────
 
 
 def _hash_password(password: str) -> str:
-    """Return a serialised scrypt record for *password*.
+    """A serialised scrypt record for *password* — ``scrypt$N$r$p$salt$hash``.
 
-    Format: ``scrypt$N$r$p$salt_b64$hash_b64`` — a single ASCII line,
-    self-describing so parameter changes can be detected on verify.
+    The record is self-describing so parameter upgrades are detectable
+    on verify and re-hashes can happen lazily later.
     """
     salt = secrets.token_bytes(16)
     hashed = hashlib.scrypt(
-        password.encode(),
-        salt=salt,
-        n=_SCRYPT_N,
-        r=_SCRYPT_R,
-        p=_SCRYPT_P,
-        dklen=_SCRYPT_DKLEN,
+        password.encode(), salt=salt, n=_SCRYPT_N, r=_SCRYPT_R, p=_SCRYPT_P, dklen=_SCRYPT_DKLEN
     )
     return "$".join(
         (
@@ -89,14 +183,11 @@ def _hash_password(password: str) -> str:
 
 
 def _verify_password(candidate: str, stored: str) -> bool:
-    """Return True when *candidate* re-hashes to the stored scrypt record."""
+    """True iff *candidate* hashes to the stored scrypt record."""
     try:
         prefix, n_s, r_s, p_s, salt_b64, hash_b64 = stored.split("$")
-    except ValueError:
-        return False
-    if prefix != _SCRYPT_PREFIX:
-        return False
-    try:
+        if prefix != _SCRYPT_PREFIX:
+            return False
         n, r, p = int(n_s), int(r_s), int(p_s)
         salt = urlsafe_b64decode(salt_b64 + "=" * (-len(salt_b64) % 4))
         expected = urlsafe_b64decode(hash_b64 + "=" * (-len(hash_b64) % 4))
@@ -106,31 +197,32 @@ def _verify_password(candidate: str, stored: str) -> bool:
     return hmac.compare_digest(got, expected)
 
 
-def _write_password_record(path: Path, record: str) -> None:
-    """Write *record* to *path* (0600, no symlink follow), enforcing mode on existing files."""
+# ── Password file I/O ───────────────────────────────────────────────────
+
+
+def _save_password(path: Path, password: str) -> str:
+    """Hash *password* and write the record to *path* (0600); return it."""
+    record = _hash_password(password)
     fd = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_TRUNC | os.O_NOFOLLOW, 0o600)
     try:
-        st = os.fstat(fd)
-        if st.st_uid != os.getuid():
+        if os.fstat(fd).st_uid != os.getuid():
             raise SystemExit(f"Refusing to write {path}: not owned by current uid.")
         # O_CREAT's mode argument is ignored on an existing file; fchmod
-        # ensures --set-password can't silently leave a loose mode from a
-        # prior run.
+        # keeps --set-password from silently leaving a loose mode.
         os.fchmod(fd, 0o600)
         os.write(fd, (record + "\n").encode())
     finally:
         os.close(fd)
-
-
-def _write_password_hash(path: Path, password: str) -> str:
-    """Hash *password* with scrypt and write the record to *path*.  Returns the record."""
-    record = _hash_password(password)
-    _write_password_record(path, record)
     return record
 
 
-def _read_password_hash(path: Path) -> str | None:
-    """Return the stored scrypt record, or ``None`` if the file does not exist."""
+def _load_password_record(path: Path) -> str | None:
+    """Stored scrypt record at *path*, or ``None`` when no file exists.
+
+    Refuses a symlink, a file not owned by the current user, or loose
+    permissions — any of these would let a local peer leak or swap
+    credentials on a shared host.
+    """
     try:
         fd = os.open(path, os.O_RDONLY | os.O_NOFOLLOW)
     except FileNotFoundError:
@@ -150,13 +242,13 @@ def _read_password_hash(path: Path) -> str | None:
         os.close(fd)
 
 
-def _prompt_password(confirm: bool = True) -> str:
-    """Prompt for a password from stdin (hidden when TTY), confirming if asked."""
+def _prompt_password() -> str:
+    """A non-empty password read (hidden on a TTY, one line from stdin otherwise)."""
     if sys.stdin.isatty():
         pw = getpass.getpass("New terok-web password: ")
         if not pw:
             raise SystemExit("Password must not be empty.")
-        if confirm and getpass.getpass("Confirm: ") != pw:
+        if getpass.getpass("Confirm: ") != pw:
             raise SystemExit("Passwords did not match.")
         return pw
     pw = sys.stdin.readline().rstrip("\n")
@@ -165,129 +257,24 @@ def _prompt_password(confirm: bool = True) -> str:
     return pw
 
 
-def _basic_auth_middleware(stored_hash: str) -> Callable[..., Awaitable[web.StreamResponse]]:
-    """Build an aiohttp middleware that enforces Basic auth for every request.
-
-    The username is fixed (:data:`_AUTH_USER`); the password is verified
-    against *stored_hash* via scrypt.  On missing or wrong creds, a 401
-    with ``WWW-Authenticate: Basic`` is returned so browsers prompt once
-    per origin and cache the credentials for the tab lifetime.
-    """
-    from aiohttp import web
-
-    challenge = {"WWW-Authenticate": f'Basic realm="{_AUTH_REALM}"'}
-    user_prefix = f"{_AUTH_USER}:".encode()
-
-    @web.middleware
-    async def mw(
-        request: web.Request,
-        handler: Callable[[web.Request], Awaitable[web.StreamResponse]],
-    ) -> web.StreamResponse:
-        """Pass through when creds verify; otherwise respond with a 401 challenge."""
-        header = request.headers.get("Authorization", "")
-        scheme, _, payload = header.partition(" ")
-        if scheme.lower() == "basic":
-            try:
-                decoded = b64decode(payload.encode(), validate=True)
-            except ValueError:
-                decoded = b""
-            if decoded.startswith(user_prefix):
-                candidate = decoded[len(user_prefix) :].decode("utf-8", errors="replace")
-                if _verify_password(candidate, stored_hash):
-                    return await handler(request)
-        return web.Response(status=401, headers=challenge, text="Unauthorized")
-
-    return mw
+# ── Wiring ──────────────────────────────────────────────────────────────
 
 
-def _build_server(
-    command: str, host: str, port: int, public_url: str | None, stored_hash: str
-) -> Server:
-    """Construct a ``textual_serve`` Server with basic-auth middleware injected.
-
-    Wraps ``Server._make_app`` on the instance so it returns the parent
-    app with our auth middleware appended.  Using instance-level shadowing
-    (instead of subclassing) keeps the indirection to one line and leaves
-    the ``Server(...)`` call shape unchanged — it breaks only if textual-
-    serve renames ``_make_app`` (asserted at import time).
-    """
-    from textual_serve.server import Server
-
-    mw = _basic_auth_middleware(stored_hash)
-    server = Server(command, host=host, port=port, public_url=public_url)
-    original_make_app = server._make_app
-
-    async def _make_app_with_auth() -> web.Application:
-        """Return the vanilla textual-serve app with our middleware appended."""
-        app = await original_make_app()
-        app.middlewares.append(mw)
-        return app
-
-    server._make_app = _make_app_with_auth
-    return server
+def _password_path() -> Path:
+    """Path of the scrypt-hashed serve password (creating its config dir if needed)."""
+    root = config_root()
+    root.mkdir(mode=0o700, parents=True, exist_ok=True)
+    return root / "serve.password"
 
 
-def _set_password_command(path: Path) -> None:
-    """Prompt for a new password, write its hash to *path*, and exit."""
-    pw = _prompt_password(confirm=True)
-    _write_password_hash(path, pw)
-    print(f"terok-web: password updated in {path}", file=sys.stderr)
-
-
-def _bootstrap_password_hash(path: Path) -> str:
-    """Load the stored hash, or mint + print a fresh random password on first run."""
-    existing = _read_password_hash(path)
-    if existing is not None:
-        return existing
-    fresh = secrets.token_urlsafe(16)
-    record = _write_password_hash(path, fresh)
-    print(
-        "terok-web: no password set — generated a random one.\n"
-        "           Copy it now; it will not be shown again.\n"
-        "           Run 'terok-web --set-password' to set your own.",
-        file=sys.stderr,
-    )
-    print(f"terok-web: password = {fresh}", file=sys.stderr)
-    return record
-
-
-def main() -> None:
-    """Launch the Terok TUI as a web application.
-
-    Uses textual-serve to expose the TUI over HTTP/WebSocket so it can be
-    accessed from a browser.  A scrypt-hashed password at
-    ``~/.config/terok/serve.password`` (mode 0600) gates the listener.
-    On first launch a random password is minted and printed once; pass
-    ``--set-password`` to pick a memorable one instead.
-    """
-    try:
-        from textual_serve.server import Server
-    except ModuleNotFoundError as exc:
-        if exc.name in ("textual_serve", "textual_serve.server"):
-            print(
-                "terok-web requires the 'textual-serve' package.\n"
-                "Install it with: pip install textual-serve",
-                file=sys.stderr,
-            )
-            sys.exit(1)
-        raise
-
-    if not hasattr(Server, "_make_app"):
-        print(
-            "Unsupported textual-serve version: Server._make_app is missing.  "
-            "terok pins the upstream seam used to inject basic-auth middleware.",
-            file=sys.stderr,
-        )
-        sys.exit(1)
-
+def _argparser() -> argparse.ArgumentParser:
+    """Argparser for ``terok-web``."""
     parser = argparse.ArgumentParser(
         prog="terok-web",
         description="Serve the Terok TUI as a web application",
     )
     parser.add_argument(
-        "--host",
-        default=_DEFAULT_HOST,
-        help=f"Host to bind to (default: {_DEFAULT_HOST})",
+        "--host", default=_DEFAULT_HOST, help=f"Host to bind to (default: {_DEFAULT_HOST})"
     )
     parser.add_argument(
         "--port",
@@ -307,23 +294,42 @@ def main() -> None:
         action="store_true",
         help="Prompt for a new Basic-auth password, store its scrypt hash, and exit.",
     )
-    args = parser.parse_args()
+    return parser
 
-    path = _password_path()
 
-    if args.set_password:
-        _set_password_command(path)
-        return
+def _valid_port(value: str) -> int:
+    """A TCP port number in the range 1–65535."""
+    try:
+        port = int(value)
+    except ValueError:
+        raise argparse.ArgumentTypeError(f"invalid port value: {value!r} (must be an integer)")
+    if port < 1 or port > 65535:
+        raise argparse.ArgumentTypeError(
+            f"invalid port value: {value!r} (must be between 1 and 65535)"
+        )
+    return port
 
-    stored_hash = _bootstrap_password_hash(path)
-    server = _build_server("terok-tui", args.host, args.port, args.public_url, stored_hash)
 
-    display_url = args.public_url or f"http://{args.host}:{args.port}/"
-    print(
-        f"terok-web: serving at {display_url} (user '{_AUTH_USER}', hash in {path})",
-        file=sys.stderr,
-    )
-    server.serve()
+def _require_textual_serve() -> None:
+    """Exit early if textual-serve is missing or its ``_make_app`` seam is gone."""
+    try:
+        from textual_serve.server import Server
+    except ModuleNotFoundError as exc:
+        if exc.name in ("textual_serve", "textual_serve.server"):
+            print(
+                "terok-web requires the 'textual-serve' package.\n"
+                "Install it with: pip install textual-serve",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+        raise
+    if not hasattr(Server, "_make_app"):
+        print(
+            "Unsupported textual-serve version: Server._make_app is missing.  "
+            "terok pins the upstream seam used to inject basic-auth middleware.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
 
 
 if __name__ == "__main__":

--- a/src/terok/tui/serve.py
+++ b/src/terok/tui/serve.py
@@ -23,6 +23,7 @@ if TYPE_CHECKING:
     from collections.abc import Awaitable, Callable
 
     from aiohttp import web
+    from textual_serve.server import Server
 
 _DEFAULT_HOST = "localhost"
 _DEFAULT_PORT = 8566
@@ -105,17 +106,27 @@ def _verify_password(candidate: str, stored: str) -> bool:
     return hmac.compare_digest(got, expected)
 
 
-def _write_password_hash(path: Path, password: str) -> None:
-    """Write the scrypt record for *password* to *path* (0600, no symlink follow)."""
-    record = _hash_password(password) + "\n"
+def _write_password_record(path: Path, record: str) -> None:
+    """Write *record* to *path* (0600, no symlink follow), enforcing mode on existing files."""
     fd = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_TRUNC | os.O_NOFOLLOW, 0o600)
     try:
         st = os.fstat(fd)
         if st.st_uid != os.getuid():
             raise SystemExit(f"Refusing to write {path}: not owned by current uid.")
-        os.write(fd, record.encode())
+        # O_CREAT's mode argument is ignored on an existing file; fchmod
+        # ensures --set-password can't silently leave a loose mode from a
+        # prior run.
+        os.fchmod(fd, 0o600)
+        os.write(fd, (record + "\n").encode())
     finally:
         os.close(fd)
+
+
+def _write_password_hash(path: Path, password: str) -> str:
+    """Hash *password* with scrypt and write the record to *path*.  Returns the record."""
+    record = _hash_password(password)
+    _write_password_record(path, record)
+    return record
 
 
 def _read_password_hash(path: Path) -> str | None:
@@ -189,7 +200,9 @@ def _basic_auth_middleware(stored_hash: str) -> Callable[..., Awaitable[web.Stre
     return mw
 
 
-def _build_server(command: str, host: str, port: int, public_url: str | None, stored_hash: str):
+def _build_server(
+    command: str, host: str, port: int, public_url: str | None, stored_hash: str
+) -> Server:
     """Construct a ``textual_serve`` Server with basic-auth middleware injected.
 
     Wraps ``Server._make_app`` on the instance so it returns the parent
@@ -204,7 +217,7 @@ def _build_server(command: str, host: str, port: int, public_url: str | None, st
     server = Server(command, host=host, port=port, public_url=public_url)
     original_make_app = server._make_app
 
-    async def _make_app_with_auth():
+    async def _make_app_with_auth() -> web.Application:
         """Return the vanilla textual-serve app with our middleware appended."""
         app = await original_make_app()
         app.middlewares.append(mw)
@@ -227,7 +240,7 @@ def _bootstrap_password_hash(path: Path) -> str:
     if existing is not None:
         return existing
     fresh = secrets.token_urlsafe(16)
-    _write_password_hash(path, fresh)
+    record = _write_password_hash(path, fresh)
     print(
         "terok-web: no password set — generated a random one.\n"
         "           Copy it now; it will not be shown again.\n"
@@ -235,7 +248,7 @@ def _bootstrap_password_hash(path: Path) -> str:
         file=sys.stderr,
     )
     print(f"terok-web: password = {fresh}", file=sys.stderr)
-    return _read_password_hash(path) or ""
+    return record
 
 
 def main() -> None:

--- a/src/terok/tui/widgets/task_detail.py
+++ b/src/terok/tui/widgets/task_detail.py
@@ -68,9 +68,7 @@ def render_task_details(
         lines.append(Text.assemble("Image:     ", Text("old", style=warning_style)))
     if task.web_port:
         base_url = f"http://{get_public_host()}:{task.web_port}/"
-        # First-hit URL carries the token; Caddy swaps it for an HttpOnly
-        # cookie and redirects to the clean path.  Old tasks (no token)
-        # fall back to the bare URL.
+        # Token in the query is what Caddy trades for its auth cookie.
         link_url = f"{base_url}?token={task.web_token}" if task.web_token else base_url
         lines.append(
             Text.assemble(

--- a/src/terok/tui/widgets/task_detail.py
+++ b/src/terok/tui/widgets/task_detail.py
@@ -67,10 +67,15 @@ def render_task_details(
     if task.status == "running" and image_old:
         lines.append(Text.assemble("Image:     ", Text("old", style=warning_style)))
     if task.web_port:
+        base_url = f"http://{get_public_host()}:{task.web_port}/"
+        # First-hit URL carries the token; Caddy swaps it for an HttpOnly
+        # cookie and redirects to the clean path.  Old tasks (no token)
+        # fall back to the bare URL.
+        link_url = f"{base_url}?token={task.web_token}" if task.web_token else base_url
         lines.append(
             Text.assemble(
                 "Web URL:   ",
-                Text(f"http://{get_public_host()}:{task.web_port}/", style=accent_style),
+                Text(base_url, style=accent_style + Style(link=link_url)),
             )
         )
     if task.mode == "cli" and project_id:

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -342,8 +342,8 @@ def write_fake_podman(bin_dir: Path, state_path: Path) -> Path:
 
             def ready_marker(args: list[str]) -> str:
                 joined = " ".join(args)
-                if "toad --serve" in joined:
-                    return "Serving http://0.0.0.0:8080"
+                if "terok-toad-entry" in joined:
+                    return "TEROK_READY"
                 if any(arg == "-p" for arg in args):
                     return "Terok Web UI started"
                 return "__CLI_READY__"

--- a/tests/integration/launch/test_task_start.py
+++ b/tests/integration/launch/test_task_start.py
@@ -149,14 +149,19 @@ class TestLaunchWorkflows:
         args = _container_args(state, toad_container)
 
         assert "Toad is serving." in result.stdout
+        # URL in stdout carries the per-task token; the listener itself is
+        # at the bare host:port form — assert that prefix.
         assert localhost_url(web_port) in result.stdout
-        assert state["containers"][toad_container]["marker"] == "Serving http://0.0.0.0:8080"
+        assert state["containers"][toad_container]["marker"] == "TEROK_READY"
         assert args[args.index("-p") + 1] == f"{LOCALHOST}:{web_port}:{TOAD_PORT}"
         assert f"{PROJECT_ID}:l2-cli" in args
-        assert "toad --serve -H 0.0.0.0 -p 8080" in args[-1]
+        # terok-toad-entry (in-container supervisor) starts Caddy + toad;
+        # terok only forwards the public URL now.
+        assert "terok-toad-entry" in args[-1]
         assert f"--public-url {localhost_url(web_port).rstrip('/')}" in args[-1]
         assert meta["mode"] == "toad"
         assert meta["web_port"] == web_port
+        assert isinstance(meta.get("web_token"), str) and meta["web_token"]
         assert meta["unrestricted"] is True
 
     def test_task_restart_starts_existing_stopped_container(

--- a/tests/unit/lib/test_tasks.py
+++ b/tests/unit/lib/test_tasks.py
@@ -534,10 +534,13 @@ class TestTask:
 
             spec = captured_runspec(sandbox_factory)
             bash_cmd = spec.command[-1]
+            # The in-container supervisor (``terok-toad-entry``) now owns
+            # the port wiring; terok only passes --public-url through.
+            assert bash_cmd.startswith("terok-toad-entry")
             assert "--public-url http://127.0.0.1:7861" in bash_cmd
-            assert "-p 8080" in bash_cmd
 
-            # Port forwarding maps host port to container toad port
+            # Host publishes port 8080 (Caddy); toad listens on loopback
+            # 8081 inside the container and is not published.
             extra = list(spec.extra_args)
             port_idx = extra.index("-p")
             assert extra[port_idx + 1] == "127.0.0.1:7861:8080"

--- a/tests/unit/tui/test_serve.py
+++ b/tests/unit/tui/test_serve.py
@@ -1,5 +1,4 @@
 # SPDX-FileCopyrightText: 2025 Jiri Vyskocil
-# SPDX-FileCopyrightText: 2026 Jiri Vyskocil
 # SPDX-License-Identifier: Apache-2.0
 
 """Tests for the terok-web serve entry point."""
@@ -7,12 +6,20 @@
 from __future__ import annotations
 
 import argparse
+import os
+import stat
 import sys
+from pathlib import Path
 from unittest import mock
 
 import pytest
 
-from terok.tui.serve import _valid_port, main
+from terok.tui.serve import (
+    _load_or_mint_password,
+    _secure_runtime_dir,
+    _valid_port,
+    main,
+)
 
 
 class TestValidPort:
@@ -94,3 +101,116 @@ class TestMain:
             "terok-tui", host="0.0.0.0", port=9000, public_url=None
         )
         mock_server_instance.serve.assert_called_once()
+
+
+class TestPasswordHandling:
+    """Tests for the ephemeral password file lifecycle."""
+
+    def test_secure_runtime_dir_creates_0700(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """First call creates the runtime dir with mode 0700."""
+        runtime = tmp_path / "x"
+        monkeypatch.setenv("XDG_RUNTIME_DIR", str(runtime))
+        out = _secure_runtime_dir()
+        assert out == runtime / "terok"
+        assert stat.S_IMODE(out.stat().st_mode) == 0o700
+
+    def test_secure_runtime_dir_rejects_loose_perms(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """A pre-existing runtime dir with 0755 is refused."""
+        runtime = tmp_path / "x" / "terok"
+        runtime.mkdir(parents=True, mode=0o755)
+        monkeypatch.setenv("XDG_RUNTIME_DIR", str(tmp_path / "x"))
+        with pytest.raises(SystemExit, match="mode "):
+            _secure_runtime_dir()
+
+    def test_secure_runtime_dir_rejects_symlink(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """A symlink as the runtime dir is refused (defends against /tmp races)."""
+        real = tmp_path / "real"
+        real.mkdir(mode=0o700)
+        link = tmp_path / "x" / "terok"
+        link.parent.mkdir()
+        link.symlink_to(real)
+        monkeypatch.setenv("XDG_RUNTIME_DIR", str(tmp_path / "x"))
+        with pytest.raises(SystemExit, match="not a plain directory"):
+            _secure_runtime_dir()
+
+    def test_mint_and_reuse_password(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+        """Fresh run mints a password; a second call returns the same value."""
+        monkeypatch.setenv("XDG_RUNTIME_DIR", str(tmp_path))
+        first = _load_or_mint_password()
+        assert first
+        path = tmp_path / "terok" / "serve.password"
+        assert stat.S_IMODE(path.stat().st_mode) == 0o600
+        second = _load_or_mint_password()
+        assert first == second
+
+    def test_rejects_loose_password_file(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """A password file left 0644 is refused on load."""
+        monkeypatch.setenv("XDG_RUNTIME_DIR", str(tmp_path))
+        _load_or_mint_password()  # seed
+        path = tmp_path / "terok" / "serve.password"
+        os.chmod(path, 0o644)
+        with pytest.raises(SystemExit, match="mode "):
+            _load_or_mint_password()
+
+
+class TestBasicAuthMiddleware:
+    """Tests for the basic-auth aiohttp middleware."""
+
+    def _run(self, coro):
+        """Run *coro* to completion using a fresh event loop."""
+        import asyncio
+
+        return asyncio.new_event_loop().run_until_complete(coro)
+
+    def test_rejects_without_credentials(self) -> None:
+        """A request without Authorization gets a 401 + Basic challenge."""
+        from aiohttp.test_utils import make_mocked_request
+
+        from terok.tui.serve import _basic_auth_middleware
+
+        mw = _basic_auth_middleware("secret")
+        req = make_mocked_request("GET", "/")
+        resp = self._run(mw(req, lambda _: None))
+        assert resp.status == 401
+        assert "Basic" in resp.headers["WWW-Authenticate"]
+
+    def test_accepts_correct_credentials(self) -> None:
+        """Valid Basic auth passes through to the inner handler."""
+        from base64 import b64encode
+
+        from aiohttp import web
+        from aiohttp.test_utils import make_mocked_request
+
+        from terok.tui.serve import _basic_auth_middleware
+
+        mw = _basic_auth_middleware("secret")
+        token = b64encode(b"terok:secret").decode()
+        req = make_mocked_request("GET", "/", headers={"Authorization": f"Basic {token}"})
+
+        async def inner(_request: web.Request) -> web.Response:
+            return web.Response(status=204)
+
+        resp = self._run(mw(req, inner))
+        assert resp.status == 204
+
+    def test_rejects_wrong_password(self) -> None:
+        """Wrong password still yields a 401 rather than passing through."""
+        from base64 import b64encode
+
+        from aiohttp.test_utils import make_mocked_request
+
+        from terok.tui.serve import _basic_auth_middleware
+
+        mw = _basic_auth_middleware("secret")
+        token = b64encode(b"terok:wrong").decode()
+        req = make_mocked_request("GET", "/", headers={"Authorization": f"Basic {token}"})
+        resp = self._run(mw(req, lambda _: None))
+        assert resp.status == 401

--- a/tests/unit/tui/test_serve.py
+++ b/tests/unit/tui/test_serve.py
@@ -164,13 +164,7 @@ class TestPasswordHandling:
 class TestBasicAuthMiddleware:
     """Tests for the basic-auth aiohttp middleware."""
 
-    def _run(self, coro):
-        """Run *coro* to completion using a fresh event loop."""
-        import asyncio
-
-        return asyncio.new_event_loop().run_until_complete(coro)
-
-    def test_rejects_without_credentials(self) -> None:
+    async def test_rejects_without_credentials(self) -> None:
         """A request without Authorization gets a 401 + Basic challenge."""
         from aiohttp.test_utils import make_mocked_request
 
@@ -178,11 +172,11 @@ class TestBasicAuthMiddleware:
 
         mw = _basic_auth_middleware("secret")
         req = make_mocked_request("GET", "/")
-        resp = self._run(mw(req, lambda _: None))
+        resp = await mw(req, lambda _: None)
         assert resp.status == 401
         assert "Basic" in resp.headers["WWW-Authenticate"]
 
-    def test_accepts_correct_credentials(self) -> None:
+    async def test_accepts_correct_credentials(self) -> None:
         """Valid Basic auth passes through to the inner handler."""
         from base64 import b64encode
 
@@ -198,10 +192,10 @@ class TestBasicAuthMiddleware:
         async def inner(_request: web.Request) -> web.Response:
             return web.Response(status=204)
 
-        resp = self._run(mw(req, inner))
+        resp = await mw(req, inner)
         assert resp.status == 204
 
-    def test_rejects_wrong_password(self) -> None:
+    async def test_rejects_wrong_password(self) -> None:
         """Wrong password still yields a 401 rather than passing through."""
         from base64 import b64encode
 
@@ -212,5 +206,5 @@ class TestBasicAuthMiddleware:
         mw = _basic_auth_middleware("secret")
         token = b64encode(b"terok:wrong").decode()
         req = make_mocked_request("GET", "/", headers={"Authorization": f"Basic {token}"})
-        resp = self._run(mw(req, lambda _: None))
+        resp = await mw(req, lambda _: None)
         assert resp.status == 401

--- a/tests/unit/tui/test_serve.py
+++ b/tests/unit/tui/test_serve.py
@@ -15,9 +15,12 @@ from unittest import mock
 import pytest
 
 from terok.tui.serve import (
-    _load_or_mint_password,
-    _secure_runtime_dir,
+    _bootstrap_password_hash,
+    _hash_password,
+    _read_password_hash,
     _valid_port,
+    _verify_password,
+    _write_password_hash,
     main,
 )
 
@@ -59,7 +62,7 @@ class TestMain:
         assert "pip install textual-serve" in captured.err
 
     def test_server_created_with_defaults(
-        self, monkeypatch: pytest.MonkeyPatch, tmp_path: pytest.TempPathFactory
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
     ) -> None:
         """Server is instantiated with default host and port when no args given."""
         mock_server_instance = mock.MagicMock()
@@ -71,7 +74,7 @@ class TestMain:
         monkeypatch.setitem(sys.modules, "textual_serve", mock.MagicMock())
         monkeypatch.setitem(sys.modules, "textual_serve.server", server_mod)
         monkeypatch.setattr("sys.argv", ["terok-web"])
-        monkeypatch.setenv("XDG_RUNTIME_DIR", str(tmp_path))
+        monkeypatch.setenv("TEROK_CONFIG_DIR", str(tmp_path))
 
         main()
 
@@ -81,7 +84,7 @@ class TestMain:
         mock_server_instance.serve.assert_called_once()
 
     def test_server_created_with_custom_args(
-        self, monkeypatch: pytest.MonkeyPatch, tmp_path: pytest.TempPathFactory
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
     ) -> None:
         """Server respects --host and --port arguments."""
         mock_server_instance = mock.MagicMock()
@@ -93,7 +96,7 @@ class TestMain:
         monkeypatch.setitem(sys.modules, "textual_serve", mock.MagicMock())
         monkeypatch.setitem(sys.modules, "textual_serve.server", server_mod)
         monkeypatch.setattr("sys.argv", ["terok-web", "--host", "0.0.0.0", "--port", "9000"])
-        monkeypatch.setenv("XDG_RUNTIME_DIR", str(tmp_path))
+        monkeypatch.setenv("TEROK_CONFIG_DIR", str(tmp_path))
 
         main()
 
@@ -103,62 +106,69 @@ class TestMain:
         mock_server_instance.serve.assert_called_once()
 
 
-class TestPasswordHandling:
-    """Tests for the ephemeral password file lifecycle."""
+class TestPasswordHashing:
+    """Tests for the scrypt password storage and verify pipeline."""
 
-    def test_secure_runtime_dir_creates_0700(
-        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
-    ) -> None:
-        """First call creates the runtime dir with mode 0700."""
-        runtime = tmp_path / "x"
-        monkeypatch.setenv("XDG_RUNTIME_DIR", str(runtime))
-        out = _secure_runtime_dir()
-        assert out == runtime / "terok"
-        assert stat.S_IMODE(out.stat().st_mode) == 0o700
+    def test_hash_roundtrip(self) -> None:
+        """A password verifies against its own hash and fails on a mismatch."""
+        record = _hash_password("hunter2")
+        assert record.startswith("scrypt$")
+        assert _verify_password("hunter2", record)
+        assert not _verify_password("hunter3", record)
 
-    def test_secure_runtime_dir_rejects_loose_perms(
-        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
-    ) -> None:
-        """A pre-existing runtime dir with 0755 is refused."""
-        runtime = tmp_path / "x" / "terok"
-        runtime.mkdir(parents=True, mode=0o755)
-        monkeypatch.setenv("XDG_RUNTIME_DIR", str(tmp_path / "x"))
-        with pytest.raises(SystemExit, match="mode "):
-            _secure_runtime_dir()
+    def test_hash_is_salted(self) -> None:
+        """Hashing the same password twice produces different records."""
+        assert _hash_password("same") != _hash_password("same")
 
-    def test_secure_runtime_dir_rejects_symlink(
-        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
-    ) -> None:
-        """A symlink as the runtime dir is refused (defends against /tmp races)."""
-        real = tmp_path / "real"
-        real.mkdir(mode=0o700)
-        link = tmp_path / "x" / "terok"
-        link.parent.mkdir()
-        link.symlink_to(real)
-        monkeypatch.setenv("XDG_RUNTIME_DIR", str(tmp_path / "x"))
-        with pytest.raises(SystemExit, match="not a plain directory"):
-            _secure_runtime_dir()
+    def test_verify_rejects_garbage(self) -> None:
+        """Malformed records never verify."""
+        assert not _verify_password("x", "not-a-record")
+        assert not _verify_password("x", "scrypt$bogus")
+        assert not _verify_password("x", "scrypt$1$1$1$!!!$!!!")
 
-    def test_mint_and_reuse_password(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
-        """Fresh run mints a password; a second call returns the same value."""
-        monkeypatch.setenv("XDG_RUNTIME_DIR", str(tmp_path))
-        first = _load_or_mint_password()
-        assert first
-        path = tmp_path / "terok" / "serve.password"
+    def test_file_roundtrip(self, tmp_path: Path) -> None:
+        """Written files come back as the original record and are mode 0600."""
+        path = tmp_path / "pw"
+        _write_password_hash(path, "s3cret")
         assert stat.S_IMODE(path.stat().st_mode) == 0o600
-        second = _load_or_mint_password()
-        assert first == second
+        record = _read_password_hash(path)
+        assert record is not None and _verify_password("s3cret", record)
 
-    def test_rejects_loose_password_file(
-        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
-    ) -> None:
-        """A password file left 0644 is refused on load."""
-        monkeypatch.setenv("XDG_RUNTIME_DIR", str(tmp_path))
-        _load_or_mint_password()  # seed
-        path = tmp_path / "terok" / "serve.password"
+    def test_read_missing_returns_none(self, tmp_path: Path) -> None:
+        """Reading a non-existent path returns ``None`` (not an error)."""
+        assert _read_password_hash(tmp_path / "nope") is None
+
+    def test_read_rejects_loose_perms(self, tmp_path: Path) -> None:
+        """A 0644 password file is refused on load."""
+        path = tmp_path / "pw"
+        _write_password_hash(path, "s3cret")
         os.chmod(path, 0o644)
         with pytest.raises(SystemExit, match="mode "):
-            _load_or_mint_password()
+            _read_password_hash(path)
+
+
+class TestBootstrap:
+    """Tests for first-launch password minting and reuse."""
+
+    def test_first_launch_mints_and_prints(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """On first launch a random password is generated, printed, and stored."""
+        path = tmp_path / "serve.password"
+        stored = _bootstrap_password_hash(path)
+        assert stored.startswith("scrypt$")
+        err = capsys.readouterr().err
+        assert "password = " in err
+        printed = next(line for line in err.splitlines() if "password = " in line)
+        password = printed.split("password = ", 1)[1]
+        assert _verify_password(password, stored)
+
+    def test_second_launch_reuses_hash(self, tmp_path: Path) -> None:
+        """If a hash already exists it is returned verbatim (no reprint)."""
+        path = tmp_path / "serve.password"
+        first = _bootstrap_password_hash(path)
+        second = _bootstrap_password_hash(path)
+        assert first == second
 
 
 class TestBasicAuthMiddleware:
@@ -168,9 +178,9 @@ class TestBasicAuthMiddleware:
         """A request without Authorization gets a 401 + Basic challenge."""
         from aiohttp.test_utils import make_mocked_request
 
-        from terok.tui.serve import _basic_auth_middleware
+        from terok.tui.serve import _basic_auth_middleware, _hash_password
 
-        mw = _basic_auth_middleware("secret")
+        mw = _basic_auth_middleware(_hash_password("secret"))
         req = make_mocked_request("GET", "/")
         resp = await mw(req, lambda _: None)
         assert resp.status == 401
@@ -183,9 +193,9 @@ class TestBasicAuthMiddleware:
         from aiohttp import web
         from aiohttp.test_utils import make_mocked_request
 
-        from terok.tui.serve import _basic_auth_middleware
+        from terok.tui.serve import _basic_auth_middleware, _hash_password
 
-        mw = _basic_auth_middleware("secret")
+        mw = _basic_auth_middleware(_hash_password("secret"))
         token = b64encode(b"terok:secret").decode()
         req = make_mocked_request("GET", "/", headers={"Authorization": f"Basic {token}"})
 
@@ -201,9 +211,9 @@ class TestBasicAuthMiddleware:
 
         from aiohttp.test_utils import make_mocked_request
 
-        from terok.tui.serve import _basic_auth_middleware
+        from terok.tui.serve import _basic_auth_middleware, _hash_password
 
-        mw = _basic_auth_middleware("secret")
+        mw = _basic_auth_middleware(_hash_password("secret"))
         token = b64encode(b"terok:wrong").decode()
         req = make_mocked_request("GET", "/", headers={"Authorization": f"Basic {token}"})
         resp = await mw(req, lambda _: None)

--- a/tests/unit/tui/test_serve.py
+++ b/tests/unit/tui/test_serve.py
@@ -51,7 +51,9 @@ class TestMain:
         assert "textual-serve" in captured.err
         assert "pip install textual-serve" in captured.err
 
-    def test_server_created_with_defaults(self, monkeypatch: pytest.MonkeyPatch) -> None:
+    def test_server_created_with_defaults(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: pytest.TempPathFactory
+    ) -> None:
         """Server is instantiated with default host and port when no args given."""
         mock_server_instance = mock.MagicMock()
         mock_server_cls = mock.MagicMock(return_value=mock_server_instance)
@@ -62,6 +64,7 @@ class TestMain:
         monkeypatch.setitem(sys.modules, "textual_serve", mock.MagicMock())
         monkeypatch.setitem(sys.modules, "textual_serve.server", server_mod)
         monkeypatch.setattr("sys.argv", ["terok-web"])
+        monkeypatch.setenv("XDG_RUNTIME_DIR", str(tmp_path))
 
         main()
 
@@ -70,7 +73,9 @@ class TestMain:
         )
         mock_server_instance.serve.assert_called_once()
 
-    def test_server_created_with_custom_args(self, monkeypatch: pytest.MonkeyPatch) -> None:
+    def test_server_created_with_custom_args(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: pytest.TempPathFactory
+    ) -> None:
         """Server respects --host and --port arguments."""
         mock_server_instance = mock.MagicMock()
         mock_server_cls = mock.MagicMock(return_value=mock_server_instance)
@@ -81,6 +86,7 @@ class TestMain:
         monkeypatch.setitem(sys.modules, "textual_serve", mock.MagicMock())
         monkeypatch.setitem(sys.modules, "textual_serve.server", server_mod)
         monkeypatch.setattr("sys.argv", ["terok-web", "--host", "0.0.0.0", "--port", "9000"])
+        monkeypatch.setenv("XDG_RUNTIME_DIR", str(tmp_path))
 
         main()
 

--- a/tests/unit/tui/test_serve.py
+++ b/tests/unit/tui/test_serve.py
@@ -15,12 +15,12 @@ from unittest import mock
 import pytest
 
 from terok.tui.serve import (
-    _bootstrap_password_hash,
+    _bootstrap_password,
     _hash_password,
-    _read_password_hash,
+    _load_password_record,
+    _save_password,
     _valid_port,
     _verify_password,
-    _write_password_hash,
     main,
 )
 
@@ -129,22 +129,22 @@ class TestPasswordHashing:
     def test_file_roundtrip(self, tmp_path: Path) -> None:
         """Written files come back as the original record and are mode 0600."""
         path = tmp_path / "pw"
-        _write_password_hash(path, "s3cret")
+        _save_password(path, "s3cret")
         assert stat.S_IMODE(path.stat().st_mode) == 0o600
-        record = _read_password_hash(path)
+        record = _load_password_record(path)
         assert record is not None and _verify_password("s3cret", record)
 
     def test_read_missing_returns_none(self, tmp_path: Path) -> None:
         """Reading a non-existent path returns ``None`` (not an error)."""
-        assert _read_password_hash(tmp_path / "nope") is None
+        assert _load_password_record(tmp_path / "nope") is None
 
     def test_read_rejects_loose_perms(self, tmp_path: Path) -> None:
         """A 0644 password file is refused on load."""
         path = tmp_path / "pw"
-        _write_password_hash(path, "s3cret")
+        _save_password(path, "s3cret")
         os.chmod(path, 0o644)
         with pytest.raises(SystemExit, match="mode "):
-            _read_password_hash(path)
+            _load_password_record(path)
 
 
 class TestBootstrap:
@@ -155,7 +155,7 @@ class TestBootstrap:
     ) -> None:
         """On first launch a random password is generated, printed, and stored."""
         path = tmp_path / "serve.password"
-        stored = _bootstrap_password_hash(path)
+        stored = _bootstrap_password(path)
         assert stored.startswith("scrypt$")
         err = capsys.readouterr().err
         assert "password = " in err
@@ -166,8 +166,8 @@ class TestBootstrap:
     def test_second_launch_reuses_hash(self, tmp_path: Path) -> None:
         """If a hash already exists it is returned verbatim (no reprint)."""
         path = tmp_path / "serve.password"
-        first = _bootstrap_password_hash(path)
-        second = _bootstrap_password_hash(path)
+        first = _bootstrap_password(path)
+        second = _bootstrap_password(path)
         assert first == second
 
 


### PR DESCRIPTION
## What

Close two "any local user can reach my web UI" holes on a shared host:
- **`toad`** (served from inside task containers) — random per-task token
- **`terok serve`** (serves `terok-tui` from the host) — user-chosen password via HTTP Basic

## How it works

### toad (paired with terok-ai/terok-executor#187)

- `task_run_toad` mints `secrets.token_urlsafe(32)` and writes it 0600 to `agent-config/toad.token` (the existing per-task bind mount). Token persists as `web_token` in task metadata.
- **Caddy inside the container** validates the token (companion PR); the published host port is therefore safe on a shared host.
- The printed URL — and the clickable link in `terok-tui`'s task detail — carry `?token=…`; Caddy swaps it for an `HttpOnly` cookie on first hit.
- `task_restart` rehydrates the token so stopped-and-restarted tasks keep working. IPv6 `TEROK_PUBLIC_HOST` values are properly bracketed in URLs (`[::1]:…`).

### terok serve

- Subclass of `textual_serve.server.Server` with an **aiohttp Basic-auth middleware** (~20 LOC, no fork of textual-serve).
- Password is **scrypt-hashed** (stdlib `hashlib.scrypt`, no new deps) at `~/.config/terok/serve.password` — mode `0600`, `O_NOFOLLOW`, uid-checked.
- **`terok-web --set-password`** prompts via `getpass` to pick a memorable password. On first launch a random one is minted and printed once.
- Per-request: scrypt rehash of the submitted password against stored salt/params, constant-time compare (~30 ms — fine for Basic-auth's cached-creds model).

## Key choices

- **Token for toad** (user never types it; clickable link injects it), **password for terok serve** (browser caches Basic-auth; memorable).
- **Hash only the serve password** — users reuse memorable passwords across places, and config dirs leak via backups/dotfile sync. The toad token is random + per-task, so plaintext 0600 is fine.
- **Cookie-seeded-from-query**, not per-request `?token=` — textual-serve's absolute URLs carry no query, so cookie is the only option that keeps WebSocket/static routes authed.
- **No TLS** — localhost context; accepted tradeoff given the future per-user single-gateway plan.

## Test plan

- [x] `make check` passes (minus one pre-existing unrelated failure).
- [x] Unit tests: scrypt hash roundtrip, Basic-auth middleware 401/200/401, clickable-link rendering, task restart token rehydration.
- [ ] Off-CI end-to-end: two-user browser flow; restart round-trip; `--set-password` UX.

**Depends on** terok-ai/terok-executor#187 — `pyproject.toml` points at the executor PR branch during tandem development; the chain release script swaps back to a release URL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added token-based authentication for toad task URLs, with tokens automatically included in browser URLs.
  * Added Basic authentication to the textual serve functionality for enhanced security.

* **Documentation**
  * Removed toad from the list of pre-installed container tools.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->