### PR TITLE
feat(desktop): delegate install/uninstall to xdg-utils when available

### DIFF
--- a/src/terok/cli/commands/_desktop_entry.py
+++ b/src/terok/cli/commands/_desktop_entry.py
@@ -172,7 +172,7 @@ def _run_xdg(binary: str, *args: str) -> None:
         return
     # nosec B603 — argv is our own literal binary path plus subcommand/arg tokens.
     try:
-        subprocess.run(  # noqa: S603  # nosec B603
+        result = subprocess.run(  # noqa: S603  # nosec B603
             [found, *args],
             check=False,
             capture_output=True,
@@ -180,6 +180,20 @@ def _run_xdg(binary: str, *args: str) -> None:
         )
     except (OSError, subprocess.TimeoutExpired) as exc:
         _log.debug("%s %s failed: %s", binary, args, exc)
+        return
+    if result.returncode != 0:
+        # ``check=False`` means we never raise — but an operator chasing
+        # a weird install state needs something to grep for.  Capture
+        # the rc + stderr at DEBUG so ``terok setup`` stays quiet while
+        # ``journalctl --user`` + log-capture wrappers can still surface
+        # the real error.
+        _log.debug(
+            "%s %s exited with %d: %s",
+            binary,
+            args,
+            result.returncode,
+            (result.stderr or b"").decode(errors="replace").strip(),
+        )
 
 
 # ── Manual fallback ───────────────────────────────────────────────────
@@ -267,7 +281,7 @@ def _run_cache_refresh(binary: str, args: list[str | Path]) -> None:
         return
     # nosec B603 — argv is a literal + controlled Path; no shell, no user input.
     try:
-        subprocess.run(  # noqa: S603  # nosec B603
+        result = subprocess.run(  # noqa: S603  # nosec B603
             [found, *[str(a) for a in args]],
             check=False,
             capture_output=True,
@@ -275,3 +289,13 @@ def _run_cache_refresh(binary: str, args: list[str | Path]) -> None:
         )
     except (OSError, subprocess.TimeoutExpired) as exc:
         _log.debug("%s refresh failed: %s", binary, exc)
+        return
+    if result.returncode != 0:
+        # Same DEBUG trail as _run_xdg — ``check=False`` keeps us quiet,
+        # the log makes the failure diagnosable after the fact.
+        _log.debug(
+            "%s exited with %d: %s",
+            binary,
+            result.returncode,
+            (result.stderr or b"").decode(errors="replace").strip(),
+        )

--- a/src/terok/cli/commands/_desktop_entry.py
+++ b/src/terok/cli/commands/_desktop_entry.py
@@ -6,17 +6,27 @@
 ``terok setup`` calls :func:`install_desktop_entry` (or the matching
 :func:`uninstall_desktop_entry`) as a default-on phase, so the TUI
 appears as *Terok* in GNOME / KDE / XFCE application menus without the
-operator knowing the template layout.  The work is three writes +
-two best-effort cache refreshes; every step soft-fails so a headless
-host without a ``.local/share`` or without ``update-desktop-database``
-never kills the wider ``terok setup`` flow.
+operator knowing the template layout.  Every step soft-fails so a
+headless host without ``.local/share`` or without ``xdg-utils`` never
+kills the wider ``terok setup`` flow.
+
+Two backends, picked at install time:
+
+1. **``xdg-utils``** (preferred — ``xdg-desktop-menu install`` +
+   ``xdg-desktop-icon install``).  Standard freedesktop tooling;
+   handles file validation via ``desktop-file-install`` and runs the
+   ``update-desktop-database`` + ``gtk-update-icon-cache`` refreshes
+   itself.  Also the same API we'd hook into from an rpm/deb
+   ``%post`` script later with ``--mode=system``.
+2. **Manual fallback** — direct write to
+   ``$XDG_DATA_HOME/applications`` + icon tree, then invoke the two
+   cache-refresh binaries ourselves.  Used when ``xdg-utils`` isn't
+   installed (minimal container images, some CI runners).
 
 The passive assets (``.desktop`` template, logo PNG) live under
 ``terok/resources/desktop/`` — this module is the *builder* that reads
-them, renders the ``{{BIN}}`` placeholder, and copies the output to
-the operator's XDG tree.  Keeping the builder outside ``resources/``
-matches the rest of the tree: that directory holds only data files
-consumed by code that lives elsewhere.
+them, renders the ``{{BIN}}`` placeholder, stages them to a tempdir,
+and delegates to the XDG tool of choice.
 """
 
 from __future__ import annotations
@@ -25,6 +35,7 @@ import logging
 import os
 import shutil
 import subprocess  # nosec B404 — cache refresh binaries are trusted
+import tempfile
 from importlib import resources as importlib_resources
 from importlib.resources.abc import Traversable
 from pathlib import Path
@@ -37,7 +48,7 @@ APP_NAME = "terok"
 
 _DESKTOP_FILE = f"{APP_NAME}.desktop"
 _ICON_FILE = f"{APP_NAME}.png"
-_ICON_SIZE_DIR = "256x256"  # fixed size; logo is 283x283, close enough for display
+_ICON_SIZE = "256"  # logo is 283x283, close enough for the 256x256 bucket
 _TEMPLATE_NAME = "terok.desktop.template"
 _LOGO_NAME = "terok-logo.png"
 
@@ -49,7 +60,13 @@ _APPLICATIONS_SUBDIR = "applications"
 _ICONS_SUBDIR = "icons"
 _HICOLOR_THEME = "hicolor"
 _APPS_SUBDIR = "apps"
+_ICON_SIZE_DIR = f"{_ICON_SIZE}x{_ICON_SIZE}"
 _DEFAULT_DATA_HOME = (".local", "share")  # $HOME/.local/share — XDG fallback
+
+_XDG_MENU_BINARY = "xdg-desktop-menu"
+_XDG_ICON_BINARY = "xdg-desktop-icon"
+
+_SUBPROCESS_TIMEOUT_S = 10
 
 
 def _resource_dir() -> Traversable:
@@ -65,7 +82,7 @@ def _resource_dir() -> Traversable:
 
 
 def install_desktop_entry(bin_path: str | Path) -> None:
-    """Write ``terok.desktop``, copy the logo into the icon theme, refresh caches.
+    """Render the launcher + copy the icon, via xdg-utils when available.
 
     Args:
         bin_path: Absolute path (or bare name) to ``terok-tui``.  The
@@ -77,32 +94,122 @@ def install_desktop_entry(bin_path: str | Path) -> None:
     rendered = (
         _load_template().replace("{{BIN}}", str(bin_path)).replace("{{TRY_EXEC}}", str(bin_path))
     )
+    logo_bytes = _resource_dir().joinpath(_LOGO_NAME).read_bytes()
+    if _xdg_utils_available():
+        _install_via_xdg_utils(rendered, logo_bytes)
+    else:
+        _install_manually(rendered, logo_bytes)
+
+
+def uninstall_desktop_entry() -> None:
+    """Remove the launcher + icon, via xdg-utils when available."""
+    if _xdg_utils_available():
+        _uninstall_via_xdg_utils()
+    else:
+        _uninstall_manually()
+
+
+def is_desktop_entry_installed() -> bool:
+    """Return True when both the ``.desktop`` and icon files exist on disk.
+
+    Probes the install tree directly rather than asking xdg-utils — both
+    backends land the same files in the same XDG-spec locations, so the
+    presence check is backend-agnostic.
+    """
+    return _desktop_entry_path().is_file() and _icon_path().is_file()
+
+
+# ── xdg-utils backend ─────────────────────────────────────────────────
+
+
+def _xdg_utils_available() -> bool:
+    """Return True only when *both* xdg-utils front-ends are on PATH."""
+    return bool(shutil.which(_XDG_MENU_BINARY) and shutil.which(_XDG_ICON_BINARY))
+
+
+def _install_via_xdg_utils(desktop_contents: str, logo_bytes: bytes) -> None:
+    """Stage the rendered files and delegate install + cache refresh to xdg-utils.
+
+    ``xdg-desktop-menu install`` runs ``desktop-file-install`` (catches
+    malformed keys), drops the file under the user's applications dir,
+    and kicks ``update-desktop-database``.  ``xdg-desktop-icon install``
+    does the equivalent for the hicolor tree including
+    ``gtk-update-icon-cache``.  Both are name-by-filename — we stage to
+    a tempdir so the basenames carry the destination names we want.
+    """
+    with tempfile.TemporaryDirectory(prefix="terok-desktop-") as td:
+        staged_dir = Path(td)
+        staged_desktop = staged_dir / _DESKTOP_FILE
+        staged_icon = staged_dir / _ICON_FILE
+        staged_desktop.write_text(desktop_contents, encoding="utf-8")
+        staged_icon.write_bytes(logo_bytes)
+        _run_xdg(
+            _XDG_MENU_BINARY,
+            "install",
+            "--novendor",
+            str(staged_desktop),
+        )
+        _run_xdg(
+            _XDG_ICON_BINARY,
+            "install",
+            "--novendor",
+            "--size",
+            _ICON_SIZE,
+            str(staged_icon),
+        )
+
+
+def _uninstall_via_xdg_utils() -> None:
+    """Delegate removal + cache refresh to xdg-utils."""
+    _run_xdg(_XDG_MENU_BINARY, "uninstall", "--novendor", _DESKTOP_FILE)
+    _run_xdg(_XDG_ICON_BINARY, "uninstall", "--novendor", "--size", _ICON_SIZE, _ICON_FILE)
+
+
+def _run_xdg(binary: str, *args: str) -> None:
+    """Invoke an xdg-utils front-end, swallow failures — install is best-effort."""
+    found = shutil.which(binary)
+    if not found:  # pragma: no cover — gated by _xdg_utils_available
+        return
+    # nosec B603 — argv is our own literal binary path plus subcommand/arg tokens.
+    try:
+        subprocess.run(  # noqa: S603  # nosec B603
+            [found, *args],
+            check=False,
+            capture_output=True,
+            timeout=_SUBPROCESS_TIMEOUT_S,
+        )
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        _log.debug("%s %s failed: %s", binary, args, exc)
+
+
+# ── Manual fallback ───────────────────────────────────────────────────
+
+
+def _install_manually(desktop_contents: str, logo_bytes: bytes) -> None:
+    """Write the launcher + icon directly and trigger cache refreshes by hand."""
     desktop_path = _desktop_entry_path()
     desktop_path.parent.mkdir(parents=True, exist_ok=True)
-    desktop_path.write_text(rendered, encoding="utf-8")
+    desktop_path.write_text(desktop_contents, encoding="utf-8")
     desktop_path.chmod(0o644)
 
-    _install_icon()
+    icon_path = _icon_path()
+    icon_path.parent.mkdir(parents=True, exist_ok=True)
+    icon_path.write_bytes(logo_bytes)
+    icon_path.chmod(0o644)
+
     _refresh_desktop_database()
     _refresh_icon_cache()
 
 
-def uninstall_desktop_entry() -> None:
-    """Remove the ``.desktop`` file and icon; refresh caches so menus forget."""
-    desktop_path = _desktop_entry_path()
-    icon_path = _icon_path()
-    for path in (desktop_path, icon_path):
+def _uninstall_manually() -> None:
+    """Unlink the launcher + icon and refresh caches so menus forget."""
+    for path in (_desktop_entry_path(), _icon_path()):
         try:
             path.unlink(missing_ok=True)
         except OSError as exc:
             _log.warning("failed to unlink %s: %s", path, exc)
     _refresh_desktop_database()
     _refresh_icon_cache()
-
-
-def is_desktop_entry_installed() -> bool:
-    """Return True when both the ``.desktop`` and icon files exist on disk."""
-    return _desktop_entry_path().is_file() and _icon_path().is_file()
 
 
 # ── Path derivation ───────────────────────────────────────────────────
@@ -126,7 +233,7 @@ def _data_home() -> Path:
     return Path(override) if override else Path.home().joinpath(*_DEFAULT_DATA_HOME)
 
 
-# ── Template + icon source loading ────────────────────────────────────
+# ── Template loading ──────────────────────────────────────────────────
 
 
 def _load_template() -> str:
@@ -134,15 +241,7 @@ def _load_template() -> str:
     return _resource_dir().joinpath(_TEMPLATE_NAME).read_text(encoding="utf-8")
 
 
-def _install_icon() -> None:
-    """Copy the bundled logo into the hicolor icon theme tree."""
-    dest = _icon_path()
-    dest.parent.mkdir(parents=True, exist_ok=True)
-    dest.write_bytes(_resource_dir().joinpath(_LOGO_NAME).read_bytes())
-    dest.chmod(0o644)
-
-
-# ── Cache refresh (best-effort) ───────────────────────────────────────
+# ── Manual cache refresh (fallback backend only) ──────────────────────
 
 
 def _refresh_desktop_database() -> None:
@@ -172,7 +271,7 @@ def _run_cache_refresh(binary: str, args: list[str | Path]) -> None:
             [found, *[str(a) for a in args]],
             check=False,
             capture_output=True,
-            timeout=10,
+            timeout=_SUBPROCESS_TIMEOUT_S,
         )
     except (OSError, subprocess.TimeoutExpired) as exc:
         _log.debug("%s refresh failed: %s", binary, exc)

--- a/tests/unit/cli/test_desktop_entry.py
+++ b/tests/unit/cli/test_desktop_entry.py
@@ -147,6 +147,32 @@ class TestInstallViaXdgUtils:
         ):
             desktop.install_desktop_entry("terok-tui")  # must not raise
 
+    def test_non_zero_xdg_exit_is_logged(
+        self,
+        xdg_data_home: Path,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """A non-zero xdg-utils exit lands in the DEBUG log with stderr + rc."""
+        import logging
+
+        caplog.set_level(logging.DEBUG, logger="terok.cli.commands._desktop_entry")
+        failing = subprocess.CompletedProcess(
+            args=[],
+            returncode=3,
+            stdout=b"",
+            stderr=b"xdg-desktop-menu: no writable system menu directory found",
+        )
+        with (
+            mock.patch(
+                "terok.cli.commands._desktop_entry.shutil.which",
+                side_effect=_which_everything,
+            ),
+            mock.patch("terok.cli.commands._desktop_entry.subprocess.run", return_value=failing),
+        ):
+            desktop.install_desktop_entry("terok-tui")
+        assert "exited with 3" in caplog.text
+        assert "no writable system menu directory" in caplog.text
+
 
 # ── Manual fallback (no xdg-utils) ────────────────────────────────────
 
@@ -222,6 +248,32 @@ class TestInstallManualFallback:
             ),
         ):
             desktop.install_desktop_entry("terok-tui")  # must not raise
+
+    def test_non_zero_cache_refresh_exit_is_logged(
+        self,
+        xdg_data_home: Path,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """A non-zero ``update-desktop-database`` / ``gtk-update-icon-cache`` exit is DEBUG-logged."""
+        import logging
+
+        caplog.set_level(logging.DEBUG, logger="terok.cli.commands._desktop_entry")
+        failing = subprocess.CompletedProcess(
+            args=[],
+            returncode=1,
+            stdout=b"",
+            stderr=b"gtk-update-icon-cache: Cache file is up to date",
+        )
+        with (
+            mock.patch(
+                "terok.cli.commands._desktop_entry.shutil.which",
+                side_effect=_which_no_xdg_utils,
+            ),
+            mock.patch("terok.cli.commands._desktop_entry.subprocess.run", return_value=failing),
+        ):
+            desktop.install_desktop_entry("terok-tui")
+        assert "exited with 1" in caplog.text
+        assert "Cache file is up to date" in caplog.text
 
 
 class TestUninstallDesktopEntry:

--- a/tests/unit/cli/test_desktop_entry.py
+++ b/tests/unit/cli/test_desktop_entry.py
@@ -21,23 +21,156 @@ def xdg_data_home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
     return tmp_path
 
 
-class TestInstallDesktopEntry:
-    """``install_desktop_entry`` writes the launcher + icon + refreshes caches."""
+# ── which-mock side effects — pick which install backend is "available" ──
+
+
+def _which_no_xdg_utils(name: str) -> str | None:
+    """``shutil.which`` side-effect: xdg-utils missing, manual cache bins present."""
+    if name in ("xdg-desktop-menu", "xdg-desktop-icon"):
+        return None
+    return f"/usr/bin/{name}"
+
+
+def _which_nothing(name: str) -> str | None:
+    """``shutil.which`` side-effect: nothing on PATH at all."""
+    return None
+
+
+def _which_everything(name: str) -> str:
+    """``shutil.which`` side-effect: every probed binary reports present."""
+    return f"/usr/bin/{name}"
+
+
+# ── xdg-utils backend (preferred) ─────────────────────────────────────
+
+
+class TestInstallViaXdgUtils:
+    """When xdg-utils is on PATH, delegate install + cache refresh to it."""
+
+    def test_invokes_xdg_desktop_menu_and_icon(self, xdg_data_home: Path) -> None:
+        """Install shells out to both xdg-utils front-ends, not manual cache bins."""
+        calls: list[list[str]] = []
+
+        def record(argv: list[str], *_a, **_kw):
+            calls.append(argv)
+            return subprocess.CompletedProcess(args=[], returncode=0, stdout=b"", stderr=b"")
+
+        with (
+            mock.patch(
+                "terok.cli.commands._desktop_entry.shutil.which",
+                side_effect=_which_everything,
+            ),
+            mock.patch("terok.cli.commands._desktop_entry.subprocess.run", side_effect=record),
+        ):
+            desktop.install_desktop_entry("/opt/venv/bin/terok-tui")
+
+        binaries = [argv[0].split("/")[-1] for argv in calls]
+        # xdg-utils exclusively — the manual update-desktop-database /
+        # gtk-update-icon-cache fallbacks must not fire.
+        assert "xdg-desktop-menu" in binaries
+        assert "xdg-desktop-icon" in binaries
+        assert "update-desktop-database" not in binaries
+        assert "gtk-update-icon-cache" not in binaries
+
+    def test_stages_files_with_target_basenames(self, xdg_data_home: Path) -> None:
+        """Staged paths handed to xdg-utils use the final ``terok.desktop`` / ``terok.png`` names.
+
+        xdg-utils names the installed resource after the source basename,
+        so staging to ``/tmp/.../terok-logo.png`` would register the
+        icon as ``terok-logo`` and the ``Icon=terok`` key would miss.
+        """
+        calls: list[list[str]] = []
+
+        with (
+            mock.patch(
+                "terok.cli.commands._desktop_entry.shutil.which",
+                side_effect=_which_everything,
+            ),
+            mock.patch(
+                "terok.cli.commands._desktop_entry.subprocess.run",
+                side_effect=lambda argv, *a, **kw: (
+                    calls.append(argv)
+                    or subprocess.CompletedProcess(args=argv, returncode=0, stdout=b"", stderr=b"")
+                ),
+            ),
+        ):
+            desktop.install_desktop_entry("terok-tui")
+
+        desktop_call = next(argv for argv in calls if argv[0].endswith("xdg-desktop-menu"))
+        icon_call = next(argv for argv in calls if argv[0].endswith("xdg-desktop-icon"))
+        assert Path(desktop_call[-1]).name == "terok.desktop"
+        assert Path(icon_call[-1]).name == "terok.png"
+        # The ``--novendor`` flag is mandatory for ``.desktop`` files not
+        # named ``{vendor}-{appname}.desktop``; xdg-utils would otherwise
+        # refuse the install.
+        assert "--novendor" in desktop_call
+        assert "--novendor" in icon_call
+        # Icon size is explicit so xdg-utils drops us into the
+        # ``hicolor/256x256/apps/`` bucket rather than guessing.
+        assert "--size" in icon_call
+        assert icon_call[icon_call.index("--size") + 1] == "256"
+
+    def test_uninstall_delegates_to_xdg_utils(self) -> None:
+        """``uninstall`` invokes the matching xdg-utils ``uninstall`` subcommands."""
+        calls: list[list[str]] = []
+
+        with (
+            mock.patch(
+                "terok.cli.commands._desktop_entry.shutil.which",
+                side_effect=_which_everything,
+            ),
+            mock.patch(
+                "terok.cli.commands._desktop_entry.subprocess.run",
+                side_effect=lambda argv, *a, **kw: (
+                    calls.append(argv)
+                    or subprocess.CompletedProcess(args=argv, returncode=0, stdout=b"", stderr=b"")
+                ),
+            ),
+        ):
+            desktop.uninstall_desktop_entry()
+
+        verbs = [(argv[0].split("/")[-1], argv[1]) for argv in calls]
+        assert ("xdg-desktop-menu", "uninstall") in verbs
+        assert ("xdg-desktop-icon", "uninstall") in verbs
+
+    def test_xdg_subprocess_failure_is_swallowed(self, xdg_data_home: Path) -> None:
+        """A hung / broken xdg-utils front-end must not raise."""
+        with (
+            mock.patch(
+                "terok.cli.commands._desktop_entry.shutil.which",
+                side_effect=_which_everything,
+            ),
+            mock.patch(
+                "terok.cli.commands._desktop_entry.subprocess.run",
+                side_effect=OSError("exec format error"),
+            ),
+        ):
+            desktop.install_desktop_entry("terok-tui")  # must not raise
+
+
+# ── Manual fallback (no xdg-utils) ────────────────────────────────────
+
+
+class TestInstallManualFallback:
+    """Without xdg-utils, write the XDG tree directly + call cache bins by hand."""
 
     def test_writes_desktop_file_with_templated_bin(self, xdg_data_home: Path) -> None:
         """``{{BIN}}`` / ``{{TRY_EXEC}}`` land as the resolved binary path."""
-        with mock.patch("terok.cli.commands._desktop_entry.shutil.which", return_value=None):
+        with mock.patch(
+            "terok.cli.commands._desktop_entry.shutil.which", side_effect=_which_nothing
+        ):
             desktop.install_desktop_entry("/usr/local/bin/terok-tui")
         content = (xdg_data_home / "applications" / "terok.desktop").read_text()
         assert "Exec=/usr/local/bin/terok-tui" in content
         assert "TryExec=/usr/local/bin/terok-tui" in content
-        # Sanity: the rest of the template carried through verbatim.
         assert "Icon=terok" in content
         assert "Terminal=true" in content
 
     def test_writes_icon_into_hicolor_tree(self, xdg_data_home: Path) -> None:
         """The bundled PNG ends up under hicolor/256x256/apps/terok.png."""
-        with mock.patch("terok.cli.commands._desktop_entry.shutil.which", return_value=None):
+        with mock.patch(
+            "terok.cli.commands._desktop_entry.shutil.which", side_effect=_which_nothing
+        ):
             desktop.install_desktop_entry("terok-tui")
         icon = xdg_data_home / "icons" / "hicolor" / "256x256" / "apps" / "terok.png"
         assert icon.is_file()
@@ -45,30 +178,32 @@ class TestInstallDesktopEntry:
         assert icon.read_bytes().startswith(b"\x89PNG\r\n\x1a\n")
 
     def test_runs_cache_refresh_binaries_when_present(self, xdg_data_home: Path) -> None:
-        """``update-desktop-database`` + ``gtk-update-icon-cache`` are invoked when on PATH."""
+        """Manual path invokes ``update-desktop-database`` + ``gtk-update-icon-cache``."""
         fake_proc = subprocess.CompletedProcess(args=[], returncode=0, stdout=b"", stderr=b"")
         calls: list[list[str]] = []
-
-        def record(argv: list[str], *_a, **_kw):
-            calls.append(argv)
-            return fake_proc
 
         with (
             mock.patch(
                 "terok.cli.commands._desktop_entry.shutil.which",
-                side_effect=lambda name: f"/usr/bin/{name}",
+                side_effect=_which_no_xdg_utils,
             ),
-            mock.patch("terok.cli.commands._desktop_entry.subprocess.run", side_effect=record),
+            mock.patch(
+                "terok.cli.commands._desktop_entry.subprocess.run",
+                side_effect=lambda argv, *a, **kw: calls.append(argv) or fake_proc,
+            ),
         ):
             desktop.install_desktop_entry("terok-tui")
+
         binaries = [argv[0].split("/")[-1] for argv in calls]
         assert "update-desktop-database" in binaries
         assert "gtk-update-icon-cache" in binaries
 
     def test_cache_refresh_skipped_when_binaries_missing(self, xdg_data_home: Path) -> None:
-        """No ``update-desktop-database`` / ``gtk-update-icon-cache`` on PATH → silent skip."""
+        """Nothing on PATH at all → no subprocess fired, install still succeeds."""
         with (
-            mock.patch("terok.cli.commands._desktop_entry.shutil.which", return_value=None),
+            mock.patch(
+                "terok.cli.commands._desktop_entry.shutil.which", side_effect=_which_nothing
+            ),
             mock.patch("terok.cli.commands._desktop_entry.subprocess.run") as run,
         ):
             desktop.install_desktop_entry("terok-tui")
@@ -79,7 +214,7 @@ class TestInstallDesktopEntry:
         with (
             mock.patch(
                 "terok.cli.commands._desktop_entry.shutil.which",
-                side_effect=lambda name: f"/usr/bin/{name}",
+                side_effect=_which_no_xdg_utils,
             ),
             mock.patch(
                 "terok.cli.commands._desktop_entry.subprocess.run",
@@ -93,7 +228,9 @@ class TestUninstallDesktopEntry:
     """``uninstall_desktop_entry`` removes both files + refreshes caches."""
 
     def test_unlinks_desktop_file_and_icon(self, xdg_data_home: Path) -> None:
-        with mock.patch("terok.cli.commands._desktop_entry.shutil.which", return_value=None):
+        with mock.patch(
+            "terok.cli.commands._desktop_entry.shutil.which", side_effect=_which_nothing
+        ):
             desktop.install_desktop_entry("terok-tui")
             assert desktop.is_desktop_entry_installed()
             desktop.uninstall_desktop_entry()
@@ -101,7 +238,9 @@ class TestUninstallDesktopEntry:
 
     def test_uninstall_when_not_installed_is_noop(self, xdg_data_home: Path) -> None:
         """Running the teardown on a clean host doesn't raise."""
-        with mock.patch("terok.cli.commands._desktop_entry.shutil.which", return_value=None):
+        with mock.patch(
+            "terok.cli.commands._desktop_entry.shutil.which", side_effect=_which_nothing
+        ):
             desktop.uninstall_desktop_entry()
         assert not desktop.is_desktop_entry_installed()
 
@@ -118,6 +257,28 @@ class TestIsDesktopEntryInstalled:
         assert desktop.is_desktop_entry_installed() is False
 
     def test_returns_true_when_both_present(self, xdg_data_home: Path) -> None:
-        with mock.patch("terok.cli.commands._desktop_entry.shutil.which", return_value=None):
+        with mock.patch(
+            "terok.cli.commands._desktop_entry.shutil.which", side_effect=_which_nothing
+        ):
             desktop.install_desktop_entry("terok-tui")
         assert desktop.is_desktop_entry_installed() is True
+
+
+class TestBackendSelection:
+    """``_xdg_utils_available`` gates the whole strategy."""
+
+    def test_both_binaries_required(self) -> None:
+        """Half-installed xdg-utils (one of the two missing) → manual fallback."""
+
+        def only_menu(name: str) -> str | None:
+            return "/usr/bin/xdg-desktop-menu" if name == "xdg-desktop-menu" else None
+
+        with mock.patch("terok.cli.commands._desktop_entry.shutil.which", side_effect=only_menu):
+            assert desktop._xdg_utils_available() is False
+
+    def test_returns_true_when_both_on_path(self) -> None:
+        """Full xdg-utils → backend switches to the delegated install."""
+        with mock.patch(
+            "terok.cli.commands._desktop_entry.shutil.which", side_effect=_which_everything
+        ):
+            assert desktop._xdg_utils_available() is True


### PR DESCRIPTION
## Summary

\`terok setup\` used to write the \`.desktop\` file and PNG directly
under \`\$XDG_DATA_HOME\` and then invoke
\`update-desktop-database\` + \`gtk-update-icon-cache\` to refresh the
caches.  Now prefer the freedesktop \`xdg-utils\` front-ends when
they're on PATH:

- \`xdg-desktop-menu install --novendor terok.desktop\` — also runs
  \`desktop-file-install\` for validation and kicks
  \`update-desktop-database\` automatically.
- \`xdg-desktop-icon install --novendor --size 256 terok.png\` — the
  same story for the hicolor icon tree.

Both name-by-basename, so rendered files are staged to a tempdir with
the target basenames (\`tempfile.TemporaryDirectory\` for cleanup).

Manual fallback (direct write + hand-rolled cache refresh) stays
intact for hosts without \`xdg-utils\` (minimal CI images, some
older BSDs).  \`_xdg_utils_available()\` requires *both*
\`xdg-desktop-menu\` *and* \`xdg-desktop-icon\` before flipping to
the delegated backend.

**Bridge to future distro packaging:** the same CLI accepts
\`--mode=system\` for root-owned installs under \`/usr/share/\`.
When we later build rpm/deb, the \`%post\` script calls the same
functions — zero rewrite.

## Test plan
- [x] \`make check\` green (lint, 1966 unit tests, tach, docstrings,
      reuse, bandit; pre-existing port-9418
      \`test_config_command_color_output\` flake unchanged).
- [x] New coverage: xdg-utils backend invoked exclusively when both
      binaries present; staged basenames match \`terok.desktop\` /
      \`terok.png\`; \`--novendor\` + \`--size 256\` flags threaded
      through; uninstall delegates to matching subcommands;
      subprocess failures swallowed; half-installed xdg-utils falls
      through to the manual backend; the manual backend still covers
      every scenario it used to.
- [ ] Integration smoke on a GNOME host with \`xdg-utils\` installed
      and on a minimal Alpine/BusyBox environment without it (handled
      on the user's test machine).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added ability to uninstall desktop application entries
  * Added a way to check whether a desktop entry is installed

* **Improvements**
  * Installation/uninstallation now selects the appropriate backend (system utilities or direct filesystem) automatically
  * More robust timeout and error handling with quieter failures and improved debug logging during cache refreshes
<!-- end of auto-generated comment: release notes by coderabbit.ai -->