### PR TITLE
feat(tui): Textual-native new-project wizard; auto-open on first run

### DIFF
--- a/src/terok/lib/domain/facade.py
+++ b/src/terok/lib/domain/facade.py
@@ -161,12 +161,25 @@ def summarize_ssh_init(result: SSHInitResult) -> None:
     print(f"  {result['public_line']}")
 
 
-def maybe_pause_for_ssh_key_registration(project_id: str) -> None:
-    """Pause so the user can register the deploy key, but only for SSH upstreams."""
+def project_needs_key_registration(project_id: str) -> bool:
+    """Return True when the project's upstream is SSH-scheme, so a deploy key must be added.
+
+    Shared predicate used by the CLI's pause helper below and the TUI
+    wizard's mid-flow "continue" gate — keeps the rule (SSH URLs need
+    registration, HTTPS and no-upstream projects don't) in one place.
+    """
     from terok_sandbox import is_ssh_url
 
-    project = load_project(project_id)
-    if is_ssh_url(project.upstream_url):
+    try:
+        project = load_project(project_id)
+    except SystemExit:
+        return False
+    return bool(project.upstream_url) and is_ssh_url(project.upstream_url)
+
+
+def maybe_pause_for_ssh_key_registration(project_id: str) -> None:
+    """Pause so the user can register the deploy key, but only for SSH upstreams."""
+    if project_needs_key_registration(project_id):
         print("\n" + "=" * 60)
         print("ACTION REQUIRED: Add the public key shown above as a")
         print("deploy key (or to your SSH keys) on the git remote.")
@@ -335,6 +348,7 @@ __all__ = [
     "summarize_ssh_init",
     "vault_db",
     "maybe_pause_for_ssh_key_registration",
+    "project_needs_key_registration",
     # Auth
     "authenticate",
     # Project state

--- a/src/terok/lib/domain/wizards/new_project.py
+++ b/src/terok/lib/domain/wizards/new_project.py
@@ -171,13 +171,32 @@ QUESTIONS: tuple[Question, ...] = (
 def validate_answer(question: Question, raw: str) -> tuple[str, str | None]:
     """Normalise and validate a raw answer for *question*.
 
-    Returns ``(value, error_or_None)`` — the transformed value and an
-    error message if the answer was rejected.  Both presenters call this
-    so validation semantics stay identical regardless of UI.
+    Returns ``(value, error_or_None)`` — the normalised value and an
+    error message if the answer was rejected.  Both presenters call
+    this so validation semantics stay identical regardless of UI.
+
+    Normalisation, in order:
+
+    1. Strip surrounding whitespace (copy-paste leftovers, accidental
+       trailing spaces).  All-whitespace input is indistinguishable
+       from empty for the required/optional check.
+    2. Apply ``question.transform`` if set (e.g. ``str.lower``).
+    3. Enforce the required flag against the final value.
+    4. For ``kind="choice"``, the value must be one of the declared
+       slugs — defensive against presenter bugs that might submit a
+       label, index, or free-form typo.
+    5. Run ``question.validate`` for field-specific rules.
     """
-    value = question.transform(raw) if question.transform else raw
+    value = raw.strip()
+    if question.transform:
+        value = question.transform(value)
     if question.required and not value:
         return value, f"{question.prompt} is required."
+    if question.kind == "choice" and value:
+        valid_slugs = {slug for slug, _label in question.choices}
+        if value not in valid_slugs:
+            allowed = ", ".join(sorted(valid_slugs))
+            return value, f"{question.prompt} must be one of: {allowed}"
     if question.validate:
         err = question.validate(value)
         if err:
@@ -210,6 +229,13 @@ def _prompt_choice(title: str, options: list[tuple[str, str]]) -> str | None:
     return None
 
 
+#: Exact text terok writes into the snippet tempfile before handing it to
+#: ``$EDITOR``.  Matching this verbatim keeps the trimmer from eating
+#: intentional user comments at the top of the file — only *our* boilerplate
+#: goes away, any other leading ``#`` lines the user types survive.
+_SNIPPET_PREAMBLE = "# Add custom Dockerfile commands below.\n# Empty file = no snippet.\n"
+
+
 def _prompt_image_snippet() -> str:
     """Optionally open an editor for a custom image snippet.
 
@@ -222,7 +248,7 @@ def _prompt_image_snippet() -> str:
     with tempfile.NamedTemporaryFile(
         suffix=".dockerfile", prefix="terok-snippet-", mode="w", delete=False
     ) as tmp:
-        tmp.write("# Add custom Dockerfile commands below.\n# Empty file = no snippet.\n")
+        tmp.write(_SNIPPET_PREAMBLE)
         tmp_path = Path(tmp.name)
 
     try:
@@ -237,18 +263,18 @@ def _prompt_image_snippet() -> str:
 
 
 def _trim_snippet_preamble(content: str) -> str:
-    """Strip leading comment-only lines (the boilerplate preamble) and trailing blanks."""
-    raw_lines = content.splitlines()
-    start_idx = 0
-    while start_idx < len(raw_lines):
-        stripped = raw_lines[start_idx].strip()
-        if stripped and not stripped.startswith("#"):
-            break
-        start_idx += 1
-    trimmed = raw_lines[start_idx:]
-    while trimmed and not trimmed[-1].strip():
-        trimmed.pop()
-    return "\n".join(trimmed)
+    """Strip exactly the injected preamble and trailing blanks.
+
+    The earlier implementation pruned every leading comment line, which
+    would eat user-intended ``# TODO`` or copyright notices.  We instead
+    match :data:`_SNIPPET_PREAMBLE` verbatim — if the user didn't
+    remove it, drop it; if they did, leave the rest alone.
+    """
+    if content.startswith(_SNIPPET_PREAMBLE):
+        content = content[len(_SNIPPET_PREAMBLE) :]
+    # Trailing blanks stay stripped — meaningful-whitespace policy
+    # is the same regardless of whether the preamble was intact.
+    return content.rstrip("\n").rstrip()
 
 
 def _ask_cli(question: Question) -> str | None:

--- a/src/terok/lib/domain/wizards/new_project.py
+++ b/src/terok/lib/domain/wizards/new_project.py
@@ -1,14 +1,34 @@
 # SPDX-FileCopyrightText: 2026 Jiri Vyskocil
 # SPDX-License-Identifier: Apache-2.0
 
-"""Interactive project wizard for creating new project configurations."""
+"""Declarative wizard schema shared by the CLI prompt loop and the TUI modal.
+
+The wizard asks a fixed set of questions to build a new project config.
+Declaring them as :class:`Question` records keeps two presenters — the
+CLI's sequential prompts and the TUI's multi-field form — using one
+source of truth: same labels, same validation, same transforms.
+
+A presenter's only job is to elicit a raw string per question.  The
+shared :func:`validate_answer` then normalises it, runs the question's
+validator, and returns either the accepted value or an error the
+presenter can display.  When every question has an accepted answer, the
+collected values go to :func:`generate_config`, which writes the
+``project.yml`` template and returns the path.
+
+:func:`collect_wizard_inputs` is the CLI presenter (uses ``input()``);
+the TUI presenter lives in :mod:`terok.tui.wizard_screens`.
+"""
+
+from __future__ import annotations
 
 import sys
 import tempfile
 from collections.abc import Callable
+from dataclasses import dataclass
 from importlib import resources
 from importlib.resources.abc import Traversable
 from pathlib import Path
+from typing import Literal
 
 from terok.ui_utils.editor import open_in_editor
 
@@ -16,6 +36,8 @@ from ...core.config import user_projects_dir
 from ...core.project_model import validate_project_id
 from ...util.fs import ensure_dir_writable
 from ...util.template_utils import render_template
+
+# ── Vocabulary ────────────────────────────────────────────────────────
 
 # The wizard picks a project template by asking two independent
 # questions (security mode + base image) instead of one combinatorial
@@ -37,6 +59,51 @@ BASES: list[tuple[str, str]] = sorted(
 _TEMPLATE_DIR: Traversable = resources.files("terok") / "resources" / "templates" / "projects"
 
 
+# ── Question declarations ─────────────────────────────────────────────
+
+QuestionKind = Literal["choice", "text", "editor"]
+
+
+@dataclass(frozen=True)
+class Question:
+    """One wizard prompt — what to ask, how to validate, what shape the answer takes.
+
+    The presenter decides the visual treatment (numbered menu vs radio
+    buttons, ``input()`` vs Textual ``Input``, ``$EDITOR`` vs ``TextArea``);
+    the declaration here drives everything else.
+    """
+
+    key: str
+    """Name of this field in the collected-values dict."""
+
+    kind: QuestionKind
+    """Shape of the input — drives which widget / prompt style a presenter uses."""
+
+    prompt: str
+    """Short one-line question, used as both CLI prompt and TUI label."""
+
+    help: str = ""
+    """Longer explanation, rendered next to the input in the TUI; unused in CLI."""
+
+    choices: tuple[tuple[str, str], ...] = ()
+    """Allowed values for ``kind="choice"`` as ``(value, label)`` pairs."""
+
+    required: bool = False
+    """Reject empty answers with ``"<prompt> is required."``"""
+
+    transform: Callable[[str], str] | None = None
+    """Optional normalisation applied before validation (e.g. ``str.lower``)."""
+
+    validate: Callable[[str], str | None] | None = None
+    """Optional validator returning an error string or ``None`` when accepted."""
+
+    placeholder: str = ""
+    """Hint string, rendered inside the Textual ``Input``; unused in CLI."""
+
+    default_visible: bool = False
+    """When True, CLI prompt shows ``"(optional)"`` to telegraph "Enter is fine"."""
+
+
 def _validate_project_id(project_id: str) -> str | None:
     """Return an error message if *project_id* is invalid, else ``None``."""
     if not project_id:
@@ -46,6 +113,79 @@ def _validate_project_id(project_id: str) -> str | None:
     except SystemExit as exc:
         return str(exc)
     return None
+
+
+QUESTIONS: tuple[Question, ...] = (
+    Question(
+        key="security_class",
+        kind="choice",
+        prompt="Select security mode",
+        choices=tuple(SECURITY_CLASSES),
+        required=True,
+    ),
+    Question(
+        key="base",
+        kind="choice",
+        prompt="Select base image",
+        choices=tuple(BASES),
+        required=True,
+    ),
+    Question(
+        key="project_id",
+        kind="text",
+        prompt="Project ID",
+        required=True,
+        transform=str.lower,
+        validate=_validate_project_id,
+        placeholder="lowercase; letters, digits, hyphens, underscores",
+    ),
+    Question(
+        key="upstream_url",
+        kind="text",
+        prompt="Upstream git URL",
+        help="Leave empty for a local-only project (no remote).",
+        placeholder="git@github.com:org/repo.git or https://…",
+        default_visible=True,
+    ),
+    Question(
+        key="default_branch",
+        kind="text",
+        prompt="Default branch",
+        help="Leave empty to use the remote's default (or ``main`` when no remote).",
+        placeholder="main",
+        default_visible=True,
+    ),
+    Question(
+        key="user_snippet",
+        kind="editor",
+        prompt="Custom image snippet",
+        help=(
+            "Optional Dockerfile fragment appended to the project image.  "
+            "Use for extra packages, env vars, or setup commands."
+        ),
+        default_visible=True,
+    ),
+)
+
+
+def validate_answer(question: Question, raw: str) -> tuple[str, str | None]:
+    """Normalise and validate a raw answer for *question*.
+
+    Returns ``(value, error_or_None)`` — the transformed value and an
+    error message if the answer was rejected.  Both presenters call this
+    so validation semantics stay identical regardless of UI.
+    """
+    value = question.transform(raw) if question.transform else raw
+    if question.required and not value:
+        return value, f"{question.prompt} is required."
+    if question.validate:
+        err = question.validate(value)
+        if err:
+            return value, err
+    return value, None
+
+
+# ── CLI presenter ─────────────────────────────────────────────────────
 
 
 def _prompt(message: str, default: str = "") -> str:
@@ -93,79 +233,77 @@ def _prompt_image_snippet() -> str:
     finally:
         tmp_path.unlink(missing_ok=True)
 
-    # Strip comment-only preamble that the user didn't edit, but preserve
-    # the original structure (including indentation and internal comments)
-    raw_lines = content.splitlines()
+    return _trim_snippet_preamble(content)
 
-    # Skip leading blank or comment-only lines (the boilerplate preamble)
+
+def _trim_snippet_preamble(content: str) -> str:
+    """Strip leading comment-only lines (the boilerplate preamble) and trailing blanks."""
+    raw_lines = content.splitlines()
     start_idx = 0
     while start_idx < len(raw_lines):
         stripped = raw_lines[start_idx].strip()
         if stripped and not stripped.startswith("#"):
             break
         start_idx += 1
-
     trimmed = raw_lines[start_idx:]
-
-    # Optionally strip trailing blank lines to avoid meaningless whitespace
     while trimmed and not trimmed[-1].strip():
         trimmed.pop()
-
     return "\n".join(trimmed)
 
 
-def collect_wizard_inputs() -> dict | None:
-    """Run the interactive prompt flow and return collected values.
+def _ask_cli(question: Question) -> str | None:
+    """Elicit a raw string from the terminal for *question*.
 
-    Returns a dict with keys: ``security_class``, ``base``, ``project_id``,
-    ``upstream_url``, ``default_branch``, ``user_snippet``.
-    Returns ``None`` if the user cancels (Ctrl+C) or makes an invalid selection.
+    ``None`` means the user's first interaction was structurally invalid
+    for a choice (e.g. non-numeric input to the menu) — the CLI treats
+    that as a cancel signal, matching the pre-refactor behaviour.
     """
+    match question.kind:
+        case "choice":
+            return _prompt_choice(question.prompt + ":", list(question.choices))
+        case "editor":
+            return _prompt_image_snippet()
+        case "text":
+            # Text prompts allow blank retry; the caller loops until
+            # ``validate_answer`` accepts the input.
+            return _prompt(
+                f"\n{question.prompt}" if question.required else question.prompt,
+            )
+
+
+def collect_wizard_inputs() -> dict | None:
+    """Drive the CLI prompt loop for every question in :data:`QUESTIONS`.
+
+    Returns a dict keyed by ``Question.key`` when all answers are
+    accepted, or ``None`` if the user cancels (Ctrl+C, EOF, or an
+    invalid choice-menu selection).
+    """
+    values: dict[str, str] = {}
     try:
-        security_class = _prompt_choice("Select security mode:", SECURITY_CLASSES)
-        if security_class is None:
-            print("Invalid mode selection.", file=sys.stderr)
-            return None
-
-        base = _prompt_choice("Select base image:", BASES)
-        if base is None:
-            print("Invalid base image selection.", file=sys.stderr)
-            return None
-
-        # Project ID
-        while True:
-            project_id = _prompt("\nProject ID")
-            lowered = project_id.lower()
-            if lowered != project_id:
-                print(f"Note: project ID lowercased to '{lowered}'")
-                project_id = lowered
-            error = _validate_project_id(project_id)
-            if error is None:
-                break
-            print(error, file=sys.stderr)
-
-        # Upstream URL (optional — empty creates a project with no remote;
-        # the host-side gate will still initialise as a bare local repo).
-        upstream_url = _prompt("Upstream git URL (empty for local-only)")
-
-        # Default branch (empty = use remote's default branch, or ``main``
-        # when there's no remote to consult).
-        default_branch = _prompt("Default branch (empty → remote default)")
-
-        # Image snippet
-        user_snippet = _prompt_image_snippet()
-
-        return {
-            "security_class": security_class,
-            "base": base,
-            "project_id": project_id,
-            "upstream_url": upstream_url,
-            "default_branch": default_branch,
-            "user_snippet": user_snippet,
-        }
+        for question in QUESTIONS:
+            while True:
+                raw = _ask_cli(question)
+                if raw is None:
+                    # Choice menus return None on structurally bad input,
+                    # which the pre-refactor flow treated as cancellation.
+                    print(f"Invalid {question.key} selection.", file=sys.stderr)
+                    return None
+                value, error = validate_answer(question, raw)
+                if error is None:
+                    if question.transform and value != raw:
+                        # Surface the normalisation so the user sees *what*
+                        # their answer became (e.g. uppercase → lowercase).
+                        print(f"Note: {question.prompt.lower()} lowercased to '{value}'")
+                    values[question.key] = value
+                    break
+                print(error, file=sys.stderr)
+        return values
     except (KeyboardInterrupt, EOFError):
         print("\nWizard cancelled.")
         return None
+
+
+# ── Config rendering ──────────────────────────────────────────────────
 
 
 def generate_config(values: dict) -> Path:
@@ -216,6 +354,41 @@ def generate_config(values: dict) -> Path:
 
     config_path.write_text(rendered, encoding="utf-8")
     return config_path
+
+
+def render_project_yaml(values: dict) -> str:
+    """Render ``project.yml`` without writing it — used by the TUI review screen."""
+    filename = f"{values['security_class']}-{values['base']}.yml"
+    traversable = _TEMPLATE_DIR / filename
+    with resources.as_file(traversable) as template_path:
+        return render_template(
+            template_path,
+            {
+                "PROJECT_ID": values["project_id"],
+                "UPSTREAM_URL": values["upstream_url"],
+                "DEFAULT_BRANCH": values["default_branch"],
+                "USER_SNIPPET": values["user_snippet"],
+            },
+        )
+
+
+def write_project_yaml(project_id: str, rendered: str, *, overwrite: bool = False) -> Path:
+    """Write *rendered* YAML to ``<user_projects_dir>/<project_id>/project.yml``.
+
+    The TUI reviews YAML in a ``TextArea`` before writing, so this is the
+    write half of :func:`generate_config` — kept separate so the TUI can
+    pass tweaked content without re-rendering the template.
+    """
+    project_dir = user_projects_dir() / project_id
+    ensure_dir_writable(project_dir, "Project")
+    config_path = project_dir / "project.yml"
+    if config_path.exists() and not overwrite:
+        return config_path
+    config_path.write_text(rendered, encoding="utf-8")
+    return config_path
+
+
+# ── CLI edit-and-init follow-up ───────────────────────────────────────
 
 
 def offer_edit_then_init(
@@ -270,3 +443,19 @@ def run_wizard(init_fn: Callable[[str], None] | None = None) -> Path | None:
 
     offer_edit_then_init(config_path, project_id, init_fn)
     return config_path
+
+
+__all__ = [
+    "BASES",
+    "QUESTIONS",
+    "Question",
+    "QuestionKind",
+    "SECURITY_CLASSES",
+    "collect_wizard_inputs",
+    "generate_config",
+    "offer_edit_then_init",
+    "render_project_yaml",
+    "run_wizard",
+    "validate_answer",
+    "write_project_yaml",
+]

--- a/src/terok/tui/app.py
+++ b/src/terok/tui/app.py
@@ -306,6 +306,9 @@ if _HAS_TEXTUAL:
             # Selection persistence
             self._last_selected_project: str | None = None
             self._last_selected_tasks: dict[str, str] = {}  # project_id -> task_id
+            # First-run nudge marker — flipped when the wizard has auto-opened
+            # once, so subsequent empty-install starts don't nag.
+            self._first_run_dismissed: bool = False
 
         def _update_title(self):
             """Update the TUI title with version and branch information."""
@@ -392,6 +395,23 @@ if _HAS_TEXTUAL:
             # Start periodic gate server polling
             self._start_gate_server_polling()
 
+            # First-run nudge: zero projects *and* zero broken configs on
+            # a fresh install → auto-open the wizard so the user never
+            # lands on a blank TUI wondering what to do next.  The
+            # dismissed flag persists through ``terok-state.json`` so a
+            # user who closes the wizard once isn't nagged again.
+            if not self._projects_by_id and not self._broken_by_id:
+                await self._maybe_show_first_run_wizard()
+
+        async def _maybe_show_first_run_wizard(self) -> None:
+            """Auto-open the wizard on a genuinely-empty install, once per user."""
+            if getattr(self, "_first_run_dismissed", False):
+                return
+            self._first_run_dismissed = True
+            self._save_selection_state()
+            # The action kicks off a worker; no need to await.
+            self.action_new_project_wizard()
+
         def _log_layout_debug(self) -> None:
             """Write a one-shot snapshot of key widget sizes to the state dir.
 
@@ -457,10 +477,12 @@ if _HAS_TEXTUAL:
                         state = json.load(f)
                         self._last_selected_project = state.get("last_project")
                         self._last_selected_tasks = state.get("last_tasks", {})
+                        self._first_run_dismissed = bool(state.get("first_run_dismissed", False))
             except Exception:
                 # If loading fails, just start with empty state
                 self._last_selected_project = None
                 self._last_selected_tasks = {}
+                self._first_run_dismissed = False
 
         def _save_selection_state(self) -> None:
             """Save current selection state to persistent storage."""
@@ -472,6 +494,7 @@ if _HAS_TEXTUAL:
                 state = {
                     "last_project": self.current_project_id,
                     "last_tasks": self._last_selected_tasks,
+                    "first_run_dismissed": getattr(self, "_first_run_dismissed", False),
                 }
                 with state_path.open("w", encoding="utf-8") as f:
                     json.dump(state, f)

--- a/src/terok/tui/project_actions.py
+++ b/src/terok/tui/project_actions.py
@@ -516,16 +516,24 @@ class ProjectActionsMixin:
             final_yaml = review_result
             break
 
-        ok = await self.push_screen_wait(InitProgressScreen(values["project_id"], final_yaml))
-        if ok:
-            self.notify(f"Project '{values['project_id']}' is ready.")
-        else:
-            self.notify(
-                f"Project '{values['project_id']}' created but init did not complete. "
-                "Fix any issues and run `terok project init` from the CLI.",
-                severity="warning",
-                timeout=10,
-            )
+        outcome = await self.push_screen_wait(InitProgressScreen(values["project_id"], final_yaml))
+        from .wizard_screens import InitOutcome
+
+        match outcome:
+            case InitOutcome.SUCCESS:
+                self.notify(f"Project '{values['project_id']}' is ready.")
+            case InitOutcome.DECLINED:
+                # User chose to keep the existing project.yml — benign
+                # no-op, not an error.  No notification needed; the log
+                # pane already told them what happened.
+                pass
+            case InitOutcome.FAILED:
+                self.notify(
+                    f"Project '{values['project_id']}' created but init did not complete. "
+                    "Fix any issues and run `terok project init` from the CLI.",
+                    severity="warning",
+                    timeout=10,
+                )
         await self.refresh_projects()
 
     # --- Project delete ---

--- a/src/terok/tui/project_actions.py
+++ b/src/terok/tui/project_actions.py
@@ -482,26 +482,40 @@ class ProjectActionsMixin:
 
     @work(exclusive=True)
     async def _run_wizard_flow(self) -> None:
-        """Drive form → review → init-progress, refreshing the list at the end."""
+        """Drive form → review → init-progress, refreshing the list at the end.
+
+        The form/review loop preserves answers on "Back": the form
+        screen accepts an *initial* prefill dict, and the review
+        screen's ``REVIEW_BACK`` sentinel tells us to re-open the form
+        with the user's previous input instead of starting fresh.
+        ``None`` from either screen abandons the wizard.
+        """
         from ..lib.domain.wizards.new_project import render_project_yaml
         from .wizard_screens import (
+            REVIEW_BACK,
             InitProgressScreen,
             ProjectReviewScreen,
             WizardFormScreen,
         )
 
-        values = await self.push_screen_wait(WizardFormScreen())
-        if values is None:
-            return  # user cancelled the form
+        values: dict[str, str] | None = None
+        while True:
+            values = await self.push_screen_wait(WizardFormScreen(initial=values))
+            if values is None:
+                return  # user cancelled the form
 
-        rendered = render_project_yaml(values)
-        final_yaml = await self.push_screen_wait(
-            ProjectReviewScreen(values["project_id"], rendered)
-        )
-        if final_yaml is None:
-            # "Back" on the review screen abandons the wizard.  Users who
-            # want partial edits already have the inline review pane.
-            return
+            rendered = render_project_yaml(values)
+            review_result = await self.push_screen_wait(
+                ProjectReviewScreen(values["project_id"], rendered)
+            )
+            if review_result is None:
+                return  # Escape on the review screen — abandon
+            if review_result is REVIEW_BACK:
+                continue  # loop back to the form, prefilled
+            # review_result is the (possibly edited) YAML string.
+            final_yaml = review_result
+            break
+
         ok = await self.push_screen_wait(InitProgressScreen(values["project_id"], final_yaml))
         if ok:
             self.notify(f"Project '{values['project_id']}' is ready.")

--- a/src/terok/tui/project_actions.py
+++ b/src/terok/tui/project_actions.py
@@ -11,7 +11,6 @@ project and task actions.
 import os
 import shlex
 import subprocess
-import sys
 from collections.abc import Callable
 
 from terok_sandbox import (
@@ -24,6 +23,7 @@ from terok_sandbox import (
     uninstall_systemd_units,
     uninstall_vault_systemd,
 )
+from textual import work
 
 from ..lib.core.projects import load_project
 from ..lib.domain.facade import (
@@ -129,7 +129,15 @@ class ProjectActionsMixin:
         cname: str,
         label: str = "Opened",
     ) -> None:
-        """Launch *cmd* via tmux/terminal/web, falling back to a suspended TUI."""
+        """Launch *cmd* via tmux/terminal/web, falling back to a suspended TUI.
+
+        The in-process ``suspend()`` fallback is refused under
+        textual-serve — the web TUI has no terminal to suspend *to*,
+        and the attempt literally kills the served session.  Web users
+        get a notification with the equivalent CLI command instead.
+        """
+        from .shell_launch import is_web_mode
+
         method, port = launch_login(cmd, title=title)
 
         if method == "tmux":
@@ -139,6 +147,13 @@ class ProjectActionsMixin:
         elif method == "web" and port is not None:
             self.open_url(f"http://localhost:{port}")
             self.notify(f"{label} in browser: {cname}")
+        elif is_web_mode():
+            self.notify(
+                f"No terminal available in web mode.  Open a host shell and run: "
+                f"terok login {cname}",
+                severity="warning",
+                timeout=15,
+            )
         else:
             with self.suspend():
                 try:
@@ -454,30 +469,50 @@ class ProjectActionsMixin:
 
     # --- Project wizard ---
 
-    async def action_new_project_wizard(self) -> None:
-        """Launch the CLI project wizard in a suspended terminal."""
-        with self.suspend():
-            # Under Nix (and other setups where ``sys.executable`` is a
-            # wrapper that normally rewrites the env on startup) spawning
-            # directly from the TUI bypasses that wrapper, and the child
-            # ``python -m terok.cli`` can't find the ``terok`` package on
-            # its import path.  Passing the parent's ``sys.path`` through
-            # as ``PYTHONPATH`` lets the subprocess resolve the same
-            # install the TUI is running from.  See #717 by Franz Pöschel.
-            env = {**os.environ, "PYTHONPATH": os.pathsep.join(sys.path)}
-            try:
-                result = subprocess.run(
-                    [sys.executable, "-m", "terok.cli", "project", "wizard"],
-                    check=False,
-                    env=env,
-                )
-                if result.returncode != 0:
-                    print(f"Wizard exited with code {result.returncode}")
-            except Exception as e:
-                print(f"Error: {e}")
-            input("\n[Press Enter to return to TerokTUI] ")
+    def action_new_project_wizard(self) -> None:
+        """Open the Textual-native new-project wizard.
+
+        Kicks off the wizard flow in a Textual worker so that
+        ``push_screen_wait`` — which requires an active worker — can
+        sequence the three screens from one coroutine.  The old
+        subprocess+suspend path was incompatible with ``textual-serve``
+        (web TUI) — see issue #473.
+        """
+        self._run_wizard_flow()
+
+    @work(exclusive=True)
+    async def _run_wizard_flow(self) -> None:
+        """Drive form → review → init-progress, refreshing the list at the end."""
+        from ..lib.domain.wizards.new_project import render_project_yaml
+        from .wizard_screens import (
+            InitProgressScreen,
+            ProjectReviewScreen,
+            WizardFormScreen,
+        )
+
+        values = await self.push_screen_wait(WizardFormScreen())
+        if values is None:
+            return  # user cancelled the form
+
+        rendered = render_project_yaml(values)
+        final_yaml = await self.push_screen_wait(
+            ProjectReviewScreen(values["project_id"], rendered)
+        )
+        if final_yaml is None:
+            # "Back" on the review screen abandons the wizard.  Users who
+            # want partial edits already have the inline review pane.
+            return
+        ok = await self.push_screen_wait(InitProgressScreen(values["project_id"], final_yaml))
+        if ok:
+            self.notify(f"Project '{values['project_id']}' is ready.")
+        else:
+            self.notify(
+                f"Project '{values['project_id']}' created but init did not complete. "
+                "Fix any issues and run `terok project init` from the CLI.",
+                severity="warning",
+                timeout=10,
+            )
         await self.refresh_projects()
-        self.notify("Project list refreshed.")
 
     # --- Project delete ---
 

--- a/src/terok/tui/wizard_screens.py
+++ b/src/terok/tui/wizard_screens.py
@@ -35,6 +35,7 @@ from textual.containers import Horizontal, Vertical, VerticalScroll
 from textual.screen import ModalScreen
 from textual.widgets import Button, Input, Label, RadioButton, RadioSet, RichLog, Static, TextArea
 
+from ..lib.domain.facade import project_needs_key_registration
 from ..lib.domain.wizards.new_project import (
     QUESTIONS,
     Question,
@@ -393,11 +394,37 @@ class InitProgressScreen(ModalScreen[bool]):
                 yield Button("Close", id="wizard-init-close", variant="default", disabled=True)
 
     async def on_mount(self) -> None:
-        """Persist the reviewed YAML then kick off the background worker."""
+        """Persist the reviewed YAML, then kick off the background worker.
+
+        A write failure (read-only dir, disk full, permission change) is
+        rendered into the log pane and the Close button is re-enabled so
+        the user can dismiss the modal cleanly — we never call
+        :meth:`_run_init` on a partial-write state, which would either
+        run against a stale config on disk or fail the first facade step
+        with a confusing secondary error.
+        """
         log = self.query_one("#wizard-init-log", RichLog)
         log.write(f"[dim]Writing project.yml for {self._project_id}…[/]")
-        write_project_yaml(self._project_id, self._rendered_yaml, overwrite=True)
+        try:
+            write_project_yaml(self._project_id, self._rendered_yaml, overwrite=True)
+        except (OSError, SystemExit) as exc:
+            log.write(f"[red]Failed to write project.yml: {exc}[/]")
+            self._finish_with_close_button()
+            return
         self._run_init()
+
+    def _finish_with_close_button(self) -> None:
+        """Enable the Close button after the screen reaches a terminal state.
+
+        Used both from ``on_mount`` when the write fails and from the
+        worker's ``finally`` block on success / error — the single path
+        keeps the button's enable/label/variant in sync no matter which
+        branch reached the end.
+        """
+        button = self.query_one("#wizard-init-close", Button)
+        button.disabled = False
+        button.variant = "success" if self._ok else "warning"
+        button.label = "Done" if self._ok else "Close"
 
     # ── Step status helpers ───────────────────────────────────────────
 
@@ -448,7 +475,7 @@ class InitProgressScreen(ModalScreen[bool]):
             self._mark("ssh", "done", f"key id {result['key_id']}")
             log.write(f"[green]✓[/] SSH key minted: {result['comment']}")
 
-            if _needs_key_registration(self._project_id):
+            if project_needs_key_registration(self._project_id):
                 self.query_one("#wizard-init-ssh-pubkey", TextArea).text = result["public_line"]
                 self.query_one("#wizard-init-ssh-key").styles.display = "block"
                 log.write(
@@ -510,11 +537,7 @@ class InitProgressScreen(ModalScreen[bool]):
                     self._mark(key, "failed", str(exc))
                     break
         finally:
-            self.query_one("#wizard-init-close", Button).disabled = False
-            self.query_one("#wizard-init-close", Button).variant = (
-                "success" if self._ok else "warning"
-            )
-            self.query_one("#wizard-init-close", Button).label = "Done" if self._ok else "Close"
+            self._finish_with_close_button()
 
     # ── Button handlers ───────────────────────────────────────────────
 
@@ -534,19 +557,6 @@ class InitProgressScreen(ModalScreen[bool]):
 
 
 # ── Helpers ───────────────────────────────────────────────────────────
-
-
-def _needs_key_registration(project_id: str) -> bool:
-    """Return True when the project's upstream is an SSH URL and thus needs a deploy-key pause."""
-    from terok_sandbox import is_ssh_url
-
-    from ..lib.core.projects import load_project
-
-    try:
-        project = load_project(project_id)
-    except SystemExit:
-        return False
-    return bool(project.upstream_url) and is_ssh_url(project.upstream_url)
 
 
 @contextlib.contextmanager

--- a/src/terok/tui/wizard_screens.py
+++ b/src/terok/tui/wizard_screens.py
@@ -1,0 +1,569 @@
+# SPDX-FileCopyrightText: 2026 Jiri Vyskocil
+# SPDX-License-Identifier: Apache-2.0
+
+"""Textual modal screens for the new-project wizard.
+
+Three screens drive the flow:
+
+1. :class:`WizardFormScreen` — one form that collects every
+   :data:`terok.lib.domain.wizards.new_project.QUESTIONS` answer at
+   once.  Shares vocabulary + validation with the CLI wizard.
+2. :class:`ProjectReviewScreen` — shows the rendered ``project.yml`` in
+   a ``TextArea`` for last-minute edits before commit.
+3. :class:`InitProgressScreen` — runs ssh-init → generate → build →
+   gate-sync as a background worker, updating a per-step status list
+   and surfacing the public key when the user needs to register it.
+
+Each screen is its own ``ModalScreen`` and dismisses with a result;
+the orchestration lives on the main app
+(:class:`terok.tui.app.TerokTUI._launch_project_wizard`).
+
+No ``app.suspend()`` — this replaces the CLI-subprocess path that
+textual-serve cannot support.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import io
+from typing import Any
+
+from textual import on, work
+from textual.app import ComposeResult
+from textual.binding import Binding
+from textual.containers import Horizontal, Vertical, VerticalScroll
+from textual.screen import ModalScreen
+from textual.widgets import Button, Input, Label, RadioButton, RadioSet, RichLog, Static, TextArea
+
+from ..lib.domain.wizards.new_project import (
+    QUESTIONS,
+    Question,
+    validate_answer,
+    write_project_yaml,
+)
+
+# ── Step 1: the form ──────────────────────────────────────────────────
+
+
+class WizardFormScreen(ModalScreen["dict[str, str] | None"]):
+    """First wizard screen — one form with every question, validated on submit.
+
+    Dismisses with the collected values dict (keys = ``Question.key``)
+    or ``None`` on cancel.
+    """
+
+    BINDINGS = [
+        Binding("escape", "cancel", "Cancel"),
+    ]
+
+    CSS = """
+    WizardFormScreen {
+        align: center middle;
+    }
+
+    #wizard-form-dialog {
+        width: 80;
+        height: auto;
+        max-height: 90%;
+        border: heavy $primary;
+        border-title-align: right;
+        background: $surface;
+        padding: 1 2;
+    }
+
+    #wizard-form-scroll {
+        height: auto;
+        max-height: 32;
+    }
+
+    .wizard-field {
+        margin-bottom: 1;
+        height: auto;
+    }
+
+    .wizard-help {
+        color: $text-muted;
+    }
+
+    .wizard-error {
+        color: $error;
+    }
+
+    #wizard-form-buttons {
+        height: auto;
+        align-horizontal: right;
+        margin-top: 1;
+    }
+
+    #wizard-form-buttons Button {
+        margin-left: 1;
+    }
+
+    RadioSet {
+        border: round $primary-darken-2;
+        padding: 0 1;
+    }
+
+    TextArea {
+        height: 8;
+    }
+    """
+
+    def __init__(self) -> None:
+        """Build a fresh wizard form — no prefill."""
+        super().__init__()
+        self._errors: dict[str, Label] = {}
+
+    def compose(self) -> ComposeResult:
+        """Lay out one widget per question, plus footer buttons."""
+        dialog = Vertical(id="wizard-form-dialog")
+        dialog.border_title = "New project"
+        with dialog, VerticalScroll(id="wizard-form-scroll"):
+            for q in QUESTIONS:
+                yield from self._field(q)
+
+        with Horizontal(id="wizard-form-buttons"):
+            yield Button("Cancel", id="wizard-form-cancel", variant="default")
+            yield Button("Create", id="wizard-form-create", variant="primary")
+
+    def _field(self, q: Question) -> ComposeResult:
+        """Render the label, help, input widget, and error slot for *q*."""
+        label = f"{q.prompt}" + ("" if q.required else "  (optional)")
+        yield Label(label, classes="wizard-field")
+        if q.help:
+            yield Label(q.help, classes="wizard-help")
+        match q.kind:
+            case "choice":
+                yield from self._choice_widget(q)
+            case "text":
+                yield Input(placeholder=q.placeholder, id=self._widget_id(q))
+            case "editor":
+                yield TextArea(id=self._widget_id(q), language=None)
+        err = Label("", classes="wizard-error", id=self._error_id(q))
+        self._errors[q.key] = err
+        yield err
+
+    def _choice_widget(self, q: Question) -> ComposeResult:
+        """Render a ``RadioSet`` for a choice question.
+
+        ``RadioButton.value=True`` is set on the first option so the
+        form is never in an "initially no selection" state — matches
+        the CLI where the user *must* pick something.
+        """
+        with RadioSet(id=self._widget_id(q)):
+            for i, (slug, label) in enumerate(q.choices):
+                yield RadioButton(label, value=(i == 0), name=slug)
+
+    @staticmethod
+    def _widget_id(q: Question) -> str:
+        return f"wizard-field-{q.key}"
+
+    @staticmethod
+    def _error_id(q: Question) -> str:
+        return f"wizard-error-{q.key}"
+
+    # ── Actions ────────────────────────────────────────────────────────
+
+    def action_cancel(self) -> None:
+        """Dismiss without collecting values."""
+        self.dismiss(None)
+
+    @on(Button.Pressed, "#wizard-form-cancel")
+    def _on_cancel(self) -> None:
+        self.dismiss(None)
+
+    @on(Button.Pressed, "#wizard-form-create")
+    def _on_create(self) -> None:
+        """Validate every field; on success dismiss with the collected dict."""
+        values: dict[str, str] = {}
+        any_error = False
+        for q in QUESTIONS:
+            raw = self._read_raw(q)
+            value, error = validate_answer(q, raw)
+            if error is None:
+                values[q.key] = value
+                self._errors[q.key].update("")
+            else:
+                self._errors[q.key].update(error)
+                any_error = True
+        if not any_error:
+            self.dismiss(values)
+
+    def _read_raw(self, q: Question) -> str:
+        """Pull the current raw string out of the widget for *q*."""
+        widget_id = f"#{self._widget_id(q)}"
+        match q.kind:
+            case "choice":
+                rs = self.query_one(widget_id, RadioSet)
+                pressed = rs.pressed_button
+                # ``RadioSet`` always has a pressed button because we
+                # initialised the first one pressed; name holds the slug.
+                return pressed.name if pressed is not None else ""
+            case "text":
+                return self.query_one(widget_id, Input).value
+            case "editor":
+                return self.query_one(widget_id, TextArea).text
+
+
+# ── Step 2: review rendered YAML ──────────────────────────────────────
+
+
+class ProjectReviewScreen(ModalScreen["str | None"]):
+    """Show the rendered ``project.yml`` in an editable ``TextArea``.
+
+    Dismisses with the (possibly edited) YAML string when the user
+    confirms, or ``None`` on cancel / back.  The TUI equivalent of the
+    CLI wizard's "Edit configuration file before setup? [Y/n]" step,
+    but inline instead of suspending to ``$EDITOR`` — textual-serve
+    cannot do the latter.
+    """
+
+    BINDINGS = [
+        Binding("escape", "cancel", "Back"),
+    ]
+
+    CSS = """
+    ProjectReviewScreen {
+        align: center middle;
+    }
+
+    #wizard-review-dialog {
+        width: 90;
+        height: 80%;
+        border: heavy $primary;
+        border-title-align: right;
+        background: $surface;
+        padding: 1 2;
+    }
+
+    #wizard-review-yaml {
+        height: 1fr;
+        margin-bottom: 1;
+    }
+
+    #wizard-review-buttons {
+        height: auto;
+        align-horizontal: right;
+    }
+
+    #wizard-review-buttons Button {
+        margin-left: 1;
+    }
+    """
+
+    def __init__(self, project_id: str, rendered: str) -> None:
+        """Create the review screen with the initial rendered YAML text."""
+        super().__init__()
+        self._project_id = project_id
+        self._rendered = rendered
+
+    def compose(self) -> ComposeResult:
+        """Build the editable YAML pane and Back/Initialize buttons."""
+        dialog = Vertical(id="wizard-review-dialog")
+        dialog.border_title = f"Review project.yml — {self._project_id}"
+        with dialog:
+            yield TextArea.code_editor(
+                self._rendered,
+                language="yaml",
+                id="wizard-review-yaml",
+            )
+            with Horizontal(id="wizard-review-buttons"):
+                yield Button("Back", id="wizard-review-back", variant="default")
+                yield Button("Initialize project", id="wizard-review-init", variant="primary")
+
+    def action_cancel(self) -> None:
+        """Dismiss with ``None`` — caller may re-open the form screen."""
+        self.dismiss(None)
+
+    @on(Button.Pressed, "#wizard-review-back")
+    def _on_back(self) -> None:
+        self.dismiss(None)
+
+    @on(Button.Pressed, "#wizard-review-init")
+    def _on_init(self) -> None:
+        yaml_text = self.query_one("#wizard-review-yaml", TextArea).text
+        self.dismiss(yaml_text)
+
+
+# ── Step 3: initialize project (ssh-init → generate → build → gate) ──
+
+
+class InitProgressScreen(ModalScreen[bool]):
+    """Run ``cmd_project_init``'s four steps as a background worker.
+
+    Dismisses ``True`` on success, ``False`` on failure or cancellation.
+    The SSH-key registration pause in :func:`maybe_pause_for_ssh_key_registration`
+    is replaced by a mid-wizard continue button that gates the next
+    step — no blocking ``input()`` in a Textual worker.
+    """
+
+    BINDINGS = [
+        Binding("escape", "maybe_cancel", "Close"),
+    ]
+
+    CSS = """
+    InitProgressScreen {
+        align: center middle;
+    }
+
+    #wizard-init-dialog {
+        width: 90;
+        height: 80%;
+        border: heavy $primary;
+        border-title-align: right;
+        background: $surface;
+        padding: 1 2;
+    }
+
+    #wizard-init-steps {
+        height: auto;
+        margin-bottom: 1;
+    }
+
+    .wizard-init-step {
+        height: auto;
+    }
+
+    #wizard-init-log {
+        height: 1fr;
+        border: round $primary-darken-2;
+        margin-bottom: 1;
+    }
+
+    #wizard-init-ssh-key {
+        height: auto;
+        border: round $warning;
+        background: $surface;
+        padding: 1;
+        margin-bottom: 1;
+        display: none;
+    }
+
+    #wizard-init-buttons {
+        height: auto;
+        align-horizontal: right;
+    }
+
+    #wizard-init-buttons Button {
+        margin-left: 1;
+    }
+    """
+
+    #: Ordered list of step keys (must match ``_run_steps`` implementation).
+    _STEP_KEYS: tuple[str, ...] = ("ssh", "generate", "build", "gate")
+    _STEP_LABELS: dict[str, str] = {
+        "ssh": "SSH key",
+        "generate": "Dockerfiles",
+        "build": "Build images",
+        "gate": "Gate sync",
+    }
+
+    def __init__(self, project_id: str, rendered_yaml: str) -> None:
+        """Create the init screen with the project ID and final YAML text."""
+        super().__init__()
+        self._project_id = project_id
+        self._rendered_yaml = rendered_yaml
+        self._ssh_continue: Any = None  # an asyncio.Event, set when user clicks continue
+        self._ok = False
+
+    def compose(self) -> ComposeResult:
+        """Build the per-step status list, log pane, and buttons."""
+        dialog = Vertical(id="wizard-init-dialog")
+        dialog.border_title = f"Initializing project — {self._project_id}"
+        with dialog:
+            with Vertical(id="wizard-init-steps"):
+                for key in self._STEP_KEYS:
+                    yield Static(
+                        self._step_text(key, "pending"),
+                        classes="wizard-init-step",
+                        id=self._step_id(key),
+                    )
+            # Hidden until ssh-init runs + upstream is SSH-scheme
+            with Vertical(id="wizard-init-ssh-key"):
+                yield Label("SSH public key — register this on your git remote:")
+                yield TextArea("", id="wizard-init-ssh-pubkey", read_only=True)
+                with Horizontal():
+                    yield Button(
+                        "I've registered the key — continue",
+                        id="wizard-init-ssh-continue",
+                        variant="primary",
+                    )
+            yield RichLog(id="wizard-init-log", markup=True, wrap=True)
+            with Horizontal(id="wizard-init-buttons"):
+                yield Button("Close", id="wizard-init-close", variant="default", disabled=True)
+
+    async def on_mount(self) -> None:
+        """Persist the reviewed YAML then kick off the background worker."""
+        log = self.query_one("#wizard-init-log", RichLog)
+        log.write(f"[dim]Writing project.yml for {self._project_id}…[/]")
+        write_project_yaml(self._project_id, self._rendered_yaml, overwrite=True)
+        self._run_init()
+
+    # ── Step status helpers ───────────────────────────────────────────
+
+    def _step_text(self, key: str, status: str, detail: str = "") -> str:
+        """Render one step's label with a status badge."""
+        badges = {
+            "pending": "[dim]•[/]",
+            "running": "[yellow]⋯[/]",
+            "done": "[green]✓[/]",
+            "failed": "[red]✗[/]",
+            "skipped": "[dim]–[/]",
+        }
+        extra = f" — {detail}" if detail else ""
+        return f"{badges.get(status, '•')} {self._STEP_LABELS[key]}{extra}"
+
+    @staticmethod
+    def _step_id(key: str) -> str:
+        return f"wizard-init-step-{key}"
+
+    def _mark(self, key: str, status: str, detail: str = "") -> None:
+        self.query_one(f"#{self._step_id(key)}", Static).update(
+            self._step_text(key, status, detail)
+        )
+
+    # ── Background worker ─────────────────────────────────────────────
+
+    @work(exclusive=True)
+    async def _run_init(self) -> None:
+        """Drive the four init steps, updating UI between each."""
+        import asyncio
+
+        from terok.lib.core.projects import load_project
+        from terok.lib.domain.facade import (
+            build_images,
+            generate_dockerfiles,
+            make_git_gate,
+            provision_ssh_key,
+            summarize_ssh_init,
+        )
+
+        log = self.query_one("#wizard-init-log", RichLog)
+        self._ssh_continue = asyncio.Event()
+
+        try:
+            # Step 1: SSH
+            self._mark("ssh", "running")
+            result = await asyncio.to_thread(provision_ssh_key, self._project_id)
+            self._mark("ssh", "done", f"key id {result['key_id']}")
+            log.write(f"[green]✓[/] SSH key minted: {result['comment']}")
+
+            if _needs_key_registration(self._project_id):
+                self.query_one("#wizard-init-ssh-pubkey", TextArea).text = result["public_line"]
+                self.query_one("#wizard-init-ssh-key").styles.display = "block"
+                log.write(
+                    "[yellow]Register the public key on the git remote, then click Continue.[/]"
+                )
+                await self._ssh_continue.wait()
+                self.query_one("#wizard-init-ssh-key").styles.display = "none"
+
+            # Silent stdout capture — the facade's summarise/print lines
+            # land in the log instead of the terminal.  podman subprocess
+            # output is lost (it writes to a real fd); future work: a
+            # reusable log-tailer widget (see issue #473).
+            with _log_capture(log):
+                summarize_ssh_init(result)
+
+            # Step 2: Dockerfiles
+            self._mark("generate", "running")
+            with _log_capture(log):
+                await asyncio.to_thread(generate_dockerfiles, self._project_id)
+            self._mark("generate", "done")
+
+            # Step 3: Build
+            self._mark("build", "running", "this can take several minutes")
+            log.write(
+                "[dim]Running image build in the background — podman's output goes to the "
+                "terminal that launched terok, not this pane.[/]"
+            )
+            await asyncio.to_thread(build_images, self._project_id)
+            self._mark("build", "done")
+
+            # Step 4: Gate sync — load_project to read gate_enabled
+            project = load_project(self._project_id)
+            if not project.gate_enabled:
+                self._mark("gate", "skipped", "gate.enabled: false")
+                log.write("[dim]Gate disabled in project.yml — skipping gate-sync.[/]")
+            else:
+                self._mark("gate", "running")
+                res = await asyncio.to_thread(lambda: make_git_gate(project).sync())
+                if res["success"]:
+                    upstream_hint = (
+                        f"upstream {res['upstream_url']}"
+                        if res.get("upstream_url")
+                        else "local-only bare repo"
+                    )
+                    self._mark("gate", "done", upstream_hint)
+                else:
+                    errors = ", ".join(res.get("errors", []))
+                    self._mark("gate", "failed", errors)
+                    raise RuntimeError(f"Gate sync failed: {errors}")
+
+            self._ok = True
+            log.write(f"[green]Project '{self._project_id}' is ready.[/]")
+        except Exception as exc:
+            log.write(f"[red]Error: {exc}[/]")
+            # Mark the currently-running step failed (whichever one raised).
+            for key in self._STEP_KEYS:
+                widget = self.query_one(f"#{self._step_id(key)}", Static)
+                if "⋯" in str(widget.renderable):
+                    self._mark(key, "failed", str(exc))
+                    break
+        finally:
+            self.query_one("#wizard-init-close", Button).disabled = False
+            self.query_one("#wizard-init-close", Button).variant = (
+                "success" if self._ok else "warning"
+            )
+            self.query_one("#wizard-init-close", Button).label = "Done" if self._ok else "Close"
+
+    # ── Button handlers ───────────────────────────────────────────────
+
+    @on(Button.Pressed, "#wizard-init-ssh-continue")
+    def _on_ssh_continue(self) -> None:
+        if self._ssh_continue is not None:
+            self._ssh_continue.set()
+
+    @on(Button.Pressed, "#wizard-init-close")
+    def _on_close(self) -> None:
+        self.dismiss(self._ok)
+
+    def action_maybe_cancel(self) -> None:
+        """Escape only dismisses once the worker has finished."""
+        if not self.query_one("#wizard-init-close", Button).disabled:
+            self.dismiss(self._ok)
+
+
+# ── Helpers ───────────────────────────────────────────────────────────
+
+
+def _needs_key_registration(project_id: str) -> bool:
+    """Return True when the project's upstream is an SSH URL and thus needs a deploy-key pause."""
+    from terok_sandbox import is_ssh_url
+
+    from ..lib.core.projects import load_project
+
+    try:
+        project = load_project(project_id)
+    except SystemExit:
+        return False
+    return bool(project.upstream_url) and is_ssh_url(project.upstream_url)
+
+
+@contextlib.contextmanager
+def _log_capture(log: RichLog):
+    """Redirect Python-level stdout into *log* for the duration of the block.
+
+    Python-level ``print()`` calls from the facade land in the log
+    pane.  Subprocess output (``podman build``) is not captured — those
+    writes go through the kernel file descriptor, not through
+    ``sys.stdout``.  A richer log-tailer widget that also captures
+    subprocess streams is tracked in issue #473.
+    """
+    buffer = io.StringIO()
+    with contextlib.redirect_stdout(buffer):
+        try:
+            yield
+        finally:
+            text = buffer.getvalue().rstrip()
+            if text:
+                log.write(text)

--- a/src/terok/tui/wizard_screens.py
+++ b/src/terok/tui/wizard_screens.py
@@ -26,6 +26,7 @@ from __future__ import annotations
 
 import contextlib
 import io
+from pathlib import Path
 from typing import Any
 
 from textual import on, work
@@ -110,10 +111,17 @@ class WizardFormScreen(ModalScreen["dict[str, str] | None"]):
     }
     """
 
-    def __init__(self) -> None:
-        """Build a fresh wizard form — no prefill."""
+    def __init__(self, initial: dict[str, str] | None = None) -> None:
+        """Build a fresh wizard form, optionally pre-filled with previous answers.
+
+        *initial* is the dict returned by a prior run of this screen —
+        passed back in when the user clicks "Back" on the review screen
+        so their typing survives the round trip.  Keys not in *initial*
+        fall back to "first choice selected" / empty string.
+        """
         super().__init__()
         self._errors: dict[str, Label] = {}
+        self._initial: dict[str, str] = dict(initial) if initial else {}
 
     def compose(self) -> ComposeResult:
         """Lay out one widget per question, plus footer buttons."""
@@ -133,27 +141,32 @@ class WizardFormScreen(ModalScreen["dict[str, str] | None"]):
         yield Label(label, classes="wizard-field")
         if q.help:
             yield Label(q.help, classes="wizard-help")
+        preset = self._initial.get(q.key, "")
         match q.kind:
             case "choice":
-                yield from self._choice_widget(q)
+                yield from self._choice_widget(q, selected_slug=preset)
             case "text":
-                yield Input(placeholder=q.placeholder, id=self._widget_id(q))
+                yield Input(value=preset, placeholder=q.placeholder, id=self._widget_id(q))
             case "editor":
-                yield TextArea(id=self._widget_id(q), language=None)
+                yield TextArea(preset, id=self._widget_id(q), language=None)
         err = Label("", classes="wizard-error", id=self._error_id(q))
         self._errors[q.key] = err
         yield err
 
-    def _choice_widget(self, q: Question) -> ComposeResult:
-        """Render a ``RadioSet`` for a choice question.
+    def _choice_widget(self, q: Question, *, selected_slug: str = "") -> ComposeResult:
+        """Render a ``RadioSet`` for a choice question, optionally preselecting *selected_slug*.
 
-        ``RadioButton.value=True`` is set on the first option so the
-        form is never in an "initially no selection" state — matches
-        the CLI where the user *must* pick something.
+        When the prefill slug matches one of the choices it takes
+        precedence; otherwise the first option is preselected — the
+        form is never in an "initially no selection" state, matching
+        the CLI's "pick a number" semantics.
         """
+        valid_slugs = {slug for slug, _ in q.choices}
+        preset_slug = selected_slug if selected_slug in valid_slugs else ""
         with RadioSet(id=self._widget_id(q)):
             for i, (slug, label) in enumerate(q.choices):
-                yield RadioButton(label, value=(i == 0), name=slug)
+                selected = (slug == preset_slug) if preset_slug else (i == 0)
+                yield RadioButton(label, value=selected, name=slug)
 
     @staticmethod
     def _widget_id(q: Question) -> str:
@@ -209,18 +222,27 @@ class WizardFormScreen(ModalScreen["dict[str, str] | None"]):
 # ── Step 2: review rendered YAML ──────────────────────────────────────
 
 
-class ProjectReviewScreen(ModalScreen["str | None"]):
+#: Sentinel returned by :class:`ProjectReviewScreen` when the user clicks
+#: "Back" — distinguishes "go back to the form, keep my answers" from
+#: "cancel the whole wizard".  A distinct object lets the caller use
+#: ``is REVIEW_BACK`` for the three-way branch without overloading the
+#: string/None type.
+REVIEW_BACK: object = object()
+
+
+class ProjectReviewScreen(ModalScreen["str | object | None"]):
     """Show the rendered ``project.yml`` in an editable ``TextArea``.
 
-    Dismisses with the (possibly edited) YAML string when the user
-    confirms, or ``None`` on cancel / back.  The TUI equivalent of the
-    CLI wizard's "Edit configuration file before setup? [Y/n]" step,
-    but inline instead of suspending to ``$EDITOR`` — textual-serve
-    cannot do the latter.
+    Dismisses with one of three results:
+
+    - The (possibly edited) YAML string → user clicked "Initialize".
+    - :data:`REVIEW_BACK` → user clicked "Back"; caller should re-open
+      the form with the previous answers as prefill.
+    - ``None`` → user hit Escape; wizard is abandoned.
     """
 
     BINDINGS = [
-        Binding("escape", "cancel", "Back"),
+        Binding("escape", "cancel", "Cancel"),
     ]
 
     CSS = """
@@ -273,12 +295,13 @@ class ProjectReviewScreen(ModalScreen["str | None"]):
                 yield Button("Initialize project", id="wizard-review-init", variant="primary")
 
     def action_cancel(self) -> None:
-        """Dismiss with ``None`` — caller may re-open the form screen."""
+        """Escape abandons the wizard — dismiss with ``None``."""
         self.dismiss(None)
 
     @on(Button.Pressed, "#wizard-review-back")
     def _on_back(self) -> None:
-        self.dismiss(None)
+        """Back returns to the form with the previous answers preserved."""
+        self.dismiss(REVIEW_BACK)
 
     @on(Button.Pressed, "#wizard-review-init")
     def _on_init(self) -> None:
@@ -394,16 +417,32 @@ class InitProgressScreen(ModalScreen[bool]):
                 yield Button("Close", id="wizard-init-close", variant="default", disabled=True)
 
     async def on_mount(self) -> None:
-        """Persist the reviewed YAML, then kick off the background worker.
+        """Confirm overwrite when needed, persist the YAML, then run init.
 
-        A write failure (read-only dir, disk full, permission change) is
-        rendered into the log pane and the Close button is re-enabled so
-        the user can dismiss the modal cleanly — we never call
-        :meth:`_run_init` on a partial-write state, which would either
-        run against a stale config on disk or fail the first facade step
-        with a confusing secondary error.
+        When a ``project.yml`` already exists for this project ID, the
+        TUI mirrors the CLI's overwrite prompt via a modal confirm.
+        The heavy lifting (confirm → write → worker) happens in a
+        ``@work`` coroutine so ``push_screen_wait`` has the worker
+        context it needs.  A write failure is rendered into the log
+        pane and the Close button is re-enabled; ``_run_init`` never
+        runs on a partial-write state.
         """
+        self._run_init_with_confirm()
+
+    @work(exclusive=True)
+    async def _run_init_with_confirm(self) -> None:
+        """Top-level coroutine that sequences overwrite-confirm → write → run."""
         log = self.query_one("#wizard-init-log", RichLog)
+        existing = self._existing_project_yaml_path()
+        if existing is not None:
+            if not await self._confirm_overwrite(existing):
+                log.write(
+                    "[yellow]Keeping existing project.yml — nothing written, "
+                    "nothing initialised.[/]"
+                )
+                self._finish_with_close_button()
+                return
+
         log.write(f"[dim]Writing project.yml for {self._project_id}…[/]")
         try:
             write_project_yaml(self._project_id, self._rendered_yaml, overwrite=True)
@@ -411,7 +450,31 @@ class InitProgressScreen(ModalScreen[bool]):
             log.write(f"[red]Failed to write project.yml: {exc}[/]")
             self._finish_with_close_button()
             return
-        self._run_init()
+        await self._run_init()
+
+    def _existing_project_yaml_path(self) -> Path | None:
+        """Return the on-disk ``project.yml`` path if it already exists, else None."""
+        from ..lib.core.config import user_projects_dir
+
+        candidate = user_projects_dir() / self._project_id / "project.yml"
+        return candidate if candidate.is_file() else None
+
+    async def _confirm_overwrite(self, path: Path) -> bool:
+        """Show the shared ``ConfirmDestructiveScreen`` for a project.yml overwrite."""
+        from .screens import ConfirmDestructiveScreen
+
+        return bool(
+            await self.app.push_screen_wait(
+                ConfirmDestructiveScreen(
+                    message=(
+                        f"A configuration for project '{self._project_id}' already "
+                        f"exists at:\n\n{path}\n\nOverwrite with the reviewed content?"
+                    ),
+                    title=f"Overwrite project.yml — {self._project_id}",
+                    confirm_label="Overwrite",
+                )
+            )
+        )
 
     def _finish_with_close_button(self) -> None:
         """Enable the Close button after the screen reaches a terminal state.
@@ -451,9 +514,13 @@ class InitProgressScreen(ModalScreen[bool]):
 
     # ── Background worker ─────────────────────────────────────────────
 
-    @work(exclusive=True)
     async def _run_init(self) -> None:
-        """Drive the four init steps, updating UI between each."""
+        """Drive the four init steps, updating UI between each.
+
+        Runs inside the ``@work`` context established by
+        :meth:`_run_init_with_confirm` — no extra decorator needed;
+        nesting workers confuses Textual's exclusivity tracking.
+        """
         import asyncio
 
         from terok.lib.core.projects import load_project

--- a/src/terok/tui/wizard_screens.py
+++ b/src/terok/tui/wizard_screens.py
@@ -25,6 +25,7 @@ textual-serve cannot support.
 from __future__ import annotations
 
 import contextlib
+import enum
 import io
 from pathlib import Path
 from typing import Any
@@ -65,8 +66,7 @@ class WizardFormScreen(ModalScreen["dict[str, str] | None"]):
 
     #wizard-form-dialog {
         width: 80;
-        height: auto;
-        max-height: 90%;
+        height: 90%;
         border: heavy $primary;
         border-title-align: right;
         background: $surface;
@@ -74,8 +74,7 @@ class WizardFormScreen(ModalScreen["dict[str, str] | None"]):
     }
 
     #wizard-form-scroll {
-        height: auto;
-        max-height: 32;
+        height: 1fr;
     }
 
     .wizard-field {
@@ -92,7 +91,7 @@ class WizardFormScreen(ModalScreen["dict[str, str] | None"]):
     }
 
     #wizard-form-buttons {
-        height: auto;
+        height: 3;
         align-horizontal: right;
         margin-top: 1;
     }
@@ -124,16 +123,21 @@ class WizardFormScreen(ModalScreen["dict[str, str] | None"]):
         self._initial: dict[str, str] = dict(initial) if initial else {}
 
     def compose(self) -> ComposeResult:
-        """Lay out one widget per question, plus footer buttons."""
+        """Lay out one widget per question, plus footer buttons.
+
+        Form fields live in a scrollable pane; the button row is pinned
+        below them but still inside the dialog border so both scroll
+        area and buttons render inside the modal, not alongside it.
+        """
         dialog = Vertical(id="wizard-form-dialog")
         dialog.border_title = "New project"
-        with dialog, VerticalScroll(id="wizard-form-scroll"):
-            for q in QUESTIONS:
-                yield from self._field(q)
-
-        with Horizontal(id="wizard-form-buttons"):
-            yield Button("Cancel", id="wizard-form-cancel", variant="default")
-            yield Button("Create", id="wizard-form-create", variant="primary")
+        with dialog:
+            with VerticalScroll(id="wizard-form-scroll"):
+                for q in QUESTIONS:
+                    yield from self._field(q)
+            with Horizontal(id="wizard-form-buttons"):
+                yield Button("Cancel", id="wizard-form-cancel", variant="default")
+                yield Button("Create", id="wizard-form-create", variant="primary")
 
     def _field(self, q: Question) -> ComposeResult:
         """Render the label, help, input widget, and error slot for *q*."""
@@ -312,11 +316,26 @@ class ProjectReviewScreen(ModalScreen["str | object | None"]):
 # ── Step 3: initialize project (ssh-init → generate → build → gate) ──
 
 
-class InitProgressScreen(ModalScreen[bool]):
+class InitOutcome(enum.Enum):
+    """Result of :class:`InitProgressScreen` — three distinct states.
+
+    ``SUCCESS`` and ``FAILED`` are the obvious outcomes; ``DECLINED``
+    covers the case where the user deliberately chose not to overwrite
+    an existing ``project.yml``.  The caller needs all three to render
+    the right follow-up notification: a decline is a benign no-op, not
+    an error.
+    """
+
+    SUCCESS = "success"
+    FAILED = "failed"
+    DECLINED = "declined"
+
+
+class InitProgressScreen(ModalScreen[InitOutcome]):
     """Run ``cmd_project_init``'s four steps as a background worker.
 
-    Dismisses ``True`` on success, ``False`` on failure or cancellation.
-    The SSH-key registration pause in :func:`maybe_pause_for_ssh_key_registration`
+    Dismisses with one of the :class:`InitOutcome` values.  The SSH-key
+    registration pause in :func:`maybe_pause_for_ssh_key_registration`
     is replaced by a mid-wizard continue button that gates the next
     step — no blocking ``input()`` in a Textual worker.
     """
@@ -388,7 +407,10 @@ class InitProgressScreen(ModalScreen[bool]):
         self._project_id = project_id
         self._rendered_yaml = rendered_yaml
         self._ssh_continue: Any = None  # an asyncio.Event, set when user clicks continue
-        self._ok = False
+        # Default pessimistic — the worker flips this to SUCCESS on a clean
+        # finish, DECLINED when the user opts out of overwriting, and leaves
+        # it on FAILED when a step raises.
+        self._outcome: InitOutcome = InitOutcome.FAILED
 
     def compose(self) -> ComposeResult:
         """Build the per-step status list, log pane, and buttons."""
@@ -440,6 +462,10 @@ class InitProgressScreen(ModalScreen[bool]):
                     "[yellow]Keeping existing project.yml — nothing written, "
                     "nothing initialised.[/]"
                 )
+                # A declined overwrite is the user's deliberate choice —
+                # not a failure — so the screen dismisses with a distinct
+                # outcome the caller can branch on.
+                self._outcome = InitOutcome.DECLINED
                 self._finish_with_close_button()
                 return
 
@@ -479,15 +505,25 @@ class InitProgressScreen(ModalScreen[bool]):
     def _finish_with_close_button(self) -> None:
         """Enable the Close button after the screen reaches a terminal state.
 
-        Used both from ``on_mount`` when the write fails and from the
-        worker's ``finally`` block on success / error — the single path
-        keeps the button's enable/label/variant in sync no matter which
-        branch reached the end.
+        Called from ``on_mount`` when the write fails, from the decline
+        branch in ``_run_init_with_confirm``, and from the worker's
+        ``finally`` block.  Button label/variant mirror the outcome so
+        a declined overwrite doesn't masquerade as a failed init.
         """
+        variant_for = {
+            InitOutcome.SUCCESS: "success",
+            InitOutcome.FAILED: "warning",
+            InitOutcome.DECLINED: "default",
+        }
+        label_for = {
+            InitOutcome.SUCCESS: "Done",
+            InitOutcome.FAILED: "Close",
+            InitOutcome.DECLINED: "Close",
+        }
         button = self.query_one("#wizard-init-close", Button)
         button.disabled = False
-        button.variant = "success" if self._ok else "warning"
-        button.label = "Done" if self._ok else "Close"
+        button.variant = variant_for[self._outcome]
+        button.label = label_for[self._outcome]
 
     # ── Step status helpers ───────────────────────────────────────────
 
@@ -593,9 +629,14 @@ class InitProgressScreen(ModalScreen[bool]):
                     self._mark("gate", "failed", errors)
                     raise RuntimeError(f"Gate sync failed: {errors}")
 
-            self._ok = True
+            self._outcome = InitOutcome.SUCCESS
             log.write(f"[green]Project '{self._project_id}' is ready.[/]")
-        except Exception as exc:
+        except (Exception, SystemExit) as exc:
+            # Many facade calls (``load_project``, etc.) signal user-
+            # friendly errors with ``SystemExit`` which does *not*
+            # inherit from ``Exception``; widening the catch keeps
+            # those messages inside the log pane instead of bubbling
+            # out of the worker and vanishing silently.
             log.write(f"[red]Error: {exc}[/]")
             # Mark the currently-running step failed (whichever one raised).
             for key in self._STEP_KEYS:
@@ -615,12 +656,12 @@ class InitProgressScreen(ModalScreen[bool]):
 
     @on(Button.Pressed, "#wizard-init-close")
     def _on_close(self) -> None:
-        self.dismiss(self._ok)
+        self.dismiss(self._outcome)
 
     def action_maybe_cancel(self) -> None:
         """Escape only dismisses once the worker has finished."""
         if not self.query_one("#wizard-init-close", Button).disabled:
-            self.dismiss(self._ok)
+            self.dismiss(self._outcome)
 
 
 # ── Helpers ───────────────────────────────────────────────────────────

--- a/tach.toml
+++ b/tach.toml
@@ -794,6 +794,7 @@ expose = [
     "is_task_image_old",
     "register_ssh_key",
     "maybe_pause_for_ssh_key_registration",
+    "project_needs_key_registration",
     "provision_ssh_key",
     "summarize_ssh_init",
     "vault_db",

--- a/tach.toml
+++ b/tach.toml
@@ -737,7 +737,17 @@ expose = ["wait_for_container_exit", "follow_container_logs_cmd"]
 from = ["terok.lib.orchestration.autopilot"]
 
 [[interfaces]]
-expose = ["run_wizard", "offer_edit_then_init", "collect_wizard_inputs", "generate_config"]
+expose = [
+    "QUESTIONS",
+    "Question",
+    "collect_wizard_inputs",
+    "generate_config",
+    "offer_edit_then_init",
+    "render_project_yaml",
+    "run_wizard",
+    "validate_answer",
+    "write_project_yaml",
+]
 from = ["terok.lib.domain.wizards.new_project"]
 
 # Facade interface (stable boundary for presentation layer)

--- a/tach.toml
+++ b/tach.toml
@@ -77,6 +77,7 @@ depends_on = [
     "terok.lib.core.runtime",
     "terok.lib.core.version",
     "terok.lib.domain.facade",
+    "terok.lib.domain.wizards.new_project",
     "terok.lib.util.emoji",
     "terok.lib.util.yaml",
 ]

--- a/tests/unit/lib/test_wizard.py
+++ b/tests/unit/lib/test_wizard.py
@@ -413,6 +413,31 @@ class TestValidateAnswer:
         assert value == snippet
         assert err is None
 
+    def test_surrounding_whitespace_is_stripped(self) -> None:
+        """Leading/trailing whitespace is removed before validation and transform."""
+        value, err = validate_answer(_q("project_id"), "  MyProj  ")
+        assert value == "myproj"
+        assert err is None
+
+    def test_all_whitespace_answer_counts_as_empty_for_required(self) -> None:
+        """``'   '`` → required field rejected the same way an empty string is."""
+        value, err = validate_answer(_q("project_id"), "   ")
+        assert value == ""
+        assert err is not None
+        assert "required" in err
+
+    def test_unknown_choice_slug_is_rejected(self) -> None:
+        """Defensive check: a bogus slug for a choice question returns an error."""
+        value, err = validate_answer(_q("security_class"), "bogus")
+        assert err is not None
+        assert "must be one of" in err
+
+    def test_whitespace_only_optional_text_accepted_as_empty(self) -> None:
+        """Optional text field: spaces collapse to empty and pass through cleanly."""
+        value, err = validate_answer(_q("upstream_url"), "   ")
+        assert value == ""
+        assert err is None
+
 
 # ---------------------------------------------------------------------------
 # render_project_yaml / write_project_yaml — TUI-only rendering helpers that

--- a/tests/unit/lib/test_wizard.py
+++ b/tests/unit/lib/test_wizard.py
@@ -13,11 +13,16 @@ import pytest
 
 from terok.lib.domain.wizards.new_project import (
     BASES,
+    QUESTIONS,
     SECURITY_CLASSES,
+    Question,
     _validate_project_id,
     collect_wizard_inputs,
     generate_config,
+    render_project_yaml,
     run_wizard,
+    validate_answer,
+    write_project_yaml,
 )
 from tests.testfs import mock_wizard_project_file
 
@@ -352,3 +357,125 @@ def test_run_wizard(
         init_fn.assert_called_once_with(collect_result["project_id"])
     elif init_fn is not None:
         init_fn.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# validate_answer — spec surface shared by the CLI loop and the TUI modal.
+# Parametrised so presenter tests can lean on this as the source of truth
+# for per-field behaviour.
+# ---------------------------------------------------------------------------
+
+
+def _q(key: str) -> Question:
+    """Look up the declared question for *key* — fails fast on drift."""
+    for q in QUESTIONS:
+        if q.key == key:
+            return q
+    raise AssertionError(f"No question with key {key!r} in QUESTIONS")
+
+
+class TestValidateAnswer:
+    """validate_answer covers every branch a presenter would need to handle."""
+
+    def test_choice_accepts_declared_slug(self) -> None:
+        """A raw slug from choices passes through unchanged."""
+        value, err = validate_answer(_q("security_class"), "online")
+        assert value == "online"
+        assert err is None
+
+    def test_required_rejects_empty(self) -> None:
+        """A required question refuses empty input with the standard message."""
+        value, err = validate_answer(_q("project_id"), "")
+        assert err is not None
+        assert "required" in err
+
+    def test_optional_accepts_empty(self) -> None:
+        """An optional question (upstream_url) is fine with an empty answer."""
+        value, err = validate_answer(_q("upstream_url"), "")
+        assert value == ""
+        assert err is None
+
+    def test_transform_runs_before_validation(self) -> None:
+        """str.lower on project_id normalises before the regex check fires."""
+        value, err = validate_answer(_q("project_id"), "MyProject")
+        assert value == "myproject"
+        assert err is None
+
+    def test_validator_surfaces_error(self) -> None:
+        """The project-id validator rejects malformed slugs verbatim."""
+        value, err = validate_answer(_q("project_id"), "has spaces")
+        assert err is not None
+
+    def test_editor_kind_accepts_arbitrary_text(self) -> None:
+        """Editor-style questions have no validator; any string goes through."""
+        snippet = "RUN apt-get update && apt-get install -y ripgrep"
+        value, err = validate_answer(_q("user_snippet"), snippet)
+        assert value == snippet
+        assert err is None
+
+
+# ---------------------------------------------------------------------------
+# render_project_yaml / write_project_yaml — TUI-only rendering helpers that
+# need the same template resolution as generate_config.
+# ---------------------------------------------------------------------------
+
+
+class TestRenderAndWrite:
+    """The two-halves split of generate_config used by the TUI review path."""
+
+    def test_render_project_yaml_matches_generate_output(self) -> None:
+        """In-memory render must equal the file generate_config writes."""
+        values = wizard_values(project_id="renderp", upstream_url="https://example.com/r.git")
+        rendered = render_project_yaml(values)
+        with tempfile.TemporaryDirectory() as td:
+            with patch(
+                "terok.lib.domain.wizards.new_project.user_projects_dir", return_value=Path(td)
+            ):
+                path = generate_config(values)
+            assert path.read_text(encoding="utf-8") == rendered
+
+    def test_write_project_yaml_refuses_overwrite_by_default(self) -> None:
+        """A second write without ``overwrite=True`` leaves the original in place."""
+        with (
+            tempfile.TemporaryDirectory() as td,
+            patch("terok.lib.domain.wizards.new_project.user_projects_dir", return_value=Path(td)),
+        ):
+            first = write_project_yaml("scratch", "first: true\n")
+            second = write_project_yaml("scratch", "second: true\n")
+            assert first == second
+            assert first.read_text() == "first: true\n"
+
+    def test_write_project_yaml_overwrite_true_replaces_contents(self) -> None:
+        """``overwrite=True`` replaces the contents — used by the TUI review path."""
+        with (
+            tempfile.TemporaryDirectory() as td,
+            patch("terok.lib.domain.wizards.new_project.user_projects_dir", return_value=Path(td)),
+        ):
+            write_project_yaml("scratch", "first: true\n")
+            path = write_project_yaml("scratch", "second: true\n", overwrite=True)
+            assert path.read_text() == "second: true\n"
+
+
+# ---------------------------------------------------------------------------
+# QUESTIONS registry — ordering and shape invariants the presenters rely on.
+# ---------------------------------------------------------------------------
+
+
+class TestQuestionsRegistry:
+    """Guard against accidental drift in the wizard vocabulary."""
+
+    def test_declared_keys_unique(self) -> None:
+        keys = [q.key for q in QUESTIONS]
+        assert len(keys) == len(set(keys))
+
+    def test_first_two_are_choice_questions(self) -> None:
+        """Template filename is ``{security}-{base}.yml`` — both must be choice."""
+        assert QUESTIONS[0].key == "security_class"
+        assert QUESTIONS[0].kind == "choice"
+        assert QUESTIONS[1].key == "base"
+        assert QUESTIONS[1].kind == "choice"
+
+    def test_every_choice_has_non_empty_options(self) -> None:
+        for q in QUESTIONS:
+            if q.kind == "choice":
+                assert q.choices, f"{q.key} has empty choices"

--- a/tests/unit/tui/test_wizard_screens.py
+++ b/tests/unit/tui/test_wizard_screens.py
@@ -204,3 +204,35 @@ def test_touched_wizard_yaml_survives_roundtrip() -> None:
     ):
         path = write_project_yaml("roundtrip", rendered, overwrite=True)
         assert path.read_text() == rendered
+
+
+# ── InitProgressScreen — error paths ──────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_init_screen_write_failure_surfaces_in_log() -> None:
+    """A failed ``write_project_yaml`` renders the error and enables Close.
+
+    The worker's facade pipeline is *not* entered — a write that fails
+    is a stale project.yml waiting to happen, and downstream steps
+    would just fail secondarily on a confusing error.
+    """
+    from terok.tui.wizard_screens import InitProgressScreen
+
+    def _boom(*_args, **_kwargs):
+        raise OSError("read-only filesystem")
+
+    app = _WizardHost(InitProgressScreen("demo", "project:\n  id: demo\n"))
+    with (
+        patch("terok.tui.wizard_screens.write_project_yaml", side_effect=_boom),
+        patch("terok.tui.wizard_screens.InitProgressScreen._run_init") as mock_run_init,
+    ):
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            screen = app.screen
+            assert isinstance(screen, InitProgressScreen)
+            close_button = screen.query_one("#wizard-init-close")
+            # Close button is enabled so the user can dismiss cleanly.
+            assert close_button.disabled is False
+            # The worker was never invoked on the failed-write path.
+            mock_run_init.assert_not_called()

--- a/tests/unit/tui/test_wizard_screens.py
+++ b/tests/unit/tui/test_wizard_screens.py
@@ -1,0 +1,206 @@
+# SPDX-FileCopyrightText: 2026 Jiri Vyskocil
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the Textual-native new-project wizard screens.
+
+These drive the three modal screens via Textual's built-in ``Pilot``
+harness.  The heavy semantic tests (question schema, validation,
+rendering) live in ``tests/unit/lib/test_wizard.py`` — this module
+just confirms the screens wire the right widgets to the shared
+``validate_answer`` and dismiss with the expected results.
+"""
+
+from __future__ import annotations
+
+import tempfile
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from textual.app import App
+from textual.widgets import Input, Label, RadioButton, RadioSet, TextArea
+
+from terok.lib.domain.wizards.new_project import QUESTIONS, Question
+from terok.tui.wizard_screens import ProjectReviewScreen, WizardFormScreen
+
+
+def _question(key: str) -> Question:
+    for q in QUESTIONS:
+        if q.key == key:
+            return q
+    raise AssertionError(f"No question with key {key!r}")
+
+
+_SENTINEL_PENDING = object()
+
+
+class _WizardHost(App):
+    """Minimal test host that pushes a screen and stashes its dismissal result.
+
+    Uses the callback form of ``push_screen`` because ``push_screen_wait``
+    requires a running worker — Textual's ``run_test`` does not provide
+    one out of the box.
+    """
+
+    def __init__(self, screen) -> None:
+        super().__init__()
+        self._screen_to_push = screen
+        self.result: object = _SENTINEL_PENDING
+
+    def on_mount(self) -> None:
+        self.push_screen(self._screen_to_push, self._capture)
+
+    def _capture(self, result: object) -> None:
+        self.result = result
+
+
+# ── WizardFormScreen ──────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_wizard_form_cancel_dismisses_with_none() -> None:
+    """Pressing Cancel dismisses the form with ``None``."""
+    app = _WizardHost(WizardFormScreen())
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        await pilot.click("#wizard-form-cancel")
+        await pilot.pause()
+    assert app.result is None
+
+
+@pytest.mark.asyncio
+async def test_wizard_form_submit_blocks_on_validation_error() -> None:
+    """Empty required project_id surfaces the shared ``validate_answer`` message."""
+    app = _WizardHost(WizardFormScreen())
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        # Leave project_id empty and click Create — should NOT dismiss.
+        await pilot.click("#wizard-form-create")
+        await pilot.pause()
+        screen = app.screen
+        assert isinstance(screen, WizardFormScreen)
+        error_label = screen.query_one("#wizard-error-project_id", Label)
+        rendered = error_label.render()
+        assert "required" in str(rendered).lower()
+    # Still showing the form when the test exited — no dismissal.
+    assert app.result is _SENTINEL_PENDING
+
+
+@pytest.mark.asyncio
+async def test_wizard_form_submit_returns_collected_dict() -> None:
+    """Valid inputs across every question dismiss with a complete values dict."""
+    app = _WizardHost(WizardFormScreen())
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        # Fill project_id so validation passes.
+        pid_input = app.screen.query_one("#wizard-field-project_id", Input)
+        pid_input.value = "demo-proj"
+        # Leave upstream + branch + snippet empty (all optional).
+        await pilot.click("#wizard-form-create")
+        await pilot.pause()
+    assert isinstance(app.result, dict)
+    assert app.result["project_id"] == "demo-proj"
+    # First radio button is pre-selected on each choice; confirm it mapped
+    # through to the slug, not the label.
+    assert app.result["security_class"] == _question("security_class").choices[0][0]
+    assert app.result["base"] == _question("base").choices[0][0]
+    # Optional fields default to empty strings.
+    assert app.result["upstream_url"] == ""
+    assert app.result["default_branch"] == ""
+    assert app.result["user_snippet"] == ""
+
+
+@pytest.mark.asyncio
+async def test_wizard_form_lowercases_project_id() -> None:
+    """``str.lower`` transform runs before validation on submit."""
+    app = _WizardHost(WizardFormScreen())
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        app.screen.query_one("#wizard-field-project_id", Input).value = "MixedCaseID"
+        await pilot.click("#wizard-form-create")
+        await pilot.pause()
+    assert isinstance(app.result, dict)
+    assert app.result["project_id"] == "mixedcaseid"
+
+
+@pytest.mark.asyncio
+async def test_wizard_form_radio_selection_picks_other_option() -> None:
+    """Selecting the second radio on a choice question flips the dismissed slug."""
+    app = _WizardHost(WizardFormScreen())
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        # Select the second option of security_class (gatekeeping).
+        sec_radioset = app.screen.query_one("#wizard-field-security_class", RadioSet)
+        buttons = list(sec_radioset.query(RadioButton))
+        buttons[1].value = True
+        app.screen.query_one("#wizard-field-project_id", Input).value = "p1"
+        await pilot.click("#wizard-form-create")
+        await pilot.pause()
+    assert isinstance(app.result, dict)
+    assert app.result["security_class"] == _question("security_class").choices[1][0]
+
+
+# ── ProjectReviewScreen ───────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_review_screen_back_dismisses_with_none() -> None:
+    """Back button dismisses with ``None`` — caller re-opens the form."""
+    app = _WizardHost(ProjectReviewScreen("demo", "project:\n  id: demo\n"))
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        await pilot.click("#wizard-review-back")
+        await pilot.pause()
+    assert app.result is None
+
+
+@pytest.mark.asyncio
+async def test_review_screen_initialize_returns_edited_yaml() -> None:
+    """Edits to the TextArea flow through to the dismissed string."""
+    app = _WizardHost(ProjectReviewScreen("demo", "project:\n  id: demo\n"))
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        ta = app.screen.query_one("#wizard-review-yaml", TextArea)
+        ta.text = "project:\n  id: demo\n  edited: true\n"
+        await pilot.click("#wizard-review-init")
+        await pilot.pause()
+    assert app.result == "project:\n  id: demo\n  edited: true\n"
+
+
+# ── Registry-level smoke ──────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_form_renders_one_widget_per_question() -> None:
+    """Each declared question produces a field with the expected ID."""
+    app = _WizardHost(WizardFormScreen())
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        for q in QUESTIONS:
+            # The field widget exists and has the deterministic ID the
+            # read_raw loop relies on.
+            assert app.screen.query_one(f"#wizard-field-{q.key}")
+
+
+def test_touched_wizard_yaml_survives_roundtrip() -> None:
+    """Integration: form dict → render → write_project_yaml round-trips content."""
+    from terok.lib.domain.wizards.new_project import (
+        render_project_yaml,
+        write_project_yaml,
+    )
+
+    values = {
+        "security_class": "online",
+        "base": "ubuntu",
+        "project_id": "roundtrip",
+        "upstream_url": "",
+        "default_branch": "main",
+        "user_snippet": "",
+    }
+    rendered = render_project_yaml(values)
+    with (
+        tempfile.TemporaryDirectory() as td,
+        patch("terok.lib.domain.wizards.new_project.user_projects_dir", return_value=Path(td)),
+    ):
+        path = write_project_yaml("roundtrip", rendered, overwrite=True)
+        assert path.read_text() == rendered

--- a/tests/unit/tui/test_wizard_screens.py
+++ b/tests/unit/tui/test_wizard_screens.py
@@ -144,12 +144,30 @@ async def test_wizard_form_radio_selection_picks_other_option() -> None:
 
 
 @pytest.mark.asyncio
-async def test_review_screen_back_dismisses_with_none() -> None:
-    """Back button dismisses with ``None`` — caller re-opens the form."""
+async def test_review_screen_back_dismisses_with_sentinel() -> None:
+    """Back button returns ``REVIEW_BACK`` — caller re-opens form with prefill."""
+    from terok.tui.wizard_screens import REVIEW_BACK
+
     app = _WizardHost(ProjectReviewScreen("demo", "project:\n  id: demo\n"))
     async with app.run_test() as pilot:
         await pilot.pause()
         await pilot.click("#wizard-review-back")
+        await pilot.pause()
+    assert app.result is REVIEW_BACK
+
+
+@pytest.mark.asyncio
+async def test_review_screen_cancel_action_abandons_with_none() -> None:
+    """The ``cancel`` action (Esc binding) abandons the wizard — distinct from Back."""
+    app = _WizardHost(ProjectReviewScreen("demo", "project:\n  id: demo\n"))
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        # Pilot key-press forwarding to modal bindings is flaky across
+        # Textual versions; invoke the bound action directly — the
+        # binding itself is covered by the screen's BINDINGS list.
+        screen = app.screen
+        assert isinstance(screen, ProjectReviewScreen)
+        screen.action_cancel()
         await pilot.pause()
     assert app.result is None
 
@@ -236,3 +254,35 @@ async def test_init_screen_write_failure_surfaces_in_log() -> None:
             assert close_button.disabled is False
             # The worker was never invoked on the failed-write path.
             mock_run_init.assert_not_called()
+
+
+# ── Form prefill (Back round-trip preservation) ──────────────────────
+
+
+@pytest.mark.asyncio
+async def test_form_prefill_populates_widgets() -> None:
+    """Re-opening the form with an *initial* dict restores every field."""
+    initial = {
+        "security_class": _question("security_class").choices[1][0],  # second choice
+        "base": _question("base").choices[2][0],
+        "project_id": "kept-from-back",
+        "upstream_url": "https://example.com/r.git",
+        "default_branch": "dev",
+        "user_snippet": "RUN echo hi",
+    }
+    app = _WizardHost(WizardFormScreen(initial=initial))
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        # Text and editor fields carry the prefill verbatim.
+        assert app.screen.query_one("#wizard-field-project_id", Input).value == "kept-from-back"
+        assert (
+            app.screen.query_one("#wizard-field-upstream_url", Input).value
+            == "https://example.com/r.git"
+        )
+        assert app.screen.query_one("#wizard-field-default_branch", Input).value == "dev"
+        assert app.screen.query_one("#wizard-field-user_snippet", TextArea).text == "RUN echo hi"
+        # Radio preselection picks the prefilled slug, not the first option.
+        sec_rs = app.screen.query_one("#wizard-field-security_class", RadioSet)
+        pressed = sec_rs.pressed_button
+        assert pressed is not None
+        assert pressed.name == initial["security_class"]

--- a/tests/unit/tui/test_wizard_screens.py
+++ b/tests/unit/tui/test_wizard_screens.py
@@ -235,7 +235,7 @@ async def test_init_screen_write_failure_surfaces_in_log() -> None:
     is a stale project.yml waiting to happen, and downstream steps
     would just fail secondarily on a confusing error.
     """
-    from terok.tui.wizard_screens import InitProgressScreen
+    from terok.tui.wizard_screens import InitOutcome, InitProgressScreen
 
     def _boom(*_args, **_kwargs):
         raise OSError("read-only filesystem")
@@ -254,6 +254,45 @@ async def test_init_screen_write_failure_surfaces_in_log() -> None:
             assert close_button.disabled is False
             # The worker was never invoked on the failed-write path.
             mock_run_init.assert_not_called()
+            # The outcome is FAILED — a write error is a real failure.
+            assert screen._outcome is InitOutcome.FAILED
+
+
+@pytest.mark.asyncio
+async def test_init_screen_decline_overwrite_distinguishes_from_failure() -> None:
+    """User-declined overwrite sets ``DECLINED`` — not FAILED — so the caller doesn't warn.
+
+    The InitProgressScreen only pushes the confirm modal when the
+    project.yml already exists, so we fabricate that via a patched
+    ``_existing_project_yaml_path`` and a patched overwrite confirmer
+    that returns False.  No filesystem write happens on this path.
+    """
+    from terok.tui.wizard_screens import InitOutcome, InitProgressScreen
+
+    app = _WizardHost(InitProgressScreen("demo", "project:\n  id: demo\n"))
+    with (
+        patch.object(
+            InitProgressScreen,
+            "_existing_project_yaml_path",
+            return_value=Path("/tmp/terok-testing/demo/project.yml"),
+        ),
+        patch.object(InitProgressScreen, "_confirm_overwrite", return_value=False),
+        patch("terok.tui.wizard_screens.write_project_yaml") as mock_write,
+        patch.object(InitProgressScreen, "_run_init") as mock_run_init,
+    ):
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            screen = app.screen
+            assert isinstance(screen, InitProgressScreen)
+            # Neither the write nor the worker ran.
+            mock_write.assert_not_called()
+            mock_run_init.assert_not_called()
+            # Outcome distinguishes decline from failure.
+            assert screen._outcome is InitOutcome.DECLINED
+            # Close button is enabled with the neutral variant.
+            close_button = screen.query_one("#wizard-init-close")
+            assert close_button.disabled is False
+            assert close_button.variant == "default"
 
 
 # ── Form prefill (Back round-trip preservation) ──────────────────────

--- a/tests/unit/tui/tui_test_helpers.py
+++ b/tests/unit/tui/tui_test_helpers.py
@@ -29,7 +29,25 @@ def build_textual_stubs() -> dict[str, types.ModuleType]:
 
         return decorator
 
+    def work(*args: Any, **kwargs: Any) -> Callable[..., Any]:
+        """Stub for ``textual.work`` — pass the function through unchanged.
+
+        The real decorator wraps the coroutine in a worker so
+        ``push_screen_wait`` has an async context; tests that import
+        TUI modules via stubs don't run the body, so identity is fine.
+        """
+        # Support both ``@work`` (direct call with the function) and
+        # ``@work(exclusive=True)`` (configured call returning a decorator).
+        if len(args) == 1 and callable(args[0]) and not kwargs:
+            return args[0]
+
+        def decorator(fn: Callable[..., Any]) -> Callable[..., Any]:
+            return fn
+
+        return decorator
+
     textual.on = on
+    textual.work = work
 
     events_mod = types.ModuleType("textual.events")
 


### PR DESCRIPTION
## Summary

Replaces the subprocess-based ``app.suspend()`` wizard path with a three-screen Textual-native flow that works under ``textual-serve`` (web TUI).  Single source of truth between CLI and TUI wizard: same questions, same validation, same config rendering — only the presentation differs.

Resolves the wizard-specific subset of #473; also lands a partial step toward the rest of that issue (login fallback now refuses in web mode instead of suspending).

## Shape

### Domain (``new_project.py``) — single source of truth

- ``Question`` dataclass + ``QUESTIONS`` tuple declare the full wizard schema (key, kind, prompt, validator, transform, placeholder, help).
- ``validate_answer(q, raw) → (value, error_or_None)`` — the shared normalise+validate entry point both presenters call.
- ``render_project_yaml`` / ``write_project_yaml`` split out of ``generate_config`` so the TUI can preview + write the edited YAML.
- CLI's ``collect_wizard_inputs`` becomes a thin loop over ``QUESTIONS`` with unchanged external behaviour.

### TUI (``wizard_screens.py``) — three modals

1. **``WizardFormScreen``** — one form, ``RadioSet`` for choices, ``Input`` for text, ``TextArea`` for the Dockerfile snippet.  All fields validated on Submit; inline error labels next to each field.
2. **``ProjectReviewScreen``** — editable ``TextArea`` with rendered ``project.yml``.  Replaces \"Edit in \$EDITOR? [Y/n]\" — textual-serve can't suspend to a local editor.
3. **``InitProgressScreen``** — runs ssh-init → generate → build → gate as a Textual ``@work`` background task with per-step status badges and a ``RichLog`` pane.  The SSH-key pause becomes a mid-wizard \"I've registered the key — continue\" button, so there's no blocking ``input()`` in a worker.  Gate sync auto-skips (\"skipped\" badge) when ``gate.enabled: false``.

``action_new_project_wizard`` kicks off a worker that sequences the three screens via ``push_screen_wait``.

### First-run trigger

``on_mount`` detects ``not valid and not broken`` (both lists empty) and auto-opens the wizard.  A ``first_run_dismissed`` flag in the existing ``terok-state.json`` ensures the nudge fires at most once per user.

### Login fallback (partial #473 progress)

``_launch_terminal_session``'s suspend fallback now refuses when ``is_web_mode()`` is true, notifying the user to run ``terok login <cname>`` from a host shell instead.  Subsequent PRs will migrate the other 23 ``_run_suspended`` callers to a reusable log-tailer widget.

## DRY — what's shared between CLI and TUI

| Concept | Lives where | Used by |
|---|---|---|
| Question set (labels, choices, validator, transform, help) | ``QUESTIONS`` | CLI loop + ``WizardFormScreen`` |
| Normalise-then-validate | ``validate_answer`` | both |
| Config rendering | ``render_project_yaml`` / ``generate_config`` | both |
| YAML write | ``write_project_yaml`` / ``generate_config`` | both |
| Init step functions | ``facade.provision_ssh_key`` etc. | CLI ``cmd_project_init`` + ``InitProgressScreen`` |

## Known limitations

- ``InitProgressScreen``'s log pane captures Python-level ``print()`` only.  ``podman build`` writes to a real file descriptor and isn't forwarded; the step badge still advances on success/failure.  A reusable log-tailer that also handles subprocess output is tracked in #473 and will migrate the remaining 23 ``_run_suspended`` sites at the same time.
- ``ProjectReviewScreen``'s \"Back\" button abandons the wizard (doesn't return to the form with prefilled values).  The inline review pane is usually enough; if not, the user re-runs the wizard.
- The first-run nudge fires once per user.  Users who want to re-trigger it can clear ``first_run_dismissed`` in ``~/.local/share/terok/terok-state.json`` or just press ``n`` in the project list.

## Test plan

- [x] Domain: parametrised tests for ``validate_answer`` across every question; round-trip test for ``render_project_yaml`` / ``write_project_yaml``; existing CLI wizard tests unchanged and passing.
- [x] TUI screens: Textual ``Pilot`` tests for form cancel / submit-with-validation-error / submit-success / transform / radio-selection; review screen back vs initialize; form-widget-per-question smoke.
- [x] ``make lint`` / ``make tach`` / ``make docstrings`` (98.4%, unchanged grade) / ``make reuse`` / ``make security`` (0 medium/high).
- [x] ``poetry run pytest tests/unit`` — 2096 passed.
- [ ] Manual smoke in a real TTY — not run here (no display).
- [ ] Manual smoke under ``textual-serve`` — not run here.

## Related

Addresses wizard portion of #473 (suspend removal).  Updates #473 with a comment summarising the remaining scope and the proposed log-tailer widget.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Multi-step, in-app project creation wizard with validated inputs, editable YAML review, overwrite confirmation, and stepwise initialization progress (including SSH key registration prompts and copyable CLI hint in web/serve mode).
  * First-run nudge: wizard auto-opens once when no projects exist; dismissal is persisted.
  * Back navigation preserves entered inputs; success/failure notifications shown and project list refreshed after completion.

* **Refactor**
  * Wizard moved from a subprocess-driven CLI to an in-process TUI flow for smoother, integrated interaction.

* **Bug Fixes**
  * Safer snippet trimming to avoid removing unrelated comment lines.
  * More accurate detection for when to prompt for SSH key registration.

* **Tests**
  * Expanded unit and TUI tests covering validation, YAML render/write round-trips, UI behaviors, and init outcomes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->