### PR TITLE
fix(auth): drop host-auth sentinel, pass None to executor

### DIFF
--- a/src/terok/lib/domain/facade.py
+++ b/src/terok/lib/domain/facade.py
@@ -174,15 +174,6 @@ def maybe_pause_for_ssh_key_registration(project_id: str) -> None:
         input("Press Enter once the key is registered... ")
 
 
-#: Container-scope sentinel used when ``authenticate`` runs without a project.
-#:
-#: ``_host`` is rejected by :func:`is_valid_project_id` (leading underscore),
-#: so it can never collide with a real project ID.  The auth flow only uses
-#: the scope string for transient container naming — credentials land in the
-#: vault provider-scoped, not project-scoped — so the sentinel is cosmetic.
-_HOST_AUTH_SENTINEL = "_host"
-
-
 def authenticate(provider: str, project_id: str | None = None) -> None:
     """Run the auth flow for *provider*, host-wide by default.
 
@@ -206,13 +197,11 @@ def authenticate(provider: str, project_id: str | None = None) -> None:
 
     if project_id is None:
         image = _resolve_host_auth_image(provider)
-        container_scope = _HOST_AUTH_SENTINEL
     else:
         image = project_cli_image(project_id)
-        container_scope = project_id
 
     _authenticate_raw(
-        container_scope,
+        project_id,
         provider,
         mounts_dir=sandbox_live_mounts_dir(),
         image=image,

--- a/tests/unit/lib/domain/test_facade.py
+++ b/tests/unit/lib/domain/test_facade.py
@@ -240,8 +240,8 @@ class TestAuthenticate:
         assert mock_auth.call_args.args[0] == "p1"
         assert mock_auth.call_args.kwargs["image"] == "terok-p1:latest"
 
-    def test_host_wide_resolves_l1_and_uses_sentinel(self) -> None:
-        """``authenticate(provider)`` (no project) uses the host sentinel and an L1 image."""
+    def test_host_wide_resolves_l1_and_passes_none_scope(self) -> None:
+        """``authenticate(provider)`` (no project) passes ``None`` scope and an L1 image."""
         from terok.lib.domain import facade
 
         with (
@@ -257,7 +257,7 @@ class TestAuthenticate:
             facade.authenticate("claude")
 
         mock_resolve.assert_called_once_with("claude")
-        assert mock_auth.call_args.args[0] == facade._HOST_AUTH_SENTINEL
+        assert mock_auth.call_args.args[0] is None
         assert mock_auth.call_args.kwargs["image"] == "terok-l1-cli:ubuntu-24.04"
 
 


### PR DESCRIPTION
## Summary

- ``terok auth gh`` (host-wide) crashed because the ``_HOST_AUTH_SENTINEL = \"_host\"`` string was passed as the container-name prefix — Podman rejects names starting with ``_``:

  ```
  Error: running container create option: names must match [a-zA-Z0-9][a-zA-Z0-9_.-]*: invalid argument
  ```

- terok-executor 0.0.108+ (terok-ai/terok-executor#219, pulled in via the recent sibling bump) now accepts ``project_id=None`` for host-wide auth and owns the container-name fallback + clean banner. Drop the sentinel in terok and pass ``None`` through.

## Test plan

- [x] ``make check`` (2075 tests, lint, tach, docstrings, reuse, bandit)
- [ ] Manual: ``terok auth gh`` runs the auth container named ``host-auth-gh`` and shows ``Authenticating GitHub CLI (host-wide)``
- [ ] Manual: ``terok auth gh --project foo`` still names the container ``foo-auth-gh`` and shows ``... for project: foo``

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified authentication scope handling logic by removing intermediate scope variable processing.

* **Tests**
  * Updated authentication tests to align with refined implementation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->