### PR TITLE
docs: document gate.enabled and the four-cell matrix

### DIFF
--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -105,18 +105,21 @@ graph TD
 
 ### Projects
 
-A **project** is a configuration that maps to a single upstream git
-repository. It defines:
+A **project** is a configuration that optionally maps to an upstream
+git repository. It defines:
 
-- The upstream URL and default branch
+- The upstream URL and default branch (both optional — a project
+  without an upstream is a valid, local-only workspace)
 - The security mode (online or gatekeeping)
+- Whether the host-side git gate runs (`gate.enabled`, default `true`)
 - SSH key configuration
 - Agent settings (provider, model, instructions)
 - Shield allowlists
 
 Projects are stored as YAML files under
 `~/.config/terok/projects/<id>/project.yml`. A project can have many tasks
-running simultaneously, all against the same upstream repo.
+running simultaneously, all against the same upstream repo (or the same
+local-only gate when no upstream is configured).
 
 ### Tasks
 
@@ -154,9 +157,14 @@ other tasks' workspaces.
 
 ## The Git Gate
 
-The **git gate** is a host-side bare mirror of the upstream repository. It
-sits between the containers and the real remote, acting as either a
-performance accelerator or a security checkpoint depending on the mode.
+The **git gate** is a host-side bare git repository managed by terok.
+When a project has an upstream configured, the gate mirrors it and
+sits between the containers and the real remote — acting as either a
+performance accelerator (online mode) or a security checkpoint
+(gatekeeping mode).  Without an upstream, the gate is a remoteless
+local repo the container can still push to.  The gate can also be
+turned off entirely via `gate.enabled: false` in project.yml; see
+[Git Gate and Security Modes](git-gate-and-security-modes.md#disabling-the-gate-gateenabled).
 
 ### How code flows through the gate
 

--- a/docs/developer.md
+++ b/docs/developer.md
@@ -157,10 +157,13 @@ See [shared-dirs.md](shared-dirs.md) for detailed documentation.
 
 | Variable | When Set | Purpose |
 |----------|----------|---------|
-| `CODE_REPO` | Always | Git URL (upstream or gate depending on mode) |
-| `GIT_BRANCH` | Always | Target branch name |
-| `CLONE_FROM` | Online mode with gate | Alternate clone source for faster init |
+| `CODE_REPO` | When the project has an upstream or an active gate | Git URL (upstream in online mode, gate in gatekeeping mode) |
+| `GIT_BRANCH` | Alongside `CODE_REPO` when a default branch is configured | Target branch name |
+| `CLONE_FROM` | Online mode with `gate.enabled: true` and a reachable gate server | Alternate clone source for faster init |
 | `EXTERNAL_REMOTE_URL` | Relaxed gatekeeping | Upstream URL for "external" remote |
+
+When the project has no `upstream_url` and `gate.enabled: false`,
+`CODE_REPO` is unset and the container starts with an empty workspace.
 
 ---
 

--- a/docs/git-gate-and-security-modes.md
+++ b/docs/git-gate-and-security-modes.md
@@ -1,11 +1,17 @@
 # Git Gate and Security Modes
 
-The **git gate** is a host-side bare mirror of the upstream repository,
-managed by [terok-sandbox](https://github.com/terok-ai/terok-sandbox).
-It serves two purposes depending on the project's security mode:
+The **git gate** is a host-side bare git repository managed by
+[terok-sandbox](https://github.com/terok-ai/terok-sandbox).  When a
+project has an upstream configured, the gate mirrors it; without one,
+it initialises as a remoteless bare repo the container can still push
+to.  The gate serves two purposes depending on the project's security
+mode:
 
 - **Online mode** — performance accelerator for cloning (the gate is not used for security; containers talk to upstream directly)
 - **Gatekeeping mode** — the default git origin for containers, directing agent pushes to the gate instead of upstream
+
+Both modes can be paired with the `gate.enabled` knob; see
+[Disabling the gate](#disabling-the-gate-gateenabled) below.
 
 ## Three Layers: Upstream → Gate → Tasks
 
@@ -140,3 +146,51 @@ gatekeeping:
     The gate works best as one layer in a defence-in-depth strategy:
     gate (push destination control) + shield (egress firewall).
     No single layer is sufficient on its own.
+
+---
+
+## Disabling the gate (`gate.enabled`)
+
+The gate is an independent knob from `security_class`.  Set
+`gate.enabled: false` in project.yml to stop terok from running a
+host-side mirror at all — the container then fetches directly from
+upstream via its own network path.  Useful when the host has no path
+to the remote (firewall blocking SSH, corporate proxy) but the
+container does, or when you simply don't want the host keeping a
+local mirror.
+
+```yaml
+project:
+  id: cp2k
+  security_class: online
+git:
+  upstream_url: git@github.com:user/cp2k.git
+gate:
+  enabled: false        # host never touches the remote
+```
+
+### Four combinations
+
+`gate.enabled` and `upstream_url` are orthogonal:
+
+| `gate.enabled` | `upstream_url` | Behaviour |
+|---|---|---|
+| `true` (default) | set | Host mirrors upstream; container clones from the mirror.  Default, matches the table above. |
+| `true` | absent | Host initialises a remoteless bare gate; the container still gets a remote to push to.  Local-only scratch projects. |
+| `false` | set | Host never touches the remote; the container fetches directly from upstream.  Escape hatch for host-side network restrictions. |
+| `false` | absent | No git plumbing at all; container workspace starts empty. |
+
+### Collapse when upstream is absent
+
+When `upstream_url` is absent, `online` and `gatekeeping` describe the
+same act — there is nothing to push beyond the gate.  Both values are
+accepted and behave identically in that sub-case.  The table above
+describes them distinctly only because they diverge once an upstream
+exists.
+
+### Incoherent combination (rejected)
+
+`security_class: gatekeeping` with `gate.enabled: false` is rejected
+at project-load time.  Gatekeeping *is* the gate-enforced mode — so
+disabling the gate in that mode is self-contradictory.  Either set
+`security_class: online` to drop the gate, or keep `gate.enabled: true`.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -217,10 +217,18 @@ image:
   user_snippet_file: user.dockerinclude  # optional
 
 git:
-  upstream_url: git@github.com:yourorg/yourrepo.git  # or https://...
+  upstream_url: git@github.com:yourorg/yourrepo.git  # optional; omit for local-only
   default_branch: main
   # authorship: human-agent  # optional: author = human, committer = agent
+
+# gate:
+#   enabled: false          # optional; skip the host-side gate mirror
+                            #           (container fetches upstream directly)
 ```
+
+See [Gate and upstream combinations](#gate-and-upstream-combinations)
+for the four cells of the (`gate.enabled`, `upstream_url`) matrix —
+scratch projects, firewalled hosts, and the defaults for each.
 
 ### Step 3: (Optional) Image Snippet
 


### PR DESCRIPTION
Catch-up after #792 landed.  The docs still described the gate as always-on and `upstream_url` as always-required — neither is true on master.

## What changed

**`docs/git-gate-and-security-modes.md`** — new "Disabling the gate (`gate.enabled`)" section with:

- A short motivation (firewalled hosts, local-only workspaces).
- The four-cell `(gate.enabled, upstream_url)` matrix.
- The collapse rule: when `upstream_url` is absent, `online` and `gatekeeping` describe the same act — both accepted, both behave identically.
- The rejection rule: `security_class: gatekeeping` with `gate.enabled: false` is incoherent and refused at load time.

**`docs/concepts.md`**

- "Projects" no longer claims upstream is mandatory; lists `gate.enabled` among the knobs.
- "The Git Gate" intro covers the three cases (mirrors upstream / local-only / disabled) and links to the disabling-the-gate section.

**`docs/developer.md`**

- Env-variable table describes when `CODE_REPO` / `GIT_BRANCH` / `CLONE_FROM` are set under the new matrix.
- Notes the all-disabled case where `CODE_REPO` stays unset and the container starts with an empty workspace.

**`docs/usage.md`** — 'Step 2: Create project.yml' shows `upstream_url` as optional and includes a commented `gate.enabled` example with a pointer to the full matrix.

Docs only — no code or behaviour changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)