### PR TITLE
fix(desktop): register icon via xdg-icon-resource, warn on fallback

### DIFF
--- a/src/terok/cli/commands/_desktop_entry.py
+++ b/src/terok/cli/commands/_desktop_entry.py
@@ -118,9 +118,12 @@ def install_desktop_entry(bin_path: str | Path) -> DesktopBackend:
         _load_template().replace("{{BIN}}", str(bin_path)).replace("{{TRY_EXEC}}", str(bin_path))
     )
     logo_bytes = _resource_dir().joinpath(_LOGO_NAME).read_bytes()
-    if _xdg_utils_available():
-        _install_via_xdg_utils(rendered, logo_bytes)
+    if _xdg_utils_available() and _install_via_xdg_utils(rendered, logo_bytes):
         return DesktopBackend.XDG_UTILS
+    # xdg-utils missing *or* it barfed (readonly menu dir, timeout, bad
+    # DE detection) — land the files ourselves so the operator still
+    # gets a working launcher, and report FALLBACK so the caller can
+    # warn.  The DEBUG log carries the xdg-utils failure detail.
     _install_manually(rendered, logo_bytes)
     return DesktopBackend.FALLBACK
 
@@ -158,7 +161,7 @@ def _xdg_utils_available() -> bool:
     return bool(shutil.which(_XDG_MENU_BINARY) and shutil.which(_XDG_ICON_RESOURCE_BINARY))
 
 
-def _install_via_xdg_utils(desktop_contents: str, logo_bytes: bytes) -> None:
+def _install_via_xdg_utils(desktop_contents: str, logo_bytes: bytes) -> bool:
     """Stage the rendered files and delegate install + cache refresh to xdg-utils.
 
     ``xdg-desktop-menu install`` runs ``desktop-file-install`` (catches
@@ -170,6 +173,13 @@ def _install_via_xdg_utils(desktop_contents: str, logo_bytes: bytes) -> None:
     tempdir (xdg-desktop-menu names it by source basename) and pass the
     icon resource name (``terok``) explicitly to ``xdg-icon-resource``
     so the theme entry is deterministic regardless of source filename.
+
+    Returns:
+        True only when *both* front-ends reported success.  A partial
+        install (menu OK, icon failed — or vice versa) reads as False
+        so the caller can retry via the manual path and land in a
+        consistent state rather than advertising XDG_UTILS for an
+        install that half-failed.
     """
     with tempfile.TemporaryDirectory(prefix="terok-desktop-") as td:
         staged_dir = Path(td)
@@ -177,13 +187,13 @@ def _install_via_xdg_utils(desktop_contents: str, logo_bytes: bytes) -> None:
         staged_icon = staged_dir / _ICON_FILE
         staged_desktop.write_text(desktop_contents, encoding="utf-8")
         staged_icon.write_bytes(logo_bytes)
-        _run_xdg(
+        menu_ok = _run_xdg(
             _XDG_MENU_BINARY,
             "install",
             "--novendor",
             str(staged_desktop),
         )
-        _run_xdg(
+        icon_ok = _run_xdg(
             _XDG_ICON_RESOURCE_BINARY,
             "install",
             "--novendor",
@@ -194,6 +204,7 @@ def _install_via_xdg_utils(desktop_contents: str, logo_bytes: bytes) -> None:
             str(staged_icon),
             APP_NAME,
         )
+    return menu_ok and icon_ok
 
 
 def _uninstall_via_xdg_utils() -> None:
@@ -210,11 +221,18 @@ def _uninstall_via_xdg_utils() -> None:
     )
 
 
-def _run_xdg(binary: str, *args: str) -> None:
-    """Invoke an xdg-utils front-end, swallow failures — install is best-effort."""
+def _run_xdg(binary: str, *args: str) -> bool:
+    """Invoke an xdg-utils front-end; return True only on rc-0, False otherwise.
+
+    Never raises — a hung / missing / broken front-end lands in DEBUG
+    so an operator chasing a weird install state can grep
+    ``journalctl --user`` without ``terok setup`` exploding.  The
+    return value lets :func:`_install_via_xdg_utils` decide whether to
+    hand off to the manual fallback.
+    """
     found = shutil.which(binary)
     if not found:  # pragma: no cover — gated by _xdg_utils_available
-        return
+        return False
     # nosec B603 — argv is our own literal binary path plus subcommand/arg tokens.
     try:
         result = subprocess.run(  # noqa: S603  # nosec B603
@@ -225,13 +243,8 @@ def _run_xdg(binary: str, *args: str) -> None:
         )
     except (OSError, subprocess.TimeoutExpired) as exc:
         _log.debug("%s %s failed: %s", binary, args, exc)
-        return
+        return False
     if result.returncode != 0:
-        # ``check=False`` means we never raise — but an operator chasing
-        # a weird install state needs something to grep for.  Capture
-        # the rc + stderr at DEBUG so ``terok setup`` stays quiet while
-        # ``journalctl --user`` + log-capture wrappers can still surface
-        # the real error.
         _log.debug(
             "%s %s exited with %d: %s",
             binary,
@@ -239,6 +252,8 @@ def _run_xdg(binary: str, *args: str) -> None:
             result.returncode,
             (result.stderr or b"").decode(errors="replace").strip(),
         )
+        return False
+    return True
 
 
 # ── Manual fallback ───────────────────────────────────────────────────

--- a/src/terok/cli/commands/_desktop_entry.py
+++ b/src/terok/cli/commands/_desktop_entry.py
@@ -133,11 +133,12 @@ def uninstall_desktop_entry() -> DesktopBackend:
 
     Returns:
         The :class:`DesktopBackend` actually used — symmetric with
-        :func:`install_desktop_entry` so a caller can phrase the teardown
-        status line the same way.
+        :func:`install_desktop_entry`.  XDG_UTILS only when both
+        front-ends reported rc 0; on failure (or xdg-utils absent) we
+        retry via manual unlinks and report FALLBACK so the teardown
+        leaves no stragglers even when xdg-utils misbehaves.
     """
-    if _xdg_utils_available():
-        _uninstall_via_xdg_utils()
+    if _xdg_utils_available() and _uninstall_via_xdg_utils():
         return DesktopBackend.XDG_UTILS
     _uninstall_manually()
     return DesktopBackend.FALLBACK
@@ -207,10 +208,17 @@ def _install_via_xdg_utils(desktop_contents: str, logo_bytes: bytes) -> bool:
     return menu_ok and icon_ok
 
 
-def _uninstall_via_xdg_utils() -> None:
-    """Delegate removal + cache refresh to xdg-utils."""
-    _run_xdg(_XDG_MENU_BINARY, "uninstall", "--novendor", _DESKTOP_FILE)
-    _run_xdg(
+def _uninstall_via_xdg_utils() -> bool:
+    """Delegate removal + cache refresh to xdg-utils.
+
+    Returns:
+        True only when *both* front-ends reported success.  A half-
+        completed teardown (menu removed, icon theme still holds
+        ``terok`` — or vice versa) reads as False so the caller can
+        retry via the manual unlinks and actually clear the state.
+    """
+    menu_ok = _run_xdg(_XDG_MENU_BINARY, "uninstall", "--novendor", _DESKTOP_FILE)
+    icon_ok = _run_xdg(
         _XDG_ICON_RESOURCE_BINARY,
         "uninstall",
         "--size",
@@ -219,6 +227,7 @@ def _uninstall_via_xdg_utils() -> None:
         _XDG_ICON_CONTEXT,
         APP_NAME,
     )
+    return menu_ok and icon_ok
 
 
 def _run_xdg(binary: str, *args: str) -> bool:

--- a/src/terok/cli/commands/_desktop_entry.py
+++ b/src/terok/cli/commands/_desktop_entry.py
@@ -10,18 +10,23 @@ operator knowing the template layout.  Every step soft-fails so a
 headless host without ``.local/share`` or without ``xdg-utils`` never
 kills the wider ``terok setup`` flow.
 
-Two backends, picked at install time:
+Preferred path is ``xdg-utils`` — ``xdg-desktop-menu install`` for the
+launcher plus ``xdg-icon-resource install --context apps`` for the
+hicolor icon theme entry.  Standard freedesktop tooling: it validates
+the ``.desktop`` via ``desktop-file-install``, drops the icon into
+``hicolor/<size>/apps/`` so ``Icon=terok`` resolves, and kicks the
+``update-desktop-database`` + ``gtk-update-icon-cache`` refreshes for
+us.  Also the same API we'd hook into later from an rpm/deb ``%post``
+with ``--mode=system``.
 
-1. **``xdg-utils``** (preferred — ``xdg-desktop-menu install`` +
-   ``xdg-desktop-icon install``).  Standard freedesktop tooling;
-   handles file validation via ``desktop-file-install`` and runs the
-   ``update-desktop-database`` + ``gtk-update-icon-cache`` refreshes
-   itself.  Also the same API we'd hook into from an rpm/deb
-   ``%post`` script later with ``--mode=system``.
-2. **Manual fallback** — direct write to
-   ``$XDG_DATA_HOME/applications`` + icon tree, then invoke the two
-   cache-refresh binaries ourselves.  Used when ``xdg-utils`` isn't
-   installed (minimal container images, some CI runners).
+When ``xdg-utils`` isn't on PATH (minimal container images, some CI
+runners) we fall back to writing the XDG tree ourselves and firing the
+cache-refresh binaries directly.  This is *best-effort*: the files end
+up in the right place on hosts that match the spec, but there's no
+``desktop-file-install`` validation and no cover for DE-specific
+layout drift.  :func:`install_desktop_entry` returns a
+:class:`DesktopBackend` so the caller can surface a gentle warning
+when the fallback kicks in.
 
 The passive assets (``.desktop`` template, logo PNG) live under
 ``terok/resources/desktop/`` — this module is the *builder* that reads
@@ -36,6 +41,7 @@ import os
 import shutil
 import subprocess  # nosec B404 — cache refresh binaries are trusted
 import tempfile
+from enum import StrEnum
 from importlib import resources as importlib_resources
 from importlib.resources.abc import Traversable
 from pathlib import Path
@@ -64,9 +70,21 @@ _ICON_SIZE_DIR = f"{_ICON_SIZE}x{_ICON_SIZE}"
 _DEFAULT_DATA_HOME = (".local", "share")  # $HOME/.local/share — XDG fallback
 
 _XDG_MENU_BINARY = "xdg-desktop-menu"
-_XDG_ICON_BINARY = "xdg-desktop-icon"
+# ``xdg-icon-resource`` registers an icon in the hicolor theme so
+# ``Icon=terok`` in the .desktop file resolves.  The similarly-named
+# ``xdg-desktop-icon`` would put the PNG on the *user's Desktop folder*
+# instead — looks plausible, skips the theme entirely.
+_XDG_ICON_RESOURCE_BINARY = "xdg-icon-resource"
+_XDG_ICON_CONTEXT = "apps"
 
 _SUBPROCESS_TIMEOUT_S = 10
+
+
+class DesktopBackend(StrEnum):
+    """Which install path :func:`install_desktop_entry` actually took."""
+
+    XDG_UTILS = "xdg-utils"
+    FALLBACK = "fallback"
 
 
 def _resource_dir() -> Traversable:
@@ -81,7 +99,7 @@ def _resource_dir() -> Traversable:
     return importlib_resources.files("terok").joinpath("resources", "desktop")
 
 
-def install_desktop_entry(bin_path: str | Path) -> None:
+def install_desktop_entry(bin_path: str | Path) -> DesktopBackend:
     """Render the launcher + copy the icon, via xdg-utils when available.
 
     Args:
@@ -90,6 +108,11 @@ def install_desktop_entry(bin_path: str | Path) -> None:
             launcher's minimal PATH often misses ``~/.local/bin``, so
             ``shutil.which("terok-tui")``'s absolute result is preferred
             over the short name.
+
+    Returns:
+        The :class:`DesktopBackend` actually used.  Callers wire this to
+        a status-line warning when the fallback kicks in so the operator
+        knows ``xdg-utils`` is missing.
     """
     rendered = (
         _load_template().replace("{{BIN}}", str(bin_path)).replace("{{TRY_EXEC}}", str(bin_path))
@@ -97,16 +120,24 @@ def install_desktop_entry(bin_path: str | Path) -> None:
     logo_bytes = _resource_dir().joinpath(_LOGO_NAME).read_bytes()
     if _xdg_utils_available():
         _install_via_xdg_utils(rendered, logo_bytes)
-    else:
-        _install_manually(rendered, logo_bytes)
+        return DesktopBackend.XDG_UTILS
+    _install_manually(rendered, logo_bytes)
+    return DesktopBackend.FALLBACK
 
 
-def uninstall_desktop_entry() -> None:
-    """Remove the launcher + icon, via xdg-utils when available."""
+def uninstall_desktop_entry() -> DesktopBackend:
+    """Remove the launcher + icon, via xdg-utils when available.
+
+    Returns:
+        The :class:`DesktopBackend` actually used — symmetric with
+        :func:`install_desktop_entry` so a caller can phrase the teardown
+        status line the same way.
+    """
     if _xdg_utils_available():
         _uninstall_via_xdg_utils()
-    else:
-        _uninstall_manually()
+        return DesktopBackend.XDG_UTILS
+    _uninstall_manually()
+    return DesktopBackend.FALLBACK
 
 
 def is_desktop_entry_installed() -> bool:
@@ -124,7 +155,7 @@ def is_desktop_entry_installed() -> bool:
 
 def _xdg_utils_available() -> bool:
     """Return True only when *both* xdg-utils front-ends are on PATH."""
-    return bool(shutil.which(_XDG_MENU_BINARY) and shutil.which(_XDG_ICON_BINARY))
+    return bool(shutil.which(_XDG_MENU_BINARY) and shutil.which(_XDG_ICON_RESOURCE_BINARY))
 
 
 def _install_via_xdg_utils(desktop_contents: str, logo_bytes: bytes) -> None:
@@ -132,10 +163,13 @@ def _install_via_xdg_utils(desktop_contents: str, logo_bytes: bytes) -> None:
 
     ``xdg-desktop-menu install`` runs ``desktop-file-install`` (catches
     malformed keys), drops the file under the user's applications dir,
-    and kicks ``update-desktop-database``.  ``xdg-desktop-icon install``
-    does the equivalent for the hicolor tree including
-    ``gtk-update-icon-cache``.  Both are name-by-filename — we stage to
-    a tempdir so the basenames carry the destination names we want.
+    and kicks ``update-desktop-database``.  ``xdg-icon-resource install
+    --context apps`` does the equivalent for the hicolor theme tree —
+    it's the tool that makes ``Icon=terok`` resolvable — and runs
+    ``gtk-update-icon-cache`` itself.  We stage the ``.desktop`` to a
+    tempdir (xdg-desktop-menu names it by source basename) and pass the
+    icon resource name (``terok``) explicitly to ``xdg-icon-resource``
+    so the theme entry is deterministic regardless of source filename.
     """
     with tempfile.TemporaryDirectory(prefix="terok-desktop-") as td:
         staged_dir = Path(td)
@@ -150,19 +184,30 @@ def _install_via_xdg_utils(desktop_contents: str, logo_bytes: bytes) -> None:
             str(staged_desktop),
         )
         _run_xdg(
-            _XDG_ICON_BINARY,
+            _XDG_ICON_RESOURCE_BINARY,
             "install",
             "--novendor",
             "--size",
             _ICON_SIZE,
+            "--context",
+            _XDG_ICON_CONTEXT,
             str(staged_icon),
+            APP_NAME,
         )
 
 
 def _uninstall_via_xdg_utils() -> None:
     """Delegate removal + cache refresh to xdg-utils."""
     _run_xdg(_XDG_MENU_BINARY, "uninstall", "--novendor", _DESKTOP_FILE)
-    _run_xdg(_XDG_ICON_BINARY, "uninstall", "--novendor", "--size", _ICON_SIZE, _ICON_FILE)
+    _run_xdg(
+        _XDG_ICON_RESOURCE_BINARY,
+        "uninstall",
+        "--size",
+        _ICON_SIZE,
+        "--context",
+        _XDG_ICON_CONTEXT,
+        APP_NAME,
+    )
 
 
 def _run_xdg(binary: str, *args: str) -> None:

--- a/src/terok/cli/commands/setup.py
+++ b/src/terok/cli/commands/setup.py
@@ -499,11 +499,12 @@ def _ensure_desktop_entry(*, check_only: bool) -> bool:
     else:
         # The fallback writes the right XDG paths on spec-compliant
         # hosts but skips desktop-file-install validation and can't
-        # cover DE-specific layout drift — flag so the operator knows
-        # to install xdg-utils for the robust path.
+        # cover DE-specific layout drift.  We also land here when
+        # xdg-utils *is* on PATH but its install calls failed (DEBUG
+        # log carries the detail) — "missing or failed" covers both.
         print(
             f"{_warn_label()} "
-            f"(installed via built-in fallback — xdg-utils not on PATH; "
+            f"(installed via built-in fallback — xdg-utils missing or failed; "
             f"install it for standard XDG registration)"
         )
     return True

--- a/src/terok/cli/commands/setup.py
+++ b/src/terok/cli/commands/setup.py
@@ -473,7 +473,7 @@ def _ensure_desktop_entry(*, check_only: bool) -> bool:
          its own, but the refresh makes it appear in the next-session
          menu without an X-server restart.
     """
-    from ._desktop_entry import install_desktop_entry, is_desktop_entry_installed
+    from ._desktop_entry import DesktopBackend, install_desktop_entry, is_desktop_entry_installed
 
     _stage_begin("Desktop entry")
     if check_only:
@@ -490,11 +490,22 @@ def _ensure_desktop_entry(*, check_only: bool) -> bool:
         # to the bare binary name so an updated PATH picks it up.
         bin_path = "terok-tui"
     try:
-        install_desktop_entry(bin_path)
+        backend = install_desktop_entry(bin_path)
     except Exception as exc:  # noqa: BLE001
         print(f"{_status_label(False)} ({exc})")
         return False
-    print(f"{_status_label(True)} (installed)")
+    if backend is DesktopBackend.XDG_UTILS:
+        print(f"{_status_label(True)} (installed)")
+    else:
+        # The fallback writes the right XDG paths on spec-compliant
+        # hosts but skips desktop-file-install validation and can't
+        # cover DE-specific layout drift — flag so the operator knows
+        # to install xdg-utils for the robust path.
+        print(
+            f"{_warn_label()} "
+            f"(installed via built-in fallback — xdg-utils not on PATH; "
+            f"install it for standard XDG registration)"
+        )
     return True
 
 

--- a/tests/unit/cli/test_cli_setup_global.py
+++ b/tests/unit/cli/test_cli_setup_global.py
@@ -868,25 +868,71 @@ class TestEnsureDesktopEntry:
         self, capsys: pytest.CaptureFixture
     ) -> None:
         """``shutil.which`` hit → absolute path threaded into the installer."""
+        from terok.cli.commands._desktop_entry import DesktopBackend
         from terok.cli.commands.setup import _ensure_desktop_entry
 
         with (
             patch("terok.cli.commands.setup.shutil.which", return_value="/opt/venv/bin/terok-tui"),
-            patch("terok.cli.commands._desktop_entry.install_desktop_entry") as install,
+            patch(
+                "terok.cli.commands._desktop_entry.install_desktop_entry",
+                return_value=DesktopBackend.XDG_UTILS,
+            ) as install,
         ):
             assert _ensure_desktop_entry(check_only=False) is True
         install.assert_called_once_with("/opt/venv/bin/terok-tui")
 
     def test_install_falls_back_to_bare_name_off_path(self, capsys: pytest.CaptureFixture) -> None:
         """Nothing on PATH → installer still runs with the bare binary name."""
+        from terok.cli.commands._desktop_entry import DesktopBackend
         from terok.cli.commands.setup import _ensure_desktop_entry
 
         with (
             patch("terok.cli.commands.setup.shutil.which", return_value=None),
-            patch("terok.cli.commands._desktop_entry.install_desktop_entry") as install,
+            patch(
+                "terok.cli.commands._desktop_entry.install_desktop_entry",
+                return_value=DesktopBackend.XDG_UTILS,
+            ) as install,
         ):
             assert _ensure_desktop_entry(check_only=False) is True
         install.assert_called_once_with("terok-tui")
+
+    def test_xdg_utils_backend_reports_ok(self, capsys: pytest.CaptureFixture) -> None:
+        """xdg-utils path → green ``ok (installed)`` with no fallback blurb."""
+        from terok.cli.commands._desktop_entry import DesktopBackend
+        from terok.cli.commands.setup import _ensure_desktop_entry
+
+        with (
+            patch("terok.cli.commands.setup.shutil.which", return_value="/usr/bin/terok-tui"),
+            patch(
+                "terok.cli.commands._desktop_entry.install_desktop_entry",
+                return_value=DesktopBackend.XDG_UTILS,
+            ),
+        ):
+            assert _ensure_desktop_entry(check_only=False) is True
+        out = capsys.readouterr().out
+        assert "(installed)" in out
+        assert "fallback" not in out
+
+    def test_fallback_backend_warns_non_threateningly(self, capsys: pytest.CaptureFixture) -> None:
+        """Manual fallback → yellow warn line that names xdg-utils as the fix.
+
+        Install still succeeds (return True) — the operator just gets a
+        heads-up that the canonical XDG tooling was missing.
+        """
+        from terok.cli.commands._desktop_entry import DesktopBackend
+        from terok.cli.commands.setup import _ensure_desktop_entry
+
+        with (
+            patch("terok.cli.commands.setup.shutil.which", return_value="/usr/bin/terok-tui"),
+            patch(
+                "terok.cli.commands._desktop_entry.install_desktop_entry",
+                return_value=DesktopBackend.FALLBACK,
+            ),
+        ):
+            assert _ensure_desktop_entry(check_only=False) is True
+        out = capsys.readouterr().out
+        assert "fallback" in out
+        assert "xdg-utils" in out
 
     def test_install_failure_soft_fails_with_fail_status(
         self, capsys: pytest.CaptureFixture

--- a/tests/unit/cli/test_desktop_entry.py
+++ b/tests/unit/cli/test_desktop_entry.py
@@ -179,6 +179,67 @@ class TestInstallViaXdgUtils:
         ):
             desktop.install_desktop_entry("terok-tui")  # must not raise
 
+    def test_xdg_failure_falls_back_to_manual(self, xdg_data_home: Path) -> None:
+        """xdg-utils on PATH but calls fail → manual path runs, backend is FALLBACK.
+
+        The whole point of the backend return: XDG_UTILS means xdg-utils
+        *actually did the work*, not "we called it and hoped".  A broken
+        front-end (readonly menu dir, DE-detection quirk) has to read as
+        FALLBACK so the operator sees the WARN.
+        """
+        failing = subprocess.CompletedProcess(
+            args=[],
+            returncode=3,
+            stdout=b"",
+            stderr=b"xdg-desktop-menu: no writable system menu directory found",
+        )
+        with (
+            mock.patch(
+                "terok.cli.commands._desktop_entry.shutil.which",
+                side_effect=_which_everything,
+            ),
+            mock.patch(
+                "terok.cli.commands._desktop_entry.subprocess.run",
+                return_value=failing,
+            ),
+        ):
+            backend = desktop.install_desktop_entry("terok-tui")
+
+        assert backend is desktop.DesktopBackend.FALLBACK
+        # Manual path actually landed the files — a FALLBACK label with
+        # no files on disk would be the worst of both worlds.
+        assert desktop.is_desktop_entry_installed()
+
+    def test_xdg_partial_failure_still_falls_back(self, xdg_data_home: Path) -> None:
+        """Menu install OK but icon install fails → still FALLBACK.
+
+        A half-success is the nastiest case — ``.desktop`` would be
+        registered with ``Icon=terok`` but the theme entry would be
+        missing, which is exactly the bug this whole change is about.
+        """
+        ok = subprocess.CompletedProcess(args=[], returncode=0, stdout=b"", stderr=b"")
+        fail = subprocess.CompletedProcess(args=[], returncode=2, stdout=b"", stderr=b"boom")
+        # _install_via_xdg_utils runs menu first, icon second — make
+        # only the icon call fail.  The cache-refresh subprocesses from
+        # the manual fallback run after and also see this sequence, so
+        # we pad with successes.
+        returns = iter([ok, fail, ok, ok, ok, ok])
+
+        with (
+            mock.patch(
+                "terok.cli.commands._desktop_entry.shutil.which",
+                side_effect=_which_everything,
+            ),
+            mock.patch(
+                "terok.cli.commands._desktop_entry.subprocess.run",
+                side_effect=lambda *a, **kw: next(returns),
+            ),
+        ):
+            backend = desktop.install_desktop_entry("terok-tui")
+
+        assert backend is desktop.DesktopBackend.FALLBACK
+        assert desktop.is_desktop_entry_installed()
+
     def test_non_zero_xdg_exit_is_logged(
         self,
         xdg_data_home: Path,

--- a/tests/unit/cli/test_desktop_entry.py
+++ b/tests/unit/cli/test_desktop_entry.py
@@ -26,7 +26,7 @@ def xdg_data_home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
 
 def _which_no_xdg_utils(name: str) -> str | None:
     """``shutil.which`` side-effect: xdg-utils missing, manual cache bins present."""
-    if name in ("xdg-desktop-menu", "xdg-desktop-icon"):
+    if name in ("xdg-desktop-menu", "xdg-icon-resource"):
         return None
     return f"/usr/bin/{name}"
 
@@ -68,16 +68,22 @@ class TestInstallViaXdgUtils:
         # xdg-utils exclusively — the manual update-desktop-database /
         # gtk-update-icon-cache fallbacks must not fire.
         assert "xdg-desktop-menu" in binaries
-        assert "xdg-desktop-icon" in binaries
+        assert "xdg-icon-resource" in binaries
+        # xdg-desktop-icon is the *wrong* tool — it installs to the
+        # user's Desktop folder, skipping the hicolor theme.  Guard the
+        # regression explicitly.
+        assert "xdg-desktop-icon" not in binaries
         assert "update-desktop-database" not in binaries
         assert "gtk-update-icon-cache" not in binaries
 
     def test_stages_files_with_target_basenames(self, xdg_data_home: Path) -> None:
         """Staged paths handed to xdg-utils use the final ``terok.desktop`` / ``terok.png`` names.
 
-        xdg-utils names the installed resource after the source basename,
-        so staging to ``/tmp/.../terok-logo.png`` would register the
-        icon as ``terok-logo`` and the ``Icon=terok`` key would miss.
+        xdg-desktop-menu names the installed ``.desktop`` after the
+        source basename, so staging to ``/tmp/.../foo.desktop`` would
+        register the launcher as ``foo``.  xdg-icon-resource takes the
+        icon resource name as a positional argument, which we pass
+        explicitly so the theme entry is always ``terok``.
         """
         calls: list[list[str]] = []
 
@@ -97,18 +103,36 @@ class TestInstallViaXdgUtils:
             desktop.install_desktop_entry("terok-tui")
 
         desktop_call = next(argv for argv in calls if argv[0].endswith("xdg-desktop-menu"))
-        icon_call = next(argv for argv in calls if argv[0].endswith("xdg-desktop-icon"))
+        icon_call = next(argv for argv in calls if argv[0].endswith("xdg-icon-resource"))
         assert Path(desktop_call[-1]).name == "terok.desktop"
-        assert Path(icon_call[-1]).name == "terok.png"
+        # xdg-icon-resource argv: ... <staged.png> <resource-name>.  The
+        # trailing positional is the resource name; the one before it is
+        # the source path.
+        assert icon_call[-1] == "terok"
+        assert Path(icon_call[-2]).name == "terok.png"
         # The ``--novendor`` flag is mandatory for ``.desktop`` files not
         # named ``{vendor}-{appname}.desktop``; xdg-utils would otherwise
         # refuse the install.
         assert "--novendor" in desktop_call
         assert "--novendor" in icon_call
-        # Icon size is explicit so xdg-utils drops us into the
-        # ``hicolor/256x256/apps/`` bucket rather than guessing.
+        # Icon size + context are explicit so xdg-icon-resource drops us
+        # into ``hicolor/256x256/apps/`` rather than guessing.
         assert "--size" in icon_call
         assert icon_call[icon_call.index("--size") + 1] == "256"
+        assert "--context" in icon_call
+        assert icon_call[icon_call.index("--context") + 1] == "apps"
+
+    def test_install_returns_xdg_utils_backend(self, xdg_data_home: Path) -> None:
+        """Return value advertises which backend was used so callers can warn."""
+        fake_proc = subprocess.CompletedProcess(args=[], returncode=0, stdout=b"", stderr=b"")
+        with (
+            mock.patch(
+                "terok.cli.commands._desktop_entry.shutil.which",
+                side_effect=_which_everything,
+            ),
+            mock.patch("terok.cli.commands._desktop_entry.subprocess.run", return_value=fake_proc),
+        ):
+            assert desktop.install_desktop_entry("terok-tui") is desktop.DesktopBackend.XDG_UTILS
 
     def test_uninstall_delegates_to_xdg_utils(self) -> None:
         """``uninstall`` invokes the matching xdg-utils ``uninstall`` subcommands."""
@@ -131,7 +155,15 @@ class TestInstallViaXdgUtils:
 
         verbs = [(argv[0].split("/")[-1], argv[1]) for argv in calls]
         assert ("xdg-desktop-menu", "uninstall") in verbs
-        assert ("xdg-desktop-icon", "uninstall") in verbs
+        assert ("xdg-icon-resource", "uninstall") in verbs
+        icon_call = next(argv for argv in calls if argv[0].endswith("xdg-icon-resource"))
+        # Uninstall takes the icon resource *name* (not a file path), in
+        # the same size + context we installed under.
+        assert icon_call[-1] == "terok"
+        assert "--size" in icon_call
+        assert icon_call[icon_call.index("--size") + 1] == "256"
+        assert "--context" in icon_call
+        assert icon_call[icon_call.index("--context") + 1] == "apps"
 
     def test_xdg_subprocess_failure_is_swallowed(self, xdg_data_home: Path) -> None:
         """A hung / broken xdg-utils front-end must not raise."""
@@ -223,6 +255,13 @@ class TestInstallManualFallback:
         binaries = [argv[0].split("/")[-1] for argv in calls]
         assert "update-desktop-database" in binaries
         assert "gtk-update-icon-cache" in binaries
+
+    def test_install_returns_fallback_backend(self, xdg_data_home: Path) -> None:
+        """With xdg-utils absent the return value says so — drives the setup warning."""
+        with mock.patch(
+            "terok.cli.commands._desktop_entry.shutil.which", side_effect=_which_nothing
+        ):
+            assert desktop.install_desktop_entry("terok-tui") is desktop.DesktopBackend.FALLBACK
 
     def test_cache_refresh_skipped_when_binaries_missing(self, xdg_data_home: Path) -> None:
         """Nothing on PATH at all → no subprocess fired, install still succeeds."""
@@ -326,6 +365,23 @@ class TestBackendSelection:
             return "/usr/bin/xdg-desktop-menu" if name == "xdg-desktop-menu" else None
 
         with mock.patch("terok.cli.commands._desktop_entry.shutil.which", side_effect=only_menu):
+            assert desktop._xdg_utils_available() is False
+
+    def test_xdg_desktop_icon_alone_is_not_enough(self) -> None:
+        """Presence of ``xdg-desktop-icon`` (wrong tool) must not flip the gate on.
+
+        Older code probed for ``xdg-desktop-icon``, but that front-end
+        installs icons to the user's Desktop folder instead of the
+        theme.  Make the regression explicit.
+        """
+
+        def only_wrong_icon_tool(name: str) -> str | None:
+            return "/usr/bin/xdg-desktop-icon" if name == "xdg-desktop-icon" else None
+
+        with mock.patch(
+            "terok.cli.commands._desktop_entry.shutil.which",
+            side_effect=only_wrong_icon_tool,
+        ):
             assert desktop._xdg_utils_available() is False
 
     def test_returns_true_when_both_on_path(self) -> None:

--- a/tests/unit/cli/test_desktop_entry.py
+++ b/tests/unit/cli/test_desktop_entry.py
@@ -134,6 +134,52 @@ class TestInstallViaXdgUtils:
         ):
             assert desktop.install_desktop_entry("terok-tui") is desktop.DesktopBackend.XDG_UTILS
 
+    def test_uninstall_returns_xdg_utils_backend(self, xdg_data_home: Path) -> None:
+        """Successful xdg-utils uninstall reports XDG_UTILS."""
+        fake_proc = subprocess.CompletedProcess(args=[], returncode=0, stdout=b"", stderr=b"")
+        with (
+            mock.patch(
+                "terok.cli.commands._desktop_entry.shutil.which",
+                side_effect=_which_everything,
+            ),
+            mock.patch("terok.cli.commands._desktop_entry.subprocess.run", return_value=fake_proc),
+        ):
+            assert desktop.uninstall_desktop_entry() is desktop.DesktopBackend.XDG_UTILS
+
+    def test_uninstall_xdg_failure_falls_back_to_manual(self, xdg_data_home: Path) -> None:
+        """xdg-utils uninstall fails → manual unlinks clean up, backend is FALLBACK.
+
+        Same rationale as the install side: a half-completed teardown
+        (menu gone, icon still registered) is the trap — retry
+        manually so the caller's "did it work?" signal is honest.
+        """
+        # Seed the XDG tree the way a prior install would have.
+        with mock.patch(
+            "terok.cli.commands._desktop_entry.shutil.which", side_effect=_which_nothing
+        ):
+            desktop.install_desktop_entry("terok-tui")
+        assert desktop.is_desktop_entry_installed()
+
+        failing = subprocess.CompletedProcess(
+            args=[],
+            returncode=3,
+            stdout=b"",
+            stderr=b"xdg-desktop-menu: nothing to uninstall",
+        )
+        with (
+            mock.patch(
+                "terok.cli.commands._desktop_entry.shutil.which",
+                side_effect=_which_everything,
+            ),
+            mock.patch("terok.cli.commands._desktop_entry.subprocess.run", return_value=failing),
+        ):
+            backend = desktop.uninstall_desktop_entry()
+
+        assert backend is desktop.DesktopBackend.FALLBACK
+        # Manual unlinks ran, so both files are gone even though
+        # xdg-utils claimed failure.
+        assert not desktop.is_desktop_entry_installed()
+
     def test_uninstall_delegates_to_xdg_utils(self) -> None:
         """``uninstall`` invokes the matching xdg-utils ``uninstall`` subcommands."""
         calls: list[list[str]] = []


### PR DESCRIPTION
## Summary

- Fix the menu icon: swap `xdg-desktop-icon install` (wrong tool — drops the PNG on the user's Desktop folder) for `xdg-icon-resource install --context apps --size 256 <png> terok`, the canonical front-end for the hicolor icon theme. The resource name is passed explicitly so the theme entry is always `terok` regardless of source basename. `Icon=terok` in the `.desktop` file now resolves.
- Reframe the manual path as an explicit *best-effort fallback* rather than a peer backend. `install_desktop_entry()` now returns a `DesktopBackend` enum (`XDG_UTILS` / `FALLBACK`) and `terok setup` prints a non-threatening yellow `WARN` line when the fallback kicks in, naming xdg-utils as the fix.
- Regression guards: tests now assert `xdg-desktop-icon` is *not* invoked, and `_xdg_utils_available()` must not flip on when only `xdg-desktop-icon` is on PATH.

## Why this bug bit

The two tools sound interchangeable but do different things. `xdg-desktop-icon install FILE` installs `FILE` onto the user's desktop folder (e.g. `~/Desktop/terok.png`). `xdg-icon-resource install --size 256 --context apps FILE NAME` installs `FILE` into `$XDG_DATA_HOME/icons/hicolor/256x256/apps/NAME.png`, which is where `Icon=<name>` in a `.desktop` file is looked up. On Fedora GNOME, xdg-utils is always present → we always took the broken path. The manual fallback wrote the hicolor tree correctly, so CI and xdg-utils-less minimal images never saw the bug.

## Test plan

- [x] `make lint` clean
- [x] `make tach` / `make lint-imports` / `make docstrings` / `make security` clean
- [x] `tests/unit/cli/test_desktop_entry.py` + `tests/unit/cli/test_cli_setup_global.py` pass (94 tests in the touched modules)
- [x] One pre-existing failure in `tests/unit/cli/test_cli_config.py::test_config_command_color_output` (port 9418 for gate unavailable — environmental, reproduces on pristine master)
- [ ] Manual verification on Fedora GNOME: `terok setup`, then confirm `~/.local/share/icons/hicolor/256x256/apps/terok.png` exists and the menu shows the logo
- [ ] Manual verification with xdg-utils uninstalled: `terok setup` emits the WARN line and the fallback still writes the hicolor path

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Installer now reports which backend was used (standard xdg-utils or built-in fallback) and surfaces a warning when fallback is used.
* **Bug Fixes**
  * More reliable detection and handling of system icon/registration tooling to avoid false-positive “installed” reports.
* **Tests**
  * Expanded tests covering backend selection, partial failures, and stricter icon/registration command expectations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->