### PR TITLE
refactor(cli): lift auth to top-level, polish help text + ordering

### DIFF
--- a/.importlinter
+++ b/.importlinter
@@ -64,7 +64,7 @@ name = terok_executor access restricted to designated modules
 type = protected
 protected_modules = terok_executor
 allowed_importers =
-    terok.cli.commands.project
+    terok.cli.commands.auth
     terok.cli.commands.setup
     terok.cli.commands.task
     terok.cli.main

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ Or do the same from the command line:
 
 ```bash
 terok project wizard                    # interactive setup
-terok project auth claude myproj                # authenticate agent
+terok auth claude myproj                # authenticate agent
 terok task start myproj                 # start a CLI agent task
 terok task start myproj --toad          # Toad multi-agent TUI (browser access)
 terok login myproj a3                   # attach to a running task by hex ID prefix

--- a/docs/index.md
+++ b/docs/index.md
@@ -69,7 +69,7 @@ Or do the same from the command line:
 
 ```bash
 terok project wizard                    # interactive setup
-terok project auth claude myproj                # authenticate agent
+terok auth claude myproj                # authenticate agent
 terok task start myproj                 # start a CLI agent task
 terok task start myproj --toad          # Toad multi-agent TUI (browser access)
 terok login myproj a3                   # attach to a running task by hex ID prefix

--- a/docs/shared-dirs.md
+++ b/docs/shared-dirs.md
@@ -102,7 +102,7 @@ static marker in the file works around this limitation.
   — you cannot have per-project or per-task Claude OAuth credentials.
 - The static marker token is not revoked between tasks.  The real OAuth
   token is still protected by the proxy and refreshed automatically.
-- API key auth for Claude (`terok project auth claude` → option 2) remains
+- API key auth for Claude (`terok auth claude` → option 2) remains
   per-task and is unaffected.
 
 ## Git Identity

--- a/src/terok/cli/commands/auth.py
+++ b/src/terok/cli/commands/auth.py
@@ -1,0 +1,43 @@
+# SPDX-FileCopyrightText: 2026 Jiri Vyskocil
+# SPDX-License-Identifier: Apache-2.0
+
+"""``auth`` top-level command — authenticate an agent/tool.
+
+Lives at the top level (not under ``project``) because upcoming work
+will enable project-less authentication — the happy path is ``terok
+auth <provider>``, with a project argument as the optional scoping
+mechanism rather than the primary axis.
+"""
+
+from __future__ import annotations
+
+import argparse
+
+from terok_executor import AUTH_PROVIDERS
+
+from ...lib.core.images import require_agent_installed
+from ...lib.core.projects import load_project
+from ...lib.domain.facade import authenticate
+from ._completers import complete_project_ids as _complete_project_ids, set_completer
+
+
+def register(subparsers: argparse._SubParsersAction[argparse.ArgumentParser]) -> None:
+    """Register the ``auth`` top-level command."""
+    provider_names = list(AUTH_PROVIDERS)
+    providers_help = ", ".join(f"{p.name} ({p.label})" for p in AUTH_PROVIDERS.values())
+    p_auth = subparsers.add_parser(
+        "auth",
+        help="Authenticate an agent/tool for a project",
+        description=f"Available providers: {providers_help}",
+    )
+    p_auth.add_argument("provider", choices=provider_names, metavar="provider")
+    set_completer(p_auth.add_argument("project_id"), _complete_project_ids)
+
+
+def dispatch(args: argparse.Namespace) -> bool:
+    """Handle ``terok auth``.  Returns True if handled."""
+    if args.cmd != "auth":
+        return False
+    require_agent_installed(load_project(args.project_id), args.provider, noun="Provider")
+    authenticate(args.project_id, args.provider)
+    return True

--- a/src/terok/cli/commands/dbus.py
+++ b/src/terok/cli/commands/dbus.py
@@ -38,7 +38,7 @@ def register(subparsers: argparse._SubParsersAction[argparse.ArgumentParser]) ->
     """Register the ``dbus-debug`` subcommand group from the terok-dbus registry."""
     p = subparsers.add_parser(
         "dbus-debug",
-        help="Debug D-Bus notifications (internal; kept until the feature matures)",
+        help="Debug D-Bus notifications",
     )
     sub = p.add_subparsers(dest="dbus_cmd", required=True)
 

--- a/src/terok/cli/commands/project.py
+++ b/src/terok/cli/commands/project.py
@@ -7,12 +7,8 @@ from __future__ import annotations
 
 import argparse
 
-from terok_executor import AUTH_PROVIDERS
-
-from ...lib.core.images import require_agent_installed
 from ...lib.core.projects import list_presets, list_projects, load_project
 from ...lib.domain.facade import (
-    authenticate,
     build_images,
     delete_project,
     derive_project,
@@ -141,17 +137,6 @@ def register(subparsers: argparse._SubParsersAction[argparse.ArgumentParser]) ->
         help="Recreate the mirror from scratch",
     )
 
-    # auth
-    provider_names = list(AUTH_PROVIDERS)
-    providers_help = ", ".join(f"{p.name} ({p.label})" for p in AUTH_PROVIDERS.values())
-    p_auth = sub.add_parser(
-        "auth",
-        help="Authenticate an agent/tool for a project",
-        description=f"Available providers: {providers_help}",
-    )
-    p_auth.add_argument("provider", choices=provider_names, metavar="provider")
-    _add_project_arg(p_auth)
-
     # presets (leaf — takes project_id directly; no further subcommand)
     p_presets = sub.add_parser("presets", help="List available presets for a project")
     _add_project_arg(p_presets)
@@ -186,9 +171,6 @@ def dispatch(args: argparse.Namespace) -> bool:
             _cmd_ssh_init(args)
         case "gate-sync":
             _cmd_gate_sync(args)
-        case "auth":
-            require_agent_installed(load_project(args.project_id), args.provider, noun="Provider")
-            authenticate(args.project_id, args.provider)
         case "presets":
             _cmd_presets(args.project_id)
         case _:  # pragma: no cover — required=True makes argparse enforce this

--- a/src/terok/cli/commands/setup.py
+++ b/src/terok/cli/commands/setup.py
@@ -397,7 +397,7 @@ def cmd_setup(*, check_only: bool = False) -> None:
     providers = ", ".join(AUTH_PROVIDERS)
     print(
         f"\nNext steps:\n"
-        f"  terok project auth <provider> <project>    Authenticate agents ({providers})\n"
+        f"  terok auth <provider> <project>            Authenticate agents ({providers})\n"
         f"  terok project wizard                       Create your first project\n"
     )
 

--- a/src/terok/cli/commands/task.py
+++ b/src/terok/cli/commands/task.py
@@ -89,11 +89,13 @@ def _resolve_unrestricted(args: argparse.Namespace) -> bool | None:
 
 
 def register(subparsers: argparse._SubParsersAction[argparse.ArgumentParser]) -> None:
-    """Register task-related subcommands."""
-    # login (top-level shortcut)
-    p_login = subparsers.add_parser("login", help="Open interactive shell in a running container")
-    _add_project_task_args(p_login)
+    """Register task-related subcommands.
 
+    Note on ordering: the ``task`` group is added *before* the flat
+    ``login`` shortcut so ``--help`` reads ``task`` → ``login``, matching
+    the mental model of "task management, with login as a quick way to
+    attach."
+    """
     # task subcommand group
     p_task = subparsers.add_parser("task", help="Manage tasks")
     tsub = p_task.add_subparsers(dest="task_cmd", required=True)
@@ -266,6 +268,11 @@ def register(subparsers: argparse._SubParsersAction[argparse.ArgumentParser]) ->
         "archive_id",
         help="Archive ID prefix (timestamp, e.g. 20260305T143000Z)",
     )
+
+    # login (top-level shortcut — registered after the task group so --help
+    # lists ``task`` → ``login`` in intuitive order)
+    p_login = subparsers.add_parser("login", help="Open interactive shell in a running container")
+    _add_project_task_args(p_login)
 
 
 def dispatch(args: argparse.Namespace) -> bool:

--- a/src/terok/cli/main.py
+++ b/src/terok/cli/main.py
@@ -16,6 +16,7 @@ import sys
 from ..lib.core.config import set_experimental
 from ..lib.core.version import format_version_string, get_version_info
 from .commands import (
+    auth,
     clearance,
     completions,
     dbus,
@@ -41,9 +42,10 @@ except ImportError:  # pragma: no cover - optional dep
 # wire_dispatch handles commands mounted via wire_group (agent, gate).
 _DISPATCHERS = [
     panic.dispatch,
-    task.dispatch,
-    project.dispatch,
     setup.dispatch,
+    auth.dispatch,
+    project.dispatch,
+    task.dispatch,
     image.dispatch,
     vault_local.dispatch,  # must precede wire_dispatch — handles `vault serve`
     wire_dispatch,
@@ -95,10 +97,10 @@ def main(prog: str = "terok") -> None:
         formatter_class=argparse.RawDescriptionHelpFormatter,
         epilog=(
             "Quick start:\n"
-            f"  1. Bootstrap:  {prog} setup                          (install host services)\n"
-            f"  2. Project:    {prog} project wizard                 (create a project)\n"
-            f"  3. Auth:       {prog} project auth claude <project>  (authenticate agents)\n"
-            f"  4. Work:       {prog} task start <project_id>        (new CLI task)\n"
+            f"  1. Bootstrap:  {prog} setup                       (install host services)\n"
+            f"  2. Auth:       {prog} auth claude <project>       (authenticate agents)\n"
+            f"  3. Project:    {prog} project wizard              (create a project)\n"
+            f"  4. Work:       {prog} task start <project_id>     (new CLI task)\n"
             f"  5. Login:      {prog} login <project_id> <task_id>\n"
             "\n"
             "Standalone agent (no project):\n"
@@ -127,18 +129,20 @@ def main(prog: str = "terok") -> None:
     )
     sub = parser.add_subparsers(dest="cmd", required=True)
 
-    # Register subcommands from each module
+    # Register subcommands.  Order matters — it's the order they appear in
+    # ``--help``.  Emergency and bootstrap first, then the daily-workflow
+    # verbs (auth → project → task → login), then operator tools, then
+    # sibling-wired groups, then dev/shell niceties.
     panic.register(sub)
-    task.register(sub)
-    project.register(sub)
     setup.register(sub)
+    auth.register(sub)
+    project.register(sub)
+    task.register(sub)  # adds the ``task`` group and the flat ``login`` shortcut
     image.register(sub)
-    shield.register(sub)
-    dbus.register(sub)
     clearance.register(sub)
     sickbay.register(sub)
+    shield.register(sub)
     info.register(sub)
-    completions.register(sub)
 
     # Mount sub-package command registries under scoped prefixes.
     # Groups that touch SandboxConfig paths receive config_factory so the
@@ -148,12 +152,12 @@ def main(prog: str = "terok") -> None:
 
     from ..lib.core.config import make_sandbox_config
 
-    wire_group(sub, "executor", AGENT_COMMANDS, help="Executor container commands")
+    wire_group(sub, "executor", AGENT_COMMANDS, help="Task container executor commands")
     wire_group(
         sub,
         "gate",
         GATE_COMMANDS,
-        help="Gate server commands",
+        help="Git gate commands",
         config_factory=make_sandbox_config,
     )
     vault_wiring = wire_group(
@@ -175,8 +179,12 @@ def main(prog: str = "terok") -> None:
         config_factory=make_sandbox_config,
     )
 
+    # Dev / shell niceties at the bottom of the help listing.
+    dbus.register(sub)
+    completions.register(sub)
+
     # TUI launcher — delegates to terok-tui entry point (dispatched before argparse)
-    sub.add_parser("tui", help="Launch the Textual TUI (same as terok-tui)")
+    sub.add_parser("tui", help="Launch the Textual TUI")
 
     # Enable bash completion if argcomplete is present and activated
     if argcomplete is not None:  # pragma: no cover - shell integration

--- a/tests/unit/cli/test_cli_auth.py
+++ b/tests/unit/cli/test_cli_auth.py
@@ -1,0 +1,56 @@
+# SPDX-FileCopyrightText: 2026 Jiri Vyskocil
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the top-level ``terok auth`` command."""
+
+from __future__ import annotations
+
+import argparse
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from terok.cli.commands.auth import dispatch, register
+
+
+def test_register_parses_provider_and_project() -> None:
+    """``auth <provider> <project>`` parses as two positional arguments."""
+    parser = argparse.ArgumentParser()
+    register(parser.add_subparsers(dest="cmd"))
+    args = parser.parse_args(["auth", "claude", "myproj"])
+    assert args.cmd == "auth"
+    assert args.provider == "claude"
+    assert args.project_id == "myproj"
+
+
+def test_register_rejects_unknown_provider() -> None:
+    """``auth <unknown>`` exits with argparse's choices error."""
+    parser = argparse.ArgumentParser()
+    register(parser.add_subparsers(dest="cmd"))
+    try:
+        parser.parse_args(["auth", "not-a-provider", "p"])
+    except SystemExit as exc:
+        assert exc.code == 2
+    else:  # pragma: no cover — defensive: argparse must exit on invalid choice
+        raise AssertionError("expected SystemExit")
+
+
+def test_dispatch_ignores_other_commands() -> None:
+    """Dispatch returns False for unrelated namespaces."""
+    assert dispatch(argparse.Namespace(cmd="task")) is False
+
+
+def test_dispatch_runs_install_check_then_authenticate() -> None:
+    """``auth`` loads the project, verifies the agent, then authenticates."""
+    fake_project = SimpleNamespace(id="p1")
+    args = argparse.Namespace(cmd="auth", provider="claude", project_id="p1")
+    with (
+        patch("terok.cli.commands.auth.load_project", return_value=fake_project),
+        patch("terok.cli.commands.auth.require_agent_installed") as mock_check,
+        patch("terok.cli.commands.auth.authenticate") as mock_auth,
+    ):
+        assert dispatch(args) is True
+
+    # The handler passes the *loaded* project object (not the raw id) into
+    # the installation check, and the noun label drives error messages.
+    mock_check.assert_called_once_with(fake_project, "claude", noun="Provider")
+    mock_auth.assert_called_once_with("p1", "claude")

--- a/tests/unit/cli/test_cli_project.py
+++ b/tests/unit/cli/test_cli_project.py
@@ -134,23 +134,6 @@ def test_dispatch_routes_to_handler(
         )
 
 
-def test_dispatch_auth_combines_two_calls() -> None:
-    """``project auth`` checks agent installation then authenticates."""
-    args = argparse.Namespace(cmd="project", project_cmd="auth", project_id="p1", provider="claude")
-    fake_project = SimpleNamespace(id="p1")
-    with (
-        patch("terok.cli.commands.project.load_project", return_value=fake_project),
-        patch("terok.cli.commands.project.require_agent_installed") as mock_check,
-        patch("terok.cli.commands.project.authenticate") as mock_auth,
-    ):
-        assert dispatch(args) is True
-
-    # ``require_agent_installed`` receives the *loaded* project object
-    # (not the raw project_id) and the noun label used for error messages.
-    mock_check.assert_called_once_with(fake_project, "claude", noun="Provider")
-    mock_auth.assert_called_once_with("p1", "claude")
-
-
 def test_dispatch_ignores_non_project_cmd() -> None:
     """Dispatch returns False for other top-level commands."""
     assert dispatch(argparse.Namespace(cmd="task")) is False


### PR DESCRIPTION
## Summary

Followup polish on the CLI restructure:

- **`auth` lifted back to top-level** (was `project auth`).  A project-less `terok auth <provider>` will soon be the happy path, so the verb no longer belongs inside the `project` group.  New `commands/auth.py` owns register/dispatch; `project.py` drops the case.
- **Help-text polish:**
  - `dbus-debug`: `Debug D-Bus notifications` (dropped the "internal; kept until the feature matures" qualifier — the group name carries the signal on its own)
  - `executor`:  `Task container executor commands`
  - `gate`:      `Git gate commands`
  - `tui`:       `Launch the Textual TUI` (dropped the same-as-terok-tui aside)
- **Top-level ordering** now follows the daily workflow: `panic, setup, auth, project, task, login, image, clearance, sickbay, shield, config, executor, gate, vault, ssh, dbus-debug, completions, tui`.  `task.py` swaps its own two `add_parser` calls so the `task` group registers before the flat `login` shortcut, matching the outer order.
- **Epilog quick-start** renumbered: bootstrap → auth → project → work → login.

Also: docs sweep for `terok project auth` → `terok auth` across README, index.md, shared-dirs.md, and setup.py's "Next steps" printout.

## Test plan

- [x] `make lint` — clean
- [x] `make tach` / `make lint-imports` — 4/4 contracts kept (allowlist swap: `project` → `auth`)
- [x] `make docstrings` — 99.4% (unchanged)
- [x] `make reuse` / `make security` — clean
- [x] 1845 unit tests pass (one pre-existing env-specific test deselected, same as earlier PRs)
- [x] New `test_cli_auth.py` covers register (+provider validation) and dispatch (with the actual `require_agent_installed` call shape pinned)
- [x] Manual smoke: `terok --help` shows the new ordering; `terok auth claude myproj` parses; `terok project --help` no longer lists `auth`

🤖 Generated with [Claude Code](https://claude.com/claude-code)