### PR TITLE
feat(project): expose run.timezone in project.yml

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -968,6 +968,25 @@ terok config import-opencode /path/to/opencode.json
 
 ---
 
+## Container Timezone
+
+Task containers follow the host's timezone by default — no configuration
+needed. Override per-project when you need a fixed zone (for example, to
+pin CI to UTC regardless of where the runner lives):
+
+```yaml
+run:
+  timezone: UTC            # or Europe/Prague, America/Los_Angeles, …
+```
+
+The value is any IANA zone name; it is resolved inside the container
+against the image's `tzdata`. Omitting `run.timezone` (or setting it to
+an empty value) falls back to host-follow — terok reads the host's
+`$TZ`, then `/etc/timezone`, then the `/etc/localtime` symlink — and
+leaves `TZ` unset if none of those resolve.
+
+---
+
 ## GPU Passthrough
 
 GPU passthrough is a per-project opt-in feature (disabled by default).

--- a/poetry.lock
+++ b/poetry.lock
@@ -3082,20 +3082,21 @@ description = "Single-agent task runner for hardened Podman containers"
 optional = false
 python-versions = ">=3.12,<4.0"
 groups = ["main"]
-files = [
-    {file = "terok_executor-0.0.100-py3-none-any.whl", hash = "sha256:3244c4c71034da5a42e643f50a2ee22522f8795c204c620a2f62825e89b6accb"},
-]
+files = []
+develop = false
 
 [package.dependencies]
 Jinja2 = ">=3.1"
 pwinput = ">=1.0.3"
 "ruamel.yaml" = ">=0.18"
-terok_sandbox = {url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.0.83/terok_sandbox-0.0.83-py3-none-any.whl"}
+terok-sandbox = {url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.0.83/terok_sandbox-0.0.83-py3-none-any.whl"}
 tomli-w = ">=1.0"
 
 [package.source]
-type = "url"
-url = "https://github.com/terok-ai/terok-executor/releases/download/v0.0.100/terok_executor-0.0.100-py3-none-any.whl"
+type = "git"
+url = "https://github.com/sliwowitz/terok-executor.git"
+reference = "feat/container-timezone"
+resolved_reference = "82fc463415247bfae8fb9a2810355a27fe773624"
 
 [[package]]
 name = "terok-sandbox"
@@ -3624,4 +3625,4 @@ propcache = ">=0.2.1"
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.12,<4.0"
-content-hash = "406e09abc3154d42542c253bfdc046237ad49d65a629cd774342854e9a3864d2"
+content-hash = "82b7d919194b5168d6c50cfec1f34378c5e17263af09ca027416f92fd956b6cd"

--- a/poetry.lock
+++ b/poetry.lock
@@ -3058,76 +3058,74 @@ tomli-w = ">=1.0,<2.0"
 
 [[package]]
 name = "terok-dbus"
-version = "0.5.9"
+version = "0.5.10"
 description = "D-Bus desktop notification package for terok"
 optional = false
 python-versions = ">=3.12,<4.0"
 groups = ["main"]
-files = []
-develop = false
+files = [
+    {file = "terok_dbus-0.5.10-py3-none-any.whl", hash = "sha256:1c855fa75dbb41fbc4c4df90e11d4ae266d5a0622677d7f375f1c0f906de52a5"},
+]
 
 [package.dependencies]
 dbus-fast = ">=2.0,<5.0"
 
 [package.source]
-type = "git"
-url = "https://github.com/sliwowitz/terok-dbus.git"
-reference = "feat/container-name-in-notifications"
-resolved_reference = "7efc4298439d13fd8605f1b0045d76b2d678b0b7"
+type = "url"
+url = "https://github.com/terok-ai/terok-dbus/releases/download/v0.5.10/terok_dbus-0.5.10-py3-none-any.whl"
 
 [[package]]
 name = "terok-executor"
-version = "0.0.100"
+version = "0.0.102"
 description = "Single-agent task runner for hardened Podman containers"
 optional = false
 python-versions = ">=3.12,<4.0"
 groups = ["main"]
-files = []
-develop = false
+files = [
+    {file = "terok_executor-0.0.102-py3-none-any.whl", hash = "sha256:fbf5a3729c2c1b09268805ba4a330a5145268959e5949365135397234a43bfe8"},
+]
 
 [package.dependencies]
 Jinja2 = ">=3.1"
 pwinput = ">=1.0.3"
 "ruamel.yaml" = ">=0.18"
-terok-sandbox = {url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.0.83/terok_sandbox-0.0.83-py3-none-any.whl"}
+terok_sandbox = {url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.0.84/terok_sandbox-0.0.84-py3-none-any.whl"}
 tomli-w = ">=1.0"
 
 [package.source]
-type = "git"
-url = "https://github.com/sliwowitz/terok-executor.git"
-reference = "feat/container-timezone"
-resolved_reference = "82fc463415247bfae8fb9a2810355a27fe773624"
+type = "url"
+url = "https://github.com/terok-ai/terok-executor/releases/download/v0.0.102/terok_executor-0.0.102-py3-none-any.whl"
 
 [[package]]
 name = "terok-sandbox"
-version = "0.0.83"
+version = "0.0.84"
 description = "Hardened Podman container runner with gate server and shield integration"
 optional = false
 python-versions = ">=3.12,<4.0"
 groups = ["main"]
 files = [
-    {file = "terok_sandbox-0.0.83-py3-none-any.whl", hash = "sha256:b234f47ee9d6eba7e0c85b397e7f5b9950ed5368070791853d07bdea4b8fbca6"},
+    {file = "terok_sandbox-0.0.84-py3-none-any.whl", hash = "sha256:bf70a78f3d1017959c0a2a6f3823af4f992a5a178d78e519a0c9abf7759ab5cf"},
 ]
 
 [package.dependencies]
 aiohttp = ">=3.9"
 cryptography = ">=46.0.7"
 platformdirs = ">=4.9.6"
-terok_shield = {url = "https://github.com/terok-ai/terok-shield/releases/download/v0.6.23/terok_shield-0.6.23-py3-none-any.whl"}
+terok_shield = {url = "https://github.com/terok-ai/terok-shield/releases/download/v0.6.24/terok_shield-0.6.24-py3-none-any.whl"}
 
 [package.source]
 type = "url"
-url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.0.83/terok_sandbox-0.0.83-py3-none-any.whl"
+url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.0.84/terok_sandbox-0.0.84-py3-none-any.whl"
 
 [[package]]
 name = "terok-shield"
-version = "0.6.23"
+version = "0.6.24"
 description = "nftables-based egress firewalling for Podman containers"
 optional = false
 python-versions = ">=3.12,<4.0"
 groups = ["main"]
 files = [
-    {file = "terok_shield-0.6.23-py3-none-any.whl", hash = "sha256:16b95da7105296f0f64bd678c9d0fd42f02242841f092c800a8f9f0488bcb39d"},
+    {file = "terok_shield-0.6.24-py3-none-any.whl", hash = "sha256:0935dd8651cd1b30ddaf7e84bc738559993cb26d981bee90c5ea2bd056f2eff3"},
 ]
 
 [package.dependencies]
@@ -3136,7 +3134,7 @@ PyYAML = ">=6.0"
 
 [package.source]
 type = "url"
-url = "https://github.com/terok-ai/terok-shield/releases/download/v0.6.23/terok_shield-0.6.23-py3-none-any.whl"
+url = "https://github.com/terok-ai/terok-shield/releases/download/v0.6.24/terok_shield-0.6.24-py3-none-any.whl"
 
 [[package]]
 name = "textual"
@@ -3625,4 +3623,4 @@ propcache = ">=0.2.1"
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.12,<4.0"
-content-hash = "82b7d919194b5168d6c50cfec1f34378c5e17263af09ca027416f92fd956b6cd"
+content-hash = "cc863af094cce06d5fc989abbebd65e81dd4bbbbeef4cfb62965d88bc0c2e659"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,7 @@ unique-namer = ">=1.3"
 textual-serve = ">=1.1.0"
 # DEV-TIME BRANCH PINS — feat/dbus-clearance-bridge chain across all four siblings.
 # The release script replaces these with release-URL pins before cutting.
-terok-executor = {url = "https://github.com/terok-ai/terok-executor/releases/download/v0.0.100/terok_executor-0.0.100-py3-none-any.whl"}
+terok-executor = {git = "https://github.com/sliwowitz/terok-executor.git", branch = "feat/container-timezone"}
 terok-sandbox = {url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.0.83/terok_sandbox-0.0.83-py3-none-any.whl"}
 terok-shield = {url = "https://github.com/terok-ai/terok-shield/releases/download/v0.6.23/terok_shield-0.6.23-py3-none-any.whl"}
 terok-dbus = {git = "https://github.com/sliwowitz/terok-dbus.git", branch = "feat/container-name-in-notifications"}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,10 +46,10 @@ unique-namer = ">=1.3"
 textual-serve = ">=1.1.0"
 # DEV-TIME BRANCH PINS — feat/dbus-clearance-bridge chain across all four siblings.
 # The release script replaces these with release-URL pins before cutting.
-terok-executor = {git = "https://github.com/sliwowitz/terok-executor.git", branch = "feat/container-timezone"}
-terok-sandbox = {url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.0.83/terok_sandbox-0.0.83-py3-none-any.whl"}
-terok-shield = {url = "https://github.com/terok-ai/terok-shield/releases/download/v0.6.23/terok_shield-0.6.23-py3-none-any.whl"}
-terok-dbus = {git = "https://github.com/sliwowitz/terok-dbus.git", branch = "feat/container-name-in-notifications"}
+terok-executor = {url = "https://github.com/terok-ai/terok-executor/releases/download/v0.0.102/terok_executor-0.0.102-py3-none-any.whl"}
+terok-sandbox = {url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.0.84/terok_sandbox-0.0.84-py3-none-any.whl"}
+terok-shield = {url = "https://github.com/terok-ai/terok-shield/releases/download/v0.6.24/terok_shield-0.6.24-py3-none-any.whl"}
+terok-dbus = {url = "https://github.com/terok-ai/terok-dbus/releases/download/v0.5.10/terok_dbus-0.5.10-py3-none-any.whl"}
 
 [tool.poetry.group.dev.dependencies]
 pydevd-pycharm = "261.23567.80"

--- a/src/terok/lib/core/project_model.py
+++ b/src/terok/lib/core/project_model.py
@@ -61,6 +61,13 @@ class ProjectConfig(BaseModel):
     """Podman ``--cpus`` limit from ``run.cpus`` in project.yml."""
     nested_containers: bool = False
     """Project runs podman/docker inside its container (see ``run.nested_containers``)."""
+    timezone: str | None = None
+    """IANA timezone for task containers (from ``run.timezone``).
+
+    ``None`` lets terok-executor fall back to the host's timezone; pass an
+    explicit string (``"UTC"``, ``"Europe/Prague"``) to override — including
+    to pin containers to UTC for reproducible runs.
+    """
     task_name_categories: list[str] | None = None
     shield_drop_on_task_run: bool = True
     shield_on_task_restart: str = "retain"

--- a/src/terok/lib/core/projects.py
+++ b/src/terok/lib/core/projects.py
@@ -194,6 +194,7 @@ def _build_project_config(
         memory_limit=raw.run.memory,
         cpu_limit=raw.run.cpus,
         nested_containers=raw.run.nested_containers,
+        timezone=raw.run.timezone,
         task_name_categories=raw.tasks.name_categories,
         shield_drop_on_task_run=shield_drop,
         shield_on_task_restart=shield_restart,

--- a/src/terok/lib/core/yaml_schema.py
+++ b/src/terok/lib/core/yaml_schema.py
@@ -267,6 +267,14 @@ class RawRunSection(BaseModel):
             "containers work under SELinux without disabling labels wholesale."
         ),
     )
+    timezone: str | None = Field(
+        default=None,
+        description=(
+            "IANA timezone for the task container (e.g. ``Europe/Prague``, "
+            "``UTC``).  Propagated as ``TZ`` — resolved against the image's "
+            "``tzdata``.  Unset (default) means follow the host's timezone."
+        ),
+    )
     hooks: RawHooksSection = Field(default_factory=RawHooksSection)
 
     @field_validator("memory", "cpus", mode="before")

--- a/src/terok/lib/orchestration/environment.py
+++ b/src/terok/lib/orchestration/environment.py
@@ -410,6 +410,7 @@ def build_task_env_and_volumes(
             unrestricted=False,  # task_runners resolves per-provider config
             shared_dir=None if sealed else project.shared_dir,
             envs_dir=sandbox_live_mounts_dir(),
+            timezone=project.timezone,
         ),
         get_roster(),
         # bypass → skip proxy entirely (no tokens, no check)

--- a/tests/unit/lib/test_projects.py
+++ b/tests/unit/lib/test_projects.py
@@ -25,6 +25,7 @@ def project_yaml(
     authorship: str | None = None,
     shield_drop_on_task_run: bool | None = None,
     shield_on_task_restart: str | None = None,
+    timezone: str | None = None,
 ) -> str:
     """Build project YAML for tests with optional sections."""
     lines = ["project:", f"  id: {project_id}"]
@@ -40,6 +41,8 @@ def project_yaml(
         shield_lines.append(f"  on_task_restart: {shield_on_task_restart}")
     if shield_lines:
         lines += ["shield:", *shield_lines]
+    if timezone is not None:
+        lines += ["run:", f"  timezone: {timezone}"]
     return "\n".join(lines) + "\n"
 
 
@@ -274,6 +277,19 @@ class TestProject:
         with project_env(project_yaml("proj-no-shared"), project_id="proj-no-shared"):
             project = load_project("proj-no-shared")
         assert project.shared_dir is None
+
+    def test_timezone_from_run_section(self) -> None:
+        """``run.timezone`` in project.yml surfaces on ``ProjectConfig.timezone``."""
+        with project_env(
+            project_yaml("proj-tz", timezone="Europe/Prague"),
+            project_id="proj-tz",
+        ):
+            assert load_project("proj-tz").timezone == "Europe/Prague"
+
+    def test_timezone_omitted_is_none(self) -> None:
+        """Without ``run.timezone`` the field is ``None`` — terok-executor will follow the host."""
+        with project_env(project_yaml("proj-no-tz"), project_id="proj-no-tz"):
+            assert load_project("proj-no-tz").timezone is None
 
     def test_get_project_state(self, mock_runtime) -> None:
         project_id = "proj3"


### PR DESCRIPTION
## Summary

- Add `run.timezone` to `project.yml` — surfaces the new `ContainerEnvSpec.timezone` knob from `terok-executor`.
- Unset (default) = follow host; explicit IANA zone (`UTC`, `Europe/Prague`, …) = pin.
- Bump all four siblings to their coordinated release wheels (dbus v0.5.10, shield v0.6.24, sandbox v0.0.84, executor v0.0.102).

## Why

Closes the host/container timezone mismatch. With the executor change, task logs / `date` / commit timestamps match what the operator sees on the host. Explicit override covers the CI pin-to-UTC case.

## Test plan

- [x] `make lint`, `make tach`, `make docstrings`, `make security` green
- [x] Full unit suite (1970 tests) passes against released wheels
- [x] `poetry.lock` regenerated with all four siblings at release URLs
- [ ] Paired integration smoke on a test machine: verify `date` inside container matches host, override with `run.timezone: UTC`, verify `$TZ` is exported in the shell

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Per-project timezone support: set run.timezone in YAML to pin a container timezone using IANA names; otherwise containers inherit the host timezone with documented fallback order.

* **Documentation**
  * Added "Container Timezone" section describing configuration, resolution via image tzdata, and fallback behavior when unset.

* **Tests**
  * Added unit tests for loading and respecting run.timezone and default host fallback.

* **Chores**
  * Updated core runtime packages to newer pinned releases and switched one dependency from branch-based source to a pinned release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->