### PR TITLE
feat(sickbay): stream check progress with grouped summaries

### DIFF
--- a/src/terok/cli/commands/sickbay.py
+++ b/src/terok/cli/commands/sickbay.py
@@ -44,6 +44,7 @@ from ...lib.core.yaml_schema import SERVICES_TCP_OPTOUT_YAML
 from ...lib.orchestration.container_doctor import run_container_doctor
 from ...lib.orchestration.hooks import run_hook
 from ...lib.orchestration.tasks import container_name, is_task_id, tasks_meta_dir
+from ...lib.util.check_reporter import CheckReporter
 from ...lib.util.yaml import load as _yaml_load
 
 # Type alias for check results: (severity, label, detail)
@@ -422,25 +423,29 @@ def _check_keyring() -> _CheckResult:
     )
 
 
-def _check_containers(
+def _stream_containers(
     project_id: str | None,
     task_id: str | None,
     *,
     fix: bool,
-) -> list[_CheckResult]:
-    """Check running task containers via the in-container doctor.
+    reporter: CheckReporter,
+) -> None:
+    """Stream in-container diagnostics through *reporter*, one task at a time.
 
     The per-task running-state check is handled inside
-    ``run_container_doctor`` — it returns an informational result for
+    ``run_container_doctor`` — it emits an informational line for
     non-running containers, so we simply forward all tasks and let the
     orchestrator decide.
     """
-    results: list[_CheckResult] = []
-
     if project_id and task_id:
-        # Single task scope
-        results.extend(run_container_doctor(project_id, task_id, fix=fix))
-        return results
+        run_container_doctor(
+            project_id,
+            task_id,
+            fix=fix,
+            reporter=reporter,
+            label_prefix=f"Task {project_id}/{task_id}: ",
+        )
+        return
 
     # Project or global scope — iterate all known tasks
     if project_id:
@@ -454,14 +459,13 @@ def _check_containers(
             continue
         for meta_file in meta_dir.glob(_TASK_META_GLOB):
             tid = meta_file.stem
-            for severity, label, detail in run_container_doctor(pid, tid, fix=fix):
-                # Prefix bare check labels with task context so multi-task
-                # output is unambiguous (early-return labels already include it)
-                if not label.startswith(("Task ", "  fix:")):
-                    label = f"Task {pid}/{tid}: {label}"
-                results.append((severity, label, detail))
-
-    return results
+            run_container_doctor(
+                pid,
+                tid,
+                fix=fix,
+                reporter=reporter,
+                label_prefix=f"Task {pid}/{tid}: ",
+            )
 
 
 def _check_selinux_policy() -> _CheckResult:
@@ -551,30 +555,23 @@ def _check_vault_migration() -> _CheckResult:
 
 
 _GLOBAL_CHECKS = [
-    _check_gate_server,
-    _check_shield,
-    _check_vault,
-    _check_vault_migration,
-    _check_ssh_signer,
-    _check_keyring,
-    _check_selinux_policy,
+    ("Gate server", _check_gate_server),
+    ("Shield", _check_shield),
+    ("Vault", _check_vault),
+    ("Vault migration", _check_vault_migration),
+    ("SSH signer", _check_ssh_signer),
+    ("Keyring", _check_keyring),
+    ("SELinux policy", _check_selinux_policy),
 ]
+"""Global checks paired with the label shown while they run.
 
-_STATUS_MARKERS = {
-    "ok": "ok",
-    "info": "info",
-    "warn": "WARN",
-    "error": "ERROR",
-}
-
-
-def _update_worst(current: str, status: str) -> str:
-    """Return the more severe of *current* and *status*."""
-    if status == "error" or current == "error":
-        return "error"
-    if status == "warn" or current == "warn":
-        return "warn"
-    return "ok"
+The check functions return their own label inside the ``_CheckResult``
+tuple, but we want to stream ``"  Gate server …… "`` *before* the
+check runs — so the user sees progress even on slow probes.  The
+label printed up front should match the one the check returns; if it
+ever drifts, the streamed line and the final marker end up on different
+rows and the output looks broken.
+"""
 
 
 def _cmd_sickbay(
@@ -582,37 +579,30 @@ def _cmd_sickbay(
     task_id: str | None = None,
     fix: bool = False,
 ) -> None:
-    """Run health checks and report results."""
-    worst = "ok"
+    """Run health checks and report results, streaming progress line-by-line."""
+    reporter = CheckReporter()
 
     if not task_id:
-        for check in _GLOBAL_CHECKS:
-            status, label, detail = check()
-            print(f"  {label} .... {_STATUS_MARKERS.get(status, status)} ({detail})")
-            worst = _update_worst(worst, status)
+        for label, check in _GLOBAL_CHECKS:
+            reporter.begin(label)
+            status, _, detail = check()
+            reporter.end(status, detail)
 
-    hook_results = _check_unfired_hooks(project_id, task_id, fix=fix)
-    for status, label, detail in hook_results:
-        print(f"  {label} .... {_STATUS_MARKERS.get(status, status)} ({detail})")
-        worst = _update_worst(worst, status)
+    for status, label, detail in _check_unfired_hooks(project_id, task_id, fix=fix):
+        reporter.emit(status, label, detail)
+    for status, label, detail in _check_shield_annotations(project_id, task_id):
+        reporter.emit(status, label, detail)
 
-    annotation_results = _check_shield_annotations(project_id, task_id)
-    for status, label, detail in annotation_results:
-        print(f"  {label} .... {_STATUS_MARKERS.get(status, status)} ({detail})")
-        worst = _update_worst(worst, status)
+    _stream_containers(project_id, task_id, fix=fix, reporter=reporter)
 
-    # In-container diagnostics for running tasks
-    container_results = _check_containers(project_id, task_id, fix=fix)
-    for status, label, detail in container_results:
-        print(f"  {label} .... {_STATUS_MARKERS.get(status, status)} ({detail})")
-        worst = _update_worst(worst, status)
+    # Single-task summary: ``ok (consistent)`` iff every check for this
+    # task came back clean.  Globals aren't run in the ``task_id`` scope,
+    # so the reporter's worst-status at this point covers exactly the
+    # three task-scoped check sets.
+    if task_id and reporter.worst_status == "ok":
+        reporter.emit("ok", f"Task {project_id}/{task_id}", "consistent")
 
-    # Print "ok (consistent)" only when scoped to a single task and every result is "ok"
-    all_ok = all(s == "ok" for s, _, _ in hook_results + annotation_results + container_results)
-    if task_id and all_ok:
-        print(f"  Task {project_id}/{task_id} .... ok (consistent)")
-
-    if worst == "error":
+    if reporter.worst_status == "error":
         sys.exit(2)
-    elif worst == "warn":
+    elif reporter.worst_status == "warn":
         sys.exit(1)

--- a/src/terok/lib/orchestration/container_doctor.py
+++ b/src/terok/lib/orchestration/container_doctor.py
@@ -30,6 +30,7 @@ from terok_sandbox.doctor import CheckVerdict, DoctorCheck, sandbox_doctor_check
 from ..core import runtime as _rt
 from ..core.config import make_sandbox_config
 from ..core.projects import load_project
+from ..util.check_reporter import CheckReporter
 from ..util.logging_utils import _log_debug
 from .tasks import container_name, load_task_meta, tasks_meta_dir
 
@@ -39,6 +40,22 @@ _CheckResult = tuple[str, str, str]
 _SHIELD_STATE_FILENAME = "shield_desired_state"
 _CONTAINER_WORKSPACE = "/workspace"  # nosec B108 — standard workspace mount point
 _SHIELD_STATE_LABEL = "Shield state"
+
+#: Map from per-check ``(category, label-prefix)`` → human-readable group
+#: heading.  Checks that match a row here are coalesced under one
+#: heading line; everything else streams individually.  The label-prefix
+#: match is "label starts with this string followed by a space and an
+#: opening paren" so ``Credential file (claude)`` maps to ``Credential
+#: file`` but not a hypothetical ``Credential file cache``.  ``None`` as
+#: the prefix matches any label within that category.
+_GROUP_HEADINGS: tuple[tuple[str, str | None, str], ...] = (
+    ("mount", "Credential file", "Credential files"),
+    ("env", "Phantom token", "Phantom tokens"),
+    ("env", "Base URL", "Base URLs"),
+    ("bridge", None, "Bridges"),
+    ("git", None, "Git config"),
+    ("network", None, "Port drift"),
+)
 
 
 # ---------------------------------------------------------------------------
@@ -341,28 +358,176 @@ def run_container_doctor(
     task_id: str,
     *,
     fix: bool = False,
+    reporter: CheckReporter | None = None,
+    label_prefix: str = "",
 ) -> list[_CheckResult]:
     """Run all layered in-container health checks for a specific task.
 
     Collects checks from sandbox, agent, and terok layers, executes probes
     via ``podman exec``, evaluates results, and optionally applies fixes.
 
-    Returns a list of ``(severity, label, detail)`` tuples for display.
+    When *reporter* is supplied, progress streams line-by-line through it
+    and noisy categories (``Credential file (...)``, ``Phantom token
+    (...)``, …) coalesce into a single group heading.  The returned list
+    is also populated for backwards-compatible callers that want the
+    aggregate; it is empty when *reporter* handled the streaming so the
+    caller doesn't re-print.
+
+    *label_prefix* is prepended to every emitted label — used by the
+    sickbay command to tag multi-task runs with ``"Task pid/tid: "``.
     """
     cname, task_dir, early = _resolve_running_container(project_id, task_id)
     if early:
+        if reporter is not None:
+            for status, label, detail in early:
+                reporter.emit(status, label, detail)
+            return []
         return early
 
-    results: list[_CheckResult] = []
-    for check in _collect_all_checks(project_id, task_dir):
-        if check.host_side:
-            results.append(_dispatch_host_side(check, task_dir, cname))
+    checks = list(_collect_all_checks(project_id, task_dir))
+
+    if reporter is None:
+        # Legacy path: collect-and-return.  No streaming, no grouping.
+        results: list[_CheckResult] = []
+        for check in checks:
+            results.extend(_execute_check(check, cname, task_dir, fix=fix))
+        return results
+
+    # Streaming path with grouping.
+    _stream_checks(checks, cname, task_dir, fix=fix, reporter=reporter, label_prefix=label_prefix)
+    return []
+
+
+def _execute_check(
+    check: DoctorCheck,
+    cname: str,
+    task_dir: Path,
+    *,
+    fix: bool,
+) -> list[_CheckResult]:
+    """Run one check and return ``[result]`` or ``[result, fix_result]``."""
+    if check.host_side:
+        return [_dispatch_host_side(check, task_dir, cname)]
+
+    verdict = _run_probe(cname, check)
+    out: list[_CheckResult] = [(verdict.severity, check.label, verdict.detail)]
+    if fix and verdict.fixable and check.fix_cmd:
+        out.append(_apply_fix(cname, check))
+    return out
+
+
+def _group_key(check: DoctorCheck) -> tuple[str | None, str]:
+    """Return ``(heading, member_label)`` — ``heading`` is ``None`` for ungrouped checks."""
+    for category, prefix, heading in _GROUP_HEADINGS:
+        if check.category != category:
             continue
+        if prefix is None:
+            return (heading, check.label)
+        # Match on "prefix (" so "Credential file (claude)" matches but
+        # something like "Credential file cache" would not.
+        if check.label.startswith(f"{prefix} ("):
+            return (heading, check.label)
+    return (None, check.label)
 
-        verdict = _run_probe(cname, check)
-        results.append((verdict.severity, check.label, verdict.detail))
 
-        if fix and verdict.fixable and check.fix_cmd:
-            results.append(_apply_fix(cname, check))
+def _stream_checks(
+    checks: list[DoctorCheck],
+    cname: str,
+    task_dir: Path,
+    *,
+    fix: bool,
+    reporter: CheckReporter,
+    label_prefix: str,
+) -> None:
+    """Emit check progress through *reporter* with per-heading grouping.
 
-    return results
+    Groups appear at the position of their *first* member and absorb any
+    later checks that share the same heading — so a category like
+    ``network`` that's contributed to by both the sandbox (TCP
+    reachability) and the terok layer (port-drift checks) produces a
+    single "Port drift" line instead of two separate ones.  Individual
+    (ungrouped) checks stream at the position where they appear.
+    """
+    # Build an ordered action list: each entry is either an individual
+    # check or a "slot" that a group will be accumulated into.  Group
+    # slots are keyed by heading so later checks with the same heading
+    # fall into the same list.
+    slots: dict[str, list[DoctorCheck]] = {}
+    plan: list[tuple[str, DoctorCheck | str]] = []  # ("one", check) | ("group", heading)
+    for check in checks:
+        heading, _ = _group_key(check)
+        if heading is None:
+            plan.append(("one", check))
+            continue
+        if heading not in slots:
+            slots[heading] = []
+            plan.append(("group", heading))
+        slots[heading].append(check)
+
+    for kind, payload in plan:
+        if kind == "one":
+            _emit_individual(
+                payload,  # type: ignore[arg-type]
+                cname,
+                task_dir,
+                fix=fix,
+                reporter=reporter,
+                label_prefix=label_prefix,
+            )
+        else:
+            heading = payload  # type: ignore[assignment]
+            _emit_group(
+                slots[heading],
+                heading,
+                cname,
+                task_dir,
+                fix=fix,
+                reporter=reporter,
+                label_prefix=label_prefix,
+            )
+
+
+def _emit_individual(
+    check: DoctorCheck,
+    cname: str,
+    task_dir: Path,
+    *,
+    fix: bool,
+    reporter: CheckReporter,
+    label_prefix: str,
+) -> None:
+    """Stream one check through the reporter (begin → run → end)."""
+    label = f"{label_prefix}{check.label}"
+    reporter.begin(label)
+    results = _execute_check(check, cname, task_dir, fix=fix)
+    # First tuple is the check itself; any extra is a fix follow-up.
+    status, _, detail = results[0]
+    reporter.end(status, detail)
+    for fix_status, fix_label, fix_detail in results[1:]:
+        reporter.emit(fix_status, f"{label_prefix}{fix_label}", fix_detail)
+
+
+def _emit_group(
+    members: list[DoctorCheck],
+    heading: str,
+    cname: str,
+    task_dir: Path,
+    *,
+    fix: bool,
+    reporter: CheckReporter,
+    label_prefix: str,
+) -> None:
+    """Run *members* silently under one heading line, then summarise."""
+    full_heading = f"{label_prefix}{heading}"
+    fix_followups: list[_CheckResult] = []
+    with reporter.group(full_heading) as g:
+        for check in members:
+            results = _execute_check(check, cname, task_dir, fix=fix)
+            status, _, detail = results[0]
+            g.track(status, check.label, detail)
+            # Fix follow-ups don't belong inside the group summary —
+            # they're separate informational lines.  Buffer and emit
+            # after the group closes.
+            fix_followups.extend(results[1:])
+    for fix_status, fix_label, fix_detail in fix_followups:
+        reporter.emit(fix_status, f"{label_prefix}{fix_label}", fix_detail)

--- a/src/terok/lib/util/check_reporter.py
+++ b/src/terok/lib/util/check_reporter.py
@@ -1,0 +1,198 @@
+# SPDX-FileCopyrightText: 2026 Jiri Vyskocil
+# SPDX-License-Identifier: Apache-2.0
+
+"""Streaming, dot-padded check reporter for ``terok sickbay`` and friends.
+
+Replaces the collect-then-print-all pattern that made long diagnostic
+runs look hung.  Each check emits its label eagerly (so the user sees
+work is happening), runs, then stamps the same line with ``ok`` /
+``WARN`` / ``ERROR``.
+
+Grouped checks (e.g. one "Credential files" heading covering seven
+per-agent credential probes) show the heading eagerly and collapse the
+members into a single summary when every member passes — the detail
+lines only appear when something fails.
+
+Worst-status aggregation is built in: ``reporter.worst_status`` follows
+the ``ok < info < warn < error`` ladder across every emission, so the
+CLI can pick its exit code off a single object.
+"""
+
+from __future__ import annotations
+
+import sys
+from collections.abc import Iterator
+from contextlib import contextmanager
+
+#: Default label column — dots pad the label up to this width so ``ok``
+#: or ``ERROR`` always lands at the same column on clean output.
+DEFAULT_LABEL_WIDTH = 60
+
+#: Human-friendly markers for each severity.
+STATUS_MARKERS = {
+    "ok": "ok",
+    "info": "info",
+    "warn": "WARN",
+    "error": "ERROR",
+}
+
+#: Severity ordering for "worst status wins" aggregation.  Higher = worse.
+_SEVERITY_RANK = {"ok": 0, "info": 1, "warn": 2, "error": 3}
+
+
+def _worse(a: str, b: str) -> str:
+    """Return the more severe of two severities (unknown → treat as ``ok``)."""
+    return a if _SEVERITY_RANK.get(a, 0) >= _SEVERITY_RANK.get(b, 0) else b
+
+
+class CheckReporter:
+    """Print check progress line-by-line with aligned ``ok``/``WARN``/``ERROR`` markers.
+
+    Use :meth:`emit` for one-shot checks whose label is known up front.
+    Use :meth:`begin` + :meth:`end` when the detail is computed between
+    showing the label and showing the verdict — the two halves land on
+    the same terminal line.  Use :meth:`group` to batch a category of
+    checks under a single heading.
+
+    Writes go through an injectable *stream* so tests can capture output
+    without touching stdout.
+    """
+
+    def __init__(self, *, width: int = DEFAULT_LABEL_WIDTH, stream=None) -> None:
+        self._width = width
+        self._stream = stream if stream is not None else sys.stdout
+        self._worst = "ok"
+
+    @property
+    def worst_status(self) -> str:
+        """The most severe status seen so far (``ok`` if nothing emitted yet)."""
+        return self._worst
+
+    # ------------------------------------------------------------------
+    # Streaming primitives
+    # ------------------------------------------------------------------
+
+    def begin(self, label: str) -> None:
+        """Emit ``  <label> ....`` without a trailing newline and flush.
+
+        The caller is expected to follow with :meth:`end` on the same
+        logical check — the status marker and detail land on the same
+        visible line.
+        """
+        self._stream.write(f"  {label} {self._dots(label)} ")
+        self._stream.flush()
+
+    def end(self, status: str, detail: str) -> None:
+        """Close the currently-open line started by :meth:`begin`.
+
+        Updates :attr:`worst_status`.  ``detail`` is wrapped in
+        parentheses — leave it empty for a bare marker.
+        """
+        self._worst = _worse(self._worst, status)
+        marker = STATUS_MARKERS.get(status, status)
+        if detail:
+            self._stream.write(f"{marker} ({detail})\n")
+        else:
+            self._stream.write(f"{marker}\n")
+        self._stream.flush()
+
+    def emit(self, status: str, label: str, detail: str) -> None:
+        """Shortcut for a check whose result is already known: ``begin`` then ``end``."""
+        self.begin(label)
+        self.end(status, detail)
+
+    # ------------------------------------------------------------------
+    # Grouped checks
+    # ------------------------------------------------------------------
+
+    @contextmanager
+    def group(self, label: str) -> Iterator[_GroupContext]:
+        """Emit a single heading line covering several related checks.
+
+        The heading is printed eagerly (so the user knows work is
+        happening); members run silently via ``ctx.add(status, detail)``
+        or ``ctx.track(status, label, detail)``; on exit the reporter
+        prints either ``ok (N checks)`` when every member passed or
+        ``WARN/ERROR (...)`` followed by an indented list of every
+        non-ok member.
+
+        Example::
+
+            with reporter.group("Credential files") as g:
+                for check in credential_checks:
+                    status, label, detail = run(check)
+                    g.track(status, label, detail)
+        """
+        self._stream.write(f"  {label} {self._dots(label)} ")
+        self._stream.flush()
+        ctx = _GroupContext()
+        try:
+            yield ctx
+        finally:
+            self._close_group(ctx)
+
+    def _close_group(self, ctx: _GroupContext) -> None:
+        results = ctx.results
+        if not results:
+            # Empty group — defensively print a "skipped" marker so the
+            # dangling line never stays open.
+            self._stream.write("ok (0 checks)\n")
+            self._stream.flush()
+            return
+
+        statuses = [s for s, _, _ in results]
+        worst = statuses[0]
+        for s in statuses[1:]:
+            worst = _worse(worst, s)
+        self._worst = _worse(self._worst, worst)
+
+        if worst == "ok":
+            self._stream.write(f"ok ({len(results)} checks)\n")
+            self._stream.flush()
+            return
+
+        # Non-ok branch: summary counts in severity order, then detail
+        # lines for every non-ok member.  Format is intentionally plain;
+        # polish can come in a follow-up once we've lived with it.
+        counts = []
+        for sev in ("error", "warn", "info", "ok"):
+            n = sum(1 for s in statuses if s == sev)
+            if n:
+                counts.append(f"{n} {sev}")
+        marker = STATUS_MARKERS.get(worst, worst)
+        self._stream.write(f"{marker} ({', '.join(counts)})\n")
+        for status, _label, detail in results:
+            if status != "ok":
+                tag = STATUS_MARKERS.get(status, status)
+                self._stream.write(f"    {tag}: {detail}\n")
+        self._stream.flush()
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+
+    def _dots(self, label: str) -> str:
+        """Return the dot-run that pads *label* up to the target column."""
+        # "  {label} {dots} " — two leading spaces, one space either side of
+        # the dots, so the column after the dots is at (width + 4).  Keep a
+        # three-dot minimum for labels that already exceed the width.
+        return "." * max(3, self._width - len(label))
+
+
+class _GroupContext:
+    """Collector handed to the caller inside :meth:`CheckReporter.group`.
+
+    Not part of the public API — callers receive it via the context
+    manager and only use ``add`` / ``track``.
+    """
+
+    def __init__(self) -> None:
+        self.results: list[tuple[str, str, str]] = []
+
+    def add(self, status: str, detail: str) -> None:
+        """Record a member result without a separate member label."""
+        self.results.append((status, "", detail))
+
+    def track(self, status: str, label: str, detail: str) -> None:
+        """Record a member result, preserving the member's own label for failure listings."""
+        self.results.append((status, label, detail))

--- a/tests/unit/cli/test_cli_sickbay.py
+++ b/tests/unit/cli/test_cli_sickbay.py
@@ -121,8 +121,8 @@ def test_cmd_sickbay_reports_health(
         return ("ok", "Vault migration", "no legacy directory")
 
     patched_checks = [
-        _stub_vault_migration if fn.__name__ == "_check_vault_migration" else fn
-        for fn in _sickbay_module._GLOBAL_CHECKS
+        (label, _stub_vault_migration if fn.__name__ == "_check_vault_migration" else fn)
+        for label, fn in _sickbay_module._GLOBAL_CHECKS
     ]
     with (
         patch("terok.cli.commands.sickbay._GLOBAL_CHECKS", patched_checks),

--- a/tests/unit/cli/test_sickbay.py
+++ b/tests/unit/cli/test_sickbay.py
@@ -19,7 +19,6 @@ from terok.cli.commands.sickbay import (
     _check_vault,
     _check_vault_migration,
     _reconcile_post_stop,
-    _update_worst,
 )
 from terok.lib.util.yaml import dump as yaml_dump
 
@@ -39,23 +38,6 @@ def _write_meta(meta_dir: Path, tid: str, meta: dict) -> Path:
     p = meta_dir / f"{tid}.yml"
     p.write_text(yaml_dump(meta))
     return p
-
-
-class TestUpdateWorst:
-    def test_ok_stays_ok(self) -> None:
-        assert _update_worst("ok", "ok") == "ok"
-
-    def test_warn_upgrades_ok(self) -> None:
-        assert _update_worst("ok", "warn") == "warn"
-
-    def test_error_upgrades_warn(self) -> None:
-        assert _update_worst("warn", "error") == "error"
-
-    def test_error_stays_error(self) -> None:
-        assert _update_worst("error", "ok") == "error"
-
-    def test_warn_stays_warn(self) -> None:
-        assert _update_worst("warn", "ok") == "warn"
 
 
 class TestCheckSshSigner:

--- a/tests/unit/lib/test_container_doctor.py
+++ b/tests/unit/lib/test_container_doctor.py
@@ -391,3 +391,217 @@ class TestRunContainerDoctor:
         assert results[0][0] == "warn"
         assert "unknown host-side check" in results[0][2]
         mock_exec.assert_not_called()
+
+
+class TestStreamingGrouping:
+    """Verify that the streaming path partitions checks by heading correctly."""
+
+    def test_group_key_maps_credentials_and_tokens(self) -> None:
+        """Labels inside known prefixes collapse to their heading; others pass through."""
+        from terok.lib.orchestration.container_doctor import _group_key
+
+        cred = DoctorCheck(
+            category="mount",
+            label="Credential file (claude)",
+            probe_cmd=[],
+            evaluate=lambda *a: CheckVerdict("ok", ""),
+        )
+        phantom = DoctorCheck(
+            category="env",
+            label="Phantom token (GH_TOKEN)",
+            probe_cmd=[],
+            evaluate=lambda *a: CheckVerdict("ok", ""),
+        )
+        base_url = DoctorCheck(
+            category="env",
+            label="Base URL (OPENAI_BASE_URL)",
+            probe_cmd=[],
+            evaluate=lambda *a: CheckVerdict("ok", ""),
+        )
+        shield = DoctorCheck(
+            category="shield",
+            label="Shield state",
+            probe_cmd=[],
+            evaluate=lambda *a: CheckVerdict("ok", ""),
+        )
+        assert _group_key(cred)[0] == "Credential files"
+        assert _group_key(phantom)[0] == "Phantom tokens"
+        assert _group_key(base_url)[0] == "Base URLs"
+        # Shield has no mapping — streams individually
+        assert _group_key(shield)[0] is None
+
+    def test_network_category_collapses_disjoint_contributors(
+        self,
+        mock_runtime,
+        tmp_path: Path,
+    ) -> None:
+        """Network checks from two layers (sandbox + terok) share one heading.
+
+        Without the grouping that partitions *then* emits, a category
+        contributed to by non-consecutive layers would produce two
+        separate "Port drift" heading lines.
+        """
+        from io import StringIO
+
+        from terok.lib.orchestration.container_doctor import (
+            run_container_doctor,
+        )
+        from terok.lib.util.check_reporter import CheckReporter
+
+        (tmp_path / "42.yml").write_text("mode: cli\n")
+
+        net_a = DoctorCheck(
+            category="network",
+            label="Token broker (TCP)",
+            probe_cmd=["true"],
+            evaluate=lambda *a: CheckVerdict("ok", "reachable"),
+        )
+        shield_check = DoctorCheck(
+            category="shield",
+            label="Shield state",
+            probe_cmd=[],
+            evaluate=lambda *a: CheckVerdict("ok", ""),
+            host_side=True,
+        )
+        net_b = DoctorCheck(
+            category="network",
+            label="Token broker port drift",
+            probe_cmd=["true"],
+            evaluate=lambda *a: CheckVerdict("ok", "matches"),
+        )
+
+        buf = StringIO()
+        reporter = CheckReporter(stream=buf)
+
+        with (
+            patch(
+                "terok.lib.orchestration.container_doctor.sandbox_doctor_checks",
+                return_value=[net_a, shield_check],
+            ),
+            patch(
+                "terok.lib.orchestration.container_doctor.agent_doctor_checks",
+                return_value=[],
+            ),
+            patch(
+                "terok.lib.orchestration.container_doctor._terok_doctor_checks",
+                return_value=[net_b],
+            ),
+            patch(
+                "terok.lib.orchestration.container_doctor.tasks_meta_dir",
+                return_value=tmp_path,
+            ),
+            patch(
+                "terok.lib.orchestration.container_doctor.load_task_meta",
+                return_value=({"mode": "cli"}, tmp_path / "42.yml"),
+            ),
+            patch(
+                "terok.lib.orchestration.container_doctor.make_sandbox_config",
+                return_value=MagicMock(),
+            ),
+            patch(
+                "terok.lib.orchestration.container_doctor.get_token_broker_port",
+                return_value=8080,
+            ),
+            patch(
+                "terok.lib.orchestration.container_doctor.get_ssh_signer_port",
+                return_value=2222,
+            ),
+            patch(
+                "terok.lib.orchestration.container_doctor._read_desired_shield_state",
+                return_value=None,
+            ),
+            patch(
+                "terok.lib.orchestration.container_doctor.load_project",
+                return_value=MagicMock(tasks_root=tmp_path),
+            ),
+            patch(
+                "terok.lib.orchestration.container_doctor._check_shield_state",
+                return_value=("ok", "Shield state", "not managed"),
+            ),
+            patch(
+                "terok.lib.orchestration.container_doctor._exec_in_container",
+                return_value=ExecResult(exit_code=0, stdout="", stderr=""),
+            ),
+        ):
+            mock_runtime.container.return_value.state = "running"
+            run_container_doctor("proj", "42", reporter=reporter)
+
+        out = buf.getvalue()
+        # Single "Port drift" heading, both network checks counted under it.
+        assert out.count("Port drift") == 1
+        assert "ok (2 checks)" in out
+        # Shield state streams individually between the group members (it's
+        # the second check), and must still appear with its own line.
+        assert "Shield state" in out
+
+    def test_legacy_callers_still_receive_list(
+        self,
+        mock_runtime,
+        tmp_path: Path,
+    ) -> None:
+        """Calling without a reporter keeps the historical return shape."""
+        from terok.lib.orchestration.container_doctor import (
+            run_container_doctor,
+        )
+
+        (tmp_path / "42.yml").write_text("mode: cli\n")
+
+        only_check = DoctorCheck(
+            category="shield",
+            label="Shield state",
+            probe_cmd=[],
+            evaluate=lambda *a: CheckVerdict("ok", ""),
+            host_side=True,
+        )
+        with (
+            patch(
+                "terok.lib.orchestration.container_doctor.sandbox_doctor_checks",
+                return_value=[only_check],
+            ),
+            patch(
+                "terok.lib.orchestration.container_doctor.agent_doctor_checks",
+                return_value=[],
+            ),
+            patch(
+                "terok.lib.orchestration.container_doctor._terok_doctor_checks",
+                return_value=[],
+            ),
+            patch(
+                "terok.lib.orchestration.container_doctor.tasks_meta_dir",
+                return_value=tmp_path,
+            ),
+            patch(
+                "terok.lib.orchestration.container_doctor.load_task_meta",
+                return_value=({"mode": "cli"}, tmp_path / "42.yml"),
+            ),
+            patch(
+                "terok.lib.orchestration.container_doctor.make_sandbox_config",
+                return_value=MagicMock(),
+            ),
+            patch(
+                "terok.lib.orchestration.container_doctor.get_token_broker_port",
+                return_value=8080,
+            ),
+            patch(
+                "terok.lib.orchestration.container_doctor.get_ssh_signer_port",
+                return_value=2222,
+            ),
+            patch(
+                "terok.lib.orchestration.container_doctor._read_desired_shield_state",
+                return_value=None,
+            ),
+            patch(
+                "terok.lib.orchestration.container_doctor.load_project",
+                return_value=MagicMock(tasks_root=tmp_path),
+            ),
+            patch(
+                "terok.lib.orchestration.container_doctor._check_shield_state",
+                return_value=("ok", "Shield state", "not managed"),
+            ),
+        ):
+            mock_runtime.container.return_value.state = "running"
+            results = run_container_doctor("proj", "42")
+
+        # Legacy path returns the accumulated list; streaming path would
+        # have returned an empty list.
+        assert results == [("ok", "Shield state", "not managed")]

--- a/tests/unit/lib/util/test_check_reporter.py
+++ b/tests/unit/lib/util/test_check_reporter.py
@@ -1,0 +1,219 @@
+# SPDX-FileCopyrightText: 2026 Jiri Vyskocil
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for :mod:`terok.lib.util.check_reporter`.
+
+Covers the three things this helper actually has to get right for
+``terok sickbay`` to behave: each line streams (no buffering until the
+end), the dot padding lands at a fixed column, and the worst-status
+aggregate follows the ``ok < info < warn < error`` ladder.  Grouped
+output collapses to a one-liner on the all-ok path and expands into
+indented failure detail when anything under the heading is non-ok.
+"""
+
+from __future__ import annotations
+
+import io
+
+import pytest
+
+from terok.lib.util.check_reporter import (
+    DEFAULT_LABEL_WIDTH,
+    STATUS_MARKERS,
+    CheckReporter,
+    _worse,
+)
+
+
+@pytest.fixture
+def buf() -> io.StringIO:
+    """Capture reporter output without touching real stdout."""
+    return io.StringIO()
+
+
+@pytest.fixture
+def reporter(buf: io.StringIO) -> CheckReporter:
+    """Reporter writing into the captured buffer at default width."""
+    return CheckReporter(stream=buf)
+
+
+class TestWorstStatus:
+    """Severity ordering used to drive the sickbay exit code."""
+
+    @pytest.mark.parametrize(
+        ("current", "new", "expected"),
+        [
+            ("ok", "ok", "ok"),
+            ("ok", "info", "info"),
+            ("info", "warn", "warn"),
+            ("warn", "error", "error"),
+            ("error", "ok", "error"),
+            ("error", "warn", "error"),
+            ("warn", "ok", "warn"),
+        ],
+    )
+    def test_severity_ladder(self, current: str, new: str, expected: str) -> None:
+        assert _worse(current, new) == expected
+
+    def test_unknown_severity_treated_as_ok(self) -> None:
+        """Unknown severity strings shouldn't upgrade a known one."""
+        assert _worse("warn", "mystery") == "warn"
+
+
+class TestEmit:
+    """One-shot ``emit`` path — the common case for global checks."""
+
+    def test_streams_label_before_status(self, buf: io.StringIO) -> None:
+        """``begin`` flushes the label before the check runs."""
+        reporter = CheckReporter(stream=buf)
+        reporter.begin("Gate server")
+        mid = buf.getvalue()
+        # The label + dots must be on the buffer *before* end() runs.
+        assert "Gate server" in mid
+        assert "\n" not in mid  # still on an open line
+
+        reporter.end("ok", "listening")
+        final = buf.getvalue()
+        assert final.endswith("ok (listening)\n")
+        assert final.count("\n") == 1
+
+    def test_marker_lands_after_dot_padding(self, buf: io.StringIO) -> None:
+        """At default width, the status word starts at a predictable column."""
+        reporter = CheckReporter(stream=buf)
+        reporter.emit("ok", "Vault", "ready")
+        out = buf.getvalue()
+        # "  Vault " + dots-to-width + " ok (ready)\n" — the ok marker is
+        # separated by exactly one space from the last dot.
+        assert out.startswith("  Vault ")
+        assert " ok (ready)\n" in out
+
+    def test_empty_detail_omits_parens(self, buf: io.StringIO) -> None:
+        reporter = CheckReporter(stream=buf)
+        reporter.emit("ok", "Silent check", "")
+        assert buf.getvalue().rstrip().endswith(" ok")
+
+    def test_worst_status_updates(self, reporter: CheckReporter) -> None:
+        reporter.emit("ok", "a", "")
+        assert reporter.worst_status == "ok"
+        reporter.emit("warn", "b", "")
+        assert reporter.worst_status == "warn"
+        reporter.emit("ok", "c", "")
+        assert reporter.worst_status == "warn"  # doesn't downgrade
+        reporter.emit("error", "d", "")
+        assert reporter.worst_status == "error"
+
+
+class TestDotPadding:
+    """Label padding keeps status markers aligned on clean output."""
+
+    def test_short_label_padded_to_width(self, buf: io.StringIO) -> None:
+        """Short labels get enough dots to hit the configured column."""
+        reporter = CheckReporter(stream=buf, width=40)
+        reporter.emit("ok", "X", "done")
+        line = buf.getvalue()
+        # "  X " + dots + " ok (done)\n" — column count up to the space
+        # before "ok" should equal 2 + label_len + 1 + dot_count + 1.
+        assert line.index("ok (done)") == 2 + 1 + 1 + (40 - 1) + 1
+
+    def test_overlong_label_gets_minimum_dots(self, buf: io.StringIO) -> None:
+        """Labels longer than the width still render — with three dots."""
+        reporter = CheckReporter(stream=buf, width=10)
+        reporter.emit("ok", "A long label that exceeds width", "ok")
+        line = buf.getvalue()
+        # Minimum three dots, not a negative multiplier.
+        assert " ... " in line
+        assert line.rstrip().endswith(" ok (ok)")
+
+    def test_default_width_constant(self) -> None:
+        """The default width is the documented 60 columns."""
+        assert DEFAULT_LABEL_WIDTH == 60
+
+
+class TestGroupHappyPath:
+    """All-ok groups collapse to a single summary line."""
+
+    def test_all_ok_prints_single_summary(self, buf: io.StringIO) -> None:
+        reporter = CheckReporter(stream=buf)
+        with reporter.group("Credential files") as g:
+            g.track("ok", "Credential file (claude)", "no credential file")
+            g.track("ok", "Credential file (codex)", "no credential file")
+            g.track("ok", "Credential file (gh)", "no credential file")
+        out = buf.getvalue()
+        # Exactly one newline — the summary line.
+        assert out.count("\n") == 1
+        assert "Credential files" in out
+        assert "ok (3 checks)" in out
+
+    def test_ok_group_does_not_expand_members(self, buf: io.StringIO) -> None:
+        """Member details never appear on the all-ok path."""
+        reporter = CheckReporter(stream=buf)
+        with reporter.group("Bridges") as g:
+            g.track("ok", "Bridge A", "alive")
+            g.track("ok", "Bridge B", "alive")
+        out = buf.getvalue()
+        assert "alive" not in out  # details suppressed
+        assert "Bridge A" not in out  # member labels suppressed
+
+    def test_empty_group_still_closes_the_line(self, buf: io.StringIO) -> None:
+        """A group with no members must terminate its open line."""
+        reporter = CheckReporter(stream=buf)
+        with reporter.group("Nothing to see"):
+            pass
+        out = buf.getvalue()
+        assert out.endswith("\n")
+        assert "0 checks" in out
+
+    def test_group_promotes_worst_status(self, reporter: CheckReporter) -> None:
+        with reporter.group("Group") as g:
+            g.track("ok", "a", "")
+            g.track("ok", "b", "")
+        assert reporter.worst_status == "ok"
+
+
+class TestGroupFailurePath:
+    """Non-ok groups expand member failures under the heading."""
+
+    def test_warn_member_expands_into_bullet(self, buf: io.StringIO) -> None:
+        reporter = CheckReporter(stream=buf)
+        with reporter.group("Phantom tokens") as g:
+            g.track("ok", "Phantom token (GH_TOKEN)", "GH_TOKEN: phantom (gh)")
+            g.track("warn", "Phantom token (SONAR_TOKEN)", "SONAR_TOKEN: not set")
+            g.track("ok", "Phantom token (OPENAI_API_KEY)", "OPENAI_API_KEY: phantom (codex)")
+        out = buf.getvalue()
+        # Summary line mentions the counts; detail only for the failure.
+        assert "WARN" in out
+        assert "2 ok" in out and "1 warn" in out
+        assert "SONAR_TOKEN: not set" in out
+        # Ok members stay collapsed — their details never leak.
+        assert "GH_TOKEN: phantom" not in out
+
+    def test_error_member_summary_uses_error_marker(self, buf: io.StringIO) -> None:
+        reporter = CheckReporter(stream=buf)
+        with reporter.group("Credential files") as g:
+            g.track("ok", "Credential file (codex)", "clean")
+            g.track("error", "Credential file (claude)", "real API key detected")
+        out = buf.getvalue()
+        # Summary header carries the worst marker (error), even with only
+        # one erroring member.
+        assert "ERROR (1 error, 1 ok)" in out
+        assert "real API key detected" in out
+        assert reporter.worst_status == "error"
+
+    def test_failure_lines_are_indented(self, buf: io.StringIO) -> None:
+        reporter = CheckReporter(stream=buf)
+        with reporter.group("Base URLs") as g:
+            g.track("warn", "Base URL (ANTHROPIC_BASE_URL)", "not set — vault bypass possible")
+        lines = buf.getvalue().splitlines()
+        # First line is the heading; second is the indented detail.
+        assert lines[0].lstrip().startswith("Base URLs")
+        assert lines[1].startswith("    ")
+        assert "not set" in lines[1]
+
+
+class TestStatusMarkersConstant:
+    """Public marker table exists for callers that want to mimic the format."""
+
+    def test_markers_contain_expected_keys(self) -> None:
+        assert set(STATUS_MARKERS) == {"ok", "info", "warn", "error"}
+        assert STATUS_MARKERS["warn"] == "WARN"
+        assert STATUS_MARKERS["error"] == "ERROR"


### PR DESCRIPTION
## Summary

- New `CheckReporter` in `src/terok/lib/util/check_reporter.py`: streams `label ....` / flush / `marker (detail)` per check and aggregates worst-status for the exit code.
- Noisy per-task categories collapse under a heading and show `ok (N checks)` on the happy path; non-ok members expand into indented detail.
- Wired into `terok sickbay` and `run_container_doctor`; legacy (no-reporter) callers keep their list-return shape.
- Group headings are partitioned first, then emitted in first-appearance order — a category split across sandbox + terok layers (e.g. `network`) renders as one heading, not two.

## Why

On projects with several tasks, the old sickbay sat silent for ~15–60 s while it walked every task and every per-agent probe, then dumped everything at once. Users thought it had hung. Streaming each check eagerly makes forward progress visible; grouping keeps the clean-run output from drowning in per-agent lines.

## Output shape (happy path)

```
  Gate server ............................................... ok (listening on :2525)
  Shield .................................................... ok (active (per-container, dnsmasq DNS))
  ...
  Task alpaka3/z71dr: Shield state .......................... ok (matches desired (down))
  Task alpaka3/z71dr: Bridges ............................... ok (2 checks)
  Task alpaka3/z71dr: Credential files ...................... ok (7 checks)
  Task alpaka3/z71dr: Phantom tokens ........................ ok (10 checks)
  Task alpaka3/z71dr: Base URLs ............................. ok (3 checks)
  Task alpaka3/z71dr: Git config ............................ ok (3 checks)
  Task alpaka3/z71dr: Port drift ............................ ok (2 checks)
```

Failure path expands the offending members under their heading (format is intentionally plain — polish pass deferred to a follow-up).

## Test plan

- [x] 23 new unit tests for `CheckReporter` (streaming order, dot padding, worst-status ladder, group happy/fail paths).
- [x] 3 new tests for `container_doctor`: `_group_key` mapping, `network` category collapsing across non-consecutive layers, legacy no-reporter callers still get the list.
- [x] `make lint` / `make tach` / `make docstrings` — clean.
- [x] Full unit suite (1991 tests) passes on Python 3.12.
- [ ] Manual smoke against a project with several tasks on a test machine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added real-time progress reporting for diagnostic checks, with status updates displayed as each check completes
  * Enhanced grouping of related checks under unified headings for improved readability and organization

* **Refactor**
  * Restructured diagnostic check execution to stream results progressively instead of collecting them in batch

<!-- end of auto-generated comment: release notes by coderabbit.ai -->