### PR TITLE
fix(release-chain): skip commit/push/PR when version is pre-bumped

### DIFF
--- a/tools/terok-release-chain.py
+++ b/tools/terok-release-chain.py
@@ -824,8 +824,17 @@ def execute_step(step: Step, plan: Plan, ctx: Ctx):
 
         case StepKind.PR_MERGE:
             if _branch_matches_upstream(repo_dir):
-                # No PR was opened — the tag step will use upstream/master.
-                console.print("[dim]No PR to merge — release payload already on master.[/]")
+                # No PR was opened.  Pin ``merge_sha`` to the current
+                # upstream/master commit so TAG doesn't re-resolve the
+                # moving ref and accidentally tag someone else's push
+                # that landed between this step and the tag step.  HEAD
+                # equals upstream/master here by the condition above.
+                step.result["merge_sha"] = sh(
+                    "git", "rev-parse", "HEAD", cwd=repo_dir, capture=True
+                ).stdout.strip()
+                console.print(
+                    f"[dim]No PR to merge — pinning tag to {step.result['merge_sha'][:12]}.[/]"
+                )
                 return
             pr_url = _find_pr_url(step.package, plan)
             # Idempotent: if already merged, just capture the SHA

--- a/tools/terok-release-chain.py
+++ b/tools/terok-release-chain.py
@@ -718,6 +718,17 @@ def _find_pr_url(package: str, plan: Plan) -> str:
     die(f"No PR URL found for {package}")
 
 
+def _branch_matches_upstream(repo_dir: Path) -> bool:
+    """Whether HEAD is already at upstream/master — no release payload to ship.
+
+    Hit when the version bump + lockfile update already landed via an earlier
+    feature PR: the release cut has nothing to commit, push, or PR — just tag.
+    """
+    head = sh("git", "rev-parse", "HEAD", cwd=repo_dir, capture=True).stdout.strip()
+    tip = sh("git", "rev-parse", "upstream/master", cwd=repo_dir, capture=True).stdout.strip()
+    return head == tip
+
+
 def execute_step(step: Step, plan: Plan, ctx: Ctx):
     """Execute a single step."""
     repo_dir = ctx.cache_dir / step.package
@@ -746,17 +757,30 @@ def execute_step(step: Step, plan: Plan, ctx: Ctx):
 
         case StepKind.GIT_COMMIT:
             sh("git", "add", "pyproject.toml", "poetry.lock", cwd=repo_dir)
-            # Idempotent: skip if HEAD already carries this commit message
-            r = sh("git", "log", "-1", "--format=%s", cwd=repo_dir, capture=True)
-            if r.stdout.strip() == p["message"]:
+            # Idempotent: HEAD already carries this commit message (re-run of a
+            # previously-committed step), or nothing is staged (a prior feature
+            # PR already landed the version bump + lockfile on master, so the
+            # release cut has nothing to commit — just tag and ship).
+            head = sh("git", "log", "-1", "--format=%s", cwd=repo_dir, capture=True)
+            if head.stdout.strip() == p["message"]:
                 console.print("[dim]Already committed — skipping.[/]")
+            elif (
+                sh("git", "diff", "--cached", "--quiet", cwd=repo_dir, check=False).returncode == 0
+            ):
+                console.print("[dim]Nothing to commit — release payload already on master.[/]")
             else:
                 sh("git", "commit", "-m", p["message"], cwd=repo_dir)
 
         case StepKind.GIT_PUSH:
-            sh("git", "push", "-u", "origin", p["branch"], "--force-with-lease", cwd=repo_dir)
+            if _branch_matches_upstream(repo_dir):
+                console.print("[dim]Branch is at upstream/master — nothing to push.[/]")
+            else:
+                sh("git", "push", "-u", "origin", p["branch"], "--force-with-lease", cwd=repo_dir)
 
         case StepKind.PR_CREATE:
+            if _branch_matches_upstream(repo_dir):
+                console.print("[dim]Branch is at upstream/master — no PR needed.[/]")
+                return
             # Idempotent: reuse existing PR for this head branch
             r = sh(
                 "gh",
@@ -799,6 +823,10 @@ def execute_step(step: Step, plan: Plan, ctx: Ctx):
                 console.print(f"PR created: {step.result['pr_url']}")
 
         case StepKind.PR_MERGE:
+            if _branch_matches_upstream(repo_dir):
+                # No PR was opened — the tag step will use upstream/master.
+                console.print("[dim]No PR to merge — release payload already on master.[/]")
+                return
             pr_url = _find_pr_url(step.package, plan)
             # Idempotent: if already merged, just capture the SHA
             st = pr_state(pr_url, gh_repo)


### PR DESCRIPTION
## Summary

- Detect the "nothing to commit, working tree clean" case in `GIT_COMMIT` and skip cleanly.
- When the release branch still matches `upstream/master` after all file ops, also skip `GIT_PUSH`, `PR_CREATE`, and `PR_MERGE`. `TAG` falls through to `upstream/master` as its target.
- New shared helper `_branch_matches_upstream()` keeps the three guard sites in sync.

## Why

`quick dbus..terok` crashed with:

\`\`\`
terok-dbus git_commit
On branch chore/release-0.5.10
nothing to commit, working tree clean
ERROR: Command failed (exit 1): git commit -m chore: release 0.5.10 Terok Logo
\`\`\`

because terok-dbus's master already carried `version = "0.5.10"` — a prior feature PR had landed the bump ahead of the release cut, so `VERSION_BUMP` → `POETRY_LOCK` was a no-op.

This is a legitimate release shape: the chain still needs to tag and ship, but doesn't need a release-PR round-trip. Before this fix the chain had no way forward without manual intervention.

## Test plan

- [x] Manual: run `quick dbus..terok` with a pre-bumped terok-dbus — previous `nothing to commit` failure → now skips cleanly through commit/push/PR/merge and the release cut continues with `TAG` against `upstream/master`.
- [x] ruff check + format clean.
- [ ] Manual sanity: normal release (no pre-bump) still goes through the commit/push/PR/merge path unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Release process now skips redundant commits, pushes, PRs, and merges when the branch is already synchronized with the upstream main branch.
  * Commit step is more idempotent: it quietly treats "nothing staged" or a matching last commit message as already applied, avoiding unnecessary actions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->