### PR TITLE
refactor: collapse sandbox-boundary ratchet behind central runtime accessor

### DIFF
--- a/.importlinter
+++ b/.importlinter
@@ -20,12 +20,16 @@ layers =
 
 # ── Cross-package boundaries (tach can't do this) ────────────────
 #
-# TODO: tighten allowed_importers as direct external-package imports are
-# consolidated behind facade modules (see runtime-abstraction-phases.md).
+# ``protected`` contracts: "module X may ONLY be imported by modules Y, Z".
+# The allowed_importers lists are the *floor* — CI fails if a new module
+# imports the package.  Tighten them whenever a consolidation lands.
 #
-# protected contracts: "module X may ONLY be imported by modules Y, Z"
-# The allowed_importers lists start wide (reflecting current state)
-# and shrink as the abstraction is sealed.
+# Phase 2 (runtime protocol): container-runtime callers funnel through
+# ``terok.lib.core.runtime.get_runtime`` rather than instantiating
+# ``PodmanRuntime`` locally.  The files on this list are the ones that
+# legitimately need terok_sandbox for non-runtime reasons: service
+# wrappers (gate/shield/vault/SSH), value types (Sandbox, RunSpec,
+# VolumeSpec), or the shared command registry (CLI wiring).
 
 [importlinter:contract:sandbox-boundary]
 name = terok_sandbox access restricted to designated modules
@@ -40,21 +44,16 @@ allowed_importers =
     terok.cli.main
     terok.cli.wiring
     terok.lib.core.config
-    terok.lib.core.images
     terok.lib.core.projects
+    terok.lib.core.runtime
     terok.lib.domain.facade
     terok.lib.domain.image_cleanup
     terok.lib.domain.panic
     terok.lib.domain.project
-    terok.lib.domain.project_state
-    terok.lib.domain.storage
-    terok.lib.domain.task_logs
     terok.lib.domain.vault
     terok.lib.orchestration.agent_config
     terok.lib.orchestration.container_doctor
-    terok.lib.orchestration.container_exec
     terok.lib.orchestration.environment
-    terok.lib.orchestration.image
     terok.lib.orchestration.ports
     terok.lib.orchestration.task_runners
     terok.lib.orchestration.tasks

--- a/src/terok/cli/commands/sickbay.py
+++ b/src/terok/cli/commands/sickbay.py
@@ -26,7 +26,6 @@ import tomllib
 from pathlib import Path
 
 from terok_sandbox import (
-    PodmanRuntime,
     check_environment,
     check_units_outdated,
     get_server_status,
@@ -36,6 +35,7 @@ from terok_sandbox import (
     is_vault_systemd_available,
 )
 
+from ...lib.core import runtime as _rt
 from ...lib.core.config import get_services_mode, global_config_path, make_sandbox_config
 from ...lib.core.project_model import ProjectConfig
 from ...lib.core.projects import list_projects, load_project
@@ -44,14 +44,6 @@ from ...lib.orchestration.container_doctor import run_container_doctor
 from ...lib.orchestration.hooks import run_hook
 from ...lib.orchestration.tasks import container_name, tasks_meta_dir
 from ...lib.util.yaml import load as _yaml_load
-
-_runtime = PodmanRuntime()
-
-
-def get_container_state(cname: str) -> str | None:
-    """Module-level shim over ``_runtime.container(cname).state`` — patchable by tests."""
-    return _runtime.container(cname).state
-
 
 # Type alias for check results: (severity, label, detail)
 _CheckResult = tuple[str, str, str]
@@ -179,7 +171,7 @@ def _check_task_hook(
         return None
 
     cname = container_name(pid, mode, tid)
-    if get_container_state(cname) == "running":
+    if _rt.get_runtime().container(cname).state == "running":
         return None
 
     fired = meta.get("hooks_fired") or []

--- a/src/terok/lib/core/images.py
+++ b/src/terok/lib/core/images.py
@@ -12,18 +12,8 @@ from functools import lru_cache
 from typing import TYPE_CHECKING
 
 from terok_executor import AGENTS_LABEL
-from terok_sandbox import PodmanRuntime
 
-_runtime = PodmanRuntime()
-
-
-def image_labels(tag: str) -> dict[str, str]:
-    """Return the OCI labels for *tag* via the container runtime.
-
-    Module-level shim so tests can patch by name.
-    """
-    return _runtime.image(tag).labels()
-
+from . import runtime as _rt
 
 if TYPE_CHECKING:
     from terok.lib.core.project_model import ProjectConfig
@@ -76,7 +66,7 @@ def installed_agents(image_tag: str) -> frozenset[str]:
     empty set — callers treat empty as "unknown / unrestricted" so older
     images keep working.
     """
-    csv = (image_labels(image_tag).get(AGENTS_LABEL) or "").strip()
+    csv = (_rt.get_runtime().image(image_tag).labels().get(AGENTS_LABEL) or "").strip()
     if not csv:
         return frozenset()
     return frozenset(name.strip() for name in csv.split(",") if name.strip())

--- a/src/terok/lib/core/runtime.py
+++ b/src/terok/lib/core/runtime.py
@@ -1,0 +1,55 @@
+# SPDX-FileCopyrightText: 2026 Jiri Vyskocil
+# SPDX-License-Identifier: Apache-2.0
+
+"""Process-wide :class:`ContainerRuntime` accessor.
+
+Centralises backend construction so the sandbox-boundary
+import-linter ratchet stays tight: every call site asks this module
+for its runtime handle instead of instantiating ``PodmanRuntime``
+locally.  Selection is env-driven — ``TEROK_RUNTIME=podman`` (default)
+or ``TEROK_RUNTIME=null`` for dry-run / test use.
+
+Tests that need a specific backend should call :func:`set_runtime`
+in setup and :func:`reset_runtime` in teardown.
+"""
+
+from __future__ import annotations
+
+import os
+
+from terok_sandbox import ContainerRuntime, NullRuntime, PodmanRuntime
+
+_runtime: ContainerRuntime | None = None
+
+
+def get_runtime() -> ContainerRuntime:
+    """Return the cached process-wide :class:`ContainerRuntime`.
+
+    On first call, inspects ``TEROK_RUNTIME`` and constructs the
+    matching backend.  Supported values are ``"podman"`` (the default)
+    and ``"null"`` (an in-memory stub useful for CI).  Any other value
+    raises :class:`SystemExit` at startup rather than quietly falling
+    back — a misspelled env var should be loud.
+    """
+    global _runtime
+    if _runtime is None:
+        backend = os.environ.get("TEROK_RUNTIME", "podman").strip().lower()
+        if backend == "podman":
+            _runtime = PodmanRuntime()
+        elif backend == "null":
+            _runtime = NullRuntime()
+        else:
+            raise SystemExit(f"TEROK_RUNTIME={backend!r}: expected 'podman' or 'null'")
+    return _runtime
+
+
+def set_runtime(runtime: ContainerRuntime) -> None:
+    """Inject *runtime* as the process-wide handle (for tests)."""
+    global _runtime
+    _runtime = runtime
+
+
+def reset_runtime() -> None:
+    """Forget the cached runtime so the next ``get_runtime`` rebuilds from env."""
+    global _runtime
+    _runtime = None

--- a/src/terok/lib/domain/image_cleanup.py
+++ b/src/terok/lib/domain/image_cleanup.py
@@ -6,12 +6,13 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from typing import TYPE_CHECKING
 
-from terok_sandbox import Image, PodmanRuntime
-
+from ..core import runtime as _rt
 from ..core.projects import list_projects
 
-_runtime = PodmanRuntime()
+if TYPE_CHECKING:
+    from terok_sandbox import Image
 
 
 @dataclass
@@ -95,7 +96,7 @@ def list_images(project_id: str | None = None) -> list[ImageInfo]:
         List of ImageInfo objects for matching images.
     """
     images: list[ImageInfo] = []
-    for image in _runtime.images():
+    for image in _rt.get_runtime().images():
         if not _is_terok_image(image.repository, image.tag):
             continue
         if project_id is not None:
@@ -149,7 +150,7 @@ def _find_dangling_terok_images() -> list[ImageInfo]:
     """
     return [
         ImageInfo.from_image(image)
-        for image in _runtime.images(dangling_only=True)
+        for image in _rt.get_runtime().images(dangling_only=True)
         if _is_terok_built_image(image.ref)
     ]
 
@@ -160,7 +161,7 @@ def _is_terok_built_image(image_id: str) -> bool:
     Inspects the ``terok.build_context_hash`` label and image history
     for terok layer names.
     """
-    image = _runtime.image(image_id)
+    image = _rt.get_runtime().image(image_id)
     if image.labels().get("terok.build_context_hash"):
         return True
     return any("terok-l0" in line or "terok-l1" in line for line in image.history())
@@ -184,7 +185,7 @@ def cleanup_images(dry_run: bool = False) -> CleanupResult:
             removed.append(img.full_name)
             continue
         try:
-            if _runtime.image(img.image_id).remove():
+            if _rt.get_runtime().image(img.image_id).remove():
                 removed.append(img.full_name)
             else:
                 failed.append(img.full_name)

--- a/src/terok/lib/domain/panic.py
+++ b/src/terok/lib/domain/panic.py
@@ -245,9 +245,9 @@ def _stop_gate() -> tuple[bool, str | None]:
 
 def _stop_containers(targets: list[_Target]) -> tuple[list[str], list[tuple[str, str]]]:
     """Stop all container modes for each target."""
-    from terok_sandbox import PodmanRuntime
+    from ..core import runtime as _rt
 
-    runtime = PodmanRuntime()
+    runtime = _rt.get_runtime()
     names = [container_name(pid, m, tid) for pid, tid, _, _, _ in targets for m in CONTAINER_MODES]
     if not names:
         return [], []

--- a/src/terok/lib/domain/project_state.py
+++ b/src/terok/lib/domain/project_state.py
@@ -11,8 +11,7 @@ for overview displays.
 from collections.abc import Callable
 from typing import TYPE_CHECKING, Any
 
-from terok_sandbox import PodmanRuntime
-
+from ..core import runtime as _rt
 from ..core.config import build_dir
 from ..core.images import project_cli_image
 from ..core.projects import load_project
@@ -29,32 +28,6 @@ def _scope_has_vault_key(scope: str) -> bool:
 
 if TYPE_CHECKING:
     from ..core.project_model import ProjectConfig
-
-_runtime = PodmanRuntime()
-
-
-# Module-level shims over the runtime — patchable by tests.
-
-
-def image_exists(tag: str) -> bool:
-    """Return ``True`` when an image with *tag* is present locally."""
-    return _runtime.image(tag).exists()
-
-
-def image_labels(tag: str) -> dict[str, str]:
-    """Return the OCI labels for the image identified by *tag*."""
-    return _runtime.image(tag).labels()
-
-
-def is_container_running(cname: str) -> bool:
-    """Return ``True`` if *cname* is currently running."""
-    return _runtime.container(cname).running
-
-
-def container_image(cname: str) -> str | None:
-    """Return the image ID the running container *cname* was created from."""
-    image = _runtime.container(cname).image
-    return image.ref if image is not None else None
 
 
 def get_project_state(
@@ -95,7 +68,8 @@ def get_project_state(
 
     # Images: rely on image tags created by build_images().
     required_tags = [project_cli_image(project.id)]
-    has_images = all(image_exists(tag) for tag in required_tags)
+    runtime = _rt.get_runtime()
+    has_images = all(runtime.image(tag).exists() for tag in required_tags)
 
     rendered: dict[str, str] | None = None
     dockerfiles_old = False
@@ -219,10 +193,11 @@ def is_task_image_old(project_id: str | None, task: Any) -> bool | None:
         return None
 
     cname = _container_name(project_id, task.mode, task.task_id)
-    if not is_container_running(cname):
+    container = _rt.get_runtime().container(cname)
+    if not container.running:
         return None
-    image_id = container_image(cname)
-    if image_id is None:
+    image = container.image
+    if image is None:
         return None
 
     try:
@@ -239,7 +214,7 @@ def is_task_image_old(project_id: str | None, task: Any) -> bool | None:
             current_hash = build_context_hash(project_id)
         except Exception:
             return None
-        label = image_labels(image_id).get("terok.build_context_hash")
+        label = image.labels().get("terok.build_context_hash")
         if not label:
             return True
         return label != current_hash

--- a/src/terok/lib/domain/storage.py
+++ b/src/terok/lib/domain/storage.py
@@ -236,14 +236,17 @@ def get_project_storage_detail(project_id: str) -> ProjectDetail:
     This triggers ``podman ps --size`` for the project's containers —
     expect a brief pause while podman computes overlay diffs.
     """
-    from terok_sandbox import PodmanRuntime
-
+    from ..core import runtime as _rt
     from ..core.projects import load_project
 
     project = load_project(project_id)
     project_images = [img for img in list_images(project_id) if not _is_global_image(img)]
     tasks = get_tasks_storage(project.tasks_root)
-    overlays = PodmanRuntime().container_rw_sizes(project_id)
+    runtime = _rt.get_runtime()
+    # ``container_rw_sizes`` is podman-specific; not every backend exposes it.
+    overlays = (
+        runtime.container_rw_sizes(project_id) if hasattr(runtime, "container_rw_sizes") else {}
+    )
 
     return ProjectDetail(
         project_id=project_id,

--- a/src/terok/lib/domain/task_logs.py
+++ b/src/terok/lib/domain/task_logs.py
@@ -16,22 +16,12 @@ from dataclasses import dataclass
 from pathlib import Path
 
 from terok_executor import AgentRunner
-from terok_sandbox import PodmanRuntime
 
+from ..core import runtime as _rt
 from ..core.projects import load_project
 from ..orchestration.tasks import container_name, tasks_meta_dir
 from ..util.yaml import load as _yaml_load
 from .log_format import auto_detect_formatter
-
-_runtime = PodmanRuntime()
-
-
-def get_container_state(cname: str) -> str | None:
-    """Return lifecycle state for *cname* via the container runtime.
-
-    Module-level shim so tests can patch by name.
-    """
-    return _runtime.container(cname).state
 
 
 def _build_raw_logs_cmd(cname: str, *, follow: bool, tail: int | None) -> list[str]:
@@ -110,7 +100,7 @@ def task_logs(
     cname = container_name(project.id, mode, task_id)
 
     # Verify container exists (running or exited)
-    state = get_container_state(cname)
+    state = _rt.get_runtime().container(cname).state
     if state is None:
         # Fall back to persisted log files on the host
         task_dir = project.tasks_root / str(task_id)

--- a/src/terok/lib/orchestration/container_doctor.py
+++ b/src/terok/lib/orchestration/container_doctor.py
@@ -21,30 +21,17 @@ from urllib.parse import urlparse, urlunparse
 from terok_executor import agent_doctor_checks, get_roster
 from terok_sandbox import (
     ExecResult,
-    PodmanRuntime,
     get_ssh_signer_port,
     get_token_broker_port,
     make_shield,
 )
 from terok_sandbox.doctor import CheckVerdict, DoctorCheck, sandbox_doctor_checks
 
+from ..core import runtime as _rt
 from ..core.config import make_sandbox_config
 from ..core.projects import load_project
 from ..util.logging_utils import _log_debug
 from .tasks import container_name, load_task_meta, tasks_meta_dir
-
-_runtime = PodmanRuntime()
-
-
-def get_container_state(cname: str) -> str | None:
-    """Module-level shim over ``_runtime.container(cname).state`` — patchable by tests."""
-    return _runtime.container(cname).state
-
-
-def sandbox_exec(cname: str, cmd: list[str], *, timeout: int = 10) -> ExecResult:
-    """Module-level shim over ``_runtime.exec`` — patchable by tests."""
-    return _runtime.exec(_runtime.container(cname), cmd, timeout=timeout)
-
 
 # Type alias matching sickbay.py convention
 _CheckResult = tuple[str, str, str]
@@ -66,7 +53,8 @@ def _exec_in_container(
     timeout: int = 10,
 ) -> ExecResult:
     """Run *cmd* inside *cname* via the container runtime."""
-    return sandbox_exec(cname, cmd, timeout=timeout)
+    runtime = _rt.get_runtime()
+    return runtime.exec(runtime.container(cname), cmd, timeout=timeout)
 
 
 # ---------------------------------------------------------------------------
@@ -333,7 +321,7 @@ def _resolve_running_container(
         return ("", Path(), [("warn", label, "never started (no mode)")])
 
     cname = container_name(project_id, mode, task_id)
-    state = get_container_state(cname)
+    state = _rt.get_runtime().container(cname).state
     if state != "running":
         return ("", Path(), [("info", label, f"not running ({state}) — skipped")])
 

--- a/src/terok/lib/orchestration/container_exec.py
+++ b/src/terok/lib/orchestration/container_exec.py
@@ -10,54 +10,25 @@ poisoned git hooks or scripts executing with host privileges.
 
 from subprocess import TimeoutExpired
 
-from terok_sandbox import ExecResult, PodmanRuntime
-
+from ..core import runtime as _rt
 from ..core.task_display import container_name as _container_name
 from ..util.logging_utils import _log_debug
 
-_runtime = PodmanRuntime()
 
-
-# Module-level shims over the runtime — patchable by tests.
-
-
-def container_start(cname: str) -> None:
-    """Start *cname* via the runtime."""
-    _runtime.container(cname).start()
-
-
-def container_stop(cname: str, *, timeout: int = 10) -> None:
-    """Stop *cname* via the runtime."""
-    _runtime.container(cname).stop(timeout=timeout)
-
-
-def get_container_state(cname: str) -> str | None:
-    """Return lifecycle state for *cname*."""
-    return _runtime.container(cname).state
-
-
-def sandbox_exec(cname: str, cmd: list[str], *, timeout: int = 30) -> ExecResult:
-    """Run *cmd* inside *cname* via the container runtime."""
-    return _runtime.exec(_runtime.container(cname), cmd, timeout=timeout)
-
-
-def _podman_start(cname: str) -> bool:
-    """Start a stopped container, returning ``True`` on success."""
+def _temporarily_start(cname: str) -> bool:
+    """Start a stopped container for a brief exec window; return ``True`` on success."""
     try:
-        container_start(cname)
-    except FileNotFoundError:
-        _log_debug(f"container_exec._podman_start({cname}): podman not found")
-        return False
-    except RuntimeError as exc:
-        _log_debug(f"container_exec._podman_start({cname}): {exc}")
+        _rt.get_runtime().container(cname).start()
+    except (FileNotFoundError, RuntimeError) as exc:
+        _log_debug(f"container_exec._temporarily_start({cname}): {exc}")
         return False
     return True
 
 
-def _podman_stop(cname: str, timeout: int = 10) -> None:
-    """Stop a container best-effort."""
+def _stop_quietly(cname: str, *, timeout: int = 10) -> None:
+    """Stop a container best-effort; swallow missing-binary and runtime errors."""
     try:
-        container_stop(cname, timeout=timeout)
+        _rt.get_runtime().container(cname).stop(timeout=timeout)
     except (FileNotFoundError, RuntimeError):
         pass
 
@@ -87,8 +58,10 @@ def container_git_diff(
     ``/workspace`` path — the host ``workspace-dangerous`` path is never
     passed to any subprocess.
     """
+    runtime = _rt.get_runtime()
     cname = _container_name(project_id, mode, task_id)
-    state = get_container_state(cname)
+    container = runtime.container(cname)
+    state = container.state
 
     if state is None:
         _log_debug(f"container_git_diff: container {cname} not found")
@@ -102,12 +75,14 @@ def container_git_diff(
             # commits, network calls, and other side effects.
             _log_debug(f"container_git_diff: refusing to restart exited headless container {cname}")
             return None
-        if not _podman_start(cname):
+        if not _temporarily_start(cname):
             return None
         restarted = True
 
     try:
-        result = sandbox_exec(cname, ["git", "-C", "/workspace", "diff", *args], timeout=timeout)
+        result = runtime.exec(
+            container, ["git", "-C", "/workspace", "diff", *args], timeout=timeout
+        )
         if not result.ok:
             _log_debug(f"container_git_diff: git diff failed rc={result.exit_code}")
             return None
@@ -117,4 +92,4 @@ def container_git_diff(
         return None
     finally:
         if restarted:
-            _podman_stop(cname)
+            _stop_quietly(cname)

--- a/src/terok/lib/orchestration/image.py
+++ b/src/terok/lib/orchestration/image.py
@@ -28,15 +28,13 @@ from terok_executor import (
     stage_tmux_config,
     stage_toad_agents,
 )
-from terok_sandbox import PodmanRuntime
 
+from ..core import runtime as _rt
 from ..core.config import build_dir
 from ..core.images import project_cli_image, project_dev_image
 from ..core.project_model import ProjectConfig
 from ..core.projects import load_project
 from ..util.fs import ensure_dir
-
-_runtime = PodmanRuntime()
 
 # ---------- helpers ----------
 
@@ -48,7 +46,7 @@ def _image_exists(image: str) -> bool:
     same-module symbol so existing test mocks (``patch("terok.lib.
     orchestration.image._image_exists")``) keep working.
     """
-    return _runtime.image(image).exists()
+    return _rt.get_runtime().image(image).exists()
 
 
 # ---------- Hashing ----------

--- a/src/terok/lib/orchestration/task_runners.py
+++ b/src/terok/lib/orchestration/task_runners.py
@@ -8,7 +8,6 @@ from __future__ import annotations
 import os
 import secrets
 import shlex
-from collections.abc import Callable, Sequence
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from pathlib import Path
@@ -24,13 +23,13 @@ from terok_executor import (
 )
 from terok_sandbox import (
     LifecycleHooks,
-    PodmanRuntime,
     Sandbox,
     Sharing,
     VolumeSpec,
     down as _shield_down_impl,
 )
 
+from ..core import runtime as _rt
 from ..core.config import (
     SHIELD_SECURITY_HINT,
     get_public_host,
@@ -64,53 +63,6 @@ from .tasks import (
 
 if TYPE_CHECKING:
     from ..core.project_model import ProjectConfig
-
-_runtime = PodmanRuntime()
-
-
-# Internal convenience wrappers around ``_runtime`` — module-level so
-# tests can patch them by name.  Production code also uses these names
-# directly; they're one-liners on top of the runtime's OOP surface.
-
-
-def get_container_state(cname: str) -> str | None:
-    """Return lifecycle state for *cname* via the container runtime."""
-    return _runtime.container(cname).state
-
-
-def is_container_running(cname: str) -> bool:
-    """Return ``True`` if *cname* is currently running."""
-    return _runtime.container(cname).running
-
-
-def container_start(cname: str) -> None:
-    """Start *cname* via the runtime; raise ``RuntimeError`` on failure."""
-    _runtime.container(cname).start()
-
-
-def container_stop(cname: str, *, timeout: int = 10) -> None:
-    """Stop *cname* via the runtime."""
-    _runtime.container(cname).stop(timeout=timeout)
-
-
-def stream_initial_logs(
-    *,
-    container_name: str,
-    timeout_sec: float | None,
-    ready_check: Callable[[str], bool],
-) -> bool:
-    """Stream logs for *container_name* until *ready_check* matches or timeout."""
-    return _runtime.container(container_name).stream_initial_logs(ready_check, timeout_sec)
-
-
-def wait_for_exit(cname: str, timeout: float | None = None) -> int:
-    """Wait for *cname* to exit; return its exit code."""
-    return _runtime.container(cname).wait(timeout)
-
-
-def login_command(cname: str, *, command: Sequence[str] = ()) -> list[str]:
-    """Return the argv for interactively logging into *cname*."""
-    return _runtime.container(cname).login_command(command=tuple(command))
 
 
 _LOCALHOST = "127.0.0.1"
@@ -339,7 +291,7 @@ def _prepare_agent_config(
 def _podman_start(cname: str) -> None:
     """Start an existing container, raising SystemExit on failure."""
     try:
-        container_start(cname)
+        _rt.get_runtime().container(cname).start()
     except FileNotFoundError:
         raise SystemExit("podman not found; please install podman")
     except RuntimeError as exc:
@@ -348,7 +300,7 @@ def _podman_start(cname: str) -> None:
 
 def _assert_running(cname: str) -> None:
     """Verify a container is running after start, or raise SystemExit."""
-    post_state = get_container_state(cname)
+    post_state = _rt.get_runtime().container(cname).state
     if post_state != "running":
         raise SystemExit(
             f"Container {cname} failed to start (state: {post_state}). "
@@ -359,7 +311,7 @@ def _assert_running(cname: str) -> None:
 def _print_login_instructions(project_id: str, task_id: str, cname: str, color: bool) -> None:
     """Print how to log into a CLI container."""
     login_cmd = f"terok login {project_id} {task_id}"
-    raw_cmd = shlex.join(login_command(cname, command=("bash",)))
+    raw_cmd = shlex.join(_rt.get_runtime().container(cname).login_command(command=("bash",)))
     print(f"Login with: {_blue(login_cmd, color)}")
     print(f"  (or:      {_blue(raw_cmd, color)})")
 
@@ -565,7 +517,7 @@ def task_run_cli(
     meta, meta_path = load_task_meta(project.id, task_id, "cli")
 
     cname = container_name(project.id, "cli", task_id)
-    container_state = get_container_state(cname)
+    container_state = _rt.get_runtime().container(cname).state
 
     # If container already exists, handle it
     if container_state is not None:
@@ -657,8 +609,7 @@ def task_run_cli(
     )
 
     # Stream initial logs until ready marker is seen (or timeout), then detach
-    stream_initial_logs(
-        container_name=cname,
+    _rt.get_runtime().container(cname).stream_initial_logs(
         ready_check=lambda line: "__CLI_READY__" in line or ">> init complete" in line,
         timeout_sec=60.0,
     )
@@ -710,7 +661,7 @@ def task_run_toad(
     meta, meta_path = load_task_meta(project.id, task_id, "toad")
 
     cname = container_name(project.id, "toad", task_id)
-    container_state = get_container_state(cname)
+    container_state = _rt.get_runtime().container(cname).state
 
     pub_host = get_public_host()
 
@@ -816,13 +767,16 @@ def task_run_toad(
         """Return True when the supervisor wrapper reports both listeners are up."""
         return "TEROK_READY" in line
 
-    ready = stream_initial_logs(
-        container_name=cname,
-        ready_check=_toad_ready,
-        timeout_sec=None,
+    ready = (
+        _rt.get_runtime()
+        .container(cname)
+        .stream_initial_logs(
+            ready_check=_toad_ready,
+            timeout_sec=None,
+        )
     )
 
-    if not ready or not is_container_running(cname):
+    if not ready or not _rt.get_runtime().container(cname).running:
         print(f"Toad failed to start. Check logs: podman logs {cname}")
         raise SystemExit(1)
 
@@ -1033,7 +987,7 @@ def task_run_headless(request: HeadlessRunRequest) -> str:
     color_enabled = _supports_color()
 
     if request.follow:
-        exit_code = wait_for_exit(cname)
+        exit_code = _rt.get_runtime().container(cname).wait()
         _print_run_summary(project.id, task_id, "run", task_dir / "workspace-dangerous")
 
         update_task_exit_code(project.id, task_id, exit_code)
@@ -1096,7 +1050,7 @@ def task_followup_headless(
         )
 
     cname = container_name(project.id, "run", task_id)
-    container_state = get_container_state(cname)
+    container_state = _rt.get_runtime().container(cname).state
     if container_state == "running":
         raise SystemExit(
             f"Container {cname} is still running. "
@@ -1172,7 +1126,7 @@ def task_followup_headless(
     color_enabled = _supports_color()
 
     if follow:
-        exit_code = wait_for_exit(cname)
+        exit_code = _rt.get_runtime().container(cname).wait()
         _print_run_summary(project.id, task_id, "run", task_dir / "workspace-dangerous")
 
         update_task_exit_code(project.id, task_id, exit_code)
@@ -1208,7 +1162,7 @@ def task_restart(project_id: str, task_id: str) -> None:
         raise SystemExit(f"Task {task_id} has never been run (no mode set)")
 
     cname = container_name(project.id, mode, task_id)
-    container_state = get_container_state(cname)
+    container_state = _rt.get_runtime().container(cname).state
 
     print(f"Restarting task {project_id}/{task_id} ({mode})...")
     ensure_vault()
@@ -1232,7 +1186,7 @@ def task_restart(project_id: str, task_id: str) -> None:
     if container_state == "running":
         # Container is running - stop it first, then start it again
         try:
-            container_stop(cname, timeout=project.shutdown_timeout)
+            _rt.get_runtime().container(cname).stop(timeout=project.shutdown_timeout)
         except FileNotFoundError:
             raise SystemExit("podman not found; please install podman")
         except RuntimeError as exc:

--- a/src/terok/lib/orchestration/tasks.py
+++ b/src/terok/lib/orchestration/tasks.py
@@ -21,8 +21,8 @@ from datetime import UTC, datetime
 from pathlib import Path
 
 from terok_executor import AgentRunner
-from terok_sandbox import PodmanRuntime
 
+from ..core import runtime as _rt
 from ..core.config import archive_dir, state_dir
 from ..core.projects import ProjectConfig, load_project
 from ..core.task_display import (
@@ -46,24 +46,6 @@ from ..util.host_cmd import WORKSPACE_DANGEROUS_DIRNAME
 from ..util.logging_utils import _log_debug
 from ..util.yaml import dump as _yaml_dump, load as _yaml_load
 from .container_exec import container_git_diff
-
-_runtime = PodmanRuntime()
-
-
-# Internal convenience wrappers around ``_runtime`` — module-level so
-# tests can patch them by name.  Production code also uses these names
-# directly (they're one-liners, purely syntactic sugar).
-
-
-def get_container_state(cname: str) -> str | None:
-    """Return lifecycle state for *cname* via the container runtime."""
-    return _runtime.container(cname).state
-
-
-def stop_task_containers(names: list[str]):
-    """Force-remove the named containers; return per-name remove results."""
-    return _runtime.force_remove([_runtime.container(n) for n in names])
-
 
 # ---------- Task ID generation ----------
 
@@ -112,7 +94,7 @@ def get_task_container_state(project_id: str, task_id: str, mode: str | None) ->
     if not mode:
         return None
     cname = container_name(project_id, mode, task_id)
-    return get_container_state(cname)
+    return _rt.get_runtime().container(cname).state
 
 
 @dataclass(kw_only=True)
@@ -248,7 +230,7 @@ def get_task_meta(project_id: str, task_id: str) -> TaskMeta:
     if mode is not None:
         try:
             cname = container_name(project_id, mode, task_id)
-            live_state = get_container_state(cname)
+            live_state = _rt.get_runtime().container(cname).state
         except Exception:
             pass
     # Hydrate work status from agent-config (same logic as _get_tasks)
@@ -559,7 +541,7 @@ def get_all_task_states(
     Returns:
         ``{task_id: container_state_or_None}`` dict.
     """
-    container_states = _runtime.container_states(project_id)
+    container_states = _rt.get_runtime().container_states(project_id)
     result: dict[str, str | None] = {}
     for t in tasks:
         if t.mode:
@@ -770,7 +752,7 @@ def _task_delete(project: ProjectConfig, task_id: str) -> TaskDeleteResult:
     names = [container_name(project.id, mode, str(task_id)) for mode in CONTAINER_MODES]
     containers_removed = True
     try:
-        rm_results = stop_task_containers(names)
+        rm_results = _rt.get_runtime().force_remove([_rt.get_runtime().container(n) for n in names])
     except Exception as exc:
         _log_debug(f"task_delete: stop_task_containers raised: {exc}")
         warnings.append(f"Container removal failed: {exc}")
@@ -863,7 +845,7 @@ def _validate_login(project: ProjectConfig, task_id: str) -> tuple[str, str]:
         )
 
     cname = container_name(project.id, mode, task_id)
-    state = get_container_state(cname)
+    state = _rt.get_runtime().container(cname).state
     if state is None:
         raise SystemExit(
             f"Container {cname} does not exist. "
@@ -880,7 +862,7 @@ def _validate_login(project: ProjectConfig, task_id: str) -> tuple[str, str]:
 def _get_login_command(project: ProjectConfig, task_id: str) -> list[str]:
     """Return the command to interactively log into a task container."""
     cname, _mode = _validate_login(project, task_id)
-    return _runtime.container(cname).login_command()
+    return _rt.get_runtime().container(cname).login_command()
 
 
 def _task_login(project: ProjectConfig, task_id: str) -> None:
@@ -909,14 +891,14 @@ def _task_stop(project: ProjectConfig, task_id: str, *, timeout: int | None = No
 
     cname = container_name(project.id, mode, task_id)
 
-    state = get_container_state(cname)
+    state = _rt.get_runtime().container(cname).state
     if state is None:
         raise SystemExit(f"Task {task_id} container does not exist")
     if state not in ("running", "paused"):
         raise SystemExit(f"Task {task_id} container is not stoppable (state: {state})")
 
     try:
-        _runtime.container(cname).stop(timeout=effective_timeout)
+        _rt.get_runtime().container(cname).stop(timeout=effective_timeout)
     except FileNotFoundError:
         raise SystemExit("podman not found; please install podman")
     except RuntimeError as exc:
@@ -987,7 +969,7 @@ def task_status(project_id: str, task_id: str) -> None:
     cs = None
     if mode:
         cname = container_name(project.id, mode, task_id)
-        cs = get_container_state(cname)
+        cs = _rt.get_runtime().container(cname).state
 
     # Build TaskMeta for effective_status / mode_emoji computation
     task = TaskMeta(

--- a/src/terok/tui/screens.py
+++ b/src/terok/tui/screens.py
@@ -1299,12 +1299,11 @@ class TaskLaunchScreen(screen.ModalScreen["tuple[str, str, str, str, str, str | 
         If the container never appears after many polls, updates the status
         to indicate a likely launch failure so the user can dismiss.
         """
-        from terok_sandbox import PodmanRuntime
-
+        from ..lib.core import runtime as _rt
         from ..lib.orchestration.tasks import get_task_meta
 
         self._poll_count += 1
-        state = PodmanRuntime().container(self._container_name).state
+        state = _rt.get_runtime().container(self._container_name).state
         status_widget = self.query_one("#launch-status", Static)
         if state == "running":
             # Also check that mode is set in task metadata — this is written

--- a/src/terok/tui/task_actions.py
+++ b/src/terok/tui/task_actions.py
@@ -14,12 +14,9 @@ from contextlib import redirect_stdout
 from pathlib import Path
 
 from terok_executor import parse_md_agent
-from terok_sandbox import (
-    PodmanRuntime,
-    down as shield_down,
-    up as shield_up,
-)
+from terok_sandbox import down as shield_down, up as shield_up
 
+from ..lib.core import runtime as _rt
 from ..lib.core.config import get_shield_bypass_firewall_no_protection
 from ..lib.core.projects import load_project
 from ..lib.core.task_display import effective_status
@@ -53,8 +50,6 @@ from .screens import (
     TaskNameScreen,
 )
 from .widgets import TaskList
-
-_runtime = PodmanRuntime()
 
 
 def _build_interactive_agent_command(provider: object, prompt: str | None) -> str:
@@ -536,7 +531,7 @@ class TaskActionsMixin:
         tid = task.task_id
         cname = container_name(pid, task.mode, tid)
 
-        state = _runtime.container(cname).state
+        state = _rt.get_runtime().container(cname).state
         if state is None:
             self.notify(f"No container found for task {tid}.")
             return

--- a/tach.toml
+++ b/tach.toml
@@ -378,6 +378,12 @@ depends_on = [
 [[modules]]
 path = "terok.lib.core.images"
 layer = "core"
+depends_on = ["terok.lib.core.runtime"]
+
+# Process-wide ContainerRuntime accessor
+[[modules]]
+path = "terok.lib.core.runtime"
+layer = "core"
 depends_on = []
 
 # Task display types and status computation

--- a/tach.toml
+++ b/tach.toml
@@ -50,6 +50,7 @@ depends_on = [
     "terok.lib.orchestration.tasks",
     "terok.lib.core.config",
     "terok.lib.core.projects",
+    "terok.lib.core.runtime",
     "terok.lib.core.version",
     "terok.lib.domain.facade",
     "terok.lib.domain.storage",
@@ -71,6 +72,7 @@ depends_on = [
     "terok.lib.orchestration.tasks",
     "terok.lib.core.config",
     "terok.lib.core.projects",
+    "terok.lib.core.runtime",
     "terok.lib.core.version",
     "terok.lib.domain.facade",
     "terok.lib.util.emoji",
@@ -90,6 +92,7 @@ depends_on = [
     "terok.lib.core.config",
     "terok.lib.core.paths",
     "terok.lib.core.projects",
+    "terok.lib.core.runtime",
     "terok.lib.orchestration.tasks",
 ]
 
@@ -160,6 +163,7 @@ depends_on = [
     "terok.lib.domain.log_format",
     "terok.lib.orchestration.tasks",
     "terok.lib.core.projects",
+    "terok.lib.core.runtime",
     "terok.lib.util.yaml",
 ]
 
@@ -173,7 +177,7 @@ depends_on = ["terok.lib.util.ansi"]
 [[modules]]
 path = "terok.lib.domain.image_cleanup"
 layer = "domain"
-depends_on = ["terok.lib.core.projects"]
+depends_on = ["terok.lib.core.projects", "terok.lib.core.runtime"]
 
 # Storage usage aggregation across package stack
 [[modules]]
@@ -183,6 +187,7 @@ depends_on = [
     "terok.lib.domain.image_cleanup",
     "terok.lib.core.config",
     "terok.lib.core.projects",
+    "terok.lib.core.runtime",
 ]
 
 # Agent config resolution (terok-specific stack composition)
@@ -200,6 +205,7 @@ depends_on = [
     "terok.lib.core.config",
     "terok.lib.core.images",
     "terok.lib.core.projects",
+    "terok.lib.core.runtime",
     "terok.lib.core.task_display",
     "terok.lib.domain.vault",
 ]
@@ -234,6 +240,7 @@ depends_on = [
     "terok.lib.core.config",
     "terok.lib.core.images",
     "terok.lib.core.projects",
+    "terok.lib.core.runtime",
     "terok.lib.core.task_display",
     "terok.lib.util.ansi",
     "terok.lib.util.yaml",
@@ -247,6 +254,7 @@ depends_on = [
     "terok.lib.orchestration.container_exec",
     "terok.lib.orchestration.hooks",
     "terok.lib.orchestration.ports",
+    "terok.lib.core.runtime",
     "terok.lib.core.task_display",
     "terok.lib.core.work_status",
     "terok.lib.core.config",
@@ -274,7 +282,13 @@ depends_on = [
 [[modules]]
 path = "terok.lib.orchestration.image"
 layer = "orchestration"
-depends_on = ["terok.lib.core.config", "terok.lib.core.images", "terok.lib.core.projects", "terok.lib.util.fs"]
+depends_on = [
+    "terok.lib.core.config",
+    "terok.lib.core.images",
+    "terok.lib.core.projects",
+    "terok.lib.core.runtime",
+    "terok.lib.util.fs",
+]
 
 # Task port allocation (delegates to terok-sandbox port registry)
 [[modules]]
@@ -292,7 +306,11 @@ depends_on = ["terok.lib.util.yaml"]
 [[modules]]
 path = "terok.lib.orchestration.container_exec"
 layer = "orchestration"
-depends_on = ["terok.lib.core.task_display", "terok.lib.util.logging_utils"]
+depends_on = [
+    "terok.lib.core.runtime",
+    "terok.lib.core.task_display",
+    "terok.lib.util.logging_utils",
+]
 
 # In-container health checks (layered doctor protocol via podman exec)
 [[modules]]
@@ -302,6 +320,7 @@ depends_on = [
     "terok.lib.orchestration.tasks",
     "terok.lib.core.config",
     "terok.lib.core.projects",
+    "terok.lib.core.runtime",
     "terok.lib.util.logging_utils",
 ]
 

--- a/tests/unit/cli/test_sickbay.py
+++ b/tests/unit/cli/test_sickbay.py
@@ -161,59 +161,45 @@ class TestCheckTaskHook:
         ):
             assert _check_task_hook("proj", "1", project, fix=False) is None
 
-    def test_running_container_returns_none(self, task_meta_dir: Path) -> None:
+    def test_running_container_returns_none(self, task_meta_dir: Path, mock_runtime) -> None:
         _write_meta(task_meta_dir, "1", {"mode": "cli"})
         project = unittest.mock.MagicMock()
-        with (
-            unittest.mock.patch(
-                "terok.cli.commands.sickbay.tasks_meta_dir", return_value=task_meta_dir
-            ),
-            unittest.mock.patch(
-                "terok.cli.commands.sickbay.get_container_state", return_value="running"
-            ),
+        mock_runtime.container.return_value.state = "running"
+        with unittest.mock.patch(
+            "terok.cli.commands.sickbay.tasks_meta_dir", return_value=task_meta_dir
         ):
             assert _check_task_hook("proj", "1", project, fix=False) is None
 
-    def test_already_fired_returns_none(self, task_meta_dir: Path) -> None:
+    def test_already_fired_returns_none(self, task_meta_dir: Path, mock_runtime) -> None:
         _write_meta(task_meta_dir, "1", {"mode": "cli", "hooks_fired": ["post_stop"]})
         project = unittest.mock.MagicMock()
-        with (
-            unittest.mock.patch(
-                "terok.cli.commands.sickbay.tasks_meta_dir", return_value=task_meta_dir
-            ),
-            unittest.mock.patch(
-                "terok.cli.commands.sickbay.get_container_state", return_value="exited"
-            ),
+        mock_runtime.container.return_value.state = "exited"
+        with unittest.mock.patch(
+            "terok.cli.commands.sickbay.tasks_meta_dir", return_value=task_meta_dir
         ):
             assert _check_task_hook("proj", "1", project, fix=False) is None
 
-    def test_unfired_returns_warn(self, task_meta_dir: Path) -> None:
+    def test_unfired_returns_warn(self, task_meta_dir: Path, mock_runtime) -> None:
         _write_meta(task_meta_dir, "1", {"mode": "cli", "hooks_fired": ["post_start"]})
         project = unittest.mock.MagicMock()
-        with (
-            unittest.mock.patch(
-                "terok.cli.commands.sickbay.tasks_meta_dir", return_value=task_meta_dir
-            ),
-            unittest.mock.patch(
-                "terok.cli.commands.sickbay.get_container_state", return_value="exited"
-            ),
+        mock_runtime.container.return_value.state = "exited"
+        with unittest.mock.patch(
+            "terok.cli.commands.sickbay.tasks_meta_dir", return_value=task_meta_dir
         ):
             result = _check_task_hook("proj", "1", project, fix=False)
             assert result is not None
             assert result[0] == "warn"
             assert "post_stop" in result[2]
 
-    def test_fix_calls_reconcile(self, task_meta_dir: Path) -> None:
+    def test_fix_calls_reconcile(self, task_meta_dir: Path, mock_runtime) -> None:
         _write_meta(task_meta_dir, "1", {"mode": "cli"})
         project = unittest.mock.MagicMock()
         project.hook_post_stop = "echo cleanup"
         project.tasks_root = task_meta_dir.parent
+        mock_runtime.container.return_value.state = None
         with (
             unittest.mock.patch(
                 "terok.cli.commands.sickbay.tasks_meta_dir", return_value=task_meta_dir
-            ),
-            unittest.mock.patch(
-                "terok.cli.commands.sickbay.get_container_state", return_value=None
             ),
             unittest.mock.patch("terok.cli.commands.sickbay.run_hook") as mock_hook,
         ):

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -14,7 +14,7 @@ to ``~/.local/share/terok/sandbox/``.
 
 from collections.abc import Iterator
 from pathlib import Path
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -69,3 +69,38 @@ def _mock_infrastructure() -> Iterator[None]:
         ),
     ):
         yield
+
+
+@pytest.fixture(autouse=True)
+def mock_runtime() -> Iterator[MagicMock]:
+    """Install a fresh :class:`MagicMock` as the process-wide ``ContainerRuntime``.
+
+    Every unit test gets an isolated mock runtime patched into
+    :func:`terok.lib.core.runtime.get_runtime`.  Tests that care about
+    specific container-level behaviour configure the mock directly
+    (``mock_runtime.container.return_value.state = "running"``); tests
+    that don't care pay no cost beyond the patch overhead.
+
+    Defaults are set so that common code paths don't trip on
+    "a Mock is not iterable" or similar:
+
+    - ``container_states`` / ``container_rw_sizes`` → ``{}``
+    - ``images`` / ``force_remove`` → ``[]``
+    - ``container(...).wait()`` → ``0`` (benign exit code)
+    - ``container(...).login_command(...)`` → a realistic podman argv
+    - ``container(...).stream_initial_logs(...)`` → ``True`` (ready)
+
+    Runs *after* ``_mock_infrastructure`` so its ``_agent_runner``
+    patch is still in place.
+    """
+    fake = MagicMock(name="mock_runtime")
+    fake.container_states.return_value = {}
+    fake.container_rw_sizes.return_value = {}
+    fake.images.return_value = []
+    fake.force_remove.return_value = []
+    container = fake.container.return_value
+    container.wait.return_value = 0
+    container.login_command.return_value = ["podman", "exec", "-it", "ctr", "bash"]
+    container.stream_initial_logs.return_value = True
+    with patch("terok.lib.core.runtime.get_runtime", return_value=fake):
+        yield fake

--- a/tests/unit/lib/test_autopilot.py
+++ b/tests/unit/lib/test_autopilot.py
@@ -7,7 +7,6 @@ from __future__ import annotations
 
 import json
 import os
-import subprocess
 import tempfile
 import unittest.mock
 from contextlib import redirect_stdout
@@ -169,16 +168,20 @@ def run_headless_request(
     config_file: Path,
     request: HeadlessRunRequest,
 ) -> TaskRunnerResult:
-    """Run ``task_run_headless`` with the standard patched test harness."""
+    """Run ``task_run_headless`` with the standard patched test harness.
+
+    Relies on the ``mock_runtime`` autouse fixture to intercept container
+    operations; container.wait() already returns 0 by default.
+    """
+    from terok.lib.core.runtime import get_runtime
+
+    wait_mock = get_runtime().container.return_value.wait
     with unittest.mock.patch.dict(os.environ, runner_env_vars(base, config_file), clear=True):
         with (
             mock_git_config(),
             unittest.mock.patch(
                 "terok.lib.orchestration.task_runners._agent_runner"
             ) as sandbox_factory,
-            unittest.mock.patch(
-                "terok.lib.orchestration.task_runners.wait_for_exit", return_value=0
-            ) as wait_mock,
             unittest.mock.patch("terok.lib.orchestration.task_runners._print_run_summary"),
         ):
             buffer = StringIO()
@@ -202,27 +205,30 @@ def run_followup_request(
     follow: bool = True,
 ) -> TaskRunnerResult:
     """Run ``task_followup_headless`` with the standard patched success harness."""
+    from terok.lib.core.runtime import get_runtime
+
+    runtime = get_runtime()
+    container = runtime.container.return_value
+    if isinstance(container_state, list):
+        type(container).state = unittest.mock.PropertyMock(
+            side_effect=iter(container_state).__next__
+        )
+    else:
+        container.state = container_state
+    # ``start()`` is fire-and-forget now (raises on failure); default mock returns None.
+    start_mock = container.start
+    wait_mock = container.wait  # already returns 0 via fixture default
     with unittest.mock.patch.dict(
         os.environ, runner_env_vars(base, base / "config.yml"), clear=True
     ):
         with (
             mock_git_config(),
-            unittest.mock.patch("terok.lib.orchestration.task_runners.container_start") as run_mock,
-            unittest.mock.patch(
-                "terok.lib.orchestration.task_runners.get_container_state",
-                side_effect=container_state if isinstance(container_state, list) else None,
-                return_value=None if isinstance(container_state, list) else container_state,
-            ),
-            unittest.mock.patch(
-                "terok.lib.orchestration.task_runners.wait_for_exit", return_value=0
-            ) as wait_mock,
             unittest.mock.patch("terok.lib.orchestration.task_runners._print_run_summary"),
         ):
-            run_mock.return_value = subprocess.CompletedProcess([], 0, stderr="")
             buffer = StringIO()
             with redirect_stdout(buffer):
                 task_followup_headless(project_id, task_id, prompt, follow=follow)
-    return TaskRunnerResult(output=buffer.getvalue(), run_mock=run_mock, wait_mock=wait_mock)
+    return TaskRunnerResult(output=buffer.getvalue(), run_mock=start_mock, wait_mock=wait_mock)
 
 
 def _spec_volumes(result: TaskRunnerResult) -> tuple:
@@ -548,8 +554,8 @@ class TestTaskFollowupHeadless:
             assert "initial prompt" in history
             assert "---" in history
 
-    def test_followup_uses_container_start(self) -> None:
-        """Follow-up uses container_start, not sandbox.run."""
+    def test_followup_uses_container_start(self, mock_runtime) -> None:
+        """Follow-up starts the task's container via the runtime."""
         with tempfile.TemporaryDirectory() as td:
             base = Path(td)
             task_id = self._create_completed_task(base, "proj_start")
@@ -557,8 +563,7 @@ class TestTaskFollowupHeadless:
                 base, "proj_start", task_id, "continue", container_state=["exited", "running"]
             )
             result.run_mock.assert_called_once()
-            cname = result.run_mock.call_args[0][0]
-            assert cname == f"proj_start-run-{task_id}"
+            mock_runtime.container.assert_any_call(f"proj_start-run-{task_id}")
 
     def test_followup_rejects_non_run_mode(self) -> None:
         """Follow-up rejects tasks that aren't headless (mode != 'run')."""
@@ -583,7 +588,7 @@ class TestTaskFollowupHeadless:
                         task_followup_headless("proj_mode", task_id, "test")
                     assert "not a headless task" in str(ctx.value)
 
-    def test_followup_rejects_running_task(self) -> None:
+    def test_followup_rejects_running_task(self, mock_runtime) -> None:
         """Follow-up rejects tasks that are still running."""
         with tempfile.TemporaryDirectory() as td:
             base = Path(td)
@@ -602,32 +607,22 @@ class TestTaskFollowupHeadless:
                     meta["mode"] = "run"
                     meta_path.write_text(yaml_dump(meta))
 
-                    with (
-                        unittest.mock.patch(
-                            "terok.lib.orchestration.task_runners.get_container_state",
-                            return_value="running",
-                        ),
-                        pytest.raises(SystemExit) as ctx,
-                    ):
+                    mock_runtime.container.return_value.state = "running"
+                    with pytest.raises(SystemExit) as ctx:
                         task_followup_headless("proj_run", task_id, "test")
                     assert "still running" in str(ctx.value)
 
-    def test_followup_rejects_running_container(self) -> None:
+    def test_followup_rejects_running_container(self, mock_runtime) -> None:
         """Follow-up rejects when container is still running (stale metadata)."""
         with tempfile.TemporaryDirectory() as td:
             base = Path(td)
             task_id = self._create_completed_task(base, "proj_crun")
+            mock_runtime.container.return_value.state = "running"
 
             with unittest.mock.patch.dict(
                 os.environ, runner_env_vars(base, base / "config.yml"), clear=True
             ):
-                with (
-                    mock_git_config(),
-                    unittest.mock.patch(
-                        "terok.lib.orchestration.task_runners.get_container_state",
-                        return_value="running",
-                    ),
-                ):
+                with mock_git_config():
                     with pytest.raises(SystemExit) as ctx:
                         task_followup_headless("proj_crun", task_id, "test")
                     assert "still running" in str(ctx.value)
@@ -646,12 +641,15 @@ class TestTaskFollowupHeadless:
             meta = read_task_meta(base, "proj_meta2", task_id)
             assert meta["exit_code"] == 0
 
-    def test_followup_no_follow_mode(self) -> None:
+    def test_followup_no_follow_mode(self, mock_runtime) -> None:
         """Follow-up with follow=False prints detached info and skips wait."""
         with tempfile.TemporaryDirectory() as td:
             base = Path(td)
 
             task_id = self._create_completed_task(base, "proj_meta2")
+            # Clear wait-call history from the setup phase so the assertion
+            # below only sees calls made by the follow-up itself.
+            mock_runtime.container.return_value.wait.reset_mock()
 
             result = run_followup_request(
                 base,
@@ -668,51 +666,40 @@ class TestTaskFollowupHeadless:
             meta = read_task_meta(base, "proj_meta2", task_id)
             assert meta["exit_code"] is None
 
-    def test_followup_container_not_found(self) -> None:
+    def test_followup_container_not_found(self, mock_runtime) -> None:
         """Follow-up raises SystemExit with 'not found' when container has been removed."""
         with tempfile.TemporaryDirectory() as td:
             base = Path(td)
             task_id = self._create_completed_task(base, "proj_notfound")
+            mock_runtime.container.return_value.state = None
 
             with unittest.mock.patch.dict(
                 os.environ, runner_env_vars(base, base / "config.yml"), clear=True
             ):
-                with (
-                    mock_git_config(),
-                    unittest.mock.patch(
-                        "terok.lib.orchestration.task_runners.get_container_state",
-                        return_value=None,
-                    ),
-                ):
+                with mock_git_config():
                     with pytest.raises(SystemExit) as ctx:
                         task_followup_headless("proj_notfound", task_id, "test")
                     assert "not found" in str(ctx.value)
 
-    def test_followup_start_fails(self) -> None:
+    def test_followup_start_fails(self, mock_runtime) -> None:
         """Follow-up raises SystemExit when container remains exited after start."""
         with tempfile.TemporaryDirectory() as td:
             base = Path(td)
             task_id = self._create_completed_task(base, "proj_startfail")
+            container_mock = mock_runtime.container.return_value
+            type(container_mock).state = unittest.mock.PropertyMock(
+                side_effect=iter(["exited", "exited"]).__next__
+            )
 
             with unittest.mock.patch.dict(
                 os.environ, runner_env_vars(base, base / "config.yml"), clear=True
             ):
-                with (
-                    mock_git_config(),
-                    unittest.mock.patch(
-                        "terok.lib.orchestration.task_runners.container_start"
-                    ) as run_mock,
-                    unittest.mock.patch(
-                        "terok.lib.orchestration.task_runners.get_container_state",
-                        side_effect=["exited", "exited"],
-                    ),
-                ):
-                    run_mock.return_value = subprocess.CompletedProcess([], 0, stderr="")
+                with mock_git_config():
                     with pytest.raises(SystemExit) as ctx:
                         task_followup_headless("proj_startfail", task_id, "test")
                     assert "failed to start" in str(ctx.value)
 
-    def test_sealed_followup_uses_inject_prompt(self) -> None:
+    def test_sealed_followup_uses_inject_prompt(self, mock_runtime) -> None:
         """Sealed projects inject the follow-up prompt via podman cp, not host files."""
         with tempfile.TemporaryDirectory() as td:
             base = Path(td)
@@ -730,25 +717,19 @@ class TestTaskFollowupHeadless:
             task_id = result.task_id
             assert task_id is not None
 
+            container_mock = mock_runtime.container.return_value
+            type(container_mock).state = unittest.mock.PropertyMock(
+                side_effect=iter(["exited", "running"]).__next__
+            )
+
             with unittest.mock.patch.dict(
                 os.environ, runner_env_vars(base, config_file), clear=True
             ):
                 with (
                     mock_git_config(),
-                    unittest.mock.patch(
-                        "terok.lib.orchestration.task_runners.container_start"
-                    ) as run_mock,
-                    unittest.mock.patch(
-                        "terok.lib.orchestration.task_runners.get_container_state",
-                        side_effect=["exited", "running"],
-                    ),
-                    unittest.mock.patch(
-                        "terok.lib.orchestration.task_runners.wait_for_exit", return_value=0
-                    ),
                     unittest.mock.patch("terok.lib.orchestration.task_runners._print_run_summary"),
                     unittest.mock.patch("terok_sandbox.Sandbox") as mock_sandbox_cls,
                 ):
-                    run_mock.return_value = subprocess.CompletedProcess([], 0, stderr="")
                     buffer = StringIO()
                     with redirect_stdout(buffer):
                         task_followup_headless("proj_sealed", task_id, "sealed follow-up")

--- a/tests/unit/lib/test_autopilot.py
+++ b/tests/unit/lib/test_autopilot.py
@@ -5,6 +5,7 @@
 
 from __future__ import annotations
 
+import contextlib
 import json
 import os
 import tempfile
@@ -209,25 +210,34 @@ def run_followup_request(
 
     runtime = get_runtime()
     container = runtime.container.return_value
-    if isinstance(container_state, list):
-        type(container).state = unittest.mock.PropertyMock(
-            side_effect=iter(container_state).__next__
-        )
-    else:
-        container.state = container_state
     # ``start()`` is fire-and-forget now (raises on failure); default mock returns None.
     start_mock = container.start
     wait_mock = container.wait  # already returns 0 via fixture default
-    with unittest.mock.patch.dict(
-        os.environ, runner_env_vars(base, base / "config.yml"), clear=True
+
+    state_patch: contextlib.AbstractContextManager
+    if isinstance(container_state, list):
+        state_patch = unittest.mock.patch.object(
+            type(container),
+            "state",
+            new_callable=unittest.mock.PropertyMock,
+            side_effect=iter(container_state).__next__,
+            create=True,
+        )
+    else:
+        container.state = container_state
+        state_patch = contextlib.nullcontext()
+
+    with (
+        state_patch,
+        unittest.mock.patch.dict(
+            os.environ, runner_env_vars(base, base / "config.yml"), clear=True
+        ),
+        mock_git_config(),
+        unittest.mock.patch("terok.lib.orchestration.task_runners._print_run_summary"),
     ):
-        with (
-            mock_git_config(),
-            unittest.mock.patch("terok.lib.orchestration.task_runners._print_run_summary"),
-        ):
-            buffer = StringIO()
-            with redirect_stdout(buffer):
-                task_followup_headless(project_id, task_id, prompt, follow=follow)
+        buffer = StringIO()
+        with redirect_stdout(buffer):
+            task_followup_headless(project_id, task_id, prompt, follow=follow)
     return TaskRunnerResult(output=buffer.getvalue(), run_mock=start_mock, wait_mock=wait_mock)
 
 
@@ -687,17 +697,23 @@ class TestTaskFollowupHeadless:
             base = Path(td)
             task_id = self._create_completed_task(base, "proj_startfail")
             container_mock = mock_runtime.container.return_value
-            type(container_mock).state = unittest.mock.PropertyMock(
-                side_effect=iter(["exited", "exited"]).__next__
-            )
 
-            with unittest.mock.patch.dict(
-                os.environ, runner_env_vars(base, base / "config.yml"), clear=True
+            with (
+                unittest.mock.patch.object(
+                    type(container_mock),
+                    "state",
+                    new_callable=unittest.mock.PropertyMock,
+                    side_effect=iter(["exited", "exited"]).__next__,
+                    create=True,
+                ),
+                unittest.mock.patch.dict(
+                    os.environ, runner_env_vars(base, base / "config.yml"), clear=True
+                ),
+                mock_git_config(),
             ):
-                with mock_git_config():
-                    with pytest.raises(SystemExit) as ctx:
-                        task_followup_headless("proj_startfail", task_id, "test")
-                    assert "failed to start" in str(ctx.value)
+                with pytest.raises(SystemExit) as ctx:
+                    task_followup_headless("proj_startfail", task_id, "test")
+                assert "failed to start" in str(ctx.value)
 
     def test_sealed_followup_uses_inject_prompt(self, mock_runtime) -> None:
         """Sealed projects inject the follow-up prompt via podman cp, not host files."""
@@ -718,21 +734,25 @@ class TestTaskFollowupHeadless:
             assert task_id is not None
 
             container_mock = mock_runtime.container.return_value
-            type(container_mock).state = unittest.mock.PropertyMock(
-                side_effect=iter(["exited", "running"]).__next__
-            )
 
-            with unittest.mock.patch.dict(
-                os.environ, runner_env_vars(base, config_file), clear=True
+            with (
+                unittest.mock.patch.object(
+                    type(container_mock),
+                    "state",
+                    new_callable=unittest.mock.PropertyMock,
+                    side_effect=iter(["exited", "running"]).__next__,
+                    create=True,
+                ),
+                unittest.mock.patch.dict(
+                    os.environ, runner_env_vars(base, config_file), clear=True
+                ),
+                mock_git_config(),
+                unittest.mock.patch("terok.lib.orchestration.task_runners._print_run_summary"),
+                unittest.mock.patch("terok_sandbox.Sandbox") as mock_sandbox_cls,
             ):
-                with (
-                    mock_git_config(),
-                    unittest.mock.patch("terok.lib.orchestration.task_runners._print_run_summary"),
-                    unittest.mock.patch("terok_sandbox.Sandbox") as mock_sandbox_cls,
-                ):
-                    buffer = StringIO()
-                    with redirect_stdout(buffer):
-                        task_followup_headless("proj_sealed", task_id, "sealed follow-up")
+                buffer = StringIO()
+                with redirect_stdout(buffer):
+                    task_followup_headless("proj_sealed", task_id, "sealed follow-up")
 
                     # inject_prompt should have been called via Sandbox.copy_to
                     mock_sandbox_cls.return_value.copy_to.assert_called_once()

--- a/tests/unit/lib/test_container_doctor.py
+++ b/tests/unit/lib/test_container_doctor.py
@@ -27,12 +27,15 @@ MOCK_TASK_DIR = MOCK_BASE / "projects" / "proj" / "tasks" / "42"
 class TestExecInContainer:
     """Low-level sandbox exec helper."""
 
-    def test_delegates_to_sandbox_exec(self) -> None:
-        with patch("terok.lib.orchestration.container_doctor.sandbox_exec") as mock_exec:
-            mock_exec.return_value = ExecResult(exit_code=0, stdout="ok\n", stderr="")
-            result = _exec_in_container("proj-cli-42", ["echo", "hello"])
-            assert result.exit_code == 0
-            mock_exec.assert_called_once_with("proj-cli-42", ["echo", "hello"], timeout=10)
+    def test_delegates_to_runtime_exec(self, mock_runtime) -> None:
+        mock_runtime.exec.return_value = ExecResult(exit_code=0, stdout="ok\n", stderr="")
+        result = _exec_in_container("proj-cli-42", ["echo", "hello"])
+        assert result.exit_code == 0
+        mock_runtime.container.assert_any_call("proj-cli-42")
+        mock_runtime.exec.assert_called_once()
+        args, kwargs = mock_runtime.exec.call_args
+        assert args[1] == ["echo", "hello"]
+        assert kwargs == {"timeout": 10}
 
 
 class TestGitIdentityCheck:
@@ -167,20 +170,19 @@ class TestRunContainerDoctor:
         assert results[0][0] == "warn"
         assert "never started" in results[0][2]
 
-    @patch("terok.lib.orchestration.container_doctor.get_container_state")
     @patch("terok.lib.orchestration.container_doctor.load_task_meta")
     @patch("terok.lib.orchestration.container_doctor.tasks_meta_dir")
     def test_skips_non_running(
         self,
         mock_meta_dir: MagicMock,
         mock_load: MagicMock,
-        mock_state: MagicMock,
         tmp_path: Path,
+        mock_runtime,
     ) -> None:
         (tmp_path / "42.yml").write_text("mode: cli\nname: test\n")
         mock_meta_dir.return_value = tmp_path
         mock_load.return_value = ({"mode": "cli"}, tmp_path / "42.yml")
-        mock_state.return_value = "exited"
+        mock_runtime.container.return_value.state = "exited"
         results = run_container_doctor("proj", "42")
         assert results[0][0] == "info"
         assert "not running" in results[0][2]
@@ -195,14 +197,12 @@ class TestRunContainerDoctor:
     @patch("terok.lib.orchestration.container_doctor.get_ssh_signer_port")
     @patch("terok.lib.orchestration.container_doctor.get_token_broker_port")
     @patch("terok.lib.orchestration.container_doctor.make_sandbox_config")
-    @patch("terok.lib.orchestration.container_doctor.get_container_state")
     @patch("terok.lib.orchestration.container_doctor.load_task_meta")
     @patch("terok.lib.orchestration.container_doctor.tasks_meta_dir")
     def test_running_container_executes_probes(
         self,
         mock_meta_dir: MagicMock,
         mock_load_meta: MagicMock,
-        mock_state: MagicMock,
         mock_sandbox_cfg: MagicMock,
         mock_broker_port: MagicMock,
         mock_ssh_port: MagicMock,
@@ -214,12 +214,13 @@ class TestRunContainerDoctor:
         mock_terok_checks: MagicMock,
         mock_exec: MagicMock,
         tmp_path: Path,
+        mock_runtime,
     ) -> None:
         # Arrange: task metadata exists and container is running
         (tmp_path / "42.yml").write_text("mode: cli\n")
         mock_meta_dir.return_value = tmp_path
         mock_load_meta.return_value = ({"mode": "cli"}, tmp_path / "42.yml")
-        mock_state.return_value = "running"
+        mock_runtime.container.return_value.state = "running"
         mock_sandbox_cfg.return_value = MagicMock()
         mock_broker_port.return_value = 8080
         mock_ssh_port.return_value = 2222
@@ -261,14 +262,12 @@ class TestRunContainerDoctor:
     @patch("terok.lib.orchestration.container_doctor.get_ssh_signer_port")
     @patch("terok.lib.orchestration.container_doctor.get_token_broker_port")
     @patch("terok.lib.orchestration.container_doctor.make_sandbox_config")
-    @patch("terok.lib.orchestration.container_doctor.get_container_state")
     @patch("terok.lib.orchestration.container_doctor.load_task_meta")
     @patch("terok.lib.orchestration.container_doctor.tasks_meta_dir")
     def test_fix_application(
         self,
         mock_meta_dir: MagicMock,
         mock_load_meta: MagicMock,
-        mock_state: MagicMock,
         mock_sandbox_cfg: MagicMock,
         mock_broker_port: MagicMock,
         mock_ssh_port: MagicMock,
@@ -280,12 +279,13 @@ class TestRunContainerDoctor:
         mock_terok_checks: MagicMock,
         mock_exec: MagicMock,
         tmp_path: Path,
+        mock_runtime,
     ) -> None:
         # Arrange
         (tmp_path / "42.yml").write_text("mode: cli\n")
         mock_meta_dir.return_value = tmp_path
         mock_load_meta.return_value = ({"mode": "cli"}, tmp_path / "42.yml")
-        mock_state.return_value = "running"
+        mock_runtime.container.return_value.state = "running"
         mock_sandbox_cfg.return_value = MagicMock()
         mock_broker_port.return_value = 8080
         mock_ssh_port.return_value = 2222
@@ -337,14 +337,12 @@ class TestRunContainerDoctor:
     @patch("terok.lib.orchestration.container_doctor.get_ssh_signer_port")
     @patch("terok.lib.orchestration.container_doctor.get_token_broker_port")
     @patch("terok.lib.orchestration.container_doctor.make_sandbox_config")
-    @patch("terok.lib.orchestration.container_doctor.get_container_state")
     @patch("terok.lib.orchestration.container_doctor.load_task_meta")
     @patch("terok.lib.orchestration.container_doctor.tasks_meta_dir")
     def test_host_side_unknown_check_skipped(
         self,
         mock_meta_dir: MagicMock,
         mock_load_meta: MagicMock,
-        mock_state: MagicMock,
         mock_sandbox_cfg: MagicMock,
         mock_broker_port: MagicMock,
         mock_ssh_port: MagicMock,
@@ -356,12 +354,13 @@ class TestRunContainerDoctor:
         mock_terok_checks: MagicMock,
         mock_exec: MagicMock,
         tmp_path: Path,
+        mock_runtime,
     ) -> None:
         # Arrange
         (tmp_path / "42.yml").write_text("mode: cli\n")
         mock_meta_dir.return_value = tmp_path
         mock_load_meta.return_value = ({"mode": "cli"}, tmp_path / "42.yml")
-        mock_state.return_value = "running"
+        mock_runtime.container.return_value.state = "running"
         mock_sandbox_cfg.return_value = MagicMock()
         mock_broker_port.return_value = 8080
         mock_ssh_port.return_value = 2222

--- a/tests/unit/lib/test_container_exec.py
+++ b/tests/unit/lib/test_container_exec.py
@@ -4,96 +4,73 @@
 """Unit tests for container-based command execution."""
 
 import subprocess
-import unittest.mock
 
 from terok_sandbox import ExecResult
 
 from terok.lib.orchestration.container_exec import container_git_diff
 
-_MOD = "terok.lib.orchestration.container_exec"
-
 
 class TestContainerGitDiff:
     """Tests for container_git_diff."""
 
-    def test_running_container_returns_diff(self) -> None:
+    def test_running_container_returns_diff(self, mock_runtime) -> None:
         """Diff output returned when the container is already running."""
         expected = "diff --git a/f.txt b/f.txt\n+hello\n"
-        exec_result = ExecResult(exit_code=0, stdout=expected, stderr="")
-        with (
-            unittest.mock.patch(f"{_MOD}.get_container_state", return_value="running"),
-            unittest.mock.patch(f"{_MOD}.sandbox_exec", return_value=exec_result) as mock_exec,
-            unittest.mock.patch(f"{_MOD}.container_start") as mock_start,
-        ):
-            result = container_git_diff("proj", "1", "cli", "HEAD")
-            assert result == expected
-            mock_exec.assert_called_once()
-            mock_start.assert_not_called()
+        mock_runtime.container.return_value.state = "running"
+        mock_runtime.exec.return_value = ExecResult(exit_code=0, stdout=expected, stderr="")
+        result = container_git_diff("proj", "1", "cli", "HEAD")
+        assert result == expected
+        mock_runtime.exec.assert_called_once()
+        mock_runtime.container.return_value.start.assert_not_called()
 
-    def test_stopped_container_restarts_and_stops(self) -> None:
+    def test_stopped_container_restarts_and_stops(self, mock_runtime) -> None:
         """Stopped CLI container is started, exec'd, and stopped again."""
         expected = " 1 file changed\n"
-        start_result = subprocess.CompletedProcess(args=[], returncode=0, stderr="")
-        exec_result = ExecResult(exit_code=0, stdout=expected, stderr="")
-        stop_result = subprocess.CompletedProcess(args=[], returncode=0, stderr="")
-        with (
-            unittest.mock.patch(f"{_MOD}.get_container_state", return_value="exited"),
-            unittest.mock.patch(f"{_MOD}.container_start", return_value=start_result) as mock_start,
-            unittest.mock.patch(f"{_MOD}.sandbox_exec", return_value=exec_result) as mock_exec,
-            unittest.mock.patch(f"{_MOD}.container_stop", return_value=stop_result) as mock_stop,
-        ):
-            result = container_git_diff("proj", "2", "cli", "--stat", "HEAD@{1}..HEAD")
-            assert result == expected
+        mock_runtime.container.return_value.state = "exited"
+        mock_runtime.exec.return_value = ExecResult(exit_code=0, stdout=expected, stderr="")
+        result = container_git_diff("proj", "2", "cli", "--stat", "HEAD@{1}..HEAD")
+        assert result == expected
 
-            mock_start.assert_called_once_with("proj-cli-2")
-            mock_exec.assert_called_once_with(
-                "proj-cli-2",
-                ["git", "-C", "/workspace", "diff", "--stat", "HEAD@{1}..HEAD"],
-                timeout=30,
-            )
-            mock_stop.assert_called_once_with("proj-cli-2", timeout=10)
+        mock_runtime.container.assert_any_call("proj-cli-2")
+        container = mock_runtime.container.return_value
+        container.start.assert_called_once()
+        container.stop.assert_called_once_with(timeout=10)
+        mock_runtime.exec.assert_called_once()
+        args, kwargs = mock_runtime.exec.call_args
+        assert args[1] == ["git", "-C", "/workspace", "diff", "--stat", "HEAD@{1}..HEAD"]
+        assert kwargs == {"timeout": 30}
 
-    def test_exited_headless_container_not_restarted(self) -> None:
+    def test_exited_headless_container_not_restarted(self, mock_runtime) -> None:
         """Exited headless (run mode) containers must not be restarted."""
-        with unittest.mock.patch(f"{_MOD}.get_container_state", return_value="exited"):
-            result = container_git_diff("proj", "1", "run", "--stat", "HEAD@{1}..HEAD")
-            assert result is None
+        mock_runtime.container.return_value.state = "exited"
+        result = container_git_diff("proj", "1", "run", "--stat", "HEAD@{1}..HEAD")
+        assert result is None
+        mock_runtime.container.return_value.start.assert_not_called()
 
-    def test_no_container_returns_none(self) -> None:
+    def test_no_container_returns_none(self, mock_runtime) -> None:
         """Return None when the container does not exist."""
-        with unittest.mock.patch(f"{_MOD}.get_container_state", return_value=None):
-            result = container_git_diff("proj", "99", "cli")
-            assert result is None
+        mock_runtime.container.return_value.state = None
+        result = container_git_diff("proj", "99", "cli")
+        assert result is None
 
-    def test_podman_exec_failure_returns_none(self) -> None:
+    def test_podman_exec_failure_returns_none(self, mock_runtime) -> None:
         """Return None when git diff fails inside the container."""
-        exec_result = ExecResult(exit_code=128, stdout="", stderr="")
-        with (
-            unittest.mock.patch(f"{_MOD}.get_container_state", return_value="running"),
-            unittest.mock.patch(f"{_MOD}.sandbox_exec", return_value=exec_result),
-        ):
-            result = container_git_diff("proj", "1", "cli", "HEAD")
-            assert result is None
+        mock_runtime.container.return_value.state = "running"
+        mock_runtime.exec.return_value = ExecResult(exit_code=128, stdout="", stderr="")
+        result = container_git_diff("proj", "1", "cli", "HEAD")
+        assert result is None
 
-    def test_start_failure_returns_none(self) -> None:
+    def test_start_failure_returns_none(self, mock_runtime) -> None:
         """Return None when container start fails on a stopped container."""
-        start_result = subprocess.CompletedProcess(args=[], returncode=125, stderr="Error")
-        with (
-            unittest.mock.patch(f"{_MOD}.get_container_state", return_value="exited"),
-            unittest.mock.patch(f"{_MOD}.container_start", return_value=start_result),
-        ):
-            # "run" mode refuses to restart, so use "cli" to hit the start path
-            result = container_git_diff("proj", "1", "cli")
-            assert result is None
+        mock_runtime.container.return_value.state = "exited"
+        mock_runtime.container.return_value.start.side_effect = RuntimeError("start failed")
+        # "run" mode refuses to restart, so use "cli" to hit the start path
+        result = container_git_diff("proj", "1", "cli")
+        assert result is None
 
-    def test_timeout_returns_none(self) -> None:
-        """Return None on sandbox_exec timeout."""
-        with (
-            unittest.mock.patch(f"{_MOD}.get_container_state", return_value="running"),
-            unittest.mock.patch(
-                f"{_MOD}.sandbox_exec",
-                side_effect=subprocess.TimeoutExpired("podman", 30),
-            ),
-        ):
-            result = container_git_diff("proj", "1", "cli", "HEAD")
-            assert result is None
+    def test_timeout_returns_none(self, mock_runtime) -> None:
+        """Return None on podman exec timeout."""
+        mock_runtime.container.return_value.state = "running"
+        mock_runtime.exec.side_effect = subprocess.TimeoutExpired("podman", 30)
+        result = container_git_diff("proj", "1", "cli", "HEAD")
+        assert result is None

--- a/tests/unit/lib/test_container_lifecycle.py
+++ b/tests/unit/lib/test_container_lifecycle.py
@@ -121,7 +121,7 @@ def test_task_stop_uses_expected_timeout(
         runtime_mock.container.return_value = container
         with (
             mock_git_config(),
-            patch("terok.lib.orchestration.tasks._runtime", runtime_mock),
+            patch("terok.lib.core.runtime.get_runtime", return_value=runtime_mock),
         ):
             capture_stdout(
                 task_stop,
@@ -172,7 +172,7 @@ def test_task_restart_starts_exited_container() -> None:
         runtime_mock.container.side_effect = make_container
         with (
             mock_git_config(),
-            patch("terok.lib.orchestration.task_runners._runtime", runtime_mock),
+            patch("terok.lib.core.runtime.get_runtime", return_value=runtime_mock),
         ):
             capture_stdout(task_restart, project_id, task_id)
 
@@ -201,7 +201,7 @@ def test_task_restart_running_container_stops_then_starts() -> None:
         runtime_mock.container.return_value = shared_container
         with (
             mock_git_config(),
-            patch("terok.lib.orchestration.task_runners._runtime", runtime_mock),
+            patch("terok.lib.core.runtime.get_runtime", return_value=runtime_mock),
         ):
             output = capture_stdout(task_restart, project_id, task_id)
 
@@ -221,7 +221,7 @@ def test_task_status_reports_live_container_state() -> None:
         runtime_mock.container.return_value = _mock_container(state="exited")
         with (
             mock_git_config(),
-            patch("terok.lib.orchestration.tasks._runtime", runtime_mock),
+            patch("terok.lib.core.runtime.get_runtime", return_value=runtime_mock),
         ):
             output = capture_stdout(task_status, project_id, task_id)
 
@@ -238,6 +238,6 @@ def test_get_task_container_state_uses_project_id_and_mode() -> None:
     """Task container lookup resolves the canonical container name."""
     runtime_mock = Mock(spec=PodmanRuntime)
     runtime_mock.container.return_value = _mock_container(state="running")
-    with patch("terok.lib.orchestration.tasks._runtime", runtime_mock):
+    with patch("terok.lib.core.runtime.get_runtime", return_value=runtime_mock):
         assert get_task_container_state("proj", "1", "cli") == "running"
         runtime_mock.container.assert_called_once_with("proj-cli-1")

--- a/tests/unit/lib/test_effective_status.py
+++ b/tests/unit/lib/test_effective_status.py
@@ -208,10 +208,9 @@ def test_get_all_task_states_maps_project_container_lookup(
     tasks: list[TaskMeta],
     container_states: dict[str, str],
     expected: dict[str, str | None],
+    mock_runtime,
 ) -> None:
     """Task-state lookup maps batch project container states back to task IDs."""
-    with patch.object(
-        PodmanRuntime, "container_states", return_value=container_states
-    ) as mocked_get_states:
-        assert get_all_task_states("proj", tasks) == expected
-    mocked_get_states.assert_called_once_with("proj")
+    mock_runtime.container_states.return_value = container_states
+    assert get_all_task_states("proj", tasks) == expected
+    mock_runtime.container_states.assert_called_once_with("proj")

--- a/tests/unit/lib/test_image_cleanup.py
+++ b/tests/unit/lib/test_image_cleanup.py
@@ -93,7 +93,7 @@ class TestListImages:
         ],
         ids=["all-terok-images", "filtered-by-project", "dev-tag"],
     )
-    @unittest.mock.patch("terok.lib.domain.image_cleanup._runtime")
+    # removed — mock_runtime fixture handles it
     def test_list_images(
         self,
         mock_runtime: unittest.mock.Mock,
@@ -108,7 +108,7 @@ class TestListImages:
         images = list_images(project_id)
         assert {image.full_name for image in images} == expected_names
 
-    @unittest.mock.patch("terok.lib.domain.image_cleanup._runtime")
+    # removed — mock_runtime fixture handles it
     def test_list_images_podman_failure(self, mock_runtime: unittest.mock.Mock) -> None:
         """Runtime returns an empty list on podman failure — terok passes it through."""
         mock_runtime.images.return_value = []
@@ -199,7 +199,7 @@ class TestCleanupImages:
         ],
         ids=["dry-run", "success", "failure"],
     )
-    @unittest.mock.patch("terok.lib.domain.image_cleanup._runtime")
+    # removed — mock_runtime fixture handles it
     @unittest.mock.patch("terok.lib.domain.image_cleanup.find_orphaned_images")
     def test_cleanup_images(
         self,

--- a/tests/unit/lib/test_images.py
+++ b/tests/unit/lib/test_images.py
@@ -165,9 +165,9 @@ def test_installed_agents_missing_label_returns_empty(mock_runtime) -> None:
 
 
 def test_installed_agents_missing_image_returns_empty(mock_runtime) -> None:
-    # ``image_labels`` returns {} when the image is absent; same end-state
-    # as an unlabeled image, which is correct for the unrestricted-fallback
-    # semantics callers rely on.
+    # ``runtime.image(...).labels()`` returns {} when the image is absent —
+    # same end-state as an unlabeled image, which is correct for the
+    # unrestricted-fallback semantics callers rely on.
     _patch_labels(mock_runtime, {})
     assert images.installed_agents("terok-l1-cli:nope") == frozenset()
 

--- a/tests/unit/lib/test_images.py
+++ b/tests/unit/lib/test_images.py
@@ -139,45 +139,47 @@ def _clear_installed_agents_cache() -> None:
     images.installed_agents.cache_clear()
 
 
-def _patch_labels(monkeypatch: pytest.MonkeyPatch, labels: dict[str, str]) -> None:
-    """Stub :func:`terok_sandbox.image_labels` as seen by ``images.py``.
+def _patch_labels(mock_runtime, labels: dict[str, str]) -> None:
+    """Configure the autouse ``mock_runtime`` so ``Image.labels()`` returns *labels*.
 
-    The module imports ``image_labels`` directly, so the patch target is
-    the name in ``terok.lib.core.images``.  An empty dict mimics
-    podman's behaviour for both missing images and unlabeled images —
-    the distinction doesn't matter for the callers under test here.
+    An empty dict mimics podman's behaviour for both missing images and
+    unlabeled images — the distinction doesn't matter for the callers
+    under test here.
     """
-    monkeypatch.setattr(images, "image_labels", lambda _tag: labels)
+    # ``installed_agents`` is ``@lru_cache``-d — clear the cache so each
+    # test sees the patched labels regardless of call order.
+    images.installed_agents.cache_clear()
+    mock_runtime.image.return_value.labels.return_value = labels
 
 
-def test_installed_agents_parses_label(monkeypatch: pytest.MonkeyPatch) -> None:
-    _patch_labels(monkeypatch, {"ai.terok.agents": "claude,codex,opencode"})
+def test_installed_agents_parses_label(mock_runtime) -> None:
+    _patch_labels(mock_runtime, {"ai.terok.agents": "claude,codex,opencode"})
     assert images.installed_agents("terok-l1-cli:test") == frozenset(
         {"claude", "codex", "opencode"}
     )
 
 
-def test_installed_agents_missing_label_returns_empty(monkeypatch: pytest.MonkeyPatch) -> None:
-    _patch_labels(monkeypatch, {})
+def test_installed_agents_missing_label_returns_empty(mock_runtime) -> None:
+    _patch_labels(mock_runtime, {})
     assert images.installed_agents("terok-l1-cli:legacy") == frozenset()
 
 
-def test_installed_agents_missing_image_returns_empty(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_installed_agents_missing_image_returns_empty(mock_runtime) -> None:
     # ``image_labels`` returns {} when the image is absent; same end-state
     # as an unlabeled image, which is correct for the unrestricted-fallback
     # semantics callers rely on.
-    _patch_labels(monkeypatch, {})
+    _patch_labels(mock_runtime, {})
     assert images.installed_agents("terok-l1-cli:nope") == frozenset()
 
 
-def test_is_installed_treats_unlabeled_as_unrestricted(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_is_installed_treats_unlabeled_as_unrestricted(mock_runtime) -> None:
     # Legacy / unlabeled image: every agent is considered installed so
     # older builds keep working until the user rebuilds.
-    _patch_labels(monkeypatch, {})
+    _patch_labels(mock_runtime, {})
     assert images.is_installed("anything", "terok-l1-cli:legacy") is True
 
 
-def test_is_installed_filters_by_label(monkeypatch: pytest.MonkeyPatch) -> None:
-    _patch_labels(monkeypatch, {"ai.terok.agents": "claude,codex"})
+def test_is_installed_filters_by_label(mock_runtime) -> None:
+    _patch_labels(mock_runtime, {"ai.terok.agents": "claude,codex"})
     assert images.is_installed("claude", "terok-l1-cli:test") is True
     assert images.is_installed("vibe", "terok-l1-cli:test") is False

--- a/tests/unit/lib/test_login.py
+++ b/tests/unit/lib/test_login.py
@@ -73,35 +73,31 @@ class TestLogin:
         mode: str | None,
         container_state: str | None,
         error_text: str,
+        mock_runtime,
     ) -> None:
+        mock_runtime.container.return_value.state = container_state
         with project_env(project_yaml(project_id), project_id=project_id) as ctx:
             task_id = "deadbeef"  # nonexistent by default
             if project_id != "proj_login_unknown":
                 task_id = setup_task_with_mode(ctx, project_id, mode=mode)
-            with unittest.mock.patch(
-                "terok.lib.orchestration.tasks.get_container_state",
-                return_value=container_state,
-            ):
-                with pytest.raises(SystemExit) as exc_ctx:
-                    task_login(
-                        project_id, "deadbeef" if project_id == "proj_login_unknown" else task_id
-                    )
+            with pytest.raises(SystemExit) as exc_ctx:
+                task_login(
+                    project_id, "deadbeef" if project_id == "proj_login_unknown" else task_id
+                )
             assert error_text in str(exc_ctx.value)
 
-    def test_task_login_success(self) -> None:
+    def test_task_login_success(self, mock_runtime) -> None:
         """task_login calls os.execvp with the correct podman+tmux command."""
         project_id = "proj-cli"
         with project_env(project_yaml(project_id), project_id=project_id) as ctx:
             task_id = setup_task_with_mode(ctx, project_id, mode="cli")
-            with (
-                unittest.mock.patch(
-                    "terok.lib.orchestration.tasks.get_container_state",
-                    return_value="running",
-                ),
-                unittest.mock.patch("terok.lib.orchestration.tasks.os.execvp") as mock_exec,
-            ):
+            expected_container = f"{project_id}-cli-{task_id}"
+            mock_runtime.container.return_value.state = "running"
+            mock_runtime.container.return_value.login_command.return_value = _login_command(
+                expected_container
+            )
+            with unittest.mock.patch("terok.lib.orchestration.tasks.os.execvp") as mock_exec:
                 task_login(project_id, task_id)
-        expected_container = f"{project_id}-cli-{task_id}"
         mock_exec.assert_called_once_with("podman", _login_command(expected_container))
 
     @pytest.mark.parametrize(
@@ -112,33 +108,33 @@ class TestLogin:
     def test_get_login_command_returns_expected_container_name(
         self,
         mode: str,
+        mock_runtime,
     ) -> None:
         project_id = "proj_logincmd" if mode == "cli" else "proj_loginweb"
         with project_env(project_yaml(project_id), project_id=project_id) as ctx:
             task_id = setup_task_with_mode(ctx, project_id, mode=mode)
-            with unittest.mock.patch(
-                "terok.lib.orchestration.tasks.get_container_state",
-                return_value="running",
-            ):
-                command = get_login_command(project_id, task_id)
-        expected_container = f"{project_id}-{mode}-{task_id}"
+            expected_container = f"{project_id}-{mode}-{task_id}"
+            mock_runtime.container.return_value.state = "running"
+            mock_runtime.container.return_value.login_command.return_value = _login_command(
+                expected_container
+            )
+            command = get_login_command(project_id, task_id)
         assert command[3] == expected_container
         assert command[-5:] == ["tmux", "new-session", "-A", "-s", "main"]
 
-    def test_login_no_longer_injects_agent_config(self) -> None:
+    def test_login_no_longer_injects_agent_config(self, mock_runtime) -> None:
         """get_login_command does NOT inject agent config (handled via mount)."""
         project_id = "proj_login_cfg"
         yaml_text = f"project:\n  id: {project_id}\nagent:\n  model: sonnet\n"
         with project_env(yaml_text, project_id=project_id) as ctx:
             task_id = setup_task_with_mode(ctx, project_id, mode="cli")
-            with (
-                unittest.mock.patch(
-                    "terok.lib.orchestration.tasks.get_container_state",
-                    return_value="running",
-                ),
-                mock_git_config(),
-            ):
+            expected_container = f"{project_id}-cli-{task_id}"
+            mock_runtime.container.return_value.state = "running"
+            mock_runtime.container.return_value.login_command.return_value = _login_command(
+                expected_container
+            )
+            with mock_git_config():
                 command = get_login_command(project_id, task_id)
 
-        assert command[3] == f"{project_id}-cli-{task_id}"
+        assert command[3] == expected_container
         assert "tmux" in command

--- a/tests/unit/lib/test_panic.py
+++ b/tests/unit/lib/test_panic.py
@@ -229,26 +229,26 @@ class TestPanicStopContainers:
 class TestStopContainers:
     """Tests for _stop_containers internals."""
 
-    @patch("terok_sandbox.PodmanRuntime")
-    def test_stops_all_modes(self, mock_runtime_cls):
+    @patch("terok.lib.core.runtime.get_runtime")
+    def test_stops_all_modes(self, mock_get_runtime):
         """All container modes are generated for each target."""
         from terok.lib.domain.panic import _stop_containers
 
-        mock_runtime_cls.return_value.force_remove.return_value = []
+        mock_get_runtime.return_value.force_remove.return_value = []
         t = _target()
         stopped, errors = _stop_containers([t])
         assert not errors
         # force_remove called once with a list of container handles
-        mock_runtime_cls.return_value.force_remove.assert_called_once()
-        handles = mock_runtime_cls.return_value.force_remove.call_args[0][0]
+        mock_get_runtime.return_value.force_remove.assert_called_once()
+        handles = mock_get_runtime.return_value.force_remove.call_args[0][0]
         assert len(handles) > 0
 
-    @patch("terok_sandbox.PodmanRuntime")
-    def test_stop_exception(self, mock_runtime_cls):
+    @patch("terok.lib.core.runtime.get_runtime")
+    def test_stop_exception(self, mock_get_runtime):
         """Exception from force_remove yields errors."""
         from terok.lib.domain.panic import _stop_containers
 
-        mock_runtime_cls.return_value.force_remove.side_effect = Exception("podman died")
+        mock_get_runtime.return_value.force_remove.side_effect = Exception("podman died")
         stopped, errors = _stop_containers([_target()])
         assert not stopped
         assert all("podman died" in e for _, e in errors)

--- a/tests/unit/lib/test_projects.py
+++ b/tests/unit/lib/test_projects.py
@@ -275,7 +275,7 @@ class TestProject:
             project = load_project("proj-no-shared")
         assert project.shared_dir is None
 
-    def test_get_project_state(self) -> None:
+    def test_get_project_state(self, mock_runtime) -> None:
         project_id = "proj3"
         with project_env(
             project_yaml(project_id), project_id=project_id, with_config_file=True
@@ -288,11 +288,9 @@ class TestProject:
             gate_dir = make_sandbox_config().gate_base_path / f"{project_id}.git"
             gate_dir.mkdir(parents=True, exist_ok=True)
 
+            mock_runtime.image.return_value.exists.return_value = True
             # SSH "ready" check now hits the vault DB — stub the probe directly.
             with (
-                unittest.mock.patch(
-                    "terok.lib.domain.project_state.image_exists", return_value=True
-                ),
                 unittest.mock.patch(
                     "terok.lib.core.projects._get_global_git_config", return_value=None
                 ),

--- a/tests/unit/lib/test_staleness_detection.py
+++ b/tests/unit/lib/test_staleness_detection.py
@@ -183,15 +183,16 @@ class TestDetectStaleLayers:
 class TestIsTaskImageOld:
     """Verify is_task_image_old return values."""
 
-    def test_returns_false_when_all_current(self) -> None:
+    def test_returns_false_when_all_current(self, mock_runtime) -> None:
         """Running task with current manifest → False."""
         from terok.lib.domain.project_state import is_task_image_old
 
         task = Mock(mode="cli", task_id="42")
+        container = mock_runtime.container.return_value
+        container.running = True
+        container.image = Mock()
 
         with (
-            patch("terok.lib.domain.project_state.is_container_running", return_value=True),
-            patch("terok.lib.domain.project_state.container_image", return_value="sha256:abc123"),
             patch("terok.lib.domain.project_state._container_name", return_value="c1"),
             patch(
                 "terok.lib.orchestration.image.render_all_dockerfiles",
@@ -210,15 +211,16 @@ class TestIsTaskImageOld:
 
         assert result is False
 
-    def test_returns_true_when_stale(self) -> None:
+    def test_returns_true_when_stale(self, mock_runtime) -> None:
         """Running task with stale L1 → True."""
         from terok.lib.domain.project_state import is_task_image_old
 
         task = Mock(mode="cli", task_id="42")
+        container = mock_runtime.container.return_value
+        container.running = True
+        container.image = Mock()
 
         with (
-            patch("terok.lib.domain.project_state.is_container_running", return_value=True),
-            patch("terok.lib.domain.project_state.container_image", return_value="sha256:abc123"),
             patch("terok.lib.domain.project_state._container_name", return_value="c1"),
             patch(
                 "terok.lib.orchestration.image.render_all_dockerfiles",
@@ -251,15 +253,18 @@ class TestIsTaskImageOld:
         task = Mock(mode="cli", task_id="42")
         assert is_task_image_old(None, task) is None
 
-    def test_falls_back_to_label_check_on_exception(self) -> None:
+    def test_falls_back_to_label_check_on_exception(self, mock_runtime) -> None:
         """When manifest approach fails, falls back to L2 label comparison."""
         from terok.lib.domain.project_state import is_task_image_old
 
         task = Mock(mode="cli", task_id="42")
+        container = mock_runtime.container.return_value
+        container.running = True
+        image = Mock()
+        image.labels.return_value = {"terok.build_context_hash": "old-hash"}
+        container.image = image
 
         with (
-            patch("terok.lib.domain.project_state.is_container_running", return_value=True),
-            patch("terok.lib.domain.project_state.container_image", return_value="sha256:abc123"),
             patch("terok.lib.domain.project_state._container_name", return_value="c1"),
             # Make manifest approach fail at load_project (inside is_task_image_old)
             patch(
@@ -270,11 +275,6 @@ class TestIsTaskImageOld:
             patch(
                 "terok.lib.orchestration.image.build_context_hash",
                 return_value="current-hash",
-            ),
-            # Label on image doesn't match → stale
-            patch(
-                "terok.lib.domain.project_state.image_labels",
-                return_value={"terok.build_context_hash": "old-hash"},
             ),
         ):
             result = is_task_image_old("proj1", task)

--- a/tests/unit/lib/test_storage.py
+++ b/tests/unit/lib/test_storage.py
@@ -167,11 +167,11 @@ class TestGetStorageOverview:
 class TestGetProjectStorageDetail:
     """Detail mode queries per-task sizes and overlay data."""
 
-    @patch("terok_sandbox.PodmanRuntime.container_rw_sizes", return_value={"abc": 1024})
     @patch("terok.lib.domain.storage.get_tasks_storage", return_value=[])
     @patch("terok.lib.domain.storage.list_images", return_value=[])
     @patch("terok.lib.core.projects.load_project")
-    def test_returns_project_detail(self, mock_load, _imgs, _tasks, _overlays):
+    def test_returns_project_detail(self, mock_load, _imgs, _tasks, mock_runtime):
+        mock_runtime.container_rw_sizes.return_value = {"abc": 1024}
         mock_load.return_value = _fake_project("myproject")
         detail = get_project_storage_detail("myproject")
         assert detail.project_id == "myproject"

--- a/tests/unit/lib/test_task_runner_internals.py
+++ b/tests/unit/lib/test_task_runner_internals.py
@@ -75,36 +75,28 @@ class TestStrToBool:
 class TestPodmanStart:
     """Verify _podman_start error handling."""
 
-    _PATCH = "terok.lib.orchestration.task_runners.container_start"
-
-    def test_raises_on_missing_podman(self) -> None:
+    def test_raises_on_missing_podman(self, mock_runtime) -> None:
         """FileNotFoundError becomes SystemExit with install hint."""
         from terok.lib.orchestration.task_runners import _podman_start
 
-        with (
-            patch(self._PATCH, side_effect=FileNotFoundError),
-            pytest.raises(SystemExit, match="podman not found"),
-        ):
+        mock_runtime.container.return_value.start.side_effect = FileNotFoundError
+        with pytest.raises(SystemExit, match="podman not found"):
             _podman_start("test-ctr")
 
-    def test_raises_on_start_failure(self) -> None:
+    def test_raises_on_start_failure(self, mock_runtime) -> None:
         """Runtime failure surfaces as a user-facing SystemExit."""
         from terok.lib.orchestration.task_runners import _podman_start
 
-        with (
-            patch(self._PATCH, side_effect=RuntimeError("container not found")),
-            pytest.raises(SystemExit, match="container not found"),
-        ):
+        mock_runtime.container.return_value.start.side_effect = RuntimeError("container not found")
+        with pytest.raises(SystemExit, match="container not found"):
             _podman_start("test-ctr")
 
-    def test_raises_on_start_failure_empty_stderr(self) -> None:
+    def test_raises_on_start_failure_empty_stderr(self, mock_runtime) -> None:
         """Any RuntimeError from the runtime is translated to SystemExit."""
         from terok.lib.orchestration.task_runners import _podman_start
 
-        with (
-            patch(self._PATCH, side_effect=RuntimeError("rc=125")),
-            pytest.raises(SystemExit),
-        ):
+        mock_runtime.container.return_value.start.side_effect = RuntimeError("rc=125")
+        with pytest.raises(SystemExit):
             _podman_start("test-ctr")
 
 

--- a/tests/unit/lib/test_tasks.py
+++ b/tests/unit/lib/test_tasks.py
@@ -49,6 +49,19 @@ from tests.testfs import CONTAINER_SSH_DIR
 from tests.testnet import GATE_PORT
 
 
+def _set_state_sequence(mock_runtime, states: list[str | None]) -> None:
+    """Configure runtime.container(...).state to yield ``states`` across calls.
+
+    Each call to ``container(cname).state`` — an attribute read — pops the next
+    value from ``states``. Used when production code reads state multiple times
+    across a lifecycle transition.
+    """
+    it = iter(states)
+    type(mock_runtime.container.return_value).state = unittest.mock.PropertyMock(
+        side_effect=lambda: next(it)
+    )
+
+
 def _gate_repo_fragment(project_id: str, *, port: int = GATE_PORT) -> str:
     """Return the gate URL fragment embedded in task env vars.
 
@@ -114,9 +127,6 @@ class TestTask:
 
             with (
                 unittest.mock.patch("terok_executor.AgentRunner.capture_logs", return_value=False),
-                unittest.mock.patch(
-                    "terok.lib.orchestration.tasks.stop_task_containers", return_value=[]
-                ),
                 mock_git_config(),
             ):
                 result = task_delete(project_id, returned_id)
@@ -437,7 +447,7 @@ class TestTask:
             env, _volumes = build_task_env_and_volumes(load_project(project_id), task_id="1")
             assert env["TEROK_GIT_AUTHORSHIP"] == "human-agent"
 
-    def test_task_run_cli_colors_login_lines_when_tty(self) -> None:
+    def test_task_run_cli_colors_login_lines_when_tty(self, mock_runtime) -> None:
         project_id = "proj_cli_color"
         with project_env(
             f"project:\n  id: {project_id}\n",
@@ -446,16 +456,17 @@ class TestTask:
             clear_env=True,
         ):
             tid = task_new(project_id)
+            _set_state_sequence(mock_runtime, [None, "running"])
+            cname = f"{project_id}-cli-{tid}"
+            mock_runtime.container.return_value.login_command.return_value = [
+                "podman",
+                "exec",
+                "-it",
+                cname,
+                "bash",
+            ]
             with (
                 mock_git_config(),
-                unittest.mock.patch(
-                    "terok.lib.orchestration.task_runners.stream_initial_logs",
-                    return_value=True,
-                ),
-                unittest.mock.patch(
-                    "terok.lib.orchestration.task_runners.get_container_state",
-                    side_effect=[None, "running"],  # No existing container, then alive
-                ),
                 unittest.mock.patch(
                     "terok.lib.orchestration.task_runners._supports_color",
                     return_value=True,
@@ -474,7 +485,7 @@ class TestTask:
             assert expected_enter in output
             assert expected_stop in output
 
-    def test_task_run_cli_does_not_add_files_before_clone(self) -> None:
+    def test_task_run_cli_does_not_add_files_before_clone(self, mock_runtime) -> None:
         """Interactive CLI startup must not add files to workspace before init clone."""
         project_id = "proj_cli_clean_workspace"
         with project_env(
@@ -487,24 +498,15 @@ class TestTask:
             sandbox_live = ctx.base / "sandbox-live"
             workspace_dir = sandbox_live / "tasks" / project_id / tid / "workspace-dangerous"
             assert sorted(p.name for p in workspace_dir.iterdir()) == [".new-task-marker"]
-            with (
-                mock_git_config(),
-                unittest.mock.patch(
-                    "terok.lib.orchestration.task_runners.stream_initial_logs",
-                    return_value=True,
-                ),
-                unittest.mock.patch(
-                    "terok.lib.orchestration.task_runners.get_container_state",
-                    side_effect=[None, "running"],
-                ),
-            ):
+            _set_state_sequence(mock_runtime, [None, "running"])
+            with mock_git_config():
                 task_run_cli(project_id, tid)
 
             assert sorted(p.name for p in workspace_dir.iterdir()) == [".new-task-marker"]
             agent_mounts = ctx.base / "sandbox-live" / "mounts"
             assert (agent_mounts / "_claude-config" / "settings.json").is_file()
 
-    def test_task_run_toad_passes_public_url(self) -> None:
+    def test_task_run_toad_passes_public_url(self, mock_runtime) -> None:
         """task_run_toad must pass --public-url with the host port to toad serve."""
         project_id = "proj_toad_url"
         with project_env(
@@ -514,20 +516,10 @@ class TestTask:
             clear_env=True,
         ):
             tid = task_new(project_id)
+            mock_runtime.container.return_value.state = None
+            mock_runtime.container.return_value.running = True
             with (
                 mock_git_config(),
-                unittest.mock.patch(
-                    "terok.lib.orchestration.task_runners.stream_initial_logs",
-                    return_value=True,
-                ),
-                unittest.mock.patch(
-                    "terok.lib.orchestration.task_runners.get_container_state",
-                    return_value=None,
-                ),
-                unittest.mock.patch(
-                    "terok.lib.orchestration.task_runners.is_container_running",
-                    return_value=True,
-                ),
                 unittest.mock.patch(
                     "terok.lib.orchestration.task_runners.assign_web_port",
                     return_value=7861,
@@ -551,7 +543,9 @@ class TestTask:
             port_idx = extra.index("-p")
             assert extra[port_idx + 1] == "127.0.0.1:7861:8080"
 
-    def test_task_run_toad_uses_public_host(self, monkeypatch: pytest.MonkeyPatch) -> None:
+    def test_task_run_toad_uses_public_host(
+        self, monkeypatch: pytest.MonkeyPatch, mock_runtime
+    ) -> None:
         """task_run_toad must use TEROK_PUBLIC_HOST for URLs and bind to 0.0.0.0."""
         project_id = "proj_toad_pub"
         monkeypatch.setenv("TEROK_PUBLIC_HOST", "myserver")
@@ -564,20 +558,10 @@ class TestTask:
             # Re-apply after clear_env
             monkeypatch.setenv("TEROK_PUBLIC_HOST", "myserver")
             tid = task_new(project_id)
+            mock_runtime.container.return_value.state = None
+            mock_runtime.container.return_value.running = True
             with (
                 mock_git_config(),
-                unittest.mock.patch(
-                    "terok.lib.orchestration.task_runners.stream_initial_logs",
-                    return_value=True,
-                ),
-                unittest.mock.patch(
-                    "terok.lib.orchestration.task_runners.get_container_state",
-                    return_value=None,
-                ),
-                unittest.mock.patch(
-                    "terok.lib.orchestration.task_runners.is_container_running",
-                    return_value=True,
-                ),
                 unittest.mock.patch(
                     "terok.lib.orchestration.task_runners.assign_web_port",
                     return_value=7862,
@@ -597,7 +581,7 @@ class TestTask:
             port_idx = extra.index("-p")
             assert extra[port_idx + 1] == "0.0.0.0:7862:8080"
 
-    def test_task_run_cli_already_running(self) -> None:
+    def test_task_run_cli_already_running(self, mock_runtime) -> None:
         """task_run_cli prints message and exits when container is already running."""
         project_id = "proj_cli_running"
         with project_env(
@@ -605,13 +589,8 @@ class TestTask:
             project_id=project_id,
         ):
             tid = task_new(project_id)
-            with (
-                mock_git_config(),
-                unittest.mock.patch(
-                    "terok.lib.orchestration.task_runners.get_container_state",
-                    return_value="running",
-                ),
-            ):
+            mock_runtime.container.return_value.state = "running"
+            with mock_git_config():
                 buffer = StringIO()
                 with redirect_stdout(buffer):
                     task_run_cli(project_id, tid)
@@ -620,7 +599,7 @@ class TestTask:
                 output = buffer.getvalue()
                 assert "already running" in output
 
-    def test_task_run_cli_starts_stopped_container(self) -> None:
+    def test_task_run_cli_starts_stopped_container(self, mock_runtime) -> None:
         """task_run_cli uses 'podman start' for stopped container."""
         project_id = "proj_cli_stopped"
         with project_env(
@@ -637,24 +616,15 @@ class TestTask:
             meta_path.write_text(yaml_dump(meta))
 
             cname = f"{project_id}-cli-{tid}"
-            start_result = subprocess.CompletedProcess(args=[], returncode=0, stderr="")
-            with (
-                mock_git_config(),
-                unittest.mock.patch(
-                    "terok.lib.orchestration.task_runners.get_container_state",
-                    side_effect=["exited", "running"],  # Stopped, then alive after start
-                ),
-                unittest.mock.patch(
-                    "terok.lib.orchestration.task_runners.container_start",
-                    return_value=start_result,
-                ) as mock_start,
-            ):
+            _set_state_sequence(mock_runtime, ["exited", "running"])
+            with mock_git_config():
                 buffer = StringIO()
                 with redirect_stdout(buffer):
                     task_run_cli(project_id, tid)
 
-                # Verify container_start was called with the correct name
-                mock_start.assert_called_once_with(cname)
+                # Verify container(cname).start() was called
+                mock_runtime.container.assert_any_call(cname)
+                mock_runtime.container.return_value.start.assert_called_once_with()
 
                 # Verify metadata mode is preserved
                 meta = yaml_load(meta_path.read_text())
@@ -1071,7 +1041,7 @@ class TestResumeToadContainer:
         meta_path.write_text(yaml_dump(meta))
         (project.tasks_root / str(task_id) / "agent-config").mkdir(parents=True, exist_ok=True)
 
-    def test_resume_running_container_prints_tokenized_url(self) -> None:
+    def test_resume_running_container_prints_tokenized_url(self, mock_runtime) -> None:
         """A running container short-circuits with the printed ``?token=…`` URL."""
         project_id = "proj_resume_running"
         with project_env(
@@ -1082,13 +1052,10 @@ class TestResumeToadContainer:
         ):
             tid = task_new(project_id)
             self._seed_toad_meta(project_id, tid, port=7862, token="tok-running")
+            mock_runtime.container.return_value.state = "running"
             buf = StringIO()
             with (
                 mock_git_config(),
-                unittest.mock.patch(
-                    "terok.lib.orchestration.task_runners.get_container_state",
-                    return_value="running",
-                ),
                 unittest.mock.patch(
                     "terok.lib.orchestration.task_runners.assign_web_port",
                     return_value=7862,
@@ -1108,7 +1075,7 @@ class TestResumeToadContainer:
                 project.tasks_root / str(tid) / "agent-config" / "toad.token"
             ).read_text() == "tok-running"
 
-    def test_resume_stopped_container_restarts_and_prints_url(self) -> None:
+    def test_resume_stopped_container_restarts_and_prints_url(self, mock_runtime) -> None:
         """An existing-but-stopped container is started again with the same token."""
         project_id = "proj_resume_stopped"
         with project_env(
@@ -1119,13 +1086,10 @@ class TestResumeToadContainer:
         ):
             tid = task_new(project_id)
             self._seed_toad_meta(project_id, tid, port=7863, token="tok-stopped")
+            mock_runtime.container.return_value.state = "exited"
             buf = StringIO()
             with (
                 mock_git_config(),
-                unittest.mock.patch(
-                    "terok.lib.orchestration.task_runners.get_container_state",
-                    return_value="exited",
-                ),
                 unittest.mock.patch(
                     "terok.lib.orchestration.task_runners.assign_web_port",
                     return_value=7863,
@@ -1150,7 +1114,7 @@ class TestResumeToadContainer:
             assert "Container started" in out
             assert "?token=tok-stopped" in out
 
-    def test_resume_rejects_changed_port(self) -> None:
+    def test_resume_rejects_changed_port(self, mock_runtime) -> None:
         """If the saved port is taken by another user, fail fast."""
         project_id = "proj_resume_taken"
         with project_env(
@@ -1161,11 +1125,8 @@ class TestResumeToadContainer:
         ):
             tid = task_new(project_id)
             self._seed_toad_meta(project_id, tid, port=7864, token="tok")
+            mock_runtime.container.return_value.state = "running"
             with (
-                unittest.mock.patch(
-                    "terok.lib.orchestration.task_runners.get_container_state",
-                    return_value="running",
-                ),
                 unittest.mock.patch(
                     "terok.lib.orchestration.task_runners.assign_web_port",
                     return_value=9999,  # allocator returned a different port
@@ -1214,39 +1175,35 @@ class TestTaskLogs:
                     task_logs("proj_logs2", task_id)
                 assert "never been run" in str(cm.value)
 
-    def test_container_not_found_raises(self) -> None:
+    def test_container_not_found_raises(self, mock_runtime) -> None:
         """task_logs raises SystemExit when container doesn't exist."""
+        mock_runtime.container.return_value.state = None
         with project_env(
             "project:\n  id: proj_logs3\n",
             project_id="proj_logs3",
         ):
             with mock_git_config():
                 task_id = self._setup_task_with_mode("proj_logs3", "run")
-                with unittest.mock.patch(
-                    "terok.lib.domain.task_logs.get_container_state", return_value=None
-                ):
-                    with pytest.raises(SystemExit) as cm:
-                        task_logs("proj_logs3", task_id)
-                    assert "does not exist" in str(cm.value)
+                with pytest.raises(SystemExit) as cm:
+                    task_logs("proj_logs3", task_id)
+                assert "does not exist" in str(cm.value)
 
-    def test_negative_tail_raises(self) -> None:
+    def test_negative_tail_raises(self, mock_runtime) -> None:
         """task_logs raises SystemExit for negative tail value."""
+        mock_runtime.container.return_value.state = "running"
         with project_env(
             "project:\n  id: proj_logs4\n",
             project_id="proj_logs4",
         ):
             with mock_git_config():
                 task_id = self._setup_task_with_mode("proj_logs4", "run")
-                with unittest.mock.patch(
-                    "terok.lib.domain.task_logs.get_container_state",
-                    return_value="running",
-                ):
-                    with pytest.raises(SystemExit) as cm:
-                        task_logs("proj_logs4", task_id, LogViewOptions(tail=-1))
-                    assert "--tail must be >= 0" in str(cm.value)
+                with pytest.raises(SystemExit) as cm:
+                    task_logs("proj_logs4", task_id, LogViewOptions(tail=-1))
+                assert "--tail must be >= 0" in str(cm.value)
 
-    def test_raw_mode_exec(self) -> None:
+    def test_raw_mode_exec(self, mock_runtime) -> None:
         """task_logs in raw mode calls os.execvp."""
+        mock_runtime.container.return_value.state = "exited"
         with project_env(
             "project:\n  id: proj_logs5\n",
             project_id="proj_logs5",
@@ -1261,14 +1218,8 @@ class TestTaskLogs:
                     captured_args.append((file, args))
                     raise SystemExit(0)
 
-                with (
-                    unittest.mock.patch(
-                        "terok.lib.domain.task_logs.get_container_state",
-                        return_value="exited",
-                    ),
-                    unittest.mock.patch(
-                        "terok.lib.domain.task_logs.os.execvp", side_effect=fake_execvp
-                    ),
+                with unittest.mock.patch(
+                    "terok.lib.domain.task_logs.os.execvp", side_effect=fake_execvp
                 ):
                     with pytest.raises(SystemExit):
                         task_logs("proj_logs5", task_id, LogViewOptions(raw=True))
@@ -1276,30 +1227,26 @@ class TestTaskLogs:
                     assert captured_args[0][0] == "podman"
                     assert "logs" in captured_args[0][1]
 
-    def test_raw_mode_podman_not_found(self) -> None:
+    def test_raw_mode_podman_not_found(self, mock_runtime) -> None:
         """task_logs in raw mode raises SystemExit if podman not found."""
+        mock_runtime.container.return_value.state = "exited"
         with project_env(
             "project:\n  id: proj_logs6\n",
             project_id="proj_logs6",
         ):
             with mock_git_config():
                 task_id = self._setup_task_with_mode("proj_logs6", "cli")
-                with (
-                    unittest.mock.patch(
-                        "terok.lib.domain.task_logs.get_container_state",
-                        return_value="exited",
-                    ),
-                    unittest.mock.patch(
-                        "terok.lib.domain.task_logs.os.execvp",
-                        side_effect=FileNotFoundError("podman"),
-                    ),
+                with unittest.mock.patch(
+                    "terok.lib.domain.task_logs.os.execvp",
+                    side_effect=FileNotFoundError("podman"),
                 ):
                     with pytest.raises(SystemExit) as cm:
                         task_logs("proj_logs6", task_id, LogViewOptions(raw=True))
                     assert "podman not found" in str(cm.value)
 
-    def test_formatted_mode_feeds_formatter(self) -> None:
+    def test_formatted_mode_feeds_formatter(self, mock_runtime) -> None:
         """task_logs in formatted mode pipes lines through formatter."""
+        mock_runtime.container.return_value.state = "exited"
         with project_env(
             "project:\n  id: proj_logs7\n",
             project_id="proj_logs7",
@@ -1326,10 +1273,6 @@ class TestTaskLogs:
 
                 with (
                     unittest.mock.patch(
-                        "terok.lib.domain.task_logs.get_container_state",
-                        return_value="exited",
-                    ),
-                    unittest.mock.patch(
                         "terok.lib.domain.task_logs.AgentRunner"
                     ) as mock_runner_cls,
                     unittest.mock.patch(
@@ -1348,23 +1291,18 @@ class TestTaskLogs:
                     mock_formatter.feed_line.assert_called()
                     mock_formatter.finish.assert_called_once()
 
-    def test_formatted_mode_podman_not_found(self) -> None:
+    def test_formatted_mode_podman_not_found(self, mock_runtime) -> None:
         """task_logs in formatted mode raises SystemExit if podman not found."""
+        mock_runtime.container.return_value.state = "running"
         with project_env(
             "project:\n  id: proj_logs8\n",
             project_id="proj_logs8",
         ):
             with mock_git_config():
                 task_id = self._setup_task_with_mode("proj_logs8", "run")
-                with (
-                    unittest.mock.patch(
-                        "terok.lib.domain.task_logs.get_container_state",
-                        return_value="running",
-                    ),
-                    unittest.mock.patch(
-                        "terok.lib.domain.task_logs.AgentRunner"
-                    ) as mock_runner_cls,
-                ):
+                with unittest.mock.patch(
+                    "terok.lib.domain.task_logs.AgentRunner"
+                ) as mock_runner_cls:
                     mock_runner_cls.return_value.stream_logs_process.side_effect = (
                         FileNotFoundError("podman")
                     )
@@ -1372,8 +1310,9 @@ class TestTaskLogs:
                         task_logs("proj_logs8", task_id)
                     assert "podman not found" in str(cm.value)
 
-    def test_persisted_logs_fallback(self) -> None:
+    def test_persisted_logs_fallback(self, mock_runtime) -> None:
         """task_logs falls back to persisted log file when container is gone."""
+        mock_runtime.container.return_value.state = None
         with project_env(
             "project:\n  id: proj_logs_persist\n",
             project_id="proj_logs_persist",
@@ -1392,15 +1331,9 @@ class TestTaskLogs:
 
                 mock_formatter = unittest.mock.Mock()
 
-                with (
-                    unittest.mock.patch(
-                        "terok.lib.domain.task_logs.get_container_state",
-                        return_value=None,
-                    ),
-                    unittest.mock.patch(
-                        "terok.lib.domain.task_logs.auto_detect_formatter",
-                        return_value=mock_formatter,
-                    ),
+                with unittest.mock.patch(
+                    "terok.lib.domain.task_logs.auto_detect_formatter",
+                    return_value=mock_formatter,
                 ):
                     buf = StringIO()
                     with redirect_stdout(buf):
@@ -1410,8 +1343,9 @@ class TestTaskLogs:
                     assert mock_formatter.feed_line.call_count == 3
                     mock_formatter.finish.assert_called_once()
 
-    def test_persisted_logs_fallback_with_tail(self) -> None:
+    def test_persisted_logs_fallback_with_tail(self, mock_runtime) -> None:
         """task_logs persisted fallback respects --tail option."""
+        mock_runtime.container.return_value.state = None
         with project_env(
             "project:\n  id: proj_logs_tail\n",
             project_id="proj_logs_tail",
@@ -1429,37 +1363,29 @@ class TestTaskLogs:
 
                 mock_formatter = unittest.mock.Mock()
 
-                with (
-                    unittest.mock.patch(
-                        "terok.lib.domain.task_logs.get_container_state",
-                        return_value=None,
-                    ),
-                    unittest.mock.patch(
-                        "terok.lib.domain.task_logs.auto_detect_formatter",
-                        return_value=mock_formatter,
-                    ),
+                with unittest.mock.patch(
+                    "terok.lib.domain.task_logs.auto_detect_formatter",
+                    return_value=mock_formatter,
                 ):
                     task_logs("proj_logs_tail", task_id, LogViewOptions(tail=2))
                     assert mock_formatter.feed_line.call_count == 2
 
-    def test_no_container_no_logs_raises(self) -> None:
+    def test_no_container_no_logs_raises(self, mock_runtime) -> None:
         """task_logs raises when container is gone and no persisted logs exist."""
+        mock_runtime.container.return_value.state = None
         with project_env(
             "project:\n  id: proj_logs_nolog\n",
             project_id="proj_logs_nolog",
         ):
             with mock_git_config():
                 task_id = self._setup_task_with_mode("proj_logs_nolog", "run")
-                with unittest.mock.patch(
-                    "terok.lib.domain.task_logs.get_container_state",
-                    return_value=None,
-                ):
-                    with pytest.raises(SystemExit) as cm:
-                        task_logs("proj_logs_nolog", task_id)
-                    assert "no persisted logs found" in str(cm.value)
+                with pytest.raises(SystemExit) as cm:
+                    task_logs("proj_logs_nolog", task_id)
+                assert "no persisted logs found" in str(cm.value)
 
-    def test_negative_tail_persisted_fallback_raises(self) -> None:
+    def test_negative_tail_persisted_fallback_raises(self, mock_runtime) -> None:
         """task_logs raises for negative tail even when falling back to persisted logs."""
+        mock_runtime.container.return_value.state = None
         with project_env(
             "project:\n  id: proj_logs_negtail\n",
             project_id="proj_logs_negtail",
@@ -1474,13 +1400,9 @@ class TestTaskLogs:
                 logs_dir.mkdir(parents=True, exist_ok=True)
                 (logs_dir / "container.log").write_text("a\nb\n")
 
-                with unittest.mock.patch(
-                    "terok.lib.domain.task_logs.get_container_state",
-                    return_value=None,
-                ):
-                    with pytest.raises(SystemExit) as cm:
-                        task_logs("proj_logs_negtail", task_id, LogViewOptions(tail=-1))
-                    assert "--tail must be >= 0" in str(cm.value)
+                with pytest.raises(SystemExit) as cm:
+                    task_logs("proj_logs_negtail", task_id, LogViewOptions(tail=-1))
+                assert "--tail must be >= 0" in str(cm.value)
 
 
 class TestTaskArchive:
@@ -1517,15 +1439,9 @@ class TestTaskArchive:
                     dest.write_text(log_content)
                     return True
 
-                with (
-                    unittest.mock.patch(
-                        "terok_executor.AgentRunner.capture_logs",
-                        new=_fake_capture,
-                    ),
-                    unittest.mock.patch(
-                        "terok.lib.orchestration.tasks.stop_task_containers",
-                        return_value=[],
-                    ),
+                with unittest.mock.patch(
+                    "terok_executor.AgentRunner.capture_logs",
+                    new=_fake_capture,
                 ):
                     task_delete(project_id, task_id)
 
@@ -1573,15 +1489,9 @@ class TestTaskArchive:
                     result.returncode = 0
                     return result
 
-                with (
-                    unittest.mock.patch(
-                        "terok_executor.AgentRunner.capture_logs",
-                        return_value=True,
-                    ),
-                    unittest.mock.patch(
-                        "terok.lib.orchestration.tasks.stop_task_containers",
-                        return_value=[],
-                    ),
+                with unittest.mock.patch(
+                    "terok_executor.AgentRunner.capture_logs",
+                    return_value=True,
                 ):
                     task_delete(project_id, task_id)
 
@@ -1738,6 +1648,7 @@ class TestTaskDeleteWarnings:
 
     def _delete_with_mocks(
         self,
+        mock_runtime,
         project_id: str = "proj_warn",
         *,
         token_side_effect: BaseException | None = None,
@@ -1748,6 +1659,10 @@ class TestTaskDeleteWarnings:
         """Create a task and delete it with configurable failure injections."""
         if container_results is None:
             container_results = []
+
+        mock_runtime.force_remove.return_value = [
+            self._make_rm_result(**r) for r in container_results
+        ]
 
         with project_env(
             f"project:\n  id: {project_id}\n",
@@ -1760,10 +1675,6 @@ class TestTaskDeleteWarnings:
                     unittest.mock.patch(
                         "terok_executor.AgentRunner.capture_logs",
                         return_value=True,
-                    ),
-                    unittest.mock.patch(
-                        "terok.lib.orchestration.tasks.stop_task_containers",
-                        return_value=[self._make_rm_result(**r) for r in container_results],
                     ),
                 ]
                 if token_side_effect:
@@ -1799,23 +1710,25 @@ class TestTaskDeleteWarnings:
 
                     return task_delete(project_id, task_id)
 
-    def test_clean_delete_returns_empty_warnings(self) -> None:
+    def test_clean_delete_returns_empty_warnings(self, mock_runtime) -> None:
         """Normal deletion returns TaskDeleteResult with no warnings."""
-        result = self._delete_with_mocks(project_id="proj_warn1")
+        result = self._delete_with_mocks(mock_runtime, project_id="proj_warn1")
         assert isinstance(result, TaskDeleteResult)
         assert result.warnings == []
 
-    def test_token_revoke_failure_produces_warning(self) -> None:
+    def test_token_revoke_failure_produces_warning(self, mock_runtime) -> None:
         """Failed token revoke adds a warning but deletion still completes."""
         result = self._delete_with_mocks(
+            mock_runtime,
             project_id="proj_warn2",
             token_side_effect=RuntimeError("auth server down"),
         )
         assert any("Token revoke" in w for w in result.warnings)
 
-    def test_container_rm_failure_produces_warning(self) -> None:
+    def test_container_rm_failure_produces_warning(self, mock_runtime) -> None:
         """Failed container removal adds a warning and keeps port claimed."""
         result = self._delete_with_mocks(
+            mock_runtime,
             project_id="proj_warn3",
             container_results=[
                 {"name": "proj-cli-1", "removed": True},
@@ -1826,25 +1739,28 @@ class TestTaskDeleteWarnings:
         assert not any("proj-cli-1" in w for w in result.warnings)
         assert any("Web port kept claimed" in w for w in result.warnings)
 
-    def test_workspace_rm_failure_produces_warning(self) -> None:
+    def test_workspace_rm_failure_produces_warning(self, mock_runtime) -> None:
         """Failed workspace rmtree adds a warning."""
         result = self._delete_with_mocks(
+            mock_runtime,
             project_id="proj_warn4",
             rmtree_side_effect=PermissionError("busy"),
         )
         assert any("Workspace removal" in w for w in result.warnings)
 
-    def test_metadata_rm_failure_produces_warning(self) -> None:
+    def test_metadata_rm_failure_produces_warning(self, mock_runtime) -> None:
         """Failed metadata unlink adds a warning."""
         result = self._delete_with_mocks(
+            mock_runtime,
             project_id="proj_warn5",
             unlink_side_effect=PermissionError("read-only"),
         )
         assert any("Metadata removal" in w for w in result.warnings)
 
-    def test_multiple_failures_collected(self) -> None:
+    def test_multiple_failures_collected(self, mock_runtime) -> None:
         """Multiple failures from different steps all appear in warnings."""
         result = self._delete_with_mocks(
+            mock_runtime,
             project_id="proj_warn6",
             token_side_effect=RuntimeError("offline"),
             container_results=[

--- a/tests/unit/lib/test_tasks.py
+++ b/tests/unit/lib/test_tasks.py
@@ -49,16 +49,20 @@ from tests.testfs import CONTAINER_SSH_DIR
 from tests.testnet import GATE_PORT
 
 
-def _set_state_sequence(mock_runtime, states: list[str | None]) -> None:
-    """Configure runtime.container(...).state to yield ``states`` across calls.
+def _set_state_sequence(mock_runtime, states: list[str | None]):
+    """Patch ``runtime.container(...).state`` to yield ``states`` across calls.
 
-    Each call to ``container(cname).state`` — an attribute read — pops the next
-    value from ``states``. Used when production code reads state multiple times
-    across a lifecycle transition.
+    Assigning ``PropertyMock`` directly to ``type(container)`` would leak to
+    later tests (the descriptor lives on the shared ``MagicMock`` class), so
+    we go through ``patch.object`` with ``create=True`` — the patch context
+    restores whatever was there (usually nothing) on exit.
     """
-    it = iter(states)
-    type(mock_runtime.container.return_value).state = unittest.mock.PropertyMock(
-        side_effect=lambda: next(it)
+    return unittest.mock.patch.object(
+        type(mock_runtime.container.return_value),
+        "state",
+        new_callable=unittest.mock.PropertyMock,
+        side_effect=iter(states).__next__,
+        create=True,
     )
 
 
@@ -456,7 +460,6 @@ class TestTask:
             clear_env=True,
         ):
             tid = task_new(project_id)
-            _set_state_sequence(mock_runtime, [None, "running"])
             cname = f"{project_id}-cli-{tid}"
             mock_runtime.container.return_value.login_command.return_value = [
                 "podman",
@@ -466,6 +469,7 @@ class TestTask:
                 "bash",
             ]
             with (
+                _set_state_sequence(mock_runtime, [None, "running"]),
                 mock_git_config(),
                 unittest.mock.patch(
                     "terok.lib.orchestration.task_runners._supports_color",
@@ -498,8 +502,10 @@ class TestTask:
             sandbox_live = ctx.base / "sandbox-live"
             workspace_dir = sandbox_live / "tasks" / project_id / tid / "workspace-dangerous"
             assert sorted(p.name for p in workspace_dir.iterdir()) == [".new-task-marker"]
-            _set_state_sequence(mock_runtime, [None, "running"])
-            with mock_git_config():
+            with (
+                _set_state_sequence(mock_runtime, [None, "running"]),
+                mock_git_config(),
+            ):
                 task_run_cli(project_id, tid)
 
             assert sorted(p.name for p in workspace_dir.iterdir()) == [".new-task-marker"]
@@ -616,8 +622,10 @@ class TestTask:
             meta_path.write_text(yaml_dump(meta))
 
             cname = f"{project_id}-cli-{tid}"
-            _set_state_sequence(mock_runtime, ["exited", "running"])
-            with mock_git_config():
+            with (
+                _set_state_sequence(mock_runtime, ["exited", "running"]),
+                mock_git_config(),
+            ):
                 buffer = StringIO()
                 with redirect_stdout(buffer):
                     task_run_cli(project_id, tid)


### PR DESCRIPTION
## Summary

- Adds ``terok.lib.core.runtime.get_runtime()`` — a process-wide ``ContainerRuntime`` accessor with env-driven backend selection (``TEROK_RUNTIME=podman|null``). Unknown values fail fast via ``SystemExit`` so typos aren't silently swallowed.
- Migrates every ``terok_sandbox`` runtime consumer in ``terok`` — images, image_cleanup, project_state, storage, task_logs, container_exec, container_doctor, task_runners, tasks, screens, task_actions, sickbay — to the central accessor, retiring the per-module ``_runtime`` shims and scattered ``from terok_sandbox import get_container_state`` imports.
- Shrinks the ``.importlinter`` ``sandbox-boundary`` ``allowed_importers`` list from 32 to 27 modules: six files (``core.images``, ``domain.project_state``, ``domain.storage``, ``domain.task_logs``, ``orchestration.container_exec``, ``orchestration.image``) drop off, replaced by the single ``terok.lib.core.runtime`` chokepoint.
- Adds an autouse ``mock_runtime`` fixture in ``tests/unit/conftest.py`` and migrates 17 test files to configure it instead of patching removed shims — net diff is -217 lines across the test suite.

## Why this shape

Phase 2 (terok #758) brought the ``ContainerRuntime`` protocol in from sandbox, but every call site still instantiated its own ``PodmanRuntime()``. That shape works but doesn't compose — testing required patching ``PodmanRuntime`` methods globally, or 20 different module-level ``_runtime`` shims. Funnelling construction through one module attribute (``_rt.get_runtime()``) means tests patch a single entry point and every consumer picks up the fake, and it makes the eventual ``TEROK_RUNTIME=null`` dry-run path a one-liner rather than a sweep.

## Test plan

- [x] ``make lint`` / ``make format`` — clean
- [x] ``make tach`` / ``make lint-imports`` — both green; import-linter ``sandbox-boundary`` kept with shrunken allow-list
- [x] ``make docstrings`` (96.7%) / ``make reuse`` / ``make security`` — green
- [x] Full unit suite: 1891 passing, 1 pre-existing env-collision failure (``test_config_command_color_output`` — port 9418, unrelated; reproduces on master)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Centralized runtime accessor with environment-driven initialization for pluggable container backends.

* **Refactor**
  * Replaced many per-module runtime instances and helper shims with the shared runtime accessor for consistent container handling.
  * Tests switched to a global runtime mock fixture for simpler, more reliable unit tests.

* **Chores**
  * Updated module dependency declarations and import-policy configuration to reflect the new runtime boundary.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->