### PR TITLE
fix(tui): invoke renamed `project wizard` subcommand from new-project action

### DIFF
--- a/src/terok/tui/project_actions.py
+++ b/src/terok/tui/project_actions.py
@@ -460,7 +460,7 @@ class ProjectActionsMixin:
             env = {**os.environ, "PYTHONPATH": os.pathsep.join(sys.path)}
             try:
                 result = subprocess.run(
-                    [sys.executable, "-m", "terok.cli.main", "project-wizard"],
+                    [sys.executable, "-m", "terok.cli", "project", "wizard"],
                     check=False,
                     env=env,
                 )


### PR DESCRIPTION
## Summary

The TUI's "New Project" action (`n` keybinding) crashes with:

```
terok: error: argument cmd: invalid choice: 'project-wizard'
       (choose from panic, setup, auth, project, task, ...)
Wizard exited with code 2
```

It still shells out to the pre-#744 flat command `project-wizard`. After the noun-scoped CLI restructure the wizard lives at `project wizard`, so argparse rejects the call.

## Fix

One-line: change the args vector from `["-m", "terok.cli.main", "project-wizard"]` to `["-m", "terok.cli", "project", "wizard"]`.

- Restores the wizard launch.
- Drops the `<frozen runpy>:128: RuntimeWarning: 'terok.cli.main' found in sys.modules ...` warning by invoking the package (`__main__.py` already dispatches to `main()`).
- The `PYTHONPATH=os.pathsep.join(sys.path)` propagation from #717 (the actual Nix-portability fix) is **preserved**.

## Test plan

- [ ] `terok-tui` → press `n` → wizard launches, completes, returns to TUI without the runpy warning

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated internal subprocess invocation for project wizard functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->