### PR TITLE
refactor(tui): show full task ID in task list, drop legacy 4-char slice

### DIFF
--- a/src/terok/tui/widgets/task_list.py
+++ b/src/terok/tui/widgets/task_list.py
@@ -82,7 +82,7 @@ class TaskList(ListView):
         if task.web_port is not None:
             extra_parts.append(f"port={task.web_port}")
 
-        label = f"{task.task_id[:4]} {m_emoji} {s_emoji} {task.name}"
+        label = f"{task.task_id} {m_emoji} {s_emoji} {task.name}"
         if extra_parts:
             label += f" [{'; '.join(extra_parts)}]"
         return label


### PR DESCRIPTION
## Summary

Since #762 task IDs are fixed-width Crockford-4.5 (5 chars), so the `[:4]` slice in the task-list label is now strictly harmful — it truncates the last character of every new ID.

Render the full ID instead. Any lingering pre-#762 tasks will be a touch misaligned for a day or two until they age out; not worth keeping a compat shim around.

## Test plan

- [x] `pytest tests/unit/tui/test_detail_screens.py` — 163 passed
- [ ] `terok-tui` — verify task rows show the full 5-char ID

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed truncation of task IDs in the task list—full identifiers now display correctly for better task identification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->