### PR TITLE
feat(cli): smarter completions — project-id / task-id / preset coverage

### DIFF
--- a/src/terok/cli/commands/_completers.py
+++ b/src/terok/cli/commands/_completers.py
@@ -1,7 +1,14 @@
 # SPDX-FileCopyrightText: 2026 Jiri Vyskocil
 # SPDX-License-Identifier: Apache-2.0
 
-"""Shared argcomplete completers and helpers for CLI commands."""
+"""Shared argcomplete completers and helpers for CLI commands.
+
+All completers assume the standard ``project_id`` / ``task_id`` dest
+names.  Parsers whose positionals display as ``<project>`` / ``<task>``
+(e.g. ``sickbay``) should set ``dest="project_id"`` / ``dest="task_id"``
+with a custom ``metavar=`` for display, so completers and argparse help
+stay decoupled.
+"""
 
 from __future__ import annotations
 
@@ -9,7 +16,8 @@ import argparse
 from collections.abc import Callable
 from typing import Any
 
-from ...lib.core.projects import list_projects
+from ...lib.core.projects import list_presets, list_projects
+from ...lib.domain.facade import get_tasks
 
 
 def complete_project_ids(
@@ -25,6 +33,72 @@ def complete_project_ids(
     return ids
 
 
+def complete_task_ids(
+    prefix: str, parsed_args: argparse.Namespace, **kwargs: object
+) -> list[str]:  # pragma: no cover
+    """Return task IDs matching *prefix* within ``parsed_args.project_id``.
+
+    Returns an empty list when the project arg hasn't been typed yet —
+    argcomplete uses the partially-parsed namespace, which is exactly
+    what we want to scope task-ID suggestions.
+    """
+    project_id = getattr(parsed_args, "project_id", None)
+    if not project_id:
+        return []
+    try:
+        tids = [t.task_id for t in get_tasks(project_id) if t.task_id]
+    except Exception:
+        return []
+    if prefix:
+        tids = [t for t in tids if t.startswith(prefix)]
+    return tids
+
+
+def complete_preset_names(
+    prefix: str, parsed_args: argparse.Namespace, **kwargs: object
+) -> list[str]:  # pragma: no cover
+    """Return preset names matching *prefix* for the scoped project.
+
+    ``list_presets`` requires a project ID to resolve the full tier
+    (bundled → global → project), so we only suggest presets once the
+    user has typed the project arg.  No project typed yet → empty list,
+    which leaves argcomplete silent rather than misleading.
+    """
+    project_id = getattr(parsed_args, "project_id", None)
+    if not project_id:
+        return []
+    try:
+        names = [p.name for p in list_presets(project_id)]
+    except Exception:
+        return []
+    if prefix:
+        names = [n for n in names if n.startswith(prefix)]
+    return names
+
+
 def set_completer(action: argparse.Action, fn: Callable[..., Any]) -> None:
     """Attach an argcomplete completer to *action*, ignoring missing argcomplete."""
     action.completer = fn  # type: ignore[attr-defined]
+
+
+def add_project_id(parser: argparse.ArgumentParser, **kwargs: object) -> argparse.Action:
+    """Add a ``project_id`` positional with the project-ID completer attached.
+
+    Returns the argparse action so callers can further customise it.
+    Accepts any argparse kwargs (``nargs``, ``metavar``, ``help``, etc.).
+    """
+    action = parser.add_argument("project_id", **kwargs)
+    set_completer(action, complete_project_ids)
+    return action
+
+
+def add_task_id(parser: argparse.ArgumentParser, **kwargs: object) -> argparse.Action:
+    """Add a ``task_id`` positional with the task-ID completer attached.
+
+    Returns the argparse action.  Callers should typically precede this
+    with :func:`add_project_id` so argcomplete has a project scope to
+    look up tasks under.
+    """
+    action = parser.add_argument("task_id", **kwargs)
+    set_completer(action, complete_task_ids)
+    return action

--- a/src/terok/cli/commands/info.py
+++ b/src/terok/cli/commands/info.py
@@ -49,7 +49,12 @@ def register(subparsers: argparse._SubParsersAction[argparse.ArgumentParser]) ->
         help="Show resolved agent config for a project (with provenance per level)",
     )
     set_completer(p_resolved.add_argument("project_id", help="Project ID"), _complete_project_ids)
-    p_resolved.add_argument("--preset", help="Apply a preset before showing resolved config")
+    from ._completers import complete_preset_names
+
+    set_completer(
+        p_resolved.add_argument("--preset", help="Apply a preset before showing resolved config"),
+        complete_preset_names,
+    )
 
     # config import-opencode — unchanged semantics, now under the group
     p_import_oc = config_sub.add_parser(

--- a/src/terok/cli/commands/shield.py
+++ b/src/terok/cli/commands/shield.py
@@ -109,13 +109,16 @@ def register(subparsers: argparse._SubParsersAction[argparse.ArgumentParser]) ->
         # Commands that need a container get positional project_id + task_id,
         # matching the ``terok task …`` convention.  Commands with an
         # *optional* container arg (like ``status``) get nargs="?" so they
-        # work both with and without a task target.
+        # work both with and without a task target.  Completers attach
+        # either way so tab-complete works in both forms.
+        from ._completers import add_project_id, add_task_id
+
         if cmd.needs_container:
-            sp.add_argument("project_id", help="Project ID")
-            sp.add_argument("task_id", help="Task ID")
+            add_project_id(sp, help="Project ID")
+            add_task_id(sp, help="Task ID")
         elif any(a.name == "container" for a in cmd.args):
-            sp.add_argument("project_id", nargs="?", help="Project ID")
-            sp.add_argument("task_id", nargs="?", help="Task ID")
+            add_project_id(sp, nargs="?", help="Project ID")
+            add_task_id(sp, nargs="?", help="Task ID")
 
         for arg in cmd.args:
             if arg.name == "container":
@@ -139,8 +142,16 @@ def dispatch(args: argparse.Namespace) -> bool:
     cmd_name = args.shield_cmd
 
     # install-hooks is standalone_only and needs subprocess passthrough
-    # (no registry handler)
+    # (no registry handler).  The sibling ``run_setup`` is UX-agnostic
+    # (raises ValueError on invalid combos) — terok's CLI surface turns
+    # that refusal into a SystemExit with actionable remediation text.
     if cmd_name == "install-hooks":
+        if not args.root and not args.user:
+            raise SystemExit(
+                "Specify --root (system-wide, uses sudo) or --user (user-local).\n"
+                "  terok shield install-hooks --root   # /etc/containers/oci/hooks.d\n"
+                "  terok shield install-hooks --user   # ~/.local/share/containers/oci/hooks.d"
+            )
         from terok_sandbox import run_setup as shield_run_setup
 
         shield_run_setup(root=args.root, user=args.user)

--- a/src/terok/cli/commands/sickbay.py
+++ b/src/terok/cli/commands/sickbay.py
@@ -52,8 +52,12 @@ _CheckResult = tuple[str, str, str]
 def register(subparsers: argparse._SubParsersAction[argparse.ArgumentParser]) -> None:
     """Register the ``sickbay`` subcommand."""
     p = subparsers.add_parser("sickbay", help="Run health checks and reconciliation")
-    p.add_argument("project", nargs="?", help="Scope to a single project")
-    p.add_argument("task", nargs="?", help="Scope to a single task")
+    # dest=project_id / task_id matches the rest of the CLI so the shared
+    # completers work; metavar keeps the display ``<project>``/``<task>``.
+    from ._completers import add_project_id, add_task_id
+
+    add_project_id(p, nargs="?", metavar="project", help="Scope to a single project")
+    add_task_id(p, nargs="?", metavar="task", help="Scope to a single task")
     p.add_argument("--fix", action="store_true", help="Auto-remediate issues")
 
 
@@ -62,8 +66,8 @@ def dispatch(args: argparse.Namespace) -> bool:
     if args.cmd != "sickbay":
         return False
     _cmd_sickbay(
-        project_id=getattr(args, "project", None),
-        task_id=getattr(args, "task", None),
+        project_id=getattr(args, "project_id", None),
+        task_id=getattr(args, "task_id", None),
         fix=getattr(args, "fix", False),
     )
     return True

--- a/src/terok/cli/commands/task.py
+++ b/src/terok/cli/commands/task.py
@@ -15,7 +15,6 @@ from ...lib.core.config import get_logs_partial_streaming as _get_logs_partial_s
 from ...lib.domain.facade import (
     HeadlessRunRequest,
     LogViewOptions,
-    get_tasks as _get_tasks,
     task_archive_list,
     task_archive_logs,
     task_delete,
@@ -33,34 +32,18 @@ from ...lib.domain.facade import (
     task_stop,
 )
 from ...lib.orchestration.tasks import resolve_task_id
-from ._completers import complete_project_ids as _complete_project_ids, set_completer
-
-
-def _complete_task_ids(
-    prefix: str, parsed_args: argparse.Namespace, **kwargs: object
-) -> list[str]:  # pragma: no cover
-    """Return task IDs matching *prefix* for argcomplete."""
-    project_id = getattr(parsed_args, "project_id", None)
-    if not project_id:
-        return []
-    try:
-        tids = [t.task_id for t in _get_tasks(project_id) if t.task_id]
-    except Exception:
-        return []
-    if prefix:
-        tids = [t for t in tids if t.startswith(prefix)]
-    return tids
+from ._completers import add_project_id, add_task_id, complete_preset_names, set_completer
 
 
 def _add_project_arg(parser: argparse.ArgumentParser, **kwargs: object) -> None:
     """Add a ``project_id`` positional with project-ID completion."""
-    set_completer(parser.add_argument("project_id", **kwargs), _complete_project_ids)
+    add_project_id(parser, **kwargs)
 
 
 def _add_project_task_args(parser: argparse.ArgumentParser) -> None:
     """Add ``project_id`` and ``task_id`` positionals with completers."""
-    _add_project_arg(parser)
-    set_completer(parser.add_argument("task_id"), _complete_task_ids)
+    add_project_id(parser)
+    add_task_id(parser)
 
 
 def _add_restriction_flags(parser: argparse.ArgumentParser) -> None:
@@ -139,7 +122,10 @@ def register(
         default=None,
         help="Include a non-default agent by name (repeatable)",
     )
-    t_run.add_argument("--preset", help="Name of a preset to apply (global or project-level)")
+    set_completer(
+        t_run.add_argument("--preset", help="Name of a preset to apply (global or project-level)"),
+        complete_preset_names,
+    )
     t_run.add_argument("--name", help="Human-readable task name (slug-style, e.g. fix-auth-bug)")
     _add_restriction_flags(t_run)
     # Headless-only flags (silently ignored in cli/toad modes)
@@ -201,8 +187,11 @@ def register(
             default=None,
             help="Include a non-default agent by name (repeatable)",
         )
-        t_attach.add_argument(
-            "--preset", help="Name of a preset to apply (global or project-level)"
+        set_completer(
+            t_attach.add_argument(
+                "--preset", help="Name of a preset to apply (global or project-level)"
+            ),
+            complete_preset_names,
         )
         _add_restriction_flags(t_attach)
 

--- a/tests/unit/cli/test_cli_shield.py
+++ b/tests/unit/cli/test_cli_shield.py
@@ -314,6 +314,16 @@ def test_install_hooks_dispatch(
     mock_install.assert_called_once_with(**expected)
 
 
+def test_install_hooks_requires_scope_flag() -> None:
+    """``shield install-hooks`` with neither --root nor --user shows remediation."""
+    args = argparse.Namespace(cmd="shield", shield_cmd="install-hooks", root=False, user=False)
+    with pytest.raises(SystemExit) as exc_info:
+        dispatch(args)
+    message = str(exc_info.value)
+    assert "--root" in message and "--user" in message
+    assert "terok shield install-hooks" in message
+
+
 @patch("terok_shield.cli.interactive.run_interactive")
 @patch("terok.cli.commands.shield._resolve_task", return_value=("proj-cli-1", MOCK_TASK_DIR_1))
 @patch("terok.cli.commands.shield.make_shield")

--- a/tests/unit/cli/test_completers.py
+++ b/tests/unit/cli/test_completers.py
@@ -1,0 +1,245 @@
+# SPDX-FileCopyrightText: 2026 Jiri Vyskocil
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the shared argcomplete completers and their parser-attachment helpers."""
+
+from __future__ import annotations
+
+import argparse
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+from terok.cli.commands._completers import (
+    add_project_id,
+    add_task_id,
+    complete_preset_names,
+    complete_project_ids,
+    complete_task_ids,
+    set_completer,
+)
+
+# ---------------------------------------------------------------------------
+# Individual completer functions
+# ---------------------------------------------------------------------------
+
+
+class TestCompleteProjectIds:
+    """``complete_project_ids`` returns project IDs matching the prefix."""
+
+    def test_lists_all_ids_for_empty_prefix(self) -> None:
+        with patch(
+            "terok.cli.commands._completers.list_projects",
+            return_value=[SimpleNamespace(id="alpha"), SimpleNamespace(id="beta")],
+        ):
+            result = complete_project_ids("", argparse.Namespace())
+        assert sorted(result) == ["alpha", "beta"]
+
+    def test_filters_by_prefix(self) -> None:
+        with patch(
+            "terok.cli.commands._completers.list_projects",
+            return_value=[SimpleNamespace(id="alpha"), SimpleNamespace(id="ally")],
+        ):
+            result = complete_project_ids("al", argparse.Namespace())
+        assert sorted(result) == ["ally", "alpha"]
+
+    def test_returns_empty_on_failure(self) -> None:
+        """Completers must never raise — silent empty list on error."""
+        with patch(
+            "terok.cli.commands._completers.list_projects",
+            side_effect=RuntimeError("boom"),
+        ):
+            assert complete_project_ids("", argparse.Namespace()) == []
+
+
+# ---------------------------------------------------------------------------
+
+
+class TestCompleteTaskIds:
+    """``complete_task_ids`` scopes to ``parsed_args.project_id``."""
+
+    def test_empty_when_no_project_typed_yet(self) -> None:
+        """Without a project_id on parsed_args, no task suggestions."""
+        assert complete_task_ids("", argparse.Namespace()) == []
+        assert complete_task_ids("", argparse.Namespace(project_id=None)) == []
+
+    def test_lists_tasks_for_project(self) -> None:
+        tasks = [SimpleNamespace(task_id="ab12cd34"), SimpleNamespace(task_id="cd56ef78")]
+        with patch("terok.cli.commands._completers.get_tasks", return_value=tasks) as mock:
+            result = complete_task_ids("", argparse.Namespace(project_id="myproj"))
+        mock.assert_called_once_with("myproj")
+        assert sorted(result) == ["ab12cd34", "cd56ef78"]
+
+    def test_filters_by_prefix(self) -> None:
+        tasks = [SimpleNamespace(task_id="ab12cd34"), SimpleNamespace(task_id="cd56ef78")]
+        with patch("terok.cli.commands._completers.get_tasks", return_value=tasks):
+            result = complete_task_ids("ab", argparse.Namespace(project_id="p"))
+        assert result == ["ab12cd34"]
+
+    def test_skips_tasks_without_ids(self) -> None:
+        """Tasks with a falsy ``task_id`` (defensive: shouldn't happen) are skipped."""
+        tasks = [SimpleNamespace(task_id="ab12cd34"), SimpleNamespace(task_id="")]
+        with patch("terok.cli.commands._completers.get_tasks", return_value=tasks):
+            result = complete_task_ids("", argparse.Namespace(project_id="p"))
+        assert result == ["ab12cd34"]
+
+    def test_returns_empty_on_failure(self) -> None:
+        with patch(
+            "terok.cli.commands._completers.get_tasks",
+            side_effect=RuntimeError("boom"),
+        ):
+            assert complete_task_ids("", argparse.Namespace(project_id="p")) == []
+
+
+# ---------------------------------------------------------------------------
+
+
+class TestCompletePresetNames:
+    """``complete_preset_names`` scopes to ``parsed_args.project_id``."""
+
+    def test_empty_when_no_project(self) -> None:
+        """list_presets requires a project — silent when project_id absent."""
+        assert complete_preset_names("", argparse.Namespace()) == []
+        assert complete_preset_names("", argparse.Namespace(project_id=None)) == []
+
+    def test_lists_presets_for_project(self) -> None:
+        presets = [
+            SimpleNamespace(name="solo"),
+            SimpleNamespace(name="team"),
+            SimpleNamespace(name="review"),
+        ]
+        with patch("terok.cli.commands._completers.list_presets", return_value=presets) as mock:
+            result = complete_preset_names("", argparse.Namespace(project_id="myproj"))
+        mock.assert_called_once_with("myproj")
+        assert sorted(result) == ["review", "solo", "team"]
+
+    def test_filters_by_prefix(self) -> None:
+        presets = [SimpleNamespace(name="solo"), SimpleNamespace(name="team")]
+        with patch("terok.cli.commands._completers.list_presets", return_value=presets):
+            result = complete_preset_names("s", argparse.Namespace(project_id="p"))
+        assert result == ["solo"]
+
+    def test_returns_empty_on_failure(self) -> None:
+        with patch(
+            "terok.cli.commands._completers.list_presets",
+            side_effect=RuntimeError("boom"),
+        ):
+            assert complete_preset_names("", argparse.Namespace(project_id="p")) == []
+
+
+# ---------------------------------------------------------------------------
+# Parser-attachment helpers — pin the completer to the argparse action
+# ---------------------------------------------------------------------------
+
+
+class TestParserAttachment:
+    """``add_project_id`` / ``add_task_id`` attach the right completer."""
+
+    def test_add_project_id_attaches_completer(self) -> None:
+        parser = argparse.ArgumentParser()
+        action = add_project_id(parser)
+        assert action.dest == "project_id"
+        # argcomplete reads the ``completer`` attribute — verify it's bound
+        # to the right function (not just "something callable").
+        assert action.completer is complete_project_ids
+
+    def test_add_task_id_attaches_completer(self) -> None:
+        parser = argparse.ArgumentParser()
+        action = add_task_id(parser)
+        assert action.dest == "task_id"
+        assert action.completer is complete_task_ids
+
+    def test_add_project_id_forwards_kwargs(self) -> None:
+        """Custom nargs / metavar / help must flow through to argparse."""
+        parser = argparse.ArgumentParser()
+        action = add_project_id(parser, nargs="?", metavar="project", help="...")
+        assert action.nargs == "?"
+        assert action.metavar == "project"
+
+
+# ---------------------------------------------------------------------------
+# Coverage sweep — every parser that takes project_id/task_id has a completer
+# ---------------------------------------------------------------------------
+
+
+def _walk_actions(parser: argparse.ArgumentParser, seen: set[int] | None = None) -> list:
+    """Yield every non-help action across the parser tree (including subparsers)."""
+    seen = seen if seen is not None else set()
+    if id(parser) in seen:
+        return []
+    seen.add(id(parser))
+    actions = []
+    for action in parser._actions:
+        if isinstance(action, argparse._HelpAction):
+            continue
+        if isinstance(action, argparse._SubParsersAction):
+            for sp in action.choices.values():
+                actions.extend(_walk_actions(sp, seen))
+        else:
+            actions.append(action)
+    return actions
+
+
+@pytest.mark.parametrize("prog", ["terok", "terokctl"])
+def test_every_project_id_and_task_id_has_completer(prog: str) -> None:
+    """Sweep the full parser tree — no ``project_id``/``task_id`` without a completer.
+
+    Catches regressions where someone adds a new ``project_id`` positional
+    but forgets ``add_project_id`` / ``add_task_id``.
+    """
+    import argparse as _ap
+
+    parser = _ap.ArgumentParser(prog=prog)
+    sub = parser.add_subparsers(dest="cmd")
+
+    # Register every command module — mirrors main.py's registration order
+    # but without the wire_group sibling paths (those live outside our dest
+    # naming convention).
+    from terok.cli.commands import (
+        auth,
+        clearance,
+        completions,
+        dbus,
+        image,
+        info,
+        panic,
+        project,
+        setup,
+        shield,
+        sickbay,
+        task,
+    )
+
+    panic.register(sub)
+    setup.register(sub)
+    auth.register(sub)
+    project.register(sub)
+    task.register(sub, prog=prog)
+    image.register(sub)
+    clearance.register(sub)
+    sickbay.register(sub)
+    shield.register(sub)
+    info.register(sub)
+    dbus.register(sub)
+    completions.register(sub)
+
+    missing: list[str] = []
+    for action in _walk_actions(parser):
+        if action.dest in ("project_id", "task_id"):
+            if not hasattr(action, "completer") or action.completer is None:
+                missing.append(f"{action.dest} (option_strings={action.option_strings})")
+
+    assert not missing, f"Missing completers on: {missing}"
+
+
+def test_set_completer_attaches_callable() -> None:
+    """``set_completer`` is the low-level helper; both helpers go through it."""
+
+    def my_completer(prefix, parsed_args, **kw):
+        return ["a", "b"]
+
+    parser = argparse.ArgumentParser()
+    action = parser.add_argument("--thing")
+    set_completer(action, my_completer)
+    assert action.completer is my_completer

--- a/tests/unit/lib/test_shield.py
+++ b/tests/unit/lib/test_shield.py
@@ -285,10 +285,16 @@ def test_run_setup(
     kwargs: dict[str, bool],
     expected_call: dict[str, bool] | None,
 ) -> None:
-    """Shield setup handles usage, user, and root installation paths."""
+    """Shield setup handles usage, user, and root installation paths.
+
+    The sibling ``terok_sandbox.shield.run_setup`` is UX-agnostic —
+    it raises ``ValueError`` on invalid combos.  terok's CLI handler
+    (``shield.dispatch`` → ``install-hooks`` branch) is what converts
+    that into a ``SystemExit`` with actionable remediation.
+    """
     with patch("terok_sandbox.shield.setup_hooks_direct") as mock_direct:
         if expected_call is None:
-            with pytest.raises(SystemExit, match="--root"):
+            with pytest.raises(ValueError, match="root=True or user=True"):
                 run_setup(**kwargs)
             mock_direct.assert_not_called()
         else:


### PR DESCRIPTION
## Summary

Tab completion used to be hit-or-miss.  ``terok task run <TAB>`` suggested project IDs; ``terok shield up <TAB>``, ``terok sickbay <TAB>``, and ``terok task run --preset <TAB>`` all came up empty because the completers weren't attached to every parser that takes those args.

This sweep fixes every gap and adds a coverage-guarding test so new parsers can't regress.

## What's covered now

| parser / arg | before | after |
|---|---|---|
| `task {run,delete,stop,restart,…} <project_id> <task_id>` | ✅ | ✅ |
| `project {list,delete,ssh-init,gate-sync,…} <project_id>` | ✅ | ✅ |
| `image list [<project_id>]`, `image usage --project` | ✅ | ✅ |
| `auth claude <project_id>` | ✅ | ✅ |
| `config resolved <project_id>` | ✅ | ✅ |
| `shield {up,down,allow,watch,…} <project_id> <task_id>` | ❌ | ✅ |
| `sickbay [<project>] [<task>]` | ❌ | ✅ |
| `task run --preset` / `task attach --preset` / `config resolved --preset` | ❌ | ✅ |

## Diff shape

- **`_completers.py`**: `complete_task_ids` moves here from `task.py`.  New `complete_preset_names` (scopes to the typed `project_id`; returns [] before the project arg is typed so argcomplete stays silent rather than misleading).  Two new attachment helpers, `add_project_id` and `add_task_id`, so parsers register the positional and bind the completer in one call — harder to forget.
- **`shield.py`**: the registry-driven loop that adds `project_id`/`task_id` positionals now uses the helpers.
- **`sickbay.py`**: `<project>` / `<task>` positionals gain completers.  Dest is renamed to `project_id`/`task_id` (matches the rest of the CLI); display metavar stays `project`/`task`.
- **`task.py`**: `--preset` in `task run` and `task attach` bind `complete_preset_names`.
- **`info.py`**: `config resolved --preset` same.
- **`tests/unit/cli/test_completers.py`** (new, 18 tests): per-completer unit tests (happy path, prefix filter, empty-on-error, no-project fallback) plus a parametrized sweep over both `terok` and `terokctl` parser trees that asserts every `project_id`/`task_id` action has a completer bound.  If someone adds a new parser with these positionals and forgets the helper, CI fails.

## Secondary fix — landed alongside

terok-sandbox 0.0.76 (shipped last week) made the sibling `shield.run_setup` UX-agnostic: it now raises `ValueError` on invalid flag combos.  terok's `shield install-hooks` handler was still relying on the old `SystemExit`-carrying-CLI-examples behavior, so a user who ran `terok shield install-hooks` without `--root` or `--user` would get a traceback.  Handler now validates up front (mirroring sandbox's own CLI handler) and emits a `SystemExit` with `terok shield install-hooks --root / --user` hints.

Updated `test_run_setup[missing-flags]` to expect `ValueError` at the library layer and added `test_install_hooks_requires_scope_flag` at the CLI layer.

## Test plan

- [x] `make lint` — clean
- [x] `make tach` / `make lint-imports` / `make docstrings` — all pass
- [x] 1869 unit tests pass (one pre-existing env-specific test deselected, same as earlier PRs)
- [x] Coverage-sweep test confirms every project_id/task_id action on both prog surfaces has a completer
- [ ] Manual: install bash completion (`terok completions install`), verify `terok shield up myproj<TAB>` offers task IDs and `terok task run myproj --preset <TAB>` offers preset names scoped to `myproj`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * `shield install-hooks` now requires either `--root` or `--user` flag to proceed, preventing invalid command execution.

* **Tests**
  * Added comprehensive test coverage for CLI argument auto-completion functionality.
  * Added validation tests for the shield install-hooks command requirement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->