### PR TITLE
feat(cli,auth): host-wide terok auth; project_id becomes optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,12 +78,14 @@ terok tui
 Or do the same from the command line:
 
 ```bash
-terok project wizard                    # interactive setup
-terok auth claude myproj                # authenticate agent
+terok auth claude                       # authenticate host-wide (no project needed)
+terok auth                              # interactive menu — pick multiple providers
+terok project wizard                    # interactive project setup
 terok task run myproj                   # create a CLI task and attach (default on TTY)
 terok task run myproj --no-attach       # start it detached; print login instructions
 terok task run myproj --mode toad       # Toad multi-agent TUI (browser access)
 terok login myproj a3                   # re-attach later by hex ID prefix
+terok auth claude --project myproj      # project-scoped escape hatch (uses its L2 image)
 ```
 
 For manual project configuration or CI, see the [User Guide](docs/usage.md).

--- a/src/terok/cli/commands/auth.py
+++ b/src/terok/cli/commands/auth.py
@@ -1,17 +1,23 @@
 # SPDX-FileCopyrightText: 2026 Jiri Vyskocil
 # SPDX-License-Identifier: Apache-2.0
 
-"""``auth`` top-level command — authenticate an agent/tool.
+"""``auth`` top-level command — authenticate an agent or tool.
 
-Lives at the top level (not under ``project``) because upcoming work
-will enable project-less authentication — the happy path is ``terok
-auth <provider>``, with a project argument as the optional scoping
-mechanism rather than the primary axis.
+Three invocation shapes, in increasing specificity:
+
+- ``terok auth``                         — interactive chained menu.
+- ``terok auth <provider>``              — host-wide auth for one provider.
+- ``terok auth <provider> --project ID`` — project-scoped escape hatch.
+
+Credentials land in the vault provider-scoped regardless of shape, so
+switching between host-wide and project-scoped runs does not duplicate
+or overwrite stored tokens.
 """
 
 from __future__ import annotations
 
 import argparse
+import sys
 
 from terok_executor import AUTH_PROVIDERS
 
@@ -27,17 +33,125 @@ def register(subparsers: argparse._SubParsersAction[argparse.ArgumentParser]) ->
     providers_help = ", ".join(f"{p.name} ({p.label})" for p in AUTH_PROVIDERS.values())
     p_auth = subparsers.add_parser(
         "auth",
-        help="Authenticate an agent/tool for a project",
-        description=f"Available providers: {providers_help}",
+        help="Authenticate an agent/tool (host-wide by default; --project scopes it)",
+        description=(
+            f"Available providers: {providers_help}\n\n"
+            "Without arguments, opens an interactive menu to authenticate one "
+            "or more providers in sequence.  ``terok auth <provider>`` "
+            "authenticates host-wide — credentials are shared across every "
+            "project that uses the same agent.  Pass ``--project <id>`` to "
+            "scope the auth container to a specific project's image."
+        ),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
     )
-    p_auth.add_argument("provider", choices=provider_names, metavar="provider")
-    set_completer(p_auth.add_argument("project_id"), _complete_project_ids)
+    p_auth.add_argument(
+        "provider",
+        nargs="?",
+        default=None,
+        choices=provider_names,
+        metavar="provider",
+    )
+    set_completer(
+        p_auth.add_argument(
+            "project_id",
+            nargs="?",
+            default=None,
+            help="(Legacy positional — prefer --project.)",
+        ),
+        _complete_project_ids,
+    )
+    set_completer(
+        p_auth.add_argument(
+            "--project",
+            dest="project_flag",
+            default=None,
+            help="Scope auth to a specific project's image (vault stays provider-scoped)",
+        ),
+        _complete_project_ids,
+    )
 
 
 def dispatch(args: argparse.Namespace) -> bool:
     """Handle ``terok auth``.  Returns True if handled."""
     if args.cmd != "auth":
         return False
-    require_agent_installed(load_project(args.project_id), args.provider, noun="Provider")
-    authenticate(args.project_id, args.provider)
+    # --project wins over the legacy positional if both happen to be given.
+    project_id = args.project_flag or args.project_id
+    if args.provider is None:
+        _run_interactive(project_id)
+    else:
+        _run_one(args.provider, project_id)
     return True
+
+
+# ── Implementation helpers ────────────────────────────────────────────
+
+
+def _run_one(provider: str, project_id: str | None) -> None:
+    """Authenticate a single provider, optionally scoped to a project."""
+    if project_id is not None:
+        # Project-scoped: verify the L2 image actually has the agent baked
+        # in before launching.  Host-wide auth resolves the image in the
+        # facade and does its own checks there.
+        require_agent_installed(load_project(project_id), provider, noun="Provider")
+    authenticate(provider, project_id)
+
+
+def _run_interactive(project_id: str | None) -> None:
+    """Interactively pick one or more providers and authenticate each in turn."""
+    provider_names = list(AUTH_PROVIDERS)
+    print("Authenticate agents — pick one or more (comma-separated):")
+    for i, name in enumerate(provider_names, 1):
+        info = AUTH_PROVIDERS[name]
+        modes = []
+        if info.supports_oauth:
+            modes.append("oauth")
+        if info.supports_api_key:
+            modes.append("api-key")
+        print(f"  {i:>2}. {name:<12} {info.label}  [{', '.join(modes)}]")
+
+    try:
+        answer = input("\nChoice (numbers or names, comma-separated; empty = cancel): ").strip()
+    except (EOFError, KeyboardInterrupt):
+        print()
+        return
+    if not answer:
+        return
+
+    selected = _parse_provider_selection(answer, provider_names)
+    if not selected:
+        print("Nothing selected.", file=sys.stderr)
+        return
+
+    for provider in selected:
+        print(f"\n── {provider} ─────────────────────")
+        _run_one(provider, project_id)
+
+
+def _parse_provider_selection(raw: str, provider_names: list[str]) -> list[str]:
+    """Parse a comma-separated pick-list into a de-duped ordered provider list.
+
+    Accepts either numeric indices (1-based, matching the displayed menu) or
+    provider names.  Unknown tokens are reported on stderr and skipped —
+    partial success is preferable to aborting the whole menu interaction.
+    """
+    selected: list[str] = []
+    seen: set[str] = set()
+    for token in raw.split(","):
+        token = token.strip()
+        if not token:
+            continue
+        resolved: str | None = None
+        if token.isdigit():
+            idx = int(token) - 1
+            if 0 <= idx < len(provider_names):
+                resolved = provider_names[idx]
+        elif token in provider_names:
+            resolved = token
+        if resolved is None:
+            print(f"  Skipped unknown provider: {token!r}", file=sys.stderr)
+            continue
+        if resolved not in seen:
+            selected.append(resolved)
+            seen.add(resolved)
+    return selected

--- a/src/terok/cli/commands/setup.py
+++ b/src/terok/cli/commands/setup.py
@@ -780,8 +780,8 @@ def cmd_setup(
     providers = ", ".join(AUTH_PROVIDERS)
     print(
         f"\nNext steps:\n"
+        f"  terok auth <provider>                      Host-wide auth ({providers})\n"
         f"  terok project wizard                       Create your first project\n"
-        f"  terok auth <provider> <project>            Authenticate agents ({providers})\n"
         f"  terok task run <project>                   Start a CLI task (attaches on TTY)\n"
     )
 

--- a/src/terok/cli/main.py
+++ b/src/terok/cli/main.py
@@ -98,9 +98,11 @@ def main(prog: str = "terok") -> None:
         epilog=(
             "Quick start:\n"
             f"  1. Bootstrap:  {prog} setup                       (install host services)\n"
-            f"  2. Project:    {prog} project wizard              (create a project)\n"
-            f"  3. Auth:       {prog} auth claude <project>       (authenticate agents)\n"
+            f"  2. Auth:       {prog} auth claude                 (host-wide auth — no project needed)\n"
+            f"  3. Project:    {prog} project wizard              (create a project)\n"
             f"  4. Work:       {prog} task run <project_id>       (attach into a new CLI task)\n"
+            "\n"
+            f"Bare {prog} auth opens an interactive menu for multiple providers.\n"
             "\n"
             "Standalone agent (no project):\n"
             f"  {prog} executor run claude .          (headless against cwd)\n"

--- a/src/terok/lib/domain/facade.py
+++ b/src/terok/lib/domain/facade.py
@@ -174,14 +174,27 @@ def maybe_pause_for_ssh_key_registration(project_id: str) -> None:
         input("Press Enter once the key is registered... ")
 
 
-def authenticate(project_id: str, provider: str) -> None:
-    """Run the auth flow for *provider*, injecting terok-specific config.
+#: Container-scope sentinel used when ``authenticate`` runs without a project.
+#:
+#: ``_host`` is rejected by :func:`is_valid_project_id` (leading underscore),
+#: so it can never collide with a real project ID.  The auth flow only uses
+#: the scope string for transient container naming — credentials land in the
+#: vault provider-scoped, not project-scoped — so the sentinel is cosmetic.
+_HOST_AUTH_SENTINEL = "_host"
 
-    Thin wrapper around the instrumentation-layer ``authenticate()`` that
-    supplies ``mounts_dir`` and ``image`` from terok's config/image system.
-    When ``expose_oauth_token`` is active (exposed mode), passes
-    ``expose_token`` so the real credential file is preserved instead of
-    being replaced with a phantom marker.
+
+def authenticate(provider: str, project_id: str | None = None) -> None:
+    """Run the auth flow for *provider*, host-wide by default.
+
+    When *project_id* is given, the project's L2 CLI image is reused — the
+    escape hatch for users who want project-scoped credentials or happen to
+    have a project image handy.  When omitted, terok resolves an L1 image
+    (shared across projects that build on the same base) and offers to
+    build one if none exists — the "fresh install, no project yet" path.
+
+    Vault storage is provider-scoped in both modes, so switching from a
+    per-project auth to a host-wide one later (or vice versa) does not
+    duplicate or overwrite credentials.
     """
     from ..core.config import (
         get_claude_expose_oauth_token,
@@ -190,13 +203,86 @@ def authenticate(project_id: str, provider: str) -> None:
     )
 
     expose = provider == "claude" and is_experimental() and get_claude_expose_oauth_token()
+
+    if project_id is None:
+        image = _resolve_host_auth_image(provider)
+        container_scope = _HOST_AUTH_SENTINEL
+    else:
+        image = project_cli_image(project_id)
+        container_scope = project_id
+
     _authenticate_raw(
-        project_id,
+        container_scope,
         provider,
         mounts_dir=sandbox_live_mounts_dir(),
-        image=project_cli_image(project_id),
+        image=image,
         expose_token=expose,
     )
+
+
+def _resolve_host_auth_image(provider: str) -> str:
+    """Pick (or build) an L1 image suitable for host-wide ``terok auth``.
+
+    Prefers the default full-roster L1 when present — it has every agent
+    installed, so repeated ``terok auth`` calls for different providers
+    share one image.  Falls back to a per-provider L1 that gets built on
+    demand.  For API-key-only providers no container is ever launched, so
+    any tag is acceptable; we return the full-roster name without
+    verifying it exists.
+    """
+    import sys
+
+    from terok_executor import (
+        AUTH_PROVIDERS,
+        DEFAULT_BASE_IMAGE,
+        build_base_images,
+        l1_image_tag,
+    )
+
+    info = AUTH_PROVIDERS.get(provider)
+    needs_container = info is not None and info.supports_oauth
+
+    full_roster = l1_image_tag(DEFAULT_BASE_IMAGE)
+    if image_exists(full_roster):
+        return full_roster
+
+    per_agent = l1_image_tag(DEFAULT_BASE_IMAGE, agents=(provider,))
+    if image_exists(per_agent):
+        return per_agent
+
+    if not needs_container:
+        # API-key-only providers never launch the image, so any tag is fine.
+        return full_roster
+
+    hint = (
+        "No agent image present.  Build one with: "
+        "terok project build <project>  (or terok executor build), "
+        "or pass --project <id> to reuse an existing project's image."
+    )
+    if not (sys.stdin.isatty() and sys.stdout.isatty()):
+        raise SystemExit(hint)
+
+    try:
+        answer = (
+            input(
+                f"Auth for {provider!r} needs an agent image.  "
+                f"Build the minimal L1 ({per_agent}) now? [Y/n]: "
+            )
+            .strip()
+            .lower()
+        )
+    except EOFError:
+        print()
+        raise SystemExit(hint) from None
+    except KeyboardInterrupt:
+        print()
+        raise SystemExit(130) from None
+
+    if answer in ("n", "no"):
+        raise SystemExit(hint)
+
+    build_base_images(DEFAULT_BASE_IMAGE, agents=(provider,))
+    return per_agent
 
 
 __all__ = [

--- a/src/terok/tui/project_actions.py
+++ b/src/terok/tui/project_actions.py
@@ -265,7 +265,7 @@ class ProjectActionsMixin:
             self.notify("No project selected.")
             return
         await self._run_suspended(
-            lambda: authenticate(self.current_project_id, provider),
+            lambda: authenticate(provider, self.current_project_id),
             success_msg=f"Auth completed for {provider}",
             refresh=None,
         )

--- a/tests/unit/cli/test_cli_auth.py
+++ b/tests/unit/cli/test_cli_auth.py
@@ -1,37 +1,84 @@
 # SPDX-FileCopyrightText: 2026 Jiri Vyskocil
 # SPDX-License-Identifier: Apache-2.0
 
-"""Tests for the top-level ``terok auth`` command."""
+"""Tests for the top-level ``terok auth`` command.
+
+Three invocation shapes to verify:
+
+- ``terok auth``                           → interactive menu (no provider).
+- ``terok auth <p>``                       → host-wide auth (no project_id).
+- ``terok auth <p> <id>``                  → legacy positional project.
+- ``terok auth <p> --project <id>``        → named project flag.
+"""
 
 from __future__ import annotations
 
 import argparse
+from io import StringIO
 from types import SimpleNamespace
 from unittest.mock import patch
 
-from terok.cli.commands.auth import dispatch, register
+import pytest
+
+from terok.cli.commands.auth import (
+    _parse_provider_selection,
+    _run_interactive,
+    _run_one,
+    dispatch,
+    register,
+)
 
 
-def test_register_parses_provider_and_project() -> None:
-    """``auth <provider> <project>`` parses as two positional arguments."""
+def _make_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser()
     register(parser.add_subparsers(dest="cmd"))
-    args = parser.parse_args(["auth", "claude", "myproj"])
+    return parser
+
+
+# ── argparse registration ──────────────────────────────────────────────
+
+
+def test_auth_parses_positional_provider_and_project() -> None:
+    """``auth claude myproj`` keeps parsing via the legacy two-positional form."""
+    args = _make_parser().parse_args(["auth", "claude", "myproj"])
     assert args.cmd == "auth"
     assert args.provider == "claude"
     assert args.project_id == "myproj"
+    assert args.project_flag is None
 
 
-def test_register_rejects_unknown_provider() -> None:
-    """``auth <unknown>`` exits with argparse's choices error."""
-    parser = argparse.ArgumentParser()
-    register(parser.add_subparsers(dest="cmd"))
-    try:
-        parser.parse_args(["auth", "not-a-provider", "p"])
-    except SystemExit as exc:
-        assert exc.code == 2
-    else:  # pragma: no cover — defensive: argparse must exit on invalid choice
-        raise AssertionError("expected SystemExit")
+def test_auth_parses_provider_only() -> None:
+    """``auth claude`` (no project) sets project_id to None — host-wide shape."""
+    args = _make_parser().parse_args(["auth", "claude"])
+    assert args.provider == "claude"
+    assert args.project_id is None
+    assert args.project_flag is None
+
+
+def test_auth_parses_no_arguments() -> None:
+    """``auth`` on its own leaves provider None — interactive shape."""
+    args = _make_parser().parse_args(["auth"])
+    assert args.provider is None
+    assert args.project_id is None
+    assert args.project_flag is None
+
+
+def test_auth_parses_project_flag() -> None:
+    """``auth claude --project p`` populates project_flag; positional stays None."""
+    args = _make_parser().parse_args(["auth", "claude", "--project", "p"])
+    assert args.provider == "claude"
+    assert args.project_flag == "p"
+    assert args.project_id is None
+
+
+def test_auth_rejects_unknown_provider() -> None:
+    """argparse's choices validation still fires for unknown provider names."""
+    with pytest.raises(SystemExit) as exc:
+        _make_parser().parse_args(["auth", "not-a-provider"])
+    assert exc.value.code == 2
+
+
+# ── dispatch wiring ────────────────────────────────────────────────────
 
 
 def test_dispatch_ignores_other_commands() -> None:
@@ -39,10 +86,25 @@ def test_dispatch_ignores_other_commands() -> None:
     assert dispatch(argparse.Namespace(cmd="task")) is False
 
 
-def test_dispatch_runs_install_check_then_authenticate() -> None:
-    """``auth`` loads the project, verifies the agent, then authenticates."""
+def test_dispatch_host_wide_skips_project_loading() -> None:
+    """``auth <provider>`` never touches ``load_project`` / ``require_agent_installed``."""
+    args = argparse.Namespace(cmd="auth", provider="claude", project_id=None, project_flag=None)
+    with (
+        patch("terok.cli.commands.auth.load_project") as mock_load,
+        patch("terok.cli.commands.auth.require_agent_installed") as mock_check,
+        patch("terok.cli.commands.auth.authenticate") as mock_auth,
+    ):
+        assert dispatch(args) is True
+
+    mock_load.assert_not_called()
+    mock_check.assert_not_called()
+    mock_auth.assert_called_once_with("claude", None)
+
+
+def test_dispatch_project_positional_runs_install_check() -> None:
+    """Legacy ``auth <p> <id>`` loads the project and verifies the agent."""
     fake_project = SimpleNamespace(id="p1")
-    args = argparse.Namespace(cmd="auth", provider="claude", project_id="p1")
+    args = argparse.Namespace(cmd="auth", provider="claude", project_id="p1", project_flag=None)
     with (
         patch("terok.cli.commands.auth.load_project", return_value=fake_project),
         patch("terok.cli.commands.auth.require_agent_installed") as mock_check,
@@ -50,7 +112,92 @@ def test_dispatch_runs_install_check_then_authenticate() -> None:
     ):
         assert dispatch(args) is True
 
-    # The handler passes the *loaded* project object (not the raw id) into
-    # the installation check, and the noun label drives error messages.
     mock_check.assert_called_once_with(fake_project, "claude", noun="Provider")
-    mock_auth.assert_called_once_with("p1", "claude")
+    mock_auth.assert_called_once_with("claude", "p1")
+
+
+def test_dispatch_project_flag_wins_over_positional() -> None:
+    """``--project`` wins when both the flag and the legacy positional are set."""
+    fake_project = SimpleNamespace(id="flagged")
+    args = argparse.Namespace(
+        cmd="auth", provider="claude", project_id="positional", project_flag="flagged"
+    )
+    with (
+        patch("terok.cli.commands.auth.load_project", return_value=fake_project) as mock_load,
+        patch("terok.cli.commands.auth.require_agent_installed"),
+        patch("terok.cli.commands.auth.authenticate") as mock_auth,
+    ):
+        dispatch(args)
+
+    mock_load.assert_called_once_with("flagged")
+    mock_auth.assert_called_once_with("claude", "flagged")
+
+
+def test_dispatch_no_provider_runs_interactive() -> None:
+    """``auth`` with no provider routes into the chained interactive flow."""
+    args = argparse.Namespace(cmd="auth", provider=None, project_id=None, project_flag=None)
+    with patch("terok.cli.commands.auth._run_interactive") as mock_inter:
+        dispatch(args)
+    mock_inter.assert_called_once_with(None)
+
+
+# ── interactive helpers ────────────────────────────────────────────────
+
+
+def test_parse_provider_selection_accepts_mixed_numbers_and_names() -> None:
+    """Numeric indices and names co-exist in one selection string."""
+    names = ["claude", "codex", "gh"]
+    assert _parse_provider_selection("1, gh, 2", names) == ["claude", "gh", "codex"]
+
+
+def test_parse_provider_selection_deduplicates() -> None:
+    """Repeated picks collapse to a single entry, preserving first-seen order."""
+    names = ["claude", "codex"]
+    assert _parse_provider_selection("1, claude, 1", names) == ["claude"]
+
+
+def test_parse_provider_selection_skips_unknown(capsys: pytest.CaptureFixture[str]) -> None:
+    """Unknown tokens are reported on stderr and skipped; valid picks still run."""
+    names = ["claude"]
+    picked = _parse_provider_selection("claude, bogus, 99", names)
+    assert picked == ["claude"]
+    err = capsys.readouterr().err
+    assert "bogus" in err
+    assert "99" in err
+
+
+def test_run_interactive_cancels_on_empty_answer(capsys: pytest.CaptureFixture[str]) -> None:
+    """Empty input aborts without launching any auth."""
+    with (
+        patch("sys.stdin", new=StringIO("\n")),
+        patch("terok.cli.commands.auth._run_one") as mock_run,
+    ):
+        _run_interactive(project_id=None)
+    mock_run.assert_not_called()
+
+
+def test_run_interactive_runs_each_selected_provider() -> None:
+    """Selected providers are authenticated in order, sharing the same project scope."""
+    with (
+        patch("sys.stdin", new=StringIO("claude, codex\n")),
+        patch("terok.cli.commands.auth._run_one") as mock_run,
+    ):
+        _run_interactive(project_id="myproj")
+    assert [call.args for call in mock_run.call_args_list] == [
+        ("claude", "myproj"),
+        ("codex", "myproj"),
+    ]
+
+
+# ── single-provider runner ─────────────────────────────────────────────
+
+
+def test_run_one_skips_install_check_when_host_wide() -> None:
+    """Host-wide ``_run_one`` goes straight to ``authenticate`` — no project load."""
+    with (
+        patch("terok.cli.commands.auth.load_project") as mock_load,
+        patch("terok.cli.commands.auth.authenticate") as mock_auth,
+    ):
+        _run_one("claude", project_id=None)
+    mock_load.assert_not_called()
+    mock_auth.assert_called_once_with("claude", None)

--- a/tests/unit/lib/domain/test_facade.py
+++ b/tests/unit/lib/domain/test_facade.py
@@ -211,3 +211,97 @@ class TestMaybePauseForSshKeyRegistration:
         with patch("terok.lib.domain.facade.load_project", return_value=project):
             facade.maybe_pause_for_ssh_key_registration("myproj")
         assert "ACTION REQUIRED" not in capsys.readouterr().out
+
+
+class TestAuthenticate:
+    """authenticate dispatches to the raw executor call with the right image+scope."""
+
+    def test_project_scoped_uses_l2_image(self) -> None:
+        """``authenticate(provider, project_id)`` reuses the project's L2 image."""
+        from terok.lib.domain import facade
+
+        # sandbox_live_mounts_dir / is_experimental / expose-token are
+        # lazy-imported inside the function body, so patching happens
+        # at their definition modules rather than on the facade.
+        with (
+            patch(
+                "terok.lib.domain.facade.project_cli_image", return_value="terok-p1:latest"
+            ) as mock_l2,
+            patch("terok.lib.core.config.sandbox_live_mounts_dir", return_value="/mnt"),
+            patch("terok.lib.core.config.is_experimental", return_value=False),
+            patch("terok.lib.core.config.get_claude_expose_oauth_token", return_value=False),
+            patch("terok.lib.domain.facade._authenticate_raw") as mock_auth,
+        ):
+            facade.authenticate("claude", project_id="p1")
+
+        mock_l2.assert_called_once_with("p1")
+        mock_auth.assert_called_once()
+        # Positional call arg 0 is the container-scope string: the project id.
+        assert mock_auth.call_args.args[0] == "p1"
+        assert mock_auth.call_args.kwargs["image"] == "terok-p1:latest"
+
+    def test_host_wide_resolves_l1_and_uses_sentinel(self) -> None:
+        """``authenticate(provider)`` (no project) uses the host sentinel and an L1 image."""
+        from terok.lib.domain import facade
+
+        with (
+            patch(
+                "terok.lib.domain.facade._resolve_host_auth_image",
+                return_value="terok-l1-cli:ubuntu-24.04",
+            ) as mock_resolve,
+            patch("terok.lib.core.config.sandbox_live_mounts_dir", return_value="/mnt"),
+            patch("terok.lib.core.config.is_experimental", return_value=False),
+            patch("terok.lib.core.config.get_claude_expose_oauth_token", return_value=False),
+            patch("terok.lib.domain.facade._authenticate_raw") as mock_auth,
+        ):
+            facade.authenticate("claude")
+
+        mock_resolve.assert_called_once_with("claude")
+        assert mock_auth.call_args.args[0] == facade._HOST_AUTH_SENTINEL
+        assert mock_auth.call_args.kwargs["image"] == "terok-l1-cli:ubuntu-24.04"
+
+
+class TestResolveHostAuthImage:
+    """_resolve_host_auth_image prefers an existing L1 and builds on demand."""
+
+    def test_prefers_existing_full_roster_image(self) -> None:
+        from terok.lib.domain import facade
+
+        def exists(tag: str) -> bool:
+            return tag == "terok-l1-cli:ubuntu-24.04"
+
+        with patch("terok.lib.domain.facade.image_exists", side_effect=exists):
+            image = facade._resolve_host_auth_image("claude")
+        assert image == "terok-l1-cli:ubuntu-24.04"
+
+    def test_falls_back_to_per_agent_l1(self) -> None:
+        from terok.lib.domain import facade
+
+        def exists(tag: str) -> bool:
+            return tag == "terok-l1-cli:ubuntu-24.04-claude"
+
+        with patch("terok.lib.domain.facade.image_exists", side_effect=exists):
+            image = facade._resolve_host_auth_image("claude")
+        assert image == "terok-l1-cli:ubuntu-24.04-claude"
+
+    def test_api_key_only_provider_skips_build_when_missing(self) -> None:
+        """API-key-only providers never launch a container; any tag is fine."""
+        from terok.lib.domain import facade
+
+        with patch("terok.lib.domain.facade.image_exists", return_value=False):
+            # sonar is api-key-only — no prompt, no build, just a tag.
+            image = facade._resolve_host_auth_image("sonar")
+        assert image.startswith("terok-l1-cli:")
+
+    def test_oauth_provider_exits_on_non_tty_without_image(self) -> None:
+        """Non-TTY OAuth run with no image exits with a build hint, no prompt."""
+        from terok.lib.domain import facade
+
+        with (
+            patch("terok.lib.domain.facade.image_exists", return_value=False),
+            patch("sys.stdin.isatty", return_value=False),
+            patch("sys.stdout.isatty", return_value=False),
+            pytest.raises(SystemExit) as exc,
+        ):
+            facade._resolve_host_auth_image("claude")
+        assert "terok project build" in str(exc.value) or "terok executor" in str(exc.value)


### PR DESCRIPTION
## Summary

Authentication no longer requires a project. Credentials were already stored provider-scoped in the vault — the old ``terok auth claude <project>`` signature used ``project_id`` only to name the transient auth container and to pick an image. Both are now optional.

### Three shapes, in increasing specificity

- **`terok auth`** — interactive menu. Pick one or more providers (by number or name, comma-separated); each is authenticated in turn. Shared project scope across the batch.
- **`terok auth <provider>`** — host-wide. Resolves an L1 image (default full-roster, else per-agent) and offers to build on demand when none exists. The auth container is named ``_host-auth-<provider>`` — ``_host`` is rejected by ``is_valid_project_id`` so it can never collide with a real project.
- **`terok auth <provider> --project <id>`** — project-scoped escape hatch. Reuses the project's L2 image through the existing path. Vault stays provider-scoped, so the same credential slot is overwritten rather than duplicated.

The legacy `terok auth <p> <id>` positional form continues to parse for backwards compatibility; `--project` wins if both are given.

### Why this was surgical

No `terok-executor` changes. The executor already:
- stores credentials via `_capture_credentials(provider_name, ..., credential_set="default", ...)` — provider-scoped, not project-scoped;
- accepts any `image` string for the auth container — L1 images (keyed by `base_image` + `agents`) are shared across projects and qualify;
- takes `project_id` only for transient container naming.

So the whole change is a terok-side CLI + facade refactor. Roughly a day of work, much less than my original "biggest architectural lift" estimate.

### OAuth vs API-key-only split

Of 9 providers: 3 need a container (claude, codex, gh — OAuth), 6 are API-key-only (sonar, blablador, kisski, coderabbit, glab, vibe). For API-key-only providers host-wide auth is a zero-cost vault write — no build prompt, no container launched. Only the three OAuth providers trigger the build-on-demand path.

### Signature change

`facade.authenticate(provider, project_id=None)`. The TUI project-actions handler and the CLI dispatcher are updated. Pre-0.x compatibility policy (see CLAUDE.md) allows the breaking rename.

### Docs

Quick-start epilog, `terok setup` next-steps trailer, and the README all lead with the host-wide form. Legacy per-project form documented as the escape hatch.

## Test plan

- [x] `make lint` clean
- [x] `make tach` clean
- [x] `make lint-imports` clean
- [x] `make docstrings` clean
- [x] `make reuse` clean
- [x] `make security` clean
- [x] `poetry run pytest tests/unit` — 2022 pass (was 2004 after #785; 18 new tests cover the three invocation shapes, interactive chained mode, provider-selection parser, and host-image resolution across the full-roster / per-agent / non-TTY branches)
- [ ] Manual smoke: `terok auth claude` on a fresh install — requires podman host, not run here
- [ ] Manual smoke: `terok auth` interactive menu — same

Part of the first-start UX arc started in #785.

🤖 Generated with [Claude Code](https://claude.com/claude-code)