### PR TITLE
feat(cli,tui): first-start UX pass — attach, preflight, broken-project surfacing

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,9 +80,10 @@ Or do the same from the command line:
 ```bash
 terok project wizard                    # interactive setup
 terok auth claude myproj                # authenticate agent
-terok task run myproj                 # start a CLI agent task
-terok task run myproj --mode toad     # Toad multi-agent TUI (browser access)
-terok login myproj a3                   # attach to a running task by hex ID prefix
+terok task run myproj                   # create a CLI task and attach (default on TTY)
+terok task run myproj --no-attach       # start it detached; print login instructions
+terok task run myproj --mode toad       # Toad multi-agent TUI (browser access)
+terok login myproj a3                   # re-attach later by hex ID prefix
 ```
 
 For manual project configuration or CI, see the [User Guide](docs/usage.md).

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -273,22 +273,31 @@ Supported tokens: `{{IDENTITY_FILE}}`, `{{KEY_NAME}}`, `{{PROJECT_ID}}`
 ### Step 7: Create and Run a Task
 
 ```bash
-# Create a new task
-terok task new myproj
-# Output: Created task 1 for project myproj
+# Create a new task and attach into its shell (default on a TTY).
+# Equivalent to: task run + waiting for ready + terok login — one command.
+terok task run myproj
+
+# --no-attach keeps the old behaviour: start the container and print the
+# `terok login` instructions instead of exec'ing into it.  Scripts piping
+# terok's output get --no-attach automatically (non-TTY = non-interactive).
+terok task run myproj --no-attach
+
+# If the project's image hasn't been built yet, task run prompts on a TTY
+# ("Build now? [Y/n]") and runs `project build` inline; scripts exit with
+# a hint pointing at the command.
 
 # List tasks
 terok task list myproj
-
-# Run in CLI mode (headless agent)
-terokctl task attach --mode cli myproj 1
 ```
 
 #### Additional Task Operations
 
 ```bash
-# Create and immediately run a task in one step
-terok task run myproj
+# Create a task metadata record without running it (scripting, terokctl only)
+terokctl task new myproj
+
+# Attach to an existing task (terokctl, scripting)
+terokctl task attach --mode cli myproj 1
 
 # Rename a task
 terok task rename myproj 1 fix-auth-bug

--- a/src/terok/cli/commands/setup.py
+++ b/src/terok/cli/commands/setup.py
@@ -780,8 +780,9 @@ def cmd_setup(
     providers = ", ".join(AUTH_PROVIDERS)
     print(
         f"\nNext steps:\n"
-        f"  terok auth <provider> <project>            Authenticate agents ({providers})\n"
         f"  terok project wizard                       Create your first project\n"
+        f"  terok auth <provider> <project>            Authenticate agents ({providers})\n"
+        f"  terok task run <project>                   Start a CLI task (attaches on TTY)\n"
     )
 
     if not binaries_ok:

--- a/src/terok/cli/commands/task.py
+++ b/src/terok/cli/commands/task.py
@@ -318,78 +318,25 @@ def dispatch(args: argparse.Namespace) -> bool:
 
 
 def _cmd_task_run(args: argparse.Namespace) -> None:
-    """Handle ``terok task run`` — create a task and run it in the chosen mode.
-
-    The L2 image preflight fires inside each mode branch *after* that mode's
-    cheap validation so a user who forgets e.g. ``--prompt`` in headless mode
-    sees the argparse-style error before being asked whether to spend minutes
-    building an image.
-    """
+    """Dispatch ``terok task run`` to the runner for the chosen mode."""
     mode = getattr(args, "mode", "cli")
-
     if mode == "headless":
         _cmd_task_run_headless(args)
     elif mode == "toad":
-        _ensure_project_image(args.project_id)
         _cmd_task_run_interactive(args, runner=task_run_toad, attach=False)
     else:  # mode == "cli"
-        _ensure_project_image(args.project_id)
         _cmd_task_run_interactive(args, runner=task_run_cli, attach=_resolve_attach(args))
 
 
-def _resolve_attach(args: argparse.Namespace) -> bool:
-    """Resolve --attach/--no-attach for ``task run --mode=cli``.
+def _cmd_task_run_interactive(args: argparse.Namespace, *, runner: Any, attach: bool) -> None:
+    """Create a task, launch its container, and optionally attach to it.
 
-    Default is True on an interactive TTY (``docker run -it`` mental model),
-    False otherwise — scripts piping the output want "start it and return"
-    rather than ``execvp`` into an interactive shell.
-    """
-    if args.attach is not None:
-        return bool(args.attach)
-    return sys.stdin.isatty() and sys.stdout.isatty()
-
-
-def _ensure_project_image(project_id: str) -> None:
-    """Check the project's L2 image exists; offer to build it when missing.
-
-    TTY → interactive ``Build now? [Y/n]`` prompt, then ``build_images()``
-    inline.  Non-TTY → exit with a hint so scripts stay deterministic.
-    """
-    if project_image_exists(project_id):
-        return
-
-    hint = (
-        f"Image for project {project_id!r} is not present. "
-        f"Build it first: terok project build {project_id}"
-    )
-    if not (sys.stdin.isatty() and sys.stdout.isatty()):
-        raise SystemExit(hint)
-
-    try:
-        answer = (
-            input(f"Image for project {project_id!r} is missing. Build now? [Y/n]: ")
-            .strip()
-            .lower()
-        )
-    except (EOFError, KeyboardInterrupt):
-        print()
-        raise SystemExit(hint) from None
-
-    if answer in ("n", "no"):
-        raise SystemExit(hint)
-
-    build_images(project_id)
-
-
-def _cmd_task_run_interactive(
-    args: argparse.Namespace, *, runner: Any, attach: bool = False
-) -> None:
-    """Create + run for interactive modes (cli, toad).
-
-    When *attach* is true (CLI mode on a TTY), ``execvp`` into ``task_login``
-    after the container reports ready.  Toad prints its URL + token and returns.
+    *runner* is the mode-specific launcher (CLI or Toad).  Toad prints a
+    URL + token and returns; CLI under *attach* execs into ``task_login``
+    once the container reports ready.
     """
     pid = args.project_id
+    _ensure_project_image(pid)
     tid = task_new(pid, name=getattr(args, "name", None))
     runner(
         pid,
@@ -435,6 +382,50 @@ def _cmd_task_run_headless(args: argparse.Namespace) -> None:
             unrestricted=_resolve_unrestricted(args),
         )
     )
+
+
+def _resolve_attach(args: argparse.Namespace) -> bool:
+    """Decide whether a CLI-mode ``task run`` execs into ``terok login`` on ready.
+
+    Default is True on an interactive TTY (``docker run -it`` mental model),
+    False otherwise — scripts piping the output want "start it and return"
+    rather than ``execvp`` into an interactive shell.
+    """
+    if args.attach is not None:
+        return bool(args.attach)
+    return sys.stdin.isatty() and sys.stdout.isatty()
+
+
+def _ensure_project_image(project_id: str) -> None:
+    """Ensure the project's L2 image exists, offering to build it when missing.
+
+    TTY → interactive ``Build now? [Y/n]`` prompt, then ``build_images()``
+    inline.  Non-TTY → exit with a hint so scripts stay deterministic.
+    """
+    if project_image_exists(project_id):
+        return
+
+    hint = (
+        f"Image for project {project_id!r} is not present. "
+        f"Build it first: terok project build {project_id}"
+    )
+    if not (sys.stdin.isatty() and sys.stdout.isatty()):
+        raise SystemExit(hint)
+
+    try:
+        answer = (
+            input(f"Image for project {project_id!r} is missing. Build now? [Y/n]: ")
+            .strip()
+            .lower()
+        )
+    except (EOFError, KeyboardInterrupt):
+        print()
+        raise SystemExit(hint) from None
+
+    if answer in ("n", "no"):
+        raise SystemExit(hint)
+
+    build_images(project_id)
 
 
 def _read_instructions(instructions_path: str | None) -> str | None:

--- a/src/terok/cli/commands/task.py
+++ b/src/terok/cli/commands/task.py
@@ -344,9 +344,8 @@ def _resolve_attach(args: argparse.Namespace) -> bool:
     False otherwise — scripts piping the output want "start it and return"
     rather than ``execvp`` into an interactive shell.
     """
-    explicit = getattr(args, "attach", None)
-    if explicit is not None:
-        return bool(explicit)
+    if args.attach is not None:
+        return bool(args.attach)
     return sys.stdin.isatty() and sys.stdout.isatty()
 
 

--- a/src/terok/cli/commands/task.py
+++ b/src/terok/cli/commands/task.py
@@ -15,6 +15,8 @@ from ...lib.core.config import get_logs_partial_streaming as _get_logs_partial_s
 from ...lib.domain.facade import (
     HeadlessRunRequest,
     LogViewOptions,
+    build_images,
+    project_image_exists,
     task_archive_list,
     task_archive_logs,
     task_delete,
@@ -128,6 +130,21 @@ def register(
     )
     t_run.add_argument("--name", help="Human-readable task name (slug-style, e.g. fix-auth-bug)")
     _add_restriction_flags(t_run)
+    # CLI-mode attach (default: attach when stdout is a TTY).  Headless
+    # already streams/follows on its own; toad returns a URL + token.
+    attach_group = t_run.add_mutually_exclusive_group()
+    attach_group.add_argument(
+        "--attach",
+        action="store_true",
+        default=None,
+        help="After container is ready, log into it (default on TTY, --mode=cli only)",
+    )
+    attach_group.add_argument(
+        "--no-attach",
+        dest="attach",
+        action="store_false",
+        help="Print login instructions instead of attaching",
+    )
     # Headless-only flags (silently ignored in cli/toad modes)
     t_run.add_argument(
         "--provider",
@@ -303,16 +320,72 @@ def dispatch(args: argparse.Namespace) -> bool:
 def _cmd_task_run(args: argparse.Namespace) -> None:
     """Handle ``terok task run`` — create a task and run it in the chosen mode."""
     mode = getattr(args, "mode", "cli")
+    # Preflight: the L2 CLI image must exist before any ``task run`` mode;
+    # all three runners launch containers from it.  Offered interactively on
+    # a TTY, a hard error otherwise.
+    _ensure_project_image(args.project_id)
+
     if mode == "headless":
         _cmd_task_run_headless(args)
     elif mode == "toad":
-        _cmd_task_run_interactive(args, runner=task_run_toad)
+        _cmd_task_run_interactive(args, runner=task_run_toad, attach=False)
     else:  # mode == "cli"
-        _cmd_task_run_interactive(args, runner=task_run_cli)
+        _cmd_task_run_interactive(args, runner=task_run_cli, attach=_resolve_attach(args))
 
 
-def _cmd_task_run_interactive(args: argparse.Namespace, *, runner: Any) -> None:
-    """Create + run for interactive modes (cli, toad)."""
+def _resolve_attach(args: argparse.Namespace) -> bool:
+    """Resolve --attach/--no-attach for ``task run --mode=cli``.
+
+    Default is True on an interactive TTY (``docker run -it`` mental model),
+    False otherwise — scripts piping the output want "start it and return"
+    rather than ``execvp`` into an interactive shell.
+    """
+    explicit = getattr(args, "attach", None)
+    if explicit is not None:
+        return bool(explicit)
+    return sys.stdin.isatty() and sys.stdout.isatty()
+
+
+def _ensure_project_image(project_id: str) -> None:
+    """Check the project's L2 image exists; offer to build it when missing.
+
+    TTY → interactive ``Build now? [Y/n]`` prompt, then ``build_images()``
+    inline.  Non-TTY → exit with a hint so scripts stay deterministic.
+    """
+    if project_image_exists(project_id):
+        return
+
+    hint = (
+        f"Image for project {project_id!r} is not present. "
+        f"Build it first: terok project build {project_id}"
+    )
+    if not (sys.stdin.isatty() and sys.stdout.isatty()):
+        raise SystemExit(hint)
+
+    try:
+        answer = (
+            input(f"Image for project {project_id!r} is missing. Build now? [Y/n]: ")
+            .strip()
+            .lower()
+        )
+    except (EOFError, KeyboardInterrupt):
+        print()
+        raise SystemExit(hint) from None
+
+    if answer in ("n", "no"):
+        raise SystemExit(hint)
+
+    build_images(project_id)
+
+
+def _cmd_task_run_interactive(
+    args: argparse.Namespace, *, runner: Any, attach: bool = False
+) -> None:
+    """Create + run for interactive modes (cli, toad).
+
+    When *attach* is true (CLI mode on a TTY), ``execvp`` into ``task_login``
+    after the container reports ready.  Toad prints its URL + token and returns.
+    """
     pid = args.project_id
     tid = task_new(pid, name=getattr(args, "name", None))
     runner(
@@ -322,6 +395,9 @@ def _cmd_task_run_interactive(args: argparse.Namespace, *, runner: Any) -> None:
         preset=getattr(args, "preset", None),
         unrestricted=_resolve_unrestricted(args),
     )
+    if attach:
+        # ``task_login`` calls ``os.execvp`` and never returns on success.
+        task_login(pid, tid)
 
 
 def _cmd_task_run_headless(args: argparse.Namespace) -> None:

--- a/src/terok/cli/commands/task.py
+++ b/src/terok/cli/commands/task.py
@@ -318,18 +318,22 @@ def dispatch(args: argparse.Namespace) -> bool:
 
 
 def _cmd_task_run(args: argparse.Namespace) -> None:
-    """Handle ``terok task run`` — create a task and run it in the chosen mode."""
+    """Handle ``terok task run`` — create a task and run it in the chosen mode.
+
+    The L2 image preflight fires inside each mode branch *after* that mode's
+    cheap validation so a user who forgets e.g. ``--prompt`` in headless mode
+    sees the argparse-style error before being asked whether to spend minutes
+    building an image.
+    """
     mode = getattr(args, "mode", "cli")
-    # Preflight: the L2 CLI image must exist before any ``task run`` mode;
-    # all three runners launch containers from it.  Offered interactively on
-    # a TTY, a hard error otherwise.
-    _ensure_project_image(args.project_id)
 
     if mode == "headless":
         _cmd_task_run_headless(args)
     elif mode == "toad":
+        _ensure_project_image(args.project_id)
         _cmd_task_run_interactive(args, runner=task_run_toad, attach=False)
     else:  # mode == "cli"
+        _ensure_project_image(args.project_id)
         _cmd_task_run_interactive(args, runner=task_run_cli, attach=_resolve_attach(args))
 
 
@@ -401,12 +405,19 @@ def _cmd_task_run_interactive(
 
 
 def _cmd_task_run_headless(args: argparse.Namespace) -> None:
-    """Autopilot path: create a task and run it headlessly against the prompt."""
+    """Autopilot path: create a task and run it headlessly against the prompt.
+
+    Cheap validation (``--prompt`` present, ``--instructions`` file readable)
+    runs first so the user sees those errors before the image preflight
+    potentially asks to build for several minutes.
+    """
     prompt = getattr(args, "prompt", None)
     if not prompt:
         raise SystemExit("--prompt is required when --mode=headless")
 
     instructions_text = _read_instructions(getattr(args, "instructions", None))
+
+    _ensure_project_image(args.project_id)
 
     task_run_headless(
         HeadlessRunRequest(

--- a/src/terok/cli/commands/task.py
+++ b/src/terok/cli/commands/task.py
@@ -418,9 +418,14 @@ def _ensure_project_image(project_id: str) -> None:
             .strip()
             .lower()
         )
-    except (EOFError, KeyboardInterrupt):
+    except EOFError:
+        # stdin closed — treat as implicit decline, print the hint.
         print()
         raise SystemExit(hint) from None
+    except KeyboardInterrupt:
+        # Ctrl-C stays Ctrl-C: exit 130 (conventional SIGINT), no hint.
+        print()
+        raise SystemExit(130) from None
 
     if answer in ("n", "no"):
         raise SystemExit(hint)

--- a/src/terok/cli/main.py
+++ b/src/terok/cli/main.py
@@ -98,10 +98,9 @@ def main(prog: str = "terok") -> None:
         epilog=(
             "Quick start:\n"
             f"  1. Bootstrap:  {prog} setup                       (install host services)\n"
-            f"  2. Auth:       {prog} auth claude <project>       (authenticate agents)\n"
-            f"  3. Project:    {prog} project wizard              (create a project)\n"
-            f"  4. Work:       {prog} task run <project_id>       (new CLI task)\n"
-            f"  5. Login:      {prog} login <project_id> <task_id>\n"
+            f"  2. Project:    {prog} project wizard              (create a project)\n"
+            f"  3. Auth:       {prog} auth claude <project>       (authenticate agents)\n"
+            f"  4. Work:       {prog} task run <project_id>       (attach into a new CLI task)\n"
             "\n"
             "Standalone agent (no project):\n"
             f"  {prog} executor run claude .          (headless against cwd)\n"

--- a/src/terok/lib/core/projects.py
+++ b/src/terok/lib/core/projects.py
@@ -353,27 +353,6 @@ class BrokenProject:
     error: str
 
 
-def _discover_project_paths() -> dict[str, Path]:
-    """Map each on-disk project ID to its ``project.yml`` path.
-
-    User scope wins over system scope for collisions — matches how
-    :func:`load_project` resolves the effective config.  Returning the
-    path alongside the ID lets :func:`discover_projects` carry the
-    location forward to ``BrokenProject`` without re-walking.
-    """
-    paths: dict[str, Path] = {}
-    for root in (user_projects_dir(), projects_dir()):
-        if not root.is_dir():
-            continue
-        for d in root.iterdir():
-            if not d.is_dir() or d.name in paths:
-                continue
-            yml = d / _PROJECT_YML
-            if yml.is_file() and is_valid_project_id(d.name):
-                paths[d.name] = yml
-    return paths
-
-
 def discover_projects() -> tuple[list[ProjectConfig], list[BrokenProject]]:
     """Load every project on disk, splitting successes from config-level failures.
 
@@ -413,6 +392,27 @@ def list_projects() -> list[ProjectConfig]:
         logger.warning("Skipping broken project '%s': %s", bp.id, bp.error.replace("\n", "\\n"))
         print(f"warning: skipping broken project '{bp.id}': {bp.error}", file=sys.stderr)
     return valid
+
+
+def _discover_project_paths() -> dict[str, Path]:
+    """Map each on-disk project ID to its ``project.yml`` path.
+
+    User scope wins over system scope for collisions — matches how
+    :func:`load_project` resolves the effective config.  Returning the
+    path alongside the ID lets :func:`discover_projects` carry the
+    location forward to ``BrokenProject`` without re-walking.
+    """
+    paths: dict[str, Path] = {}
+    for root in (user_projects_dir(), projects_dir()):
+        if not root.is_dir():
+            continue
+        for d in root.iterdir():
+            if not d.is_dir() or d.name in paths:
+                continue
+            yml = d / _PROJECT_YML
+            if yml.is_file() and is_valid_project_id(d.name):
+                paths[d.name] = yml
+    return paths
 
 
 _CONTROL_CHARS = re.compile(r"[\x00-\x08\x0b-\x1f\x7f-\x9f]")

--- a/src/terok/lib/core/projects.py
+++ b/src/terok/lib/core/projects.py
@@ -8,6 +8,7 @@ import re
 import shutil
 import subprocess
 import sys
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
@@ -338,14 +339,23 @@ def _find_project_root(project_id: str) -> Path:
 # ---------- Project listing ----------
 
 
-def list_projects() -> list[ProjectConfig]:
-    """Discover all projects (user + system) and return them as ProjectConfig objects.
+@dataclass(frozen=True)
+class BrokenProject:
+    """A project directory whose ``project.yml`` failed to load.
 
-    User projects override system ones with the same id.
+    Carries just enough context for the TUI to render a row and show the
+    validation error in the details pane, without forcing callers to
+    re-run the failing ``load_project`` to rediscover the message.
     """
-    ids: set[str] = set()
 
-    # Collect IDs from user and system project dirs
+    id: str
+    config_path: Path
+    error: str
+
+
+def _discover_project_ids() -> list[str]:
+    """Return sorted project IDs from user + system project dirs."""
+    ids: set[str] = set()
     for root in (user_projects_dir(), projects_dir()):
         if not root.is_dir():
             continue
@@ -354,29 +364,58 @@ def list_projects() -> list[ProjectConfig]:
                 continue
             if (d / _PROJECT_YML).is_file() and is_valid_project_id(d.name):
                 ids.add(d.name)
+    return sorted(ids)
 
-    projects: list[ProjectConfig] = []
-    for pid in sorted(ids):
-        # ``_parse_project_yaml`` wraps every config error (bad YAML,
-        # schema drift, filesystem issues) in ``SystemExit`` with a
-        # human-readable message — that's the one exception type
-        # ``load_project`` can surface here.  Skip + surface it so the
-        # broken project is visible (silently hiding turns "No projects
-        # found" into a mystery for users upgrading across schema
-        # renames).  Genuinely unexpected exceptions propagate.
+
+def _config_path_for(project_id: str) -> Path:
+    """Resolve a project's ``project.yml`` path, user scope winning over system."""
+    for root in (user_projects_dir(), projects_dir()):
+        candidate = root / project_id / _PROJECT_YML
+        if candidate.is_file():
+            return candidate
+    # Fall back to the user path — used for display when neither file is
+    # readable (shouldn't normally happen; ``_discover_project_ids`` filters).
+    return user_projects_dir() / project_id / _PROJECT_YML
+
+
+def discover_projects() -> tuple[list[ProjectConfig], list[BrokenProject]]:
+    """Load every project on disk, splitting successes from config-level failures.
+
+    The broken list lets the TUI render damaged projects alongside healthy
+    ones (issue #565) — silently hiding them turns "project vanished" into
+    a mystery.  ``_parse_project_yaml`` wraps every config error (bad YAML,
+    schema drift, filesystem issues) in ``SystemExit`` with a human-readable
+    message; anything else propagates as a genuine bug.
+    """
+    valid: list[ProjectConfig] = []
+    broken: list[BrokenProject] = []
+    for pid in _discover_project_ids():
         try:
-            projects.append(load_project(pid))
+            valid.append(load_project(pid))
         except SystemExit as exc:
             msg = _sanitize_for_tty(str(exc))
-            # Log records are one-line structured entries; a message
-            # carrying embedded newlines would split across records and
-            # could be read as injected log lines.  stderr print keeps
-            # newlines so pydantic's multi-line validation output is
-            # readable on the console.
-            logger.warning("Skipping broken project '%s': %s", pid, msg.replace("\n", "\\n"))
-            print(f"warning: skipping broken project '{pid}': {msg}", file=sys.stderr)
-            continue
-    return projects
+            broken.append(BrokenProject(id=pid, config_path=_config_path_for(pid), error=msg))
+    return valid, broken
+
+
+def list_projects() -> list[ProjectConfig]:
+    """Discover all projects (user + system), warning on broken configs.
+
+    Thin wrapper over :func:`discover_projects` that preserves the existing
+    stderr + logger diagnostics for CLI callers.  The TUI uses
+    :func:`discover_projects` directly to render broken entries in-place.
+
+    User projects override system ones with the same id.
+    """
+    valid, broken = discover_projects()
+    for bp in broken:
+        # Log records are one-line structured entries; a message carrying
+        # embedded newlines would split across records and could be read
+        # as injected log lines.  stderr print keeps newlines so pydantic's
+        # multi-line validation output is readable on the console.
+        logger.warning("Skipping broken project '%s': %s", bp.id, bp.error.replace("\n", "\\n"))
+        print(f"warning: skipping broken project '{bp.id}': {bp.error}", file=sys.stderr)
+    return valid
 
 
 _CONTROL_CHARS = re.compile(r"[\x00-\x08\x0b-\x1f\x7f-\x9f]")

--- a/src/terok/lib/core/projects.py
+++ b/src/terok/lib/core/projects.py
@@ -353,29 +353,25 @@ class BrokenProject:
     error: str
 
 
-def _discover_project_ids() -> list[str]:
-    """Return sorted project IDs from user + system project dirs."""
-    ids: set[str] = set()
+def _discover_project_paths() -> dict[str, Path]:
+    """Map each on-disk project ID to its ``project.yml`` path.
+
+    User scope wins over system scope for collisions — matches how
+    :func:`load_project` resolves the effective config.  Returning the
+    path alongside the ID lets :func:`discover_projects` carry the
+    location forward to ``BrokenProject`` without re-walking.
+    """
+    paths: dict[str, Path] = {}
     for root in (user_projects_dir(), projects_dir()):
         if not root.is_dir():
             continue
         for d in root.iterdir():
-            if not d.is_dir():
+            if not d.is_dir() or d.name in paths:
                 continue
-            if (d / _PROJECT_YML).is_file() and is_valid_project_id(d.name):
-                ids.add(d.name)
-    return sorted(ids)
-
-
-def _config_path_for(project_id: str) -> Path:
-    """Resolve a project's ``project.yml`` path, user scope winning over system."""
-    for root in (user_projects_dir(), projects_dir()):
-        candidate = root / project_id / _PROJECT_YML
-        if candidate.is_file():
-            return candidate
-    # Fall back to the user path — used for display when neither file is
-    # readable (shouldn't normally happen; ``_discover_project_ids`` filters).
-    return user_projects_dir() / project_id / _PROJECT_YML
+            yml = d / _PROJECT_YML
+            if yml.is_file() and is_valid_project_id(d.name):
+                paths[d.name] = yml
+    return paths
 
 
 def discover_projects() -> tuple[list[ProjectConfig], list[BrokenProject]]:
@@ -387,14 +383,15 @@ def discover_projects() -> tuple[list[ProjectConfig], list[BrokenProject]]:
     schema drift, filesystem issues) in ``SystemExit`` with a human-readable
     message; anything else propagates as a genuine bug.
     """
+    paths_by_id = _discover_project_paths()
     valid: list[ProjectConfig] = []
     broken: list[BrokenProject] = []
-    for pid in _discover_project_ids():
+    for pid in sorted(paths_by_id):
         try:
             valid.append(load_project(pid))
         except SystemExit as exc:
             msg = _sanitize_for_tty(str(exc))
-            broken.append(BrokenProject(id=pid, config_path=_config_path_for(pid), error=msg))
+            broken.append(BrokenProject(id=pid, config_path=paths_by_id[pid], error=msg))
     return valid, broken
 
 

--- a/src/terok/lib/domain/facade.py
+++ b/src/terok/lib/domain/facade.py
@@ -40,7 +40,7 @@ if TYPE_CHECKING:
 
 from ..core.images import project_cli_image
 from ..core.projects import derive_project as _derive_project, load_project
-from ..orchestration.image import build_images, generate_dockerfiles
+from ..orchestration.image import build_images, generate_dockerfiles, image_exists
 from ..orchestration.task_runners import (  # noqa: F401 — re-exported public API
     HeadlessRunRequest,
     task_followup_headless,
@@ -88,6 +88,11 @@ from .vault import vault_db  # noqa: F401 — re-exported public API
 def get_project(project_id: str) -> Project:
     """Load a project by ID and return a rich :class:`Project` aggregate."""
     return Project(load_project(project_id))
+
+
+def project_image_exists(project_id: str) -> bool:
+    """Return ``True`` when the project's L2 CLI image is present locally."""
+    return image_exists(project_cli_image(project_id))
 
 
 def list_projects() -> list[Project]:
@@ -205,6 +210,7 @@ __all__ = [
     # Image management
     "generate_dockerfiles",
     "build_images",
+    "project_image_exists",
     # Image listing & cleanup
     "list_images",
     "find_orphaned_images",

--- a/src/terok/lib/orchestration/image.py
+++ b/src/terok/lib/orchestration/image.py
@@ -39,27 +39,19 @@ from ..util.fs import ensure_dir
 # ---------- helpers ----------
 
 
-def _image_exists(image: str) -> bool:
-    """Check if a container image exists locally.
+def image_exists(image: str) -> bool:
+    """Return True when *image* is present in the local container store."""
+    return _image_exists(image)
 
-    Thin wrapper over the runtime's ``Image.exists`` check, kept as a
-    same-module symbol so existing test mocks (``patch("terok.lib.
-    orchestration.image._image_exists")``) keep working.
+
+def _image_exists(image: str) -> bool:
+    """Same check as :func:`image_exists`, kept as a separate symbol for tests.
+
+    The public function resolves this name on every call, so
+    ``patch("terok.lib.orchestration.image._image_exists", fake)`` reaches
+    every caller — an ``image_exists = _image_exists`` alias would not.
     """
     return _rt.get_runtime().image(image).exists()
-
-
-def image_exists(image: str) -> bool:
-    """Public wrapper around :func:`_image_exists` that stays patch-transparent.
-
-    ``image_exists = _image_exists`` would capture the reference at import
-    time, so ``monkeypatch.setattr(..., "_image_exists", fake)`` would only
-    affect same-module callers — the facade / TUI would keep using the
-    original implementation.  The delegating form below looks the module
-    attribute up at call time, so the underscore-form monkeypatches that
-    existing tests rely on continue to propagate to public callers.
-    """
-    return _image_exists(image)
 
 
 # ---------- Hashing ----------

--- a/src/terok/lib/orchestration/image.py
+++ b/src/terok/lib/orchestration/image.py
@@ -49,6 +49,12 @@ def _image_exists(image: str) -> bool:
     return _rt.get_runtime().image(image).exists()
 
 
+# Public alias — the underscore form above is retained only so pre-existing
+# test monkeypatches don't break.  New callers (facade, TUI, etc.) should
+# import :func:`image_exists` so tach can police the boundary.
+image_exists = _image_exists
+
+
 # ---------- Hashing ----------
 
 

--- a/src/terok/lib/orchestration/image.py
+++ b/src/terok/lib/orchestration/image.py
@@ -49,10 +49,17 @@ def _image_exists(image: str) -> bool:
     return _rt.get_runtime().image(image).exists()
 
 
-# Public alias — the underscore form above is retained only so pre-existing
-# test monkeypatches don't break.  New callers (facade, TUI, etc.) should
-# import :func:`image_exists` so tach can police the boundary.
-image_exists = _image_exists
+def image_exists(image: str) -> bool:
+    """Public wrapper around :func:`_image_exists` that stays patch-transparent.
+
+    ``image_exists = _image_exists`` would capture the reference at import
+    time, so ``monkeypatch.setattr(..., "_image_exists", fake)`` would only
+    affect same-module callers — the facade / TUI would keep using the
+    original implementation.  The delegating form below looks the module
+    attribute up at call time, so the underscore-form monkeypatches that
+    existing tests rely on continue to propagate to public callers.
+    """
+    return _image_exists(image)
 
 
 # ---------- Hashing ----------

--- a/src/terok/tui/app.py
+++ b/src/terok/tui/app.py
@@ -482,68 +482,79 @@ if _HAS_TEXTUAL:
         # ---------- Helpers ----------
 
         async def refresh_projects(self) -> None:
-            """Reload all projects and update the project list widget."""
-            proj_widget = self.query_one("#project-list", ProjectList)
+            """Reload projects from disk and rebuild every dependent pane."""
             projects, broken = discover_projects()
-            self._projects_by_id = {proj.id: proj for proj in projects}
+            self._projects_by_id = {p.id: p for p in projects}
             self._broken_by_id = {bp.id: bp for bp in broken}
+
+            proj_widget = self.query_one("#project-list", ProjectList)
             proj_widget.set_projects(projects, broken)
+            self._announce_newly_broken(broken)
 
-            # Surface broken configs with a one-shot notification so users on
-            # an upgrade who lost a project to schema drift see it immediately
-            # rather than having to select the row to discover it (#565).  Only
-            # fire when the set of broken IDs has changed since the last
-            # announcement so repeated refreshes don't spam the operator.
-            current_broken_ids = {bp.id for bp in broken}
-            if current_broken_ids and current_broken_ids != self._announced_broken_ids:
-                first = broken[0]
-                summary = f"{first.id}: {first.error.splitlines()[0]}"
-                extra = f" (+{len(broken) - 1} more)" if len(broken) > 1 else ""
-                self.notify(
-                    f"Broken project config detected — {summary}{extra}",
-                    severity="warning",
-                    timeout=15,
-                )
-                self._announced_broken_ids = current_broken_ids
-            elif not current_broken_ids:
-                # All breakages cleared — forget the announced set so a future
-                # regression announces again.
-                self._announced_broken_ids = set()
+            if not projects and not broken:
+                self._render_empty_project_state()
+                return
 
-            if projects or broken:
-                # Try to restore last selected project, fall back to first
-                # item (broken entries lead the list, so they win when a
-                # broken one was last selected).
-                last_project = self._last_selected_project
-                candidate_ids = [bp.id for bp in broken] + [p.id for p in projects]
-                if last_project and last_project in candidate_ids:
-                    self.current_project_id = last_project
-                    proj_widget.select_project(self.current_project_id)
-                elif self.current_project_id is None:
-                    self.current_project_id = candidate_ids[0]
-                    proj_widget.select_project(self.current_project_id)
+            self._restore_or_default_project_selection(proj_widget, projects, broken)
+            self._last_project_state = None
+            self._last_image_old = None
 
-                # Reset cached detail screen state; workers will repopulate.
-                self._last_project_state = None
-                self._last_image_old = None
-                # Broken projects have no tasks to load, and kicking off
-                # refresh_tasks would raise inside load_project.
-                if self.current_project_id in self._broken_by_id:
-                    self._render_broken_selection(self.current_project_id)
-                else:
-                    await self.refresh_tasks()
-                    self._start_upstream_polling()
+            if self.current_project_id in self._broken_by_id:
+                # Broken projects have no loadable config; ``refresh_tasks`` and
+                # the polling loop would raise inside ``load_project``.
+                self._render_broken_selection(self.current_project_id)
             else:
-                self.current_project_id = None
-                self._last_project_state = None
-                self._last_image_old = None
-                task_list = self.query_one("#task-list", TaskList)
-                task_list.set_tasks("", [])
-                task_details = self.query_one("#task-details", TaskDetails)
-                task_details.set_task(None)
-                # No projects means no meaningful project state.
-                state_widget = self.query_one("#project-state", ProjectState)
-                state_widget.set_state(None, None, None)
+                await self.refresh_tasks()
+                self._start_upstream_polling()
+
+        def _announce_newly_broken(self, broken: list[BrokenProject]) -> None:
+            """Toast once when the set of broken-project IDs changes.
+
+            Users upgrading across a schema change need to see the breakage
+            immediately — but only once per distinct set, so repeated
+            ``refresh_projects`` calls don't spam (#565).
+            """
+            current_ids = {bp.id for bp in broken}
+            if not current_ids:
+                # Breakages cleared — forget announced so a regression re-fires.
+                self._announced_broken_ids = set()
+                return
+            if current_ids == self._announced_broken_ids:
+                return
+            first = broken[0]
+            summary = f"{first.id}: {first.error.splitlines()[0]}"
+            extra = f" (+{len(broken) - 1} more)" if len(broken) > 1 else ""
+            self.notify(
+                f"Broken project config detected — {summary}{extra}",
+                severity="warning",
+                timeout=15,
+            )
+            self._announced_broken_ids = current_ids
+
+        def _restore_or_default_project_selection(
+            self,
+            proj_widget: ProjectList,
+            projects: list[ProjectConfig],
+            broken: list[BrokenProject],
+        ) -> None:
+            """Restore the previously-selected project, or fall back to the first row."""
+            candidate_ids = [bp.id for bp in broken] + [p.id for p in projects]
+            last_project = self._last_selected_project
+            if last_project and last_project in candidate_ids:
+                self.current_project_id = last_project
+                proj_widget.select_project(self.current_project_id)
+            elif self.current_project_id is None:
+                self.current_project_id = candidate_ids[0]
+                proj_widget.select_project(self.current_project_id)
+
+        def _render_empty_project_state(self) -> None:
+            """Clear every pane when no projects exist on disk at all."""
+            self.current_project_id = None
+            self._last_project_state = None
+            self._last_image_old = None
+            self.query_one("#task-list", TaskList).set_tasks("", [])
+            self.query_one("#task-details", TaskDetails).set_task(None)
+            self.query_one("#project-state", ProjectState).set_state(None, None, None)
 
         def _render_broken_selection(self, project_id: str) -> None:
             """Render a broken project's error and clear the task/details panes."""

--- a/src/terok/tui/app.py
+++ b/src/terok/tui/app.py
@@ -80,7 +80,12 @@ if _HAS_TEXTUAL:
         set_experimental,
         state_dir,
     )
-    from ..lib.core.projects import ProjectConfig, list_projects, load_project
+    from ..lib.core.projects import (
+        BrokenProject,
+        ProjectConfig,
+        discover_projects,
+        load_project,
+    )
 
     # Import version info function (shared with CLI --version)
     from ..lib.core.version import (
@@ -274,6 +279,7 @@ if _HAS_TEXTUAL:
             self.current_project_id: str | None = None
             self.current_task: TaskMeta | None = None
             self._projects_by_id: dict[str, ProjectConfig] = {}
+            self._broken_by_id: dict[str, BrokenProject] = {}
             self._last_task_count: int | None = None
             # Upstream polling state
             self._staleness_info: GateStalenessInfo | None = None
@@ -473,26 +479,47 @@ if _HAS_TEXTUAL:
         async def refresh_projects(self) -> None:
             """Reload all projects and update the project list widget."""
             proj_widget = self.query_one("#project-list", ProjectList)
-            projects = list_projects()
+            projects, broken = discover_projects()
             self._projects_by_id = {proj.id: proj for proj in projects}
-            proj_widget.set_projects(projects)
+            self._broken_by_id = {bp.id: bp for bp in broken}
+            proj_widget.set_projects(projects, broken)
 
-            if projects:
-                # Try to restore last selected project, fall back to first project
+            # Surface broken configs with a one-shot notification so users on
+            # an upgrade who lost a project to schema drift see it immediately
+            # rather than having to select the row to discover it (#565).
+            if broken:
+                first = broken[0]
+                summary = f"{first.id}: {first.error.splitlines()[0]}"
+                extra = f" (+{len(broken) - 1} more)" if len(broken) > 1 else ""
+                self.notify(
+                    f"Broken project config detected — {summary}{extra}",
+                    severity="warning",
+                    timeout=15,
+                )
+
+            if projects or broken:
+                # Try to restore last selected project, fall back to first
+                # item (broken entries lead the list, so they win when a
+                # broken one was last selected).
                 last_project = self._last_selected_project
-                if last_project and any(p.id == last_project for p in projects):
+                candidate_ids = [bp.id for bp in broken] + [p.id for p in projects]
+                if last_project and last_project in candidate_ids:
                     self.current_project_id = last_project
                     proj_widget.select_project(self.current_project_id)
                 elif self.current_project_id is None:
-                    self.current_project_id = projects[0].id
+                    self.current_project_id = candidate_ids[0]
                     proj_widget.select_project(self.current_project_id)
 
                 # Reset cached detail screen state; workers will repopulate.
                 self._last_project_state = None
                 self._last_image_old = None
-                await self.refresh_tasks()
-                # Start upstream polling for the selected project
-                self._start_upstream_polling()
+                # Broken projects have no tasks to load, and kicking off
+                # refresh_tasks would raise inside load_project.
+                if self.current_project_id in self._broken_by_id:
+                    self._render_broken_selection(self.current_project_id)
+                else:
+                    await self.refresh_tasks()
+                    self._start_upstream_polling()
             else:
                 self.current_project_id = None
                 self._last_project_state = None
@@ -504,6 +531,20 @@ if _HAS_TEXTUAL:
                 # No projects means no meaningful project state.
                 state_widget = self.query_one("#project-state", ProjectState)
                 state_widget.set_state(None, None, None)
+
+        def _render_broken_selection(self, project_id: str) -> None:
+            """Render a broken project's error and clear the task/details panes."""
+            bp = self._broken_by_id.get(project_id)
+            state_widget = self.query_one("#project-state", ProjectState)
+            if bp is None:
+                state_widget.set_state(None, None, None)
+                return
+            state_widget.set_broken(bp)
+            task_list = self.query_one("#task-list", TaskList)
+            task_list.set_tasks(project_id, [])
+            task_details = self.query_one("#task-details", TaskDetails)
+            task_details.set_task(None)
+            self.current_task = None
 
         async def refresh_tasks(self) -> None:
             """Reload tasks for the current project and update the task list."""
@@ -691,6 +732,16 @@ if _HAS_TEXTUAL:
             # Save the project selection
             self._last_selected_project = self.current_project_id
             self._save_selection_state()
+
+            # Broken projects have no loadable config, so the usual task /
+            # polling / state-worker pipeline would just raise.  Render the
+            # validation error instead and leave the rest of the panes idle
+            # until a healthy project is selected again (#565).
+            if message.is_broken:
+                self._stop_upstream_polling()
+                self._stop_container_status_polling()
+                self._render_broken_selection(message.project_id)
+                return
 
             await self.refresh_tasks()
             # Start polling for the newly selected project
@@ -1063,6 +1114,14 @@ if _HAS_TEXTUAL:
             """Show detail screen with project info and actions."""
             if not self.current_project_id:
                 self.notify("No project selected.")
+                return
+            if self.current_project_id in self._broken_by_id:
+                bp = self._broken_by_id[self.current_project_id]
+                self.notify(
+                    f"Cannot act on broken project '{bp.id}'. Fix {bp.config_path} first.",
+                    severity="warning",
+                    timeout=10,
+                )
                 return
             project = self._projects_by_id.get(self.current_project_id)
             if not project:

--- a/src/terok/tui/app.py
+++ b/src/terok/tui/app.py
@@ -280,6 +280,11 @@ if _HAS_TEXTUAL:
             self.current_task: TaskMeta | None = None
             self._projects_by_id: dict[str, ProjectConfig] = {}
             self._broken_by_id: dict[str, BrokenProject] = {}
+            # Tracks which broken-project IDs have already been toasted so
+            # repeated ``refresh_projects`` calls don't re-notify the same
+            # set on every action (#565).  Resets when all breakages clear,
+            # so a later regression toasts again.
+            self._announced_broken_ids: set[str] = set()
             self._last_task_count: int | None = None
             # Upstream polling state
             self._staleness_info: GateStalenessInfo | None = None
@@ -486,8 +491,11 @@ if _HAS_TEXTUAL:
 
             # Surface broken configs with a one-shot notification so users on
             # an upgrade who lost a project to schema drift see it immediately
-            # rather than having to select the row to discover it (#565).
-            if broken:
+            # rather than having to select the row to discover it (#565).  Only
+            # fire when the set of broken IDs has changed since the last
+            # announcement so repeated refreshes don't spam the operator.
+            current_broken_ids = {bp.id for bp in broken}
+            if current_broken_ids and current_broken_ids != self._announced_broken_ids:
                 first = broken[0]
                 summary = f"{first.id}: {first.error.splitlines()[0]}"
                 extra = f" (+{len(broken) - 1} more)" if len(broken) > 1 else ""
@@ -496,6 +504,11 @@ if _HAS_TEXTUAL:
                     severity="warning",
                     timeout=15,
                 )
+                self._announced_broken_ids = current_broken_ids
+            elif not current_broken_ids:
+                # All breakages cleared — forget the announced set so a future
+                # regression announces again.
+                self._announced_broken_ids = set()
 
             if projects or broken:
                 # Try to restore last selected project, fall back to first

--- a/src/terok/tui/widgets/__init__.py
+++ b/src/terok/tui/widgets/__init__.py
@@ -11,6 +11,7 @@ from .panic_button import PanicButton  # noqa: F401
 from .project_list import ProjectActions, ProjectList, ProjectListItem  # noqa: F401
 from .project_state import (  # noqa: F401
     ProjectState,
+    render_broken_project,
     render_project_details,
     render_project_loading,
 )
@@ -31,6 +32,7 @@ __all__ = [
     "TaskList",
     "TaskListItem",
     # Render helpers
+    "render_broken_project",
     "render_project_details",
     "render_project_loading",
     "render_task_details",

--- a/src/terok/tui/widgets/project_list.py
+++ b/src/terok/tui/widgets/project_list.py
@@ -11,19 +11,27 @@ from textual.containers import Horizontal
 from textual.message import Message
 from textual.widgets import Button, ListItem, ListView, Static
 
-from ...lib.core.projects import ProjectConfig
-from ...lib.core.task_display import GPU_DISPLAY, SECURITY_CLASS_DISPLAY, has_gpu
+from ...lib.core.projects import BrokenProject, ProjectConfig
+from ...lib.core.task_display import GPU_DISPLAY, SECURITY_CLASS_DISPLAY, StatusInfo, has_gpu
 from ...lib.util.emoji import render_emoji
+
+# Reuse the existing "failed" status badge for broken-project rows so the
+# emoji pipeline (wide glyph, --no-emoji fallback label) stays consistent
+# with how other errors render in the TUI.
+_BROKEN_BADGE = StatusInfo(label="broken", emoji="❌", color="red")
 
 
 class ProjectListItem(ListItem):
     """List item that carries project metadata."""
 
-    def __init__(self, project_id: str, label: str, generation: int) -> None:
-        """Create a project list item with its ID and display label."""
+    def __init__(
+        self, project_id: str, label: str, generation: int, *, is_broken: bool = False
+    ) -> None:
+        """Create a project list item with its ID, label, and broken flag."""
         super().__init__(Static(label, markup=False))
         self.project_id = project_id
         self.generation = generation
+        self.is_broken = is_broken
 
 
 class ProjectList(ListView):
@@ -40,22 +48,42 @@ class ProjectList(ListView):
     class ProjectSelected(Message):
         """Posted when a project is highlighted in the list."""
 
-        def __init__(self, project_id: str) -> None:
-            """Create the message with the selected project's ID."""
+        def __init__(self, project_id: str, *, is_broken: bool = False) -> None:
+            """Create the message with the selected project's ID and broken flag."""
             super().__init__()
             self.project_id = project_id
+            self.is_broken = is_broken
 
     def __init__(self, **kwargs: Any) -> None:
         """Initialize the project list with empty state."""
         super().__init__(**kwargs)
         self.projects: list[ProjectConfig] = []
+        self.broken: list[BrokenProject] = []
         self._generation = 0
 
-    def set_projects(self, projects: list[ProjectConfig]) -> None:
-        """Populate the list with projects."""
+    def set_projects(
+        self,
+        projects: list[ProjectConfig],
+        broken: list[BrokenProject] | None = None,
+    ) -> None:
+        """Populate the list with healthy and (optionally) broken projects.
+
+        Broken projects render with an error marker ahead of healthy ones so
+        they are impossible to miss; selecting one lets the app show the
+        validation error in place of the normal project state panel (#565).
+        """
         self.projects = projects
+        self.broken = list(broken or [])
         self._generation += 1
         self.clear()
+
+        # Broken first — a damaged config is the thing most likely to need
+        # attention, so putting it at the top makes the error indicator the
+        # first thing the user sees.
+        for bp in self.broken:
+            label = f"{render_emoji(_BROKEN_BADGE)} {bp.id} (broken)"
+            self.append(ProjectListItem(bp.id, label, self._generation, is_broken=True))
+
         for proj in projects:
             sec = SECURITY_CLASS_DISPLAY.get(proj.security_class, SECURITY_CLASS_DISPLAY["online"])
             gpu = GPU_DISPLAY[has_gpu(proj)]
@@ -63,11 +91,18 @@ class ProjectList(ListView):
             self.append(ProjectListItem(proj.id, label, self._generation))
 
     def select_project(self, project_id: str) -> None:
-        """Select a project by id."""
+        """Select a project by id (healthy or broken)."""
+        # Broken rows are inserted before healthy ones; walk the combined
+        # sequence in the same order they were appended.
+        for idx, bp in enumerate(self.broken):
+            if bp.id == project_id:
+                self.index = idx
+                return
+        offset = len(self.broken)
         for idx, proj in enumerate(self.projects):
             if proj.id == project_id:
-                self.index = idx
-                break
+                self.index = offset + idx
+                return
 
     def on_list_view_highlighted(self, event: ListView.Highlighted) -> None:  # type: ignore[override]
         """Update selection immediately when highlight changes."""
@@ -85,7 +120,7 @@ class ProjectList(ListView):
             return
         if item.generation != self._generation:
             return
-        self.post_message(self.ProjectSelected(item.project_id))
+        self.post_message(self.ProjectSelected(item.project_id, is_broken=item.is_broken))
 
 
 class ProjectActions(Static):

--- a/src/terok/tui/widgets/project_state.py
+++ b/src/terok/tui/widgets/project_state.py
@@ -12,7 +12,7 @@ from rich.text import Text
 from terok_sandbox import EnvironmentCheck, GateServerStatus, GateStalenessInfo
 from textual.widgets import Static
 
-from ...lib.core.projects import ProjectConfig
+from ...lib.core.projects import BrokenProject, ProjectConfig
 from ...lib.core.task_display import GPU_DISPLAY, SECURITY_CLASS_DISPLAY, has_gpu
 from ...lib.util.emoji import render_emoji
 from .task_detail import _get_css_variables
@@ -258,3 +258,26 @@ class ProjectState(Static):
                 shield_env=shield_env,
             )
         )
+
+    def set_broken(self, bp: BrokenProject) -> None:
+        """Render a broken project's validation error in place of the normal state.
+
+        The config path plus the raw error message are enough for the user to
+        open ``project.yml`` in an editor and fix whatever pydantic or the
+        YAML parser flagged — no extra round-trip to the CLI (#565).
+        """
+        variables = _get_css_variables(self)
+        error_color = variables.get("error", "red")
+        dim = Style(dim=True)
+        header = Text(f"Project:   {bp.id} ", style=Style(color=error_color, bold=True))
+        header.append("(broken)", style=Style(color=error_color))
+        lines = [
+            header,
+            Text(""),
+            Text("This project's configuration could not be loaded:"),
+            Text(""),
+            Text(bp.error, style=Style(color=error_color)),
+            Text(""),
+            Text(f"Config: {bp.config_path}", style=dim),
+        ]
+        self.update(Text("\n").join(lines))

--- a/src/terok/tui/widgets/project_state.py
+++ b/src/terok/tui/widgets/project_state.py
@@ -51,6 +51,30 @@ def render_project_loading(
     return Text("\n").join(lines)
 
 
+def render_broken_project(bp: BrokenProject, css_variables: dict[str, str] | None = None) -> Text:
+    """Render a damaged project's validation error as a Rich Text block (#565).
+
+    The config path plus the raw error message are enough for the user to
+    open ``project.yml`` in an editor and fix whatever pydantic or the
+    YAML parser flagged — no extra round-trip to the CLI.
+    """
+    variables = css_variables or {}
+    error_color = variables.get("error", "red")
+    dim = Style(dim=True)
+    header = Text(f"Project:   {bp.id} ", style=Style(color=error_color, bold=True))
+    header.append("(broken)", style=Style(color=error_color))
+    lines = [
+        header,
+        Text(""),
+        Text("This project's configuration could not be loaded:"),
+        Text(""),
+        Text(bp.error, style=Style(color=error_color)),
+        Text(""),
+        Text(f"Config: {bp.config_path}", style=dim),
+    ]
+    return Text("\n").join(lines)
+
+
 def render_project_details(
     project: ProjectConfig | None,
     state: dict | None,
@@ -260,24 +284,5 @@ class ProjectState(Static):
         )
 
     def set_broken(self, bp: BrokenProject) -> None:
-        """Render a broken project's validation error in place of the normal state.
-
-        The config path plus the raw error message are enough for the user to
-        open ``project.yml`` in an editor and fix whatever pydantic or the
-        YAML parser flagged — no extra round-trip to the CLI (#565).
-        """
-        variables = _get_css_variables(self)
-        error_color = variables.get("error", "red")
-        dim = Style(dim=True)
-        header = Text(f"Project:   {bp.id} ", style=Style(color=error_color, bold=True))
-        header.append("(broken)", style=Style(color=error_color))
-        lines = [
-            header,
-            Text(""),
-            Text("This project's configuration could not be loaded:"),
-            Text(""),
-            Text(bp.error, style=Style(color=error_color)),
-            Text(""),
-            Text(f"Config: {bp.config_path}", style=dim),
-        ]
-        self.update(Text("\n").join(lines))
+        """Show *bp*'s validation error in place of the normal infrastructure readout."""
+        self.update(render_broken_project(bp, _get_css_variables(self)))

--- a/tach.toml
+++ b/tach.toml
@@ -503,8 +503,10 @@ from = ["terok.lib.core.project_model"]
 
 [[interfaces]]
 expose = [
+    "BrokenProject",
     "ProjectConfig",
     "PresetInfo",
+    "discover_projects",
     "find_preset_path",
     "list_projects",
     "load_project",
@@ -612,6 +614,7 @@ expose = [
     "build_images",
     "build_context_hash",
     "build_context_hash_from_rendered",
+    "image_exists",
     "l0_content_hash",
     "l1_content_hash",
     "l2_content_hash",
@@ -737,6 +740,7 @@ expose = [
     "delete_project",
     "generate_dockerfiles",
     "build_images",
+    "project_image_exists",
     "list_images",
     "find_orphaned_images",
     "cleanup_images",

--- a/tests/unit/cli/test_cli_autopilot.py
+++ b/tests/unit/cli/test_cli_autopilot.py
@@ -17,7 +17,10 @@ from tests.testfs import NONEXISTENT_MARKDOWN_PATH
 
 def capture_headless_request(project: str, prompt: str, *extra_args: str) -> HeadlessRunRequest:
     """Run ``terok task run --mode headless`` and capture the forwarded request."""
-    with patch("terok.cli.commands.task.task_run_headless") as mock_run:
+    with (
+        patch("terok.cli.commands.task.project_image_exists", return_value=True),
+        patch("terok.cli.commands.task.task_run_headless") as mock_run,
+    ):
         run_cli("task", "run", project, "--mode", "headless", "--prompt", prompt, *extra_args)
 
     mock_run.assert_called_once()
@@ -203,13 +206,46 @@ def test_run_with_instructions_flag(tmp_path: Path) -> None:
 def test_run_interactive_mode_creates_and_runs(mode: str, runner_target: str) -> None:
     """``task run --mode cli|toad`` creates a new task and delegates to the runner."""
     with (
+        patch("terok.cli.commands.task.project_image_exists", return_value=True),
         patch("terok.cli.commands.task.task_new", return_value="42") as mock_new,
+        patch("terok.cli.commands.task.task_login") as mock_login,
         patch(runner_target) as mock_runner,
     ):
-        run_cli("task", "run", "myproj", "--mode", mode)
+        # --no-attach keeps the CLI test path quiet regardless of TTY state
+        # in the harness; toad mode never attaches.
+        run_cli("task", "run", "myproj", "--mode", mode, "--no-attach")
 
     mock_new.assert_called_once_with("myproj", name=None)
     mock_runner.assert_called_once_with("myproj", "42", agents=None, preset=None, unrestricted=None)
+    mock_login.assert_not_called()
+
+
+def test_run_cli_mode_attaches_on_tty() -> None:
+    """``task run --mode cli`` calls task_login after the runner when --attach."""
+    with (
+        patch("terok.cli.commands.task.project_image_exists", return_value=True),
+        patch("terok.cli.commands.task.task_new", return_value="42"),
+        patch("terok.cli.commands.task.task_run_cli"),
+        patch("terok.cli.commands.task.task_login") as mock_login,
+    ):
+        run_cli("task", "run", "myproj", "--attach")
+
+    mock_login.assert_called_once_with("myproj", "42")
+
+
+def test_run_missing_image_exits_on_non_tty(capsys: pytest.CaptureFixture[str]) -> None:
+    """Preflight refuses to build silently when stdout is not a TTY."""
+    with (
+        patch("terok.cli.commands.task.project_image_exists", return_value=False),
+        patch("terok.cli.commands.task.task_new") as mock_new,
+        patch("terok.cli.commands.task.task_run_cli") as mock_runner,
+        pytest.raises(SystemExit) as exc,
+    ):
+        run_cli("task", "run", "myproj", "--no-attach")
+
+    assert "terok project build myproj" in str(exc.value)
+    mock_new.assert_not_called()
+    mock_runner.assert_not_called()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/cli/test_cli_autopilot.py
+++ b/tests/unit/cli/test_cli_autopilot.py
@@ -220,15 +220,18 @@ def test_run_interactive_mode_creates_and_runs(mode: str, runner_target: str) ->
     mock_login.assert_not_called()
 
 
-def test_run_cli_mode_attaches_on_tty() -> None:
-    """``task run --mode cli`` calls task_login after the runner when --attach."""
+def test_run_cli_mode_attaches_by_default_on_tty() -> None:
+    """With no flag, TTY stdio triggers ``task_login`` via ``_resolve_attach``."""
     with (
+        patch("sys.stdin.isatty", return_value=True),
+        patch("sys.stdout.isatty", return_value=True),
         patch("terok.cli.commands.task.project_image_exists", return_value=True),
         patch("terok.cli.commands.task.task_new", return_value="42"),
         patch("terok.cli.commands.task.task_run_cli"),
         patch("terok.cli.commands.task.task_login") as mock_login,
     ):
-        run_cli("task", "run", "myproj", "--attach")
+        # No --attach / --no-attach — exercise the default-on-TTY branch.
+        run_cli("task", "run", "myproj")
 
     mock_login.assert_called_once_with("myproj", "42")
 

--- a/tests/unit/cli/test_cli_config.py
+++ b/tests/unit/cli/test_cli_config.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import json
 import os
+import socket
 from collections.abc import Iterator
 from contextlib import ExitStack, contextmanager
 from pathlib import Path
@@ -14,6 +15,23 @@ from unittest.mock import patch
 import pytest
 
 from tests.testcli import run_cli
+
+
+def _is_port_bindable(port: int, host: str = "127.0.0.1") -> bool:
+    """Return True when *port* can be bound on *host* right now.
+
+    ``make_sandbox_config()`` resolves the gate port through the sandbox
+    port registry, which does a real ``bind()`` probe — on a host that
+    already has a git daemon (or any other service) on 9418 the claim
+    raises.  Tests that hard-code 9418 in their fixture can use this
+    helper to ``pytest.skip`` instead of failing on those hosts.
+    """
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        try:
+            s.bind((host, port))
+        except OSError:
+            return False
+    return True
 
 
 def make_config_layout(tmp_path: Path) -> SimpleNamespace:
@@ -116,6 +134,13 @@ def run_import(file_path: Path, envs_root: Path) -> None:
 
 def test_config_command_color_output(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
     """The config command prints the expected colorized layout details."""
+    # The fixture pins ``gate_server.port`` to 9418 and ``config paths``
+    # resolves it through the sandbox port registry, which actually binds.
+    # Skip (don't fail) when the runner already has something on 9418 —
+    # typical on developer machines with a git daemon; CI doesn't.
+    if not _is_port_bindable(9418):
+        pytest.skip("port 9418 already bound on this host; runner-specific skip")
+
     layout = make_config_layout(tmp_path)
 
     with patch_config_command(layout):

--- a/tests/unit/cli/test_cli_config.py
+++ b/tests/unit/cli/test_cli_config.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 
 import json
 import os
-import socket
 from collections.abc import Iterator
 from contextlib import ExitStack, contextmanager
 from pathlib import Path
@@ -17,27 +16,17 @@ import pytest
 from tests.testcli import run_cli
 
 
-def _is_port_bindable(port: int, host: str = "127.0.0.1") -> bool:
-    """Return True when *port* can be bound on *host* right now.
+def make_config_layout(tmp_path: Path, gate_port: int) -> SimpleNamespace:
+    """Create a filesystem layout used by the ``terok config`` tests.
 
-    ``make_sandbox_config()`` resolves the gate port through the sandbox
-    port registry, which does a real ``bind()`` probe — on a host that
-    already has a git daemon (or any other service) on 9418 the claim
-    raises.  Tests that hard-code 9418 in their fixture can use this
-    helper to ``pytest.skip`` instead of failing on those hosts.
+    *gate_port* is the ``gate_server.port`` value written to the synthetic
+    ``global.yml``.  ``make_sandbox_config()`` resolves that port through
+    the sandbox port registry, which does a real ``bind()`` probe — so the
+    test needs a value it can actually bind.  Pass an ephemeral port from
+    the ``unused_tcp_port`` fixture to keep the test host-independent.
     """
-    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
-        try:
-            s.bind((host, port))
-        except OSError:
-            return False
-    return True
-
-
-def make_config_layout(tmp_path: Path) -> SimpleNamespace:
-    """Create a filesystem layout used by the ``terok config`` tests."""
     global_cfg = tmp_path / "global.yml"
-    global_cfg.write_text("gate_server:\n  port: 9418\n", encoding="utf-8")
+    global_cfg.write_text(f"gate_server:\n  port: {gate_port}\n", encoding="utf-8")
 
     user_root = tmp_path / "user-projects"
     system_root = tmp_path / "system-projects"
@@ -132,16 +121,11 @@ def run_import(file_path: Path, envs_root: Path) -> None:
         run_cli("config", "import-opencode", str(file_path))
 
 
-def test_config_command_color_output(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+def test_config_command_color_output(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str], unused_tcp_port: int
+) -> None:
     """The config command prints the expected colorized layout details."""
-    # The fixture pins ``gate_server.port`` to 9418 and ``config paths``
-    # resolves it through the sandbox port registry, which actually binds.
-    # Skip (don't fail) when the runner already has something on 9418 —
-    # typical on developer machines with a git daemon; CI doesn't.
-    if not _is_port_bindable(9418):
-        pytest.skip("port 9418 already bound on this host; runner-specific skip")
-
-    layout = make_config_layout(tmp_path)
+    layout = make_config_layout(tmp_path, gate_port=unused_tcp_port)
 
     with patch_config_command(layout):
         run_cli("config", "paths")

--- a/tests/unit/cli/test_cli_workflows.py
+++ b/tests/unit/cli/test_cli_workflows.py
@@ -235,10 +235,15 @@ class TestTaskRunInteractive:
         runner_path: str,
         expected_call: tuple[str, str, dict[str, object]],
     ) -> None:
+        # --no-attach keeps the CLI test deterministic regardless of TTY
+        # state in the pytest harness.
+        argv = [*argv, "--no-attach"]
         with (
+            unittest.mock.patch("terok.cli.commands.task.project_image_exists", return_value=True),
             unittest.mock.patch(
                 "terok.cli.commands.task.task_new", return_value=task_id
             ) as mock_new,
+            unittest.mock.patch("terok.cli.commands.task.task_login"),
             unittest.mock.patch(runner_path) as mock_runner,
         ):
             run_main(argv)

--- a/tests/unit/cli/test_cli_workflows.py
+++ b/tests/unit/cli/test_cli_workflows.py
@@ -243,13 +243,15 @@ class TestTaskRunInteractive:
             unittest.mock.patch(
                 "terok.cli.commands.task.task_new", return_value=task_id
             ) as mock_new,
-            unittest.mock.patch("terok.cli.commands.task.task_login"),
+            unittest.mock.patch("terok.cli.commands.task.task_login") as mock_task_login,
             unittest.mock.patch(runner_path) as mock_runner,
         ):
             run_main(argv)
         project_id, expected_task_id, kwargs = expected_call
         mock_new.assert_called_once_with(project_id, name=None)
         mock_runner.assert_called_once_with(project_id, expected_task_id, **kwargs)
+        # --no-attach must suppress the login exec in every interactive mode.
+        mock_task_login.assert_not_called()
 
     @pytest.mark.parametrize(
         ("argv", "patch_target", "expected_call"),

--- a/tests/unit/lib/test_projects.py
+++ b/tests/unit/lib/test_projects.py
@@ -13,7 +13,7 @@ from pathlib import Path
 import pytest
 
 from terok.lib.core.config import build_dir, make_sandbox_config, sandbox_live_dir
-from terok.lib.core.projects import list_projects, load_project
+from terok.lib.core.projects import BrokenProject, discover_projects, list_projects, load_project
 from terok.lib.domain.project_state import get_project_state
 from tests.test_utils import project_env, write_project
 
@@ -138,6 +138,31 @@ class TestProject:
         assert len(projects) == 1
         assert projects[0].upstream_url == "https://user.example/repo.git"
         assert projects[0].root == (user_projects / "proj2").resolve()
+
+    def test_discover_projects_splits_valid_and_broken(self) -> None:
+        """discover_projects returns (valid, broken) without touching stderr (#565)."""
+        with tempfile.TemporaryDirectory() as td:
+            base = Path(td)
+            config_base = base / "config"
+            projects_root = config_base / "projects"
+            write_project(
+                projects_root,
+                "good",
+                "project:\n  id: good\ngit:\n  upstream_url: https://example.com/good.git\n",
+            )
+            write_project(projects_root, "bad", "project:\n  id: bad\n  foo: [invalid\n")
+            with unittest.mock.patch.dict(
+                os.environ,
+                {"TEROK_CONFIG_DIR": str(config_base), "XDG_CONFIG_HOME": str(base / "empty")},
+            ):
+                valid, broken = discover_projects()
+
+        assert [p.id for p in valid] == ["good"]
+        assert [bp.id for bp in broken] == ["bad"]
+        bp = broken[0]
+        assert isinstance(bp, BrokenProject)
+        assert bp.config_path == (projects_root / "bad" / "project.yml")
+        assert bp.error  # message is populated and non-empty
 
     def test_list_projects_skips_malformed_yaml(self) -> None:
         with tempfile.TemporaryDirectory() as td:

--- a/tests/unit/lib/test_projects.py
+++ b/tests/unit/lib/test_projects.py
@@ -139,7 +139,9 @@ class TestProject:
         assert projects[0].upstream_url == "https://user.example/repo.git"
         assert projects[0].root == (user_projects / "proj2").resolve()
 
-    def test_discover_projects_splits_valid_and_broken(self) -> None:
+    def test_discover_projects_splits_valid_and_broken(
+        self, capsys: pytest.CaptureFixture[str]
+    ) -> None:
         """discover_projects returns (valid, broken) without touching stderr (#565)."""
         with tempfile.TemporaryDirectory() as td:
             base = Path(td)
@@ -163,6 +165,12 @@ class TestProject:
         assert isinstance(bp, BrokenProject)
         assert bp.config_path == (projects_root / "bad" / "project.yml")
         assert bp.error  # message is populated and non-empty
+
+        # discover_projects is the TUI-facing entrypoint; ``list_projects``
+        # owns the CLI-side stderr warning.  If this ever starts printing
+        # directly, the TUI would get duplicate noise on top of its toast.
+        captured = capsys.readouterr()
+        assert captured.err.strip() == ""
 
     def test_list_projects_skips_malformed_yaml(self) -> None:
         with tempfile.TemporaryDirectory() as td:


### PR DESCRIPTION
## Summary

Three small, independent wins on the path from `pipx install terok` to being inside a running task. None of them need coordinated sibling releases.

### 1. `task run --mode=cli` attaches by default on TTY
- After the container reports ready, terok `execvp`s into `terok login` — same UX pattern as `docker run -it`.
- `--no-attach` restores the old "start and print instructions" behaviour.
- Non-TTY (scripts, piped output) automatically gets `--no-attach` semantics — no change for automation.
- Headless and Toad modes are unchanged; they have their own post-run UX.

### 2. Preflight on `task run` (image-missing case)
- Checks the project's L2 image via the existing runtime abstraction (`_rt.get_runtime().image(tag).exists()` — **no new `podman` calls at the terok layer**).
- Missing + TTY → `Build now? [Y/n]` prompt; inline `build_images()` on yes.
- Missing + non-TTY → exits with `terok project build <pid>` hint.
- Other preconditions (vault/gate/shield) continue to surface via their existing error paths — they already point at `terok setup`.

### 3. Surface broken projects in the TUI (fixes #565)
- New `discover_projects() -> (valid, broken)` in `terok.lib.core.projects` + `BrokenProject` dataclass carrying id, config path, and sanitized error.
- TUI renders broken entries at the top of the list with an error badge (reuses the existing `StatusInfo`/`render_emoji` pipeline — wide-only, `--no-emoji`-aware).
- Selecting a broken entry shows the validation error in the project-state pane instead of the normal infrastructure readout.
- One-shot notification on load so upgrades that hit schema drift don't silently make projects vanish.
- `list_projects()` keeps its existing stderr/logger warning for CLI callers — it now delegates to `discover_projects()`.

### Housekeeping
- Fixed the Quick Start epilog in `main.py` (previously listed `auth` before `project wizard`, which cannot actually work).
- Same fix for the "Next steps" trailer after `terok setup`.
- README and `docs/usage.md` updated to describe the new attach/preflight defaults.
- `tach.toml` interfaces grow `BrokenProject`, `discover_projects`, `image_exists`, `project_image_exists`.

### Related epic
Step toward #685's "first-start" epic. Items #565 and #685 both reference this work; this PR closes #565 and ticks the "TUI surfacing" box for the epic's broken-project-handling subtask. First-run wizard auto-push and Textual-native wizard port are deliberately left for follow-up PRs so this one stays reviewable.

## Test plan

- [x] `make lint` / `ruff format --check` clean
- [x] `make tach` clean (interfaces updated)
- [x] `make lint-imports` clean
- [x] `make docstrings` clean (98.7% — same as baseline)
- [x] `make reuse` clean
- [x] `make security` clean (0 medium/high)
- [x] `poetry run pytest tests/unit` — 2003 pass; 1 pre-existing deselected (`test_config_command_color_output` fails on master too — port 9418 claim in the harness)
- [x] New tests: `test_discover_projects_splits_valid_and_broken`, `test_run_cli_mode_attaches_on_tty`, `test_run_missing_image_exits_on_non_tty`
- [ ] Manual smoke — not run (requires podman host; no behavioural changes to container paths, only to CLI wrappers)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * `terok task run` now auto-attaches on TTY with mutually-exclusive --attach/--no-attach flags; `--no-attach` starts detached and prints re-attach/login instructions (incl. hex-ID hint). Missing project images prompt to build on TTY.

* **TUI**
  * Broken project configs are shown with error details and block actions until fixed.

* **Documentation**
  * README and usage docs updated to reflect new `task run` flows.

* **Tests**
  * Unit tests added/updated for attach/no-attach, missing-image behavior, broken-project discovery, and conditional port availability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->