### PR TITLE
feat: delegate task log + image operations to terok-sandbox / terok-executor APIs

### DIFF
--- a/.importlinter
+++ b/.importlinter
@@ -39,16 +39,20 @@ allowed_importers =
     terok.cli.main
     terok.cli.wiring
     terok.lib.core.config
+    terok.lib.core.images
     terok.lib.core.projects
     terok.lib.domain.facade
+    terok.lib.domain.image_cleanup
     terok.lib.domain.panic
     terok.lib.domain.project
+    terok.lib.domain.project_state
     terok.lib.domain.storage
     terok.lib.domain.task_logs
     terok.lib.orchestration.agent_config
     terok.lib.orchestration.container_doctor
     terok.lib.orchestration.container_exec
     terok.lib.orchestration.environment
+    terok.lib.orchestration.image
     terok.lib.orchestration.ports
     terok.lib.orchestration.task_runners
     terok.lib.orchestration.tasks
@@ -72,11 +76,14 @@ allowed_importers =
     terok.lib.domain.facade
     terok.lib.domain.project
     terok.lib.domain.storage
+    terok.lib.domain.task_logs
     terok.lib.orchestration.autopilot
     terok.lib.orchestration.container_doctor
     terok.lib.orchestration.environment
     terok.lib.orchestration.image
     terok.lib.orchestration.task_runners
+    terok.lib.orchestration.tasks
+    terok.tui.log_viewer
     terok.tui.project_actions
     terok.tui.screens
     terok.tui.task_actions

--- a/poetry.lock
+++ b/poetry.lock
@@ -3065,34 +3065,34 @@ url = "https://github.com/terok-ai/terok-dbus/releases/download/v0.5.6/terok_dbu
 
 [[package]]
 name = "terok-executor"
-version = "0.0.89"
+version = "0.0.90"
 description = "Single-agent task runner for hardened Podman containers"
 optional = false
 python-versions = ">=3.12,<4.0"
 groups = ["main"]
 files = [
-    {file = "terok_executor-0.0.89-py3-none-any.whl", hash = "sha256:2c29a16fff923b93be581256553ab44523fe93eb1498b7e71d42aad63a06b2d5"},
+    {file = "terok_executor-0.0.90-py3-none-any.whl", hash = "sha256:21d19122b6e9300e2693a75643d29c110d411dc273fb4b5bee7235d41a6a218f"},
 ]
 
 [package.dependencies]
 Jinja2 = ">=3.1"
 "ruamel.yaml" = ">=0.18"
-terok_sandbox = {url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.0.74/terok_sandbox-0.0.74-py3-none-any.whl"}
+terok_sandbox = {url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.0.75/terok_sandbox-0.0.75-py3-none-any.whl"}
 tomli-w = ">=1.0"
 
 [package.source]
 type = "url"
-url = "https://github.com/terok-ai/terok-executor/releases/download/v0.0.89/terok_executor-0.0.89-py3-none-any.whl"
+url = "https://github.com/terok-ai/terok-executor/releases/download/v0.0.90/terok_executor-0.0.90-py3-none-any.whl"
 
 [[package]]
 name = "terok-sandbox"
-version = "0.0.74"
+version = "0.0.75"
 description = "Hardened Podman container runner with gate server and shield integration"
 optional = false
 python-versions = ">=3.12,<4.0"
 groups = ["main"]
 files = [
-    {file = "terok_sandbox-0.0.74-py3-none-any.whl", hash = "sha256:0221df8fc179dba3a0865d9d2ad42b7a04180e3736d2f0ec1e10e6df0d906555"},
+    {file = "terok_sandbox-0.0.75-py3-none-any.whl", hash = "sha256:e0e15be0d72b7fd529d7ee2e45f91f2ff754e7e882ae6a07aa19e509f6e4e8f7"},
 ]
 
 [package.dependencies]
@@ -3103,7 +3103,7 @@ terok_shield = {url = "https://github.com/terok-ai/terok-shield/releases/downloa
 
 [package.source]
 type = "url"
-url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.0.74/terok_sandbox-0.0.74-py3-none-any.whl"
+url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.0.75/terok_sandbox-0.0.75-py3-none-any.whl"
 
 [[package]]
 name = "terok-shield"
@@ -3611,4 +3611,4 @@ propcache = ">=0.2.1"
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.12,<4.0"
-content-hash = "4c62eda53677bfabcbe72bb3d4fb460985291be3b4768303a075e528d8f9cec1"
+content-hash = "13af94c1f670b5510aec1161715d7b793ea257a9a3a1e4715f77ce738cfcb18c"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,8 +44,8 @@ rich = ">=13.0"
 platformdirs = ">=4.5.1"
 unique-namer = ">=1.3"
 textual-serve = ">=1.1.0"
-terok-executor = {url = "https://github.com/terok-ai/terok-executor/releases/download/v0.0.89/terok_executor-0.0.89-py3-none-any.whl"}
-terok-sandbox = {url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.0.74/terok_sandbox-0.0.74-py3-none-any.whl"}
+terok-executor = {url = "https://github.com/terok-ai/terok-executor/releases/download/v0.0.90/terok_executor-0.0.90-py3-none-any.whl"}
+terok-sandbox = {url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.0.75/terok_sandbox-0.0.75-py3-none-any.whl"}
 terok-dbus = {url = "https://github.com/terok-ai/terok-dbus/releases/download/v0.5.6/terok_dbus-0.5.6-py3-none-any.whl"}
 
 [tool.poetry.group.dev.dependencies]

--- a/src/terok/lib/core/images.py
+++ b/src/terok/lib/core/images.py
@@ -7,13 +7,12 @@
 from __future__ import annotations
 
 import hashlib
-import json
 import re
-import subprocess
 from functools import lru_cache
 from typing import TYPE_CHECKING
 
 from terok_executor import AGENTS_LABEL
+from terok_sandbox import image_labels
 
 if TYPE_CHECKING:
     from terok.lib.core.project_model import ProjectConfig
@@ -66,22 +65,7 @@ def installed_agents(image_tag: str) -> frozenset[str]:
     empty set — callers treat empty as "unknown / unrestricted" so older
     images keep working.
     """
-    try:
-        result = subprocess.run(
-            ["podman", "inspect", "--format", "{{json .Config.Labels}}", image_tag],
-            capture_output=True,
-            text=True,
-            check=True,
-        )
-    except (FileNotFoundError, subprocess.CalledProcessError):
-        return frozenset()
-
-    try:
-        labels = json.loads(result.stdout) or {}
-    except json.JSONDecodeError:
-        return frozenset()
-
-    csv = (labels.get(AGENTS_LABEL) or "").strip()
+    csv = (image_labels(image_tag).get(AGENTS_LABEL) or "").strip()
     if not csv:
         return frozenset()
     return frozenset(name.strip() for name in csv.split(",") if name.strip())

--- a/src/terok/lib/domain/image_cleanup.py
+++ b/src/terok/lib/domain/image_cleanup.py
@@ -5,8 +5,15 @@
 
 from __future__ import annotations
 
-import subprocess
 from dataclasses import dataclass
+
+from terok_sandbox import (
+    ImageRecord,
+    image_history,
+    image_labels,
+    image_rm,
+    images_list,
+)
 
 from ..core.projects import list_projects
 
@@ -28,6 +35,17 @@ class ImageInfo:
             return f"<none> ({self.image_id[:12]})"
         return f"{self.repository}:{self.tag}"
 
+    @classmethod
+    def from_record(cls, record: ImageRecord) -> ImageInfo:
+        """Lift a sandbox :class:`ImageRecord` into terok's display type."""
+        return cls(
+            repository=record.repository,
+            tag=record.tag,
+            image_id=record.image_id,
+            size=record.size,
+            created=record.created,
+        )
+
 
 @dataclass
 class CleanupResult:
@@ -36,32 +54,6 @@ class CleanupResult:
     removed: list[str]
     failed: list[str]
     dry_run: bool
-
-
-def _run_podman(*args: str) -> subprocess.CompletedProcess[str]:
-    """Run a podman command and return the result.
-
-    Returns a synthetic failed result if podman is not found or times out,
-    so callers can check ``returncode`` without exception handling.
-    """
-    try:
-        return subprocess.run(
-            ["podman", *args],
-            capture_output=True,
-            text=True,
-            timeout=30,
-        )
-    except FileNotFoundError:
-        return subprocess.CompletedProcess(
-            args=["podman", *args], returncode=127, stdout="", stderr="podman not found"
-        )
-    except subprocess.TimeoutExpired as exc:
-        return subprocess.CompletedProcess(
-            args=["podman", *args],
-            returncode=124,
-            stdout=exc.stdout or "",
-            stderr=exc.stderr or "podman command timed out",
-        )
 
 
 def _known_project_ids() -> set[str] | None:
@@ -106,36 +98,18 @@ def list_images(project_id: str | None = None) -> list[ImageInfo]:
     Returns:
         List of ImageInfo objects for matching images.
     """
-    result = _run_podman(
-        "images",
-        "--format",
-        "{{.Repository}}\t{{.Tag}}\t{{.ID}}\t{{.Size}}\t{{.Created}}",
-        "--no-trunc",
-    )
-    if result.returncode != 0:
-        return []
-
     images: list[ImageInfo] = []
-    for line in result.stdout.strip().splitlines():
-        parts = line.split("\t", 4)
-        if len(parts) < 5:
-            continue
-        repo, tag, img_id, size, created = parts
-        if not _is_terok_image(repo, tag):
+    for record in images_list():
+        if not _is_terok_image(record.repository, record.tag):
             continue
         if project_id is not None:
             # Filter: L2 images must match the project; L0/L1 always shown
-            if _is_terok_l2_image(repo, tag) and repo != project_id:
+            if (
+                _is_terok_l2_image(record.repository, record.tag)
+                and record.repository != project_id
+            ):
                 continue
-        images.append(
-            ImageInfo(
-                repository=repo,
-                tag=tag,
-                image_id=img_id,
-                size=size,
-                created=created,
-            )
-        )
+        images.append(ImageInfo.from_record(record))
     return images
 
 
@@ -176,37 +150,15 @@ def find_orphaned_images() -> list[ImageInfo]:
 def _find_dangling_terok_images() -> list[ImageInfo]:
     """Find dangling (untagged) images that were built by terok.
 
-    Uses podman to list dangling images, then checks ancestry via labels
-    or layer history to identify those from terok builds.
+    Walks the sandbox ``images_list(dangling_only=True)`` enumeration and
+    keeps only records whose ancestry matches :func:`_is_terok_built_image`
+    (build-context-hash label or terok layer name in history).
     """
-    result = _run_podman(
-        "images",
-        "--filter",
-        "dangling=true",
-        "--format",
-        "{{.Repository}}\t{{.Tag}}\t{{.ID}}\t{{.Size}}\t{{.Created}}",
-        "--no-trunc",
-    )
-    if result.returncode != 0:
-        return []
-
-    dangling: list[ImageInfo] = []
-    for line in result.stdout.strip().splitlines():
-        parts = line.split("\t", 4)
-        if len(parts) < 5:
-            continue
-        repo, tag, img_id, size, created = parts
-        if _is_terok_built_image(img_id):
-            dangling.append(
-                ImageInfo(
-                    repository=repo,
-                    tag=tag,
-                    image_id=img_id,
-                    size=size,
-                    created=created,
-                )
-            )
-    return dangling
+    return [
+        ImageInfo.from_record(record)
+        for record in images_list(dangling_only=True)
+        if _is_terok_built_image(record.image_id)
+    ]
 
 
 def _is_terok_built_image(image_id: str) -> bool:
@@ -215,33 +167,9 @@ def _is_terok_built_image(image_id: str) -> bool:
     Inspects the ``terok.build_context_hash`` label and image history
     for terok layer names.
     """
-    # Check for terok label
-    result = _run_podman(
-        "image",
-        "inspect",
-        "--format",
-        '{{index .Config.Labels "terok.build_context_hash"}}',
-        image_id,
-    )
-    if result.returncode == 0:
-        label = result.stdout.strip()
-        if label and label != "<no value>":
-            return True
-
-    # Check image history for terok layer names
-    result = _run_podman(
-        "image",
-        "history",
-        "--format",
-        "{{.CreatedBy}}",
-        image_id,
-    )
-    if result.returncode == 0:
-        history = result.stdout
-        if "terok-l0" in history or "terok-l1" in history:
-            return True
-
-    return False
+    if image_labels(image_id).get("terok.build_context_hash"):
+        return True
+    return any("terok-l0" in line or "terok-l1" in line for line in image_history(image_id))
 
 
 def cleanup_images(dry_run: bool = False) -> CleanupResult:
@@ -261,8 +189,7 @@ def cleanup_images(dry_run: bool = False) -> CleanupResult:
         if dry_run:
             removed.append(img.full_name)
             continue
-        result = _run_podman("image", "rm", img.image_id)
-        if result.returncode == 0:
+        if image_rm(img.image_id):
             removed.append(img.full_name)
         else:
             failed.append(img.full_name)

--- a/src/terok/lib/domain/project_state.py
+++ b/src/terok/lib/domain/project_state.py
@@ -8,10 +8,10 @@ project by querying podman and the filesystem.  Used by both CLI and TUI
 for overview displays.
 """
 
-import subprocess
 from collections.abc import Callable
-from datetime import datetime
 from typing import TYPE_CHECKING, Any
+
+from terok_sandbox import container_image, image_exists, image_labels, is_container_running
 
 from ..core.config import build_dir
 from ..core.images import project_cli_image
@@ -58,25 +58,9 @@ def get_project_state(
     ]
     has_dockerfiles = all(p.is_file() for p in dockerfiles)
 
-    # Images: rely on podman image tags created by build_images().
-    has_images = False
-    try:
-        required_tags = [project_cli_image(project.id)]
-        ok = True
-        for tag in required_tags:
-            # ``podman image exists`` exits with 0 when the image is present.
-            result = subprocess.run(
-                ["podman", "image", "exists", tag],
-                stdout=subprocess.DEVNULL,
-                stderr=subprocess.DEVNULL,
-                timeout=10,
-            )
-            if result.returncode != 0:
-                ok = False
-                break
-        has_images = ok
-    except (FileNotFoundError, OSError, subprocess.TimeoutExpired):
-        has_images = False
+    # Images: rely on image tags created by build_images().
+    required_tags = [project_cli_image(project.id)]
+    has_images = all(image_exists(tag) for tag in required_tags)
 
     rendered: dict[str, str] | None = None
     dockerfiles_old = False
@@ -182,64 +166,6 @@ def _detect_stale_layers(project: "ProjectConfig", rendered: dict[str, str] | No
     return stale
 
 
-def _get_image_metadata(tag: str, label_key: str) -> tuple[datetime | None, str | None]:
-    """Return (created_datetime, label_value) for a podman image *tag*."""
-    try:
-        result = subprocess.run(
-            [
-                "podman",
-                "image",
-                "inspect",
-                "--format",
-                f'{{{{.Created}}}}\\t{{{{index .Config.Labels "{label_key}"}}}}',
-                tag,
-            ],
-            capture_output=True,
-            text=True,
-            timeout=10,
-        )
-    except (FileNotFoundError, OSError, subprocess.TimeoutExpired):
-        return None, None
-    if result.returncode != 0:
-        return None, None
-    created_raw, _, label_raw = result.stdout.partition("\t")
-    label = label_raw.strip() or None
-    if label == "<no value>":
-        label = None
-    return _parse_podman_created(created_raw), label
-
-
-def _parse_podman_created(value: str) -> datetime | None:
-    """Parse a podman ``Created`` timestamp string into a datetime."""
-    if not isinstance(value, str):
-        return None
-    value = value.strip()
-    if not value:
-        return None
-    if value.endswith("Z"):
-        value = value[:-1] + "+00:00"
-    if "." in value:
-        head, tail = value.split(".", 1)
-        tz_sep = None
-        for sep in ("+", "-"):
-            idx = tail.find(sep)
-            if idx != -1:
-                tz_sep = idx
-                break
-        if tz_sep is None:
-            frac = tail
-            tz = ""
-        else:
-            frac = tail[:tz_sep]
-            tz = tail[tz_sep:]
-        frac = (frac[:6]).ljust(6, "0")
-        value = f"{head}.{frac}{tz}"
-    try:
-        return datetime.fromisoformat(value)
-    except ValueError:
-        return None
-
-
 def is_task_image_old(project_id: str | None, task: Any) -> bool | None:
     """Check if the image used by a task's container is outdated.
 
@@ -259,29 +185,9 @@ def is_task_image_old(project_id: str | None, task: Any) -> bool | None:
         return None
 
     cname = _container_name(project_id, task.mode, task.task_id)
-    try:
-        result = subprocess.run(
-            [
-                "podman",
-                "container",
-                "inspect",
-                "--format",
-                "{{.State.Running}}\t{{.Image}}",
-                cname,
-            ],
-            capture_output=True,
-            text=True,
-            timeout=10,
-        )
-    except (FileNotFoundError, OSError, subprocess.TimeoutExpired):
+    if not is_container_running(cname):
         return None
-    if result.returncode != 0:
-        return None
-
-    running_str, _, image_id = result.stdout.partition("\t")
-    if running_str.strip().lower() != "true":
-        return None
-    image_id = image_id.strip()
+    image_id = container_image(cname)
     if not image_id:
         return None
 
@@ -299,8 +205,8 @@ def is_task_image_old(project_id: str | None, task: Any) -> bool | None:
             current_hash = build_context_hash(project_id)
         except Exception:
             return None
-        _, label = _get_image_metadata(image_id, "terok.build_context_hash")
-        if label is None:
+        label = image_labels(image_id).get("terok.build_context_hash")
+        if not label:
             return True
         return label != current_hash
 

--- a/src/terok/lib/domain/task_logs.py
+++ b/src/terok/lib/domain/task_logs.py
@@ -15,12 +15,31 @@ import subprocess
 from dataclasses import dataclass
 from pathlib import Path
 
+from terok_executor import AgentRunner
 from terok_sandbox import get_container_state
 
 from ..core.projects import load_project
 from ..orchestration.tasks import container_name, tasks_meta_dir
 from ..util.yaml import load as _yaml_load
 from .log_format import auto_detect_formatter
+
+
+def _build_raw_logs_cmd(cname: str, *, follow: bool, tail: int | None) -> list[str]:
+    """Build the ``podman logs`` argv for terok's raw mode.
+
+    "Raw" is a terok concept — the :class:`LogViewOptions` ``raw=True`` path
+    asks us to bypass our formatter pipeline and hand podman's byte stream
+    straight to the user's terminal.  It is not a podman flag.  The caller
+    uses ``os.execvp`` to replace the current process with ``podman logs``
+    so the user talks to podman directly.
+    """
+    cmd = ["podman", "logs"]
+    if follow:
+        cmd.append("-f")
+    if tail is not None:
+        cmd.extend(["--tail", str(tail)])
+    cmd.append(cname)
+    return cmd
 
 
 @dataclass(frozen=True)
@@ -99,16 +118,12 @@ def task_logs(
             f"Run 'terok task restart {project_id} {task_id}' first."
         )
 
-    # Build podman logs command
-    cmd = ["podman", "logs"]
-    if options.follow:
-        cmd.append("-f")
-    if options.tail is not None:
-        cmd.extend(["--tail", str(options.tail)])
-    cmd.append(cname)
+    runner = AgentRunner()
 
     if options.raw:
-        # Raw mode: exec podman directly, no formatting
+        # Raw mode: exec podman directly, no formatting.  os.execvp replaces
+        # this process — no executor-layer wrapping is appropriate.
+        cmd = _build_raw_logs_cmd(cname, follow=options.follow, tail=options.tail)
         try:
             os.execvp(cmd[0], cmd)
         except FileNotFoundError:
@@ -119,13 +134,11 @@ def task_logs(
     formatter = auto_detect_formatter(mode, streaming=options.streaming, provider=provider)
 
     try:
-        proc = subprocess.Popen(
-            cmd,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
-        )
+        proc = runner.stream_logs_process(cname, follow=options.follow, tail=options.tail)
     except FileNotFoundError:
         raise SystemExit("podman not found; please install podman")
+    except OSError as exc:
+        raise SystemExit(f"failed to launch podman logs: {exc}")
 
     # Handle Ctrl+C gracefully
     interrupted = False

--- a/src/terok/lib/orchestration/autopilot.py
+++ b/src/terok/lib/orchestration/autopilot.py
@@ -36,8 +36,3 @@ def wait_for_container_exit(
 
     update_task_exit_code(project_id, task_id, exit_code)
     return exit_code, None
-
-
-def follow_container_logs_cmd(container_name: str) -> list[str]:
-    """Return the podman command to follow container logs."""
-    return ["podman", "logs", "-f", container_name]

--- a/src/terok/lib/orchestration/image.py
+++ b/src/terok/lib/orchestration/image.py
@@ -12,9 +12,6 @@ three layers together.
 import hashlib
 import json
 import logging
-import shlex
-import shutil
-import subprocess
 from functools import lru_cache
 from importlib import resources
 from pathlib import Path
@@ -23,6 +20,7 @@ from typing import Any
 from terok_executor import (
     BuildError,
     build_base_images,
+    build_project_image,
     detect_family,
     l0_image_tag,
     parse_agent_selection,
@@ -30,6 +28,7 @@ from terok_executor import (
     stage_tmux_config,
     stage_toad_agents,
 )
+from terok_sandbox import image_exists as _sandbox_image_exists
 
 from ..core.config import build_dir
 from ..core.images import project_cli_image, project_dev_image
@@ -40,19 +39,14 @@ from ..util.fs import ensure_dir
 # ---------- helpers ----------
 
 
-def _check_podman_available() -> None:
-    """Raise SystemExit if podman is not on PATH."""
-    if shutil.which("podman") is None:
-        raise SystemExit("podman not found; please install podman")
-
-
 def _image_exists(image: str) -> bool:
-    """Check if a container image exists locally."""
-    result = subprocess.run(
-        ["podman", "image", "exists", image],
-        capture_output=True,
-    )
-    return result.returncode == 0
+    """Check if a container image exists locally.
+
+    Thin wrapper over :func:`terok_sandbox.image_exists` kept as a
+    same-module symbol so existing test mocks (``patch("terok.lib.
+    orchestration.image._image_exists")``) keep working.
+    """
+    return _sandbox_image_exists(image)
 
 
 # ---------- Hashing ----------
@@ -314,8 +308,6 @@ def build_images(
             ``"all"``).  When ``None``, ``project.agents`` is used (which
             itself inherits from the global ``image.agents`` config).
     """
-    _check_podman_available()
-
     project = load_project(project_id)
     base_image = project.base_image
     stage_dir = build_dir() / project.id
@@ -355,7 +347,6 @@ def build_images(
     l1_hash = l1_content_hash(rendered)
     l2_hash = l2_content_hash(rendered)
     context_hash = _sha256(l0_hash, l1_hash, l2_hash)
-    context_dir = str(stage_dir)
 
     # Resolve manifest L0/L1 hashes: use current hashes if rebuilt,
     # carry forward from previous manifest if skipped.
@@ -367,21 +358,18 @@ def build_images(
         manifest_l1_hash = prev["l1"]["content_hash"] if prev else l1_hash
 
     def _build_l2(base_arg: str, target: str) -> None:
-        """Build one L2 image variant."""
-        cmd = ["podman", "build", "-f", str(l2_path)]
-        cmd += ["--build-arg", f"BASE_IMAGE={base_arg}"]
-        cmd += ["--label", f"terok.build_context_hash={context_hash}"]
-        cmd += ["-t", target]
-        if full_rebuild:
-            cmd.append("--no-cache")
-        cmd.append(context_dir)
-        print("$", shlex.join(cmd))
+        """Build one L2 image variant — thin delegate to the executor's factory."""
         try:
-            subprocess.run(cmd, check=True)
-        except FileNotFoundError:
-            raise SystemExit("podman not found; please install podman")
-        except subprocess.CalledProcessError as e:
-            raise SystemExit(f"Build failed: {e}")
+            build_project_image(
+                dockerfile=l2_path,
+                context_dir=stage_dir,
+                target_tag=target,
+                build_args={"BASE_IMAGE": base_arg},
+                labels={"terok.build_context_hash": context_hash},
+                no_cache=full_rebuild,
+            )
+        except BuildError as exc:
+            raise SystemExit(str(exc)) from exc
 
     # Always build L2 CLI image (project layer on top of L1)
     _build_l2(l1_cli_image, l2_cli_image)

--- a/src/terok/lib/orchestration/tasks.py
+++ b/src/terok/lib/orchestration/tasks.py
@@ -16,11 +16,11 @@ import os
 import re
 import secrets
 import shutil
-import subprocess
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from pathlib import Path
 
+from terok_executor import AgentRunner
 from terok_sandbox import (
     container_stop,
     get_container_state,
@@ -662,23 +662,9 @@ def capture_task_logs(project: ProjectConfig | str, task_id: str, mode: str) -> 
     log_file = logs_dir / "container.log"
 
     cname = container_name(project.id, mode, task_id)
-    try:
-        with log_file.open("wb") as f:
-            result = subprocess.run(
-                ["podman", "logs", "--timestamps", cname],
-                stdout=f,
-                stderr=subprocess.PIPE,
-                timeout=60,
-            )
-    except (FileNotFoundError, subprocess.TimeoutExpired):
-        log_file.unlink(missing_ok=True)
-        return None
-
-    if result.returncode != 0:
-        log_file.unlink(missing_ok=True)
-        return None
-
-    return log_file
+    if AgentRunner().capture_logs(cname, log_file, timestamps=True, timeout=60.0):
+        return log_file
+    return None
 
 
 def _archive_task(project: ProjectConfig, task_id: str, meta: dict) -> Path | None:

--- a/src/terok/tui/log_viewer.py
+++ b/src/terok/tui/log_viewer.py
@@ -23,6 +23,7 @@ from enum import Enum, auto
 
 from rich.style import Style
 from rich.text import Text
+from terok_executor import AgentRunner
 from textual import screen
 from textual.app import ComposeResult
 from textual.widgets import RichLog, Static
@@ -417,16 +418,9 @@ class LogViewerScreen(screen.Screen[None]):
         else:
             formatter = _PlainTextTuiFormatter()
 
-        cmd = ["podman", "logs"]
-        if self.follow:
-            cmd.append("-f")
-        cmd.append(self.container_name)
-
         try:
-            self._process = subprocess.Popen(
-                cmd,
-                stdout=subprocess.PIPE,
-                stderr=subprocess.STDOUT,
+            self._process = AgentRunner().stream_logs_process(
+                self.container_name, follow=self.follow, merge_stderr=True
             )
         except FileNotFoundError:
             self._post_text(Text("Error: podman not found", style=_STYLE_RESULT_ERR))

--- a/tests/unit/lib/test_image.py
+++ b/tests/unit/lib/test_image.py
@@ -64,7 +64,6 @@ def build_commands(
     )
     with (
         patch("subprocess.run", side_effect=mock_run),
-        patch("terok.lib.orchestration.image._check_podman_available"),
         patch(
             "terok.lib.orchestration.image.build_base_images",
             return_value=_mock_base_images(),
@@ -416,7 +415,6 @@ class TestPackageFamily:
         with image_project_with("proj_rocky", base_image="rockylinux:9", family="rpm"):
             with (
                 patch("subprocess.run", return_value=Mock(returncode=0)),
-                patch("terok.lib.orchestration.image._check_podman_available"),
                 patch("terok.lib.orchestration.image._image_exists", return_value=True),
                 patch(
                     "terok.lib.orchestration.image.build_base_images",
@@ -434,7 +432,6 @@ class TestPackageFamily:
         with image_project_with("proj_ubuntu", base_image="ubuntu:24.04"):
             with (
                 patch("subprocess.run", return_value=Mock(returncode=0)),
-                patch("terok.lib.orchestration.image._check_podman_available"),
                 patch("terok.lib.orchestration.image._image_exists", return_value=True),
                 patch(
                     "terok.lib.orchestration.image.build_base_images",

--- a/tests/unit/lib/test_image_cleanup.py
+++ b/tests/unit/lib/test_image_cleanup.py
@@ -9,6 +9,7 @@ import subprocess
 import unittest.mock
 
 import pytest
+from terok_sandbox import ImageRecord
 
 from terok.lib.domain.image_cleanup import (
     ImageInfo,
@@ -19,8 +20,18 @@ from terok.lib.domain.image_cleanup import (
 
 
 def podman_result(stdout: str = "", returncode: int = 0) -> subprocess.CompletedProcess:
-    """Create a mock podman result."""
+    """Create a mock podman result (retained for other callers)."""
     return subprocess.CompletedProcess(args=[], returncode=returncode, stdout=stdout, stderr="")
+
+
+def _records_from_tsv(text: str) -> list[ImageRecord]:
+    """Parse the TSV shape ``podman images --format`` emits into ImageRecords."""
+    out: list[ImageRecord] = []
+    for line in text.strip().splitlines():
+        parts = line.split("\t")
+        if len(parts) == 5:
+            out.append(ImageRecord(*parts))
+    return out
 
 
 ORPHAN_IMAGE = ImageInfo("old-proj", "l2-cli", "sha256:abc", "1GB", "5 days ago")
@@ -76,21 +87,22 @@ class TestListImages:
         ],
         ids=["all-terok-images", "filtered-by-project", "dev-tag"],
     )
-    @unittest.mock.patch("terok.lib.domain.image_cleanup._run_podman")
+    @unittest.mock.patch("terok.lib.domain.image_cleanup.images_list")
     def test_list_images(
         self,
-        mock_podman: unittest.mock.Mock,
+        mock_images_list: unittest.mock.Mock,
         stdout: str,
         project_id: str | None,
         expected_names: set[str],
     ) -> None:
-        mock_podman.return_value = podman_result(stdout)
+        mock_images_list.return_value = _records_from_tsv(stdout)
         images = list_images(project_id)
         assert {image.full_name for image in images} == expected_names
 
-    @unittest.mock.patch("terok.lib.domain.image_cleanup._run_podman")
-    def test_list_images_podman_failure(self, mock_podman: unittest.mock.Mock) -> None:
-        mock_podman.return_value = podman_result(returncode=1)
+    @unittest.mock.patch("terok.lib.domain.image_cleanup.images_list")
+    def test_list_images_podman_failure(self, mock_images_list: unittest.mock.Mock) -> None:
+        """Sandbox returns an empty list on podman failure — terok passes it through."""
+        mock_images_list.return_value = []
         assert list_images() == []
 
 
@@ -177,27 +189,27 @@ class TestCleanupImages:
         ],
         ids=["dry-run", "success", "failure"],
     )
-    @unittest.mock.patch("terok.lib.domain.image_cleanup._run_podman")
+    @unittest.mock.patch("terok.lib.domain.image_cleanup.image_rm")
     @unittest.mock.patch("terok.lib.domain.image_cleanup.find_orphaned_images")
     def test_cleanup_images(
         self,
         mock_orphaned: unittest.mock.Mock,
-        mock_podman: unittest.mock.Mock,
+        mock_image_rm: unittest.mock.Mock,
         dry_run: bool,
         podman_returncode: int,
         expected_removed: list[str],
         expected_failed: list[str],
     ) -> None:
         mock_orphaned.return_value = [ORPHAN_IMAGE]
-        mock_podman.return_value = podman_result(returncode=podman_returncode)
+        mock_image_rm.return_value = podman_returncode == 0
         result = cleanup_images(dry_run=dry_run)
         assert result.dry_run is dry_run
         assert result.removed == expected_removed
         assert result.failed == expected_failed
         if dry_run:
-            mock_podman.assert_not_called()
+            mock_image_rm.assert_not_called()
         else:
-            mock_podman.assert_called_once_with("image", "rm", "sha256:abc")
+            mock_image_rm.assert_called_once_with("sha256:abc")
 
     @unittest.mock.patch("terok.lib.domain.image_cleanup.find_orphaned_images")
     def test_nothing_to_clean(self, mock_orphaned: unittest.mock.Mock) -> None:

--- a/tests/unit/lib/test_images.py
+++ b/tests/unit/lib/test_images.py
@@ -139,45 +139,45 @@ def _clear_installed_agents_cache() -> None:
     images.installed_agents.cache_clear()
 
 
-def _patch_inspect(monkeypatch: pytest.MonkeyPatch, stdout: str | Exception) -> None:
-    """Stub ``subprocess.run`` for ``podman inspect`` calls."""
-    import subprocess
+def _patch_labels(monkeypatch: pytest.MonkeyPatch, labels: dict[str, str]) -> None:
+    """Stub :func:`terok_sandbox.image_labels` as seen by ``images.py``.
 
-    def fake_run(*args: object, **kwargs: object) -> object:
-        if isinstance(stdout, Exception):
-            raise stdout
-        return subprocess.CompletedProcess(args=args, returncode=0, stdout=stdout, stderr="")
-
-    monkeypatch.setattr(images.subprocess, "run", fake_run)
+    The module imports ``image_labels`` directly, so the patch target is
+    the name in ``terok.lib.core.images``.  An empty dict mimics
+    podman's behaviour for both missing images and unlabeled images —
+    the distinction doesn't matter for the callers under test here.
+    """
+    monkeypatch.setattr(images, "image_labels", lambda _tag: labels)
 
 
 def test_installed_agents_parses_label(monkeypatch: pytest.MonkeyPatch) -> None:
-    _patch_inspect(monkeypatch, '{"ai.terok.agents": "claude,codex,opencode"}')
+    _patch_labels(monkeypatch, {"ai.terok.agents": "claude,codex,opencode"})
     assert images.installed_agents("terok-l1-cli:test") == frozenset(
         {"claude", "codex", "opencode"}
     )
 
 
 def test_installed_agents_missing_label_returns_empty(monkeypatch: pytest.MonkeyPatch) -> None:
-    _patch_inspect(monkeypatch, "{}")
+    _patch_labels(monkeypatch, {})
     assert images.installed_agents("terok-l1-cli:legacy") == frozenset()
 
 
 def test_installed_agents_missing_image_returns_empty(monkeypatch: pytest.MonkeyPatch) -> None:
-    import subprocess
-
-    _patch_inspect(monkeypatch, subprocess.CalledProcessError(1, "podman"))
+    # ``image_labels`` returns {} when the image is absent; same end-state
+    # as an unlabeled image, which is correct for the unrestricted-fallback
+    # semantics callers rely on.
+    _patch_labels(monkeypatch, {})
     assert images.installed_agents("terok-l1-cli:nope") == frozenset()
 
 
 def test_is_installed_treats_unlabeled_as_unrestricted(monkeypatch: pytest.MonkeyPatch) -> None:
     # Legacy / unlabeled image: every agent is considered installed so
     # older builds keep working until the user rebuilds.
-    _patch_inspect(monkeypatch, "{}")
+    _patch_labels(monkeypatch, {})
     assert images.is_installed("anything", "terok-l1-cli:legacy") is True
 
 
 def test_is_installed_filters_by_label(monkeypatch: pytest.MonkeyPatch) -> None:
-    _patch_inspect(monkeypatch, '{"ai.terok.agents": "claude,codex"}')
+    _patch_labels(monkeypatch, {"ai.terok.agents": "claude,codex"})
     assert images.is_installed("claude", "terok-l1-cli:test") is True
     assert images.is_installed("vibe", "terok-l1-cli:test") is False

--- a/tests/unit/lib/test_login.py
+++ b/tests/unit/lib/test_login.py
@@ -137,10 +137,8 @@ class TestLogin:
                     return_value="running",
                 ),
                 mock_git_config(),
-                unittest.mock.patch("terok.lib.orchestration.tasks.subprocess.run") as mock_run,
             ):
                 command = get_login_command(project_id, task_id)
 
         assert command[3] == f"{project_id}-cli-{task_id}"
         assert "tmux" in command
-        mock_run.assert_not_called()

--- a/tests/unit/lib/test_projects.py
+++ b/tests/unit/lib/test_projects.py
@@ -298,7 +298,9 @@ class TestProject:
             mock_sandbox_cfg.ssh_keys_dir = sandbox_state / "ssh-keys"
 
             with (
-                unittest.mock.patch("terok.lib.domain.project_state.subprocess.run") as run_mock,
+                unittest.mock.patch(
+                    "terok.lib.domain.project_state.image_exists", return_value=True
+                ),
                 unittest.mock.patch(
                     "terok.lib.core.projects._get_global_git_config", return_value=None
                 ),
@@ -307,8 +309,6 @@ class TestProject:
                     return_value=mock_sandbox_cfg,
                 ),
             ):
-                run_mock.return_value.returncode = 0
-                run_mock.return_value.stdout = "2024-01-01T00:00:00Z\t<no value>"
                 state = get_project_state(project_id, gate_commit_provider=lambda _pid: None)
 
         assert state == {

--- a/tests/unit/lib/test_staleness_detection.py
+++ b/tests/unit/lib/test_staleness_detection.py
@@ -188,10 +188,10 @@ class TestIsTaskImageOld:
         from terok.lib.domain.project_state import is_task_image_old
 
         task = Mock(mode="cli", task_id="42")
-        container_inspect = Mock(returncode=0, stdout="true\tsha256:abc123")
 
         with (
-            patch("terok.lib.domain.project_state.subprocess.run", return_value=container_inspect),
+            patch("terok.lib.domain.project_state.is_container_running", return_value=True),
+            patch("terok.lib.domain.project_state.container_image", return_value="sha256:abc123"),
             patch("terok.lib.domain.project_state._container_name", return_value="c1"),
             patch(
                 "terok.lib.orchestration.image.render_all_dockerfiles",
@@ -215,10 +215,10 @@ class TestIsTaskImageOld:
         from terok.lib.domain.project_state import is_task_image_old
 
         task = Mock(mode="cli", task_id="42")
-        container_inspect = Mock(returncode=0, stdout="true\tsha256:abc123")
 
         with (
-            patch("terok.lib.domain.project_state.subprocess.run", return_value=container_inspect),
+            patch("terok.lib.domain.project_state.is_container_running", return_value=True),
+            patch("terok.lib.domain.project_state.container_image", return_value="sha256:abc123"),
             patch("terok.lib.domain.project_state._container_name", return_value="c1"),
             patch(
                 "terok.lib.orchestration.image.render_all_dockerfiles",
@@ -253,15 +253,13 @@ class TestIsTaskImageOld:
 
     def test_falls_back_to_label_check_on_exception(self) -> None:
         """When manifest approach fails, falls back to L2 label comparison."""
-        from datetime import UTC, datetime
-
         from terok.lib.domain.project_state import is_task_image_old
 
         task = Mock(mode="cli", task_id="42")
-        container_inspect = Mock(returncode=0, stdout="true\tsha256:abc123")
 
         with (
-            patch("terok.lib.domain.project_state.subprocess.run", return_value=container_inspect),
+            patch("terok.lib.domain.project_state.is_container_running", return_value=True),
+            patch("terok.lib.domain.project_state.container_image", return_value="sha256:abc123"),
             patch("terok.lib.domain.project_state._container_name", return_value="c1"),
             # Make manifest approach fail at load_project (inside is_task_image_old)
             patch(
@@ -275,8 +273,8 @@ class TestIsTaskImageOld:
             ),
             # Label on image doesn't match → stale
             patch(
-                "terok.lib.domain.project_state._get_image_metadata",
-                return_value=(datetime.now(UTC), "old-hash"),
+                "terok.lib.domain.project_state.image_labels",
+                return_value={"terok.build_context_hash": "old-hash"},
             ),
         ):
             result = is_task_image_old("proj1", task)

--- a/tests/unit/lib/test_tasks.py
+++ b/tests/unit/lib/test_tasks.py
@@ -107,13 +107,12 @@ class TestTask:
             assert second_id != returned_id
 
             with (
-                unittest.mock.patch("terok.lib.orchestration.tasks.subprocess.run") as run_mock,
+                unittest.mock.patch("terok_executor.AgentRunner.capture_logs", return_value=False),
                 unittest.mock.patch(
                     "terok.lib.orchestration.tasks.stop_task_containers", return_value=[]
                 ),
                 mock_git_config(),
             ):
-                run_mock.return_value.returncode = 0
                 result = task_delete(project_id, returned_id)
 
             assert isinstance(result, TaskDeleteResult)
@@ -1098,20 +1097,21 @@ class TestTaskLogs:
                         return_value="exited",
                     ),
                     unittest.mock.patch(
-                        "terok.lib.domain.task_logs.subprocess.Popen",
-                        return_value=mock_proc,
-                    ),
+                        "terok.lib.domain.task_logs.AgentRunner"
+                    ) as mock_runner_cls,
                     unittest.mock.patch(
                         "terok.lib.domain.task_logs.auto_detect_formatter",
                         return_value=mock_formatter,
                     ),
                     unittest.mock.patch("select.select") as mock_select,
                 ):
+                    mock_runner_cls.return_value.stream_logs_process.return_value = mock_proc
                     mock_select.return_value = ([mock_proc.stdout], [], [])
                     buf = StringIO()
                     with redirect_stdout(buf):
                         task_logs("proj_logs7", task_id)
 
+                    mock_runner_cls.return_value.stream_logs_process.assert_called_once()
                     mock_formatter.feed_line.assert_called()
                     mock_formatter.finish.assert_called_once()
 
@@ -1129,10 +1129,12 @@ class TestTaskLogs:
                         return_value="running",
                     ),
                     unittest.mock.patch(
-                        "terok.lib.domain.task_logs.subprocess.Popen",
-                        side_effect=FileNotFoundError("podman"),
-                    ),
+                        "terok.lib.domain.task_logs.AgentRunner"
+                    ) as mock_runner_cls,
                 ):
+                    mock_runner_cls.return_value.stream_logs_process.side_effect = (
+                        FileNotFoundError("podman")
+                    )
                     with pytest.raises(SystemExit) as cm:
                         task_logs("proj_logs8", task_id)
                     assert "podman not found" in str(cm.value)
@@ -1276,20 +1278,16 @@ class TestTaskArchive:
                 logs_dir.mkdir(parents=True, exist_ok=True)
                 (logs_dir / "container.log").write_text("log content\n")
 
-                log_content = b"captured log output\n"
+                log_content = "captured log output\n"
 
-                def fake_run(cmd, *, stdout=None, stderr=None, timeout=None, **kw):
-                    """Simulate podman: write to stdout file handle or no-op for rm."""
-                    if stdout is not None and hasattr(stdout, "write"):
-                        stdout.write(log_content)
-                    result = unittest.mock.Mock()
-                    result.returncode = 0
-                    return result
+                def _fake_capture(self, cname, dest, *, timestamps=True, timeout=60.0):
+                    dest.write_text(log_content)
+                    return True
 
                 with (
                     unittest.mock.patch(
-                        "terok.lib.orchestration.tasks.subprocess.run",
-                        side_effect=fake_run,
+                        "terok_executor.AgentRunner.capture_logs",
+                        new=_fake_capture,
                     ),
                     unittest.mock.patch(
                         "terok.lib.orchestration.tasks.stop_task_containers",
@@ -1344,8 +1342,8 @@ class TestTaskArchive:
 
                 with (
                     unittest.mock.patch(
-                        "terok.lib.orchestration.tasks.subprocess.run",
-                        side_effect=fake_run,
+                        "terok_executor.AgentRunner.capture_logs",
+                        return_value=True,
                     ),
                     unittest.mock.patch(
                         "terok.lib.orchestration.tasks.stop_task_containers",
@@ -1444,7 +1442,8 @@ class TestTaskArchive:
             assert "No archived tasks found" in buf.getvalue()
 
     def test_capture_task_logs(self) -> None:
-        """capture_task_logs writes podman logs to host filesystem."""
+        """capture_task_logs delegates to AgentRunner.capture_logs and
+        returns the log file path when the executor reports success."""
         from terok.lib.orchestration.tasks import capture_task_logs
 
         project_id = "proj_capture1"
@@ -1455,28 +1454,26 @@ class TestTaskArchive:
             with mock_git_config():
                 task_id = task_new(project_id)
 
-                log_content = b"2026-03-05T12:00:00Z stdout line\n"
+                log_content = "2026-03-05T12:00:00Z stdout line\n"
 
-                def fake_run(cmd, *, stdout=None, stderr=None, timeout=None):
-                    """Write log content to stdout file handle like podman would."""
-                    if stdout is not None and hasattr(stdout, "write"):
-                        stdout.write(log_content)
-                    result = unittest.mock.Mock()
-                    result.returncode = 0
-                    return result
+                def fake_capture(self, cname, dest, *, timestamps=True, timeout=60.0):
+                    """Simulate AgentRunner.capture_logs writing to *dest*."""
+                    dest.write_text(log_content)
+                    return True
 
                 with unittest.mock.patch(
-                    "terok.lib.orchestration.tasks.subprocess.run",
-                    side_effect=fake_run,
+                    "terok_executor.AgentRunner.capture_logs",
+                    new=fake_capture,
                 ):
                     log_file = capture_task_logs(project_id, task_id, "run")
 
                 assert log_file is not None
-                content = log_file.read_text()
-                assert "stdout line" in content
+                assert "stdout line" in log_file.read_text()
 
     def test_capture_task_logs_podman_not_found(self) -> None:
-        """capture_task_logs returns None when podman is not available."""
+        """capture_task_logs returns None when the executor reports failure
+        (podman missing, timeout, non-zero returncode — all surface the same
+        way through AgentRunner.capture_logs)."""
         from terok.lib.orchestration.tasks import capture_task_logs
 
         project_id = "proj_capture2"
@@ -1488,8 +1485,8 @@ class TestTaskArchive:
                 task_id = task_new(project_id)
 
                 with unittest.mock.patch(
-                    "terok.lib.orchestration.tasks.subprocess.run",
-                    side_effect=FileNotFoundError("podman"),
+                    "terok_executor.AgentRunner.capture_logs",
+                    return_value=False,
                 ):
                     result = capture_task_logs(project_id, task_id, "run")
 
@@ -1528,8 +1525,8 @@ class TestTaskDeleteWarnings:
 
                 patches = [
                     unittest.mock.patch(
-                        "terok.lib.orchestration.tasks.subprocess.run",
-                        return_value=unittest.mock.Mock(returncode=1),
+                        "terok_executor.AgentRunner.capture_logs",
+                        return_value=True,
                     ),
                     unittest.mock.patch(
                         "terok.lib.orchestration.tasks.stop_task_containers",


### PR DESCRIPTION
## Summary

Closes Phase 1 last mile: every \`podman ...\` subprocess call in terok that was previously scattered across log-viewing, image-listing, and image-cleanup paths now flows through terok-executor's AgentRunner API or the terok-sandbox runtime primitives.  The sandbox-boundary and executor-boundary import-linter contracts are the source of truth for what's still allowed; nothing outside those allowlists calls podman directly anymore (modulo \`project_state._get_image_metadata\` / \`is_task_image_old\` which cover container-timestamp / container-inspect and are out of scope until their sibling primitives land).

**Task-level log operations** migrated to terok-executor #188:
- \`tasks.capture_task_logs\` → \`AgentRunner.capture_logs\`
- \`domain/task_logs.task_logs\` → \`AgentRunner.stream_logs_process\` (raw mode keeps \`os.execvp\` with a local command builder)
- \`tui/log_viewer\` → \`AgentRunner.stream_logs_process(merge_stderr=True)\`
- \`autopilot.follow_container_logs_cmd\` deleted (no callers)

**Image operations** migrated to terok-sandbox #173:
- \`core/images.installed_agents\` → \`image_labels(tag)\`
- \`domain/project_state\` image-existence check → \`image_exists(tag)\`
- \`orchestration/image._image_exists\` → thin wrapper over \`image_exists\` (preserves test-hook name)
- \`domain/image_cleanup\` — deletes its own \`_run_podman\` helper entirely; \`list_images\` / \`_find_dangling_terok_images\` use \`images_list\`, \`_is_terok_built_image\` uses \`image_labels\` + \`image_history\`, \`cleanup_images\` uses \`image_rm\`.
- \`ImageInfo\` gains a \`from_record\` classmethod lifting sandbox's \`ImageRecord\` into terok's display type.

\`.importlinter\` updated: \`tasks\`, \`task_logs\`, \`log_viewer\` added to executor-boundary; \`images\`, \`image_cleanup\`, \`project_state\` added to sandbox-boundary.  All four contracts kept, 0 broken.

## Dependencies

- terok-ai/terok-sandbox#173 (\`feat/image-mgmt-primitives\`)
- terok-ai/terok-executor#188 (\`feat/agentrunner-logs-api\`) — which itself transitively pins the sandbox branch

\`pyproject.toml\` branch-pins both during review.  Release chain flips URLs back to wheel downloads at tag time.

## Test plan

- [x] \`make lint\` — clean
- [x] \`make tach\` — clean
- [x] \`make lint-imports\` — 4 contracts kept
- [x] \`poetry run pytest tests/unit -q\` — 1793 passed, 1 pre-existing flake (\`test_config_command_color_output\` port race, also on upstream master)
- [x] Test harness migrated: patches \`terok_executor.AgentRunner.capture_logs\` and sandbox \`image_labels\`/\`images_list\`/\`image_rm\` instead of stubbing \`subprocess.run\`
- [ ] Integration (podman-dependent) on the test machine — manual

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Bumped versions for two internal packages in project metadata.
  * Expanded protected import allowlists to permit additional modules.

* **Refactor**
  * Consolidated log streaming/capture behind a shared runner interface.
  * Replaced direct container/image CLI calls with higher-level sandbox APIs.

* **Tests**
  * Updated unit tests and mocks to align with the new logging and sandbox interfaces.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->