### PR TITLE
refactor: consume terok-clearance hub/verdict split

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -3072,13 +3072,13 @@ tomli-w = ">=1.0,<2.0"
 
 [[package]]
 name = "terok-clearance"
-version = "0.6.0"
+version = "0.6.1"
 description = "Shield clearance and desktop notifications for terok"
 optional = false
 python-versions = ">=3.12,<4.0"
 groups = ["main"]
 files = [
-    {file = "terok_clearance-0.6.0-py3-none-any.whl", hash = "sha256:b8ee49cc613886c1b0d9847a1709888b0c590443a90aad1b75118caa54b1c0ce"},
+    {file = "terok_clearance-0.6.1-py3-none-any.whl", hash = "sha256:c629a1def80297b7eaae04bd62d3a5bec4e3851914e1434ccc2c4cd8538f7dd5"},
 ]
 
 [package.dependencies]
@@ -3087,60 +3087,60 @@ dbus-fast = ">=2.0,<5.0"
 
 [package.source]
 type = "url"
-url = "https://github.com/terok-ai/terok-clearance/releases/download/v0.6.0/terok_clearance-0.6.0-py3-none-any.whl"
+url = "https://github.com/terok-ai/terok-clearance/releases/download/v0.6.1/terok_clearance-0.6.1-py3-none-any.whl"
 
 [[package]]
 name = "terok-executor"
-version = "0.0.109"
+version = "0.0.110"
 description = "Single-agent task runner for hardened Podman containers"
 optional = false
 python-versions = ">=3.12,<4.0"
 groups = ["main"]
 files = [
-    {file = "terok_executor-0.0.109-py3-none-any.whl", hash = "sha256:067e94e6aa6d48dd150c2f8fe4098c44fa682616d84320b18f8f6dbbbe655e00"},
+    {file = "terok_executor-0.0.110-py3-none-any.whl", hash = "sha256:f07d9490a6bfddd8a89eedf1eed21e3244d36439545170ce979301d934c298c5"},
 ]
 
 [package.dependencies]
 Jinja2 = ">=3.1"
 pwinput = ">=1.0.3"
 "ruamel.yaml" = ">=0.18"
-terok_sandbox = {url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.0.90/terok_sandbox-0.0.90-py3-none-any.whl"}
+terok_sandbox = {url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.0.91/terok_sandbox-0.0.91-py3-none-any.whl"}
 tomli-w = ">=1.0"
 
 [package.source]
 type = "url"
-url = "https://github.com/terok-ai/terok-executor/releases/download/v0.0.109/terok_executor-0.0.109-py3-none-any.whl"
+url = "https://github.com/terok-ai/terok-executor/releases/download/v0.0.110/terok_executor-0.0.110-py3-none-any.whl"
 
 [[package]]
 name = "terok-sandbox"
-version = "0.0.90"
+version = "0.0.91"
 description = "Hardened Podman container runner with gate server and shield integration"
 optional = false
 python-versions = ">=3.12,<4.0"
 groups = ["main"]
 files = [
-    {file = "terok_sandbox-0.0.90-py3-none-any.whl", hash = "sha256:1ffd91dd08ce1cd0eddb2b0c0022ecc131b17ed6333c58fb09960fad660fac9d"},
+    {file = "terok_sandbox-0.0.91-py3-none-any.whl", hash = "sha256:50df0c773779239cba9049128c69a875838c0dd2b914e28c7289a878d710ea32"},
 ]
 
 [package.dependencies]
 aiohttp = ">=3.9"
 cryptography = ">=46.0.7"
 platformdirs = ">=4.9.6"
-terok_shield = {url = "https://github.com/terok-ai/terok-shield/releases/download/v0.6.28/terok_shield-0.6.28-py3-none-any.whl"}
+terok_shield = {url = "https://github.com/terok-ai/terok-shield/releases/download/v0.6.29/terok_shield-0.6.29-py3-none-any.whl"}
 
 [package.source]
 type = "url"
-url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.0.90/terok_sandbox-0.0.90-py3-none-any.whl"
+url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.0.91/terok_sandbox-0.0.91-py3-none-any.whl"
 
 [[package]]
 name = "terok-shield"
-version = "0.6.28"
+version = "0.6.29"
 description = "nftables-based egress firewalling for Podman containers"
 optional = false
 python-versions = ">=3.12,<4.0"
 groups = ["main"]
 files = [
-    {file = "terok_shield-0.6.28-py3-none-any.whl", hash = "sha256:823ca2e51b10c2f241bdaa06f8d9afa551c4e0aa57d7ec73812e31d6bf8e3af5"},
+    {file = "terok_shield-0.6.29-py3-none-any.whl", hash = "sha256:8e1cb62ba0d49649d5f37c8923bb8d61801da50a0c555cb19d85bac87d19eaa0"},
 ]
 
 [package.dependencies]
@@ -3149,7 +3149,7 @@ PyYAML = ">=6.0"
 
 [package.source]
 type = "url"
-url = "https://github.com/terok-ai/terok-shield/releases/download/v0.6.28/terok_shield-0.6.28-py3-none-any.whl"
+url = "https://github.com/terok-ai/terok-shield/releases/download/v0.6.29/terok_shield-0.6.29-py3-none-any.whl"
 
 [[package]]
 name = "textual"
@@ -3638,4 +3638,4 @@ propcache = ">=0.2.1"
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.12,<4.0"
-content-hash = "08d3a097229771823e77db11865df4615ffa89c2b07d36b98390185fce3f27f9"
+content-hash = "c5fc193968ef6f04f25b714466d2d8509ec572d67374e739cce282ba712af902"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,10 +48,10 @@ textual-serve = ">=1.1.0"
 # the two siblings that ship the feature (sandbox + executor).  Shield
 # and dbus track upstream's latest release wheels.  The release script
 # replaces the git pins with release-URL pins before cutting.
-terok-executor = {url = "https://github.com/terok-ai/terok-executor/releases/download/v0.0.109/terok_executor-0.0.109-py3-none-any.whl"}
-terok-sandbox = {url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.0.90/terok_sandbox-0.0.90-py3-none-any.whl"}
-terok-shield = {url = "https://github.com/terok-ai/terok-shield/releases/download/v0.6.28/terok_shield-0.6.28-py3-none-any.whl"}
-terok-clearance = {url = "https://github.com/terok-ai/terok-clearance/releases/download/v0.6.0/terok_clearance-0.6.0-py3-none-any.whl"}
+terok-executor = {url = "https://github.com/terok-ai/terok-executor/releases/download/v0.0.110/terok_executor-0.0.110-py3-none-any.whl"}
+terok-sandbox = {url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.0.91/terok_sandbox-0.0.91-py3-none-any.whl"}
+terok-shield = {url = "https://github.com/terok-ai/terok-shield/releases/download/v0.6.29/terok_shield-0.6.29-py3-none-any.whl"}
+terok-clearance = {url = "https://github.com/terok-ai/terok-clearance/releases/download/v0.6.1/terok_clearance-0.6.1-py3-none-any.whl"}
 
 [tool.poetry.group.dev.dependencies]
 pydevd-pycharm = "261.23567.80"

--- a/src/terok/clearance/notifier/__init__.py
+++ b/src/terok/clearance/notifier/__init__.py
@@ -4,7 +4,8 @@
 """``terok-clearance-notifier`` — bridges hub events to desktop popups.
 
 Separate systemd user service (``terok-clearance-notifier.service``)
-from the hub (``terok-dbus.service``) so the hub stays UI-agnostic —
+from the hub (``terok-clearance-hub.service``) so the hub stays
+UI-agnostic —
 headless hosts (CI, servers) run the hub without pulling in a
 desktop-notifier dependency, and desktops get richer rendering with
 terok's task-aware identity resolution.

--- a/src/terok/cli/commands/dbus.py
+++ b/src/terok/cli/commands/dbus.py
@@ -16,7 +16,7 @@ import argparse
 import asyncio
 import sys
 
-from terok_clearance._registry import COMMANDS, ArgDef
+from terok_clearance.cli.registry import COMMANDS, ArgDef
 
 
 def _add_arg(parser: argparse.ArgumentParser, arg: ArgDef) -> None:

--- a/src/terok/cli/commands/setup.py
+++ b/src/terok/cli/commands/setup.py
@@ -62,9 +62,9 @@ def register(subparsers: argparse._SubParsersAction[argparse.ArgumentParser]) ->
         "--no-dbus-bridge",
         action="store_true",
         help=(
-            "Skip the optional D-Bus clearance bridge (NFLOG reader resource + "
-            "terok-clearance hub unit).  Use on hosts with no session D-Bus or when "
-            "auditability of the hook surface is the priority."
+            "Skip the optional clearance bridge (NFLOG reader resource + "
+            "terok-clearance hub/verdict unit pair).  Use on hosts with no "
+            "session bus or when auditability of the hook surface is the priority."
         ),
     )
     p_setup.add_argument(
@@ -500,19 +500,32 @@ def _ensure_bridge_reader(*, check_only: bool) -> bool:
 
 
 def _ensure_dbus_hub(*, check_only: bool) -> bool:
-    """Install the terok-clearance systemd user unit that owns org.terok.Shield1."""
-    _stage_begin("D-Bus hub")
-    unit_path = _user_systemd_dir() / "terok-dbus.service"
-    if check_only:
-        present = unit_path.is_file()
-        print(f"{_status_label(present)}{_presence_suffix(present)}")
-        return present
+    """Install the terok-clearance hub + verdict-helper systemd user units.
 
+    The clearance hub splits across two units — ``terok-clearance-hub`` is
+    the hardened varlink server, ``terok-clearance-verdict`` is the
+    unhardened helper that execs ``terok-shield``.  Both are enabled in
+    the same pass; the helper is ``Wants=`` of the hub so either
+    ordering at boot works.
+    """
+    _stage_begin("Clearance hub")
     try:
-        from terok_clearance._install import install_service
-    except ImportError as exc:  # noqa: BLE001
+        from terok_clearance.runtime.installer import (
+            HUB_UNIT_NAME,
+            VERDICT_UNIT_NAME,
+            install_service,
+        )
+    except ImportError as exc:
         print(f"{_status_label(False)} (import failed: {exc})")
         return False
+
+    systemd_dir = _user_systemd_dir()
+    if check_only:
+        present = (systemd_dir / HUB_UNIT_NAME).is_file() and (
+            systemd_dir / VERDICT_UNIT_NAME
+        ).is_file()
+        print(f"{_status_label(present)}{_presence_suffix(present)}")
+        return present
 
     # Avoid ``shutil.which("terok-clearance-hub")`` here: a hostile PATH
     # (shell rc, unexpected cwd) could otherwise poison the ExecStart=
@@ -521,11 +534,12 @@ def _ensure_dbus_hub(*, check_only: bool) -> bool:
     # pipx venv's own Python — or whatever is actually executing this
     # process — is the one the unit ends up invoking.
     try:
-        install_service([sys.executable, "-m", "terok_clearance._cli"])
+        install_service([sys.executable, "-m", "terok_clearance.cli.main"])
     except Exception as exc:  # noqa: BLE001
         print(f"{_status_label(False)} ({exc})")
         return False
-    _enable_user_service("terok-dbus")
+    _enable_user_service("terok-clearance-hub")
+    _enable_user_service("terok-clearance-verdict")
     print(f"{_status_label(True)} (installed + enabled)")
     return True
 
@@ -536,8 +550,8 @@ def _ensure_clearance_notifier(*, check_only: bool) -> bool:
     Separate from the hub unit: the hub is headless-friendly, the
     notifier needs a desktop session (reaches for
     ``org.freedesktop.Notifications``).  Paired with ``Wants=
-    terok-dbus.service`` in the unit file so systemd starts the hub
-    first.
+    terok-clearance-hub.service`` in the unit file so systemd starts
+    the hub first.
     """
     _stage_begin("Clearance notifier")
     from terok.clearance._install import default_unit_path
@@ -572,11 +586,12 @@ def _disable_dbus_bridge(*, check_only: bool) -> bool:
     permissions denied on the systemd unit path).  ``True`` on a clean
     teardown or an already-absent install.
     """
-    _stage_begin("D-Bus bridge")
+    _stage_begin("Clearance bridge")
     if check_only:
         print(f"{_warn_label()} (opted out via --no-dbus-bridge)")
         return True
 
+    from terok_clearance import uninstall_service
     from terok_sandbox import uninstall_shield_bridge
 
     try:
@@ -585,18 +600,11 @@ def _disable_dbus_bridge(*, check_only: bool) -> bool:
         print(f"{_warn_label()} (reader uninstall: {exc})")
         return False
 
-    unit_path = _user_systemd_dir() / "terok-dbus.service"
-    if unit_path.is_file():
-        # Disable before unlinking — ``systemctl --user disable --now`` needs
-        # the unit file on disk to resolve the service name.  Removing the
-        # file first leaves the unit running and enabled with no canonical
-        # path for systemctl to operate on.
-        _disable_user_service("terok-dbus")
-        try:
-            unit_path.unlink(missing_ok=True)
-        except OSError as exc:
-            print(f"{_warn_label()} (unit removal: {exc})")
-            return False
+    try:
+        uninstall_service()
+    except Exception as exc:  # noqa: BLE001
+        print(f"{_warn_label()} (hub/verdict teardown: {exc})")
+        return False
     print(f"{_warn_label()} (disabled — audit-minimal mode)")
     return True
 

--- a/src/terok/cli/commands/sickbay.py
+++ b/src/terok/cli/commands/sickbay.py
@@ -26,10 +26,12 @@ import tomllib
 from pathlib import Path
 
 from terok_clearance import (
-    check_units_outdated as _dbus_check_units_outdated,
-    read_installed_unit_version as _dbus_read_unit_version,
+    check_units_outdated as _clearance_check_units_outdated,
+    read_installed_unit_version as _clearance_hub_unit_version,
 )
-from terok_clearance._install import UNIT_NAME as _DBUS_UNIT_NAME
+from terok_clearance.runtime.installer import (
+    HUB_UNIT_NAME as _CLEARANCE_HUB_UNIT_NAME,
+)
 from terok_sandbox import (
     check_environment,
     check_units_outdated,
@@ -143,20 +145,19 @@ def _check_shield() -> _CheckResult:
 def _check_clearance_hub() -> _CheckResult:
     """Detect drift between the installed hub unit and the shipped template.
 
-    A pre-varlink Shield1 D-Bus hub wrote the same file name and the
-    same ``ExecStart={{BIN}} serve`` line — the version marker is how
-    we tell the two generations apart.  ``None`` version with file
-    present = legacy unit; bumped ``_UNIT_VERSION`` in terok-clearance =
-    rerun-setup prompt.
+    ``check_units_outdated`` covers both the hub and the verdict
+    helper in one probe: a pre-split monolithic ``terok-dbus.service``
+    on disk, a half-installed pair (one file missing), and a stale
+    version marker all surface as a single ``warn`` here.
     """
     label = "Clearance hub"
-    outdated = _dbus_check_units_outdated()
+    outdated = _clearance_check_units_outdated()
     if outdated:
         return ("warn", label, outdated)
-    installed = _dbus_read_unit_version()
+    installed = _clearance_hub_unit_version()
     if installed is None:
-        return ("ok", label, f"{_DBUS_UNIT_NAME} not installed")
-    return ("ok", label, f"{_DBUS_UNIT_NAME} v{installed}")
+        return ("ok", label, f"{_CLEARANCE_HUB_UNIT_NAME} not installed")
+    return ("ok", label, f"{_CLEARANCE_HUB_UNIT_NAME} v{installed}")
 
 
 def _check_clearance_notifier() -> _CheckResult:

--- a/src/terok/cli/commands/uninstall.py
+++ b/src/terok/cli/commands/uninstall.py
@@ -133,32 +133,28 @@ def _uninstall_desktop_entry() -> bool:
 
 
 def _uninstall_dbus_bridge() -> bool:
-    """Remove the NFLOG reader resource + terok-clearance hub unit.
+    """Remove the NFLOG reader resource + clearance hub/verdict pair.
 
-    Order matters: ``disable --now`` stops and deactivates the service
-    while the unit file is still on disk (otherwise systemd has no unit
-    to resolve); then unlink the file; then ``daemon-reload`` so
-    systemd purges the now-dangling in-memory entry.
+    ``terok_clearance.uninstall_service`` owns the systemctl teardown
+    + unlink + daemon-reload sequence for both units — including
+    migration of a legacy pre-split ``terok-dbus.service`` — so this
+    stage is thin on top of it.
     """
+    from terok_clearance import uninstall_service
     from terok_sandbox import uninstall_shield_bridge
 
-    from .setup import _run_systemctl, _user_systemd_dir
-
-    _stage_begin("D-Bus bridge")
+    _stage_begin("Clearance bridge")
     try:
         uninstall_shield_bridge()
     except Exception as exc:  # noqa: BLE001
         print(f"{_status_label(False)} (reader: {exc})")
         return False
 
-    unit = _user_systemd_dir() / "terok-dbus.service"
-    _run_systemctl("--user", "disable", "--now", "terok-dbus")
     try:
-        unit.unlink(missing_ok=True)
-    except OSError as exc:
-        print(f"{_status_label(False)} (unit unlink: {exc})")
+        uninstall_service()
+    except Exception as exc:  # noqa: BLE001
+        print(f"{_status_label(False)} (hub/verdict teardown: {exc})")
         return False
-    _run_systemctl("--user", "daemon-reload")
 
     print(f"{_status_label(True)} (removed)")
     return True

--- a/src/terok/lib/domain/facade.py
+++ b/src/terok/lib/domain/facade.py
@@ -155,7 +155,7 @@ def summarize_ssh_init(result: SSHInitResult) -> None:
     """Render an ``ssh-init`` result for the terminal."""
     print(f"  id:          {result['key_id']}")
     print(f"  type:        {result['key_type']}")
-    print(f"  fingerprint: SHA256:{result['fingerprint']}")
+    print(f"  fingerprint: {result['fingerprint']}")
     print(f"  comment:     {result['comment']}")
     print("Public key (register as a deploy key on the remote):")
     print(f"  {result['public_line']}")

--- a/tests/unit/cli/test_cli_dbus.py
+++ b/tests/unit/cli/test_cli_dbus.py
@@ -9,7 +9,7 @@ import argparse
 from unittest.mock import patch
 
 import pytest
-from terok_clearance._registry import CommandDef
+from terok_clearance.cli.registry import CommandDef
 
 from terok.cli.commands.dbus import dispatch, register
 
@@ -70,7 +70,7 @@ def test_dispatch_returns_false_for_non_dbus_commands() -> None:
 
 def _real_args(name: str) -> tuple:
     """Return the ArgDef tuple for a real COMMANDS entry by name."""
-    from terok_clearance._registry import COMMANDS as REAL_COMMANDS
+    from terok_clearance.cli.registry import COMMANDS as REAL_COMMANDS
 
     return next(c.args for c in REAL_COMMANDS if c.name == name)
 

--- a/tests/unit/cli/test_cli_setup_global.py
+++ b/tests/unit/cli/test_cli_setup_global.py
@@ -733,19 +733,31 @@ class TestEnsureBridgeReader:
 
 
 class TestEnsureDbusHub:
-    """``_ensure_dbus_hub`` installs the systemd user unit that owns org.terok.Shield1."""
+    """``_ensure_dbus_hub`` installs the hub + verdict-helper systemd user units."""
 
     def test_check_only_present(self, tmp_path: Path, capsys: pytest.CaptureFixture) -> None:
-        """check_only reports ok when the unit file exists."""
+        """check_only reports ok only when both unit files exist."""
         unit_dir = tmp_path / "systemd/user"
         unit_dir.mkdir(parents=True)
-        (unit_dir / "terok-dbus.service").write_text("[Service]\n")
+        (unit_dir / "terok-clearance-hub.service").write_text("[Service]\n")
+        (unit_dir / "terok-clearance-verdict.service").write_text("[Service]\n")
         with patch.dict("os.environ", {"XDG_CONFIG_HOME": str(tmp_path), "HOME": str(tmp_path)}):
             assert _ensure_dbus_hub(check_only=True) is True
         assert "installed" in capsys.readouterr().out
 
+    def test_check_only_half_installed_reports_missing(
+        self, tmp_path: Path, capsys: pytest.CaptureFixture
+    ) -> None:
+        """Hub present but verdict absent → not installed (operator must rerun setup)."""
+        unit_dir = tmp_path / "systemd/user"
+        unit_dir.mkdir(parents=True)
+        (unit_dir / "terok-clearance-hub.service").write_text("[Service]\n")
+        with patch.dict("os.environ", {"XDG_CONFIG_HOME": str(tmp_path), "HOME": str(tmp_path)}):
+            assert _ensure_dbus_hub(check_only=True) is False
+        assert "not installed" in capsys.readouterr().out
+
     def test_check_only_missing(self, tmp_path: Path, capsys: pytest.CaptureFixture) -> None:
-        """check_only reports false when the unit file is absent."""
+        """check_only reports false when both unit files are absent."""
         with patch.dict("os.environ", {"XDG_CONFIG_HOME": str(tmp_path), "HOME": str(tmp_path)}):
             assert _ensure_dbus_hub(check_only=True) is False
         assert "not installed" in capsys.readouterr().out
@@ -757,20 +769,24 @@ class TestEnsureDbusHub:
         import sys as _sys
 
         with (
-            patch("terok_clearance._install.install_service") as mock_install,
+            patch("terok_clearance.runtime.installer.install_service") as mock_install,
             patch("terok.cli.commands.setup._enable_user_service") as mock_enable,
         ):
             assert _ensure_dbus_hub(check_only=False) is True
         (argv,) = mock_install.call_args[0]
-        assert argv == [_sys.executable, "-m", "terok_clearance._cli"]
-        mock_enable.assert_called_once_with("terok-dbus")
+        assert argv == [_sys.executable, "-m", "terok_clearance.cli.main"]
+        # Both units get enabled in the same pass; order is stable (hub first).
+        assert [c.args[0] for c in mock_enable.call_args_list] == [
+            "terok-clearance-hub",
+            "terok-clearance-verdict",
+        ]
         assert "installed" in capsys.readouterr().out
 
     def test_import_failure_soft_fails(self, capsys: pytest.CaptureFixture) -> None:
-        """An ImportError out of terok_clearance._install must not crash setup."""
+        """An ImportError out of terok_clearance.runtime.installer must not crash setup."""
         with patch.dict(
             "sys.modules",
-            {"terok_clearance._install": None},
+            {"terok_clearance.runtime.installer": None},
         ):
             assert _ensure_dbus_hub(check_only=False) is False
         assert "import failed" in capsys.readouterr().out
@@ -779,7 +795,7 @@ class TestEnsureDbusHub:
         """install_service exceptions are caught, reported, return False."""
         with (
             patch(
-                "terok_clearance._install.install_service",
+                "terok_clearance.runtime.installer.install_service",
                 side_effect=RuntimeError("template missing"),
             ),
             patch("terok.cli.commands.setup._enable_user_service"),
@@ -807,22 +823,17 @@ class TestDisableDbusBridge:
         mock_uninstall.assert_called_once()
         assert "disabled" in capsys.readouterr().out
 
-    def test_teardown_with_unit_removes_and_disables(
+    def test_teardown_delegates_to_uninstall_service(
         self, tmp_path: Path, capsys: pytest.CaptureFixture
     ) -> None:
-        """Present unit → unlinked + systemctl disable invoked."""
-        unit_dir = tmp_path / "systemd/user"
-        unit_dir.mkdir(parents=True)
-        unit = unit_dir / "terok-dbus.service"
-        unit.write_text("[Service]\n")
+        """Teardown is a thin wrapper around ``terok_clearance.uninstall_service``."""
         with (
             patch.dict("os.environ", {"XDG_CONFIG_HOME": str(tmp_path), "HOME": str(tmp_path)}),
             patch("terok_sandbox.uninstall_shield_bridge"),
-            patch("terok.cli.commands.setup._disable_user_service") as mock_disable,
+            patch("terok_clearance.uninstall_service") as mock_uninstall,
         ):
             assert _disable_dbus_bridge(check_only=False) is True
-        assert not unit.exists()
-        mock_disable.assert_called_once_with("terok-dbus")
+        mock_uninstall.assert_called_once()
 
     def test_uninstall_exception_returns_false(
         self, tmp_path: Path, capsys: pytest.CaptureFixture
@@ -840,22 +851,22 @@ class TestDisableDbusBridge:
         assert "reader uninstall" in out
         assert "permission denied" in out
 
-    def test_unit_removal_oserror_returns_false(
+    def test_hub_teardown_exception_returns_false(
         self, tmp_path: Path, capsys: pytest.CaptureFixture
     ) -> None:
-        """Unit file present but unlink raises OSError → WARN line + False."""
-        unit_dir = tmp_path / "systemd/user"
-        unit_dir.mkdir(parents=True)
-        unit = unit_dir / "terok-dbus.service"
-        unit.write_text("[Service]\n")
+        """``uninstall_service`` raising → WARN line + False, same shape as the reader path."""
         with (
             patch.dict("os.environ", {"XDG_CONFIG_HOME": str(tmp_path), "HOME": str(tmp_path)}),
             patch("terok_sandbox.uninstall_shield_bridge"),
-            patch("pathlib.Path.unlink", side_effect=OSError("read-only fs")),
+            patch(
+                "terok_clearance.uninstall_service",
+                side_effect=RuntimeError("read-only fs"),
+            ),
         ):
             assert _disable_dbus_bridge(check_only=False) is False
         out = capsys.readouterr().out
-        assert "unit removal" in out
+        assert "hub/verdict teardown" in out
+        assert "read-only fs" in out
 
 
 class TestEnsureDesktopEntry:
@@ -1067,12 +1078,12 @@ class TestUserServiceHelpers:
             patch("terok.cli.commands.setup.shutil.which", return_value="/bin/systemctl"),
             patch.object(sp, "run", return_value=fake),
         ):
-            _enable_user_service("terok-dbus")
+            _enable_user_service("terok-clearance-hub")
 
         log = (tmp_path / "terok" / "log" / "setup.log").read_text()
         assert "systemctl --user daemon-reload (rc=1)" in log
-        assert "systemctl --user enable terok-dbus (rc=1)" in log
-        assert "systemctl --user restart terok-dbus (rc=1)" in log
+        assert "systemctl --user enable terok-clearance-hub (rc=1)" in log
+        assert "systemctl --user restart terok-clearance-hub (rc=1)" in log
         assert "Unit not found" in log
 
     def test_disable_noop_when_systemctl_missing(self) -> None:

--- a/tests/unit/cli/test_cli_sickbay.py
+++ b/tests/unit/cli/test_cli_sickbay.py
@@ -119,7 +119,11 @@ def test_cmd_sickbay_reports_health(
     # fixture narrowly about the gate-server assertions above.
     _stubs = {
         "_check_vault_migration": ("ok", "Vault migration", "no legacy directory"),
-        "_check_clearance_hub": ("ok", "Clearance hub", "terok-dbus.service not installed"),
+        "_check_clearance_hub": (
+            "ok",
+            "Clearance hub",
+            "terok-clearance-hub.service not installed",
+        ),
         "_check_clearance_notifier": (
             "ok",
             "Clearance notifier",

--- a/tests/unit/cli/test_cli_uninstall.py
+++ b/tests/unit/cli/test_cli_uninstall.py
@@ -42,28 +42,15 @@ def test_desktop_entry_failure_reported(
     assert "FAIL" in capsys.readouterr().out
 
 
-@patch("terok.cli.commands.setup._run_systemctl")
+@patch("terok_clearance.uninstall_service")
 @patch("terok_sandbox.uninstall_shield_bridge")
 def test_dbus_bridge_removed(
-    mock_reader: MagicMock, mock_systemctl: MagicMock, capsys: pytest.CaptureFixture[str], tmp_path
+    mock_reader: MagicMock, mock_uninstall: MagicMock, capsys: pytest.CaptureFixture[str]
 ) -> None:
-    """Happy path: reader removed, unit disabled, file unlinked, daemon reloaded."""
-    unit = tmp_path / "terok-dbus.service"
-    unit.write_text("[Unit]\n")
-
-    with patch("terok.cli.commands.setup._user_systemd_dir", return_value=tmp_path):
-        assert _uninstall_dbus_bridge() is True
-
+    """Happy path: reader removed, clearance teardown delegated, ok reported."""
+    assert _uninstall_dbus_bridge() is True
     mock_reader.assert_called_once()
-    # disable --now must run before unlink; daemon-reload after.
-    assert mock_systemctl.call_args_list[0].args[:4] == (
-        "--user",
-        "disable",
-        "--now",
-        "terok-dbus",
-    )
-    assert mock_systemctl.call_args_list[1].args == ("--user", "daemon-reload")
-    assert not unit.exists()
+    mock_uninstall.assert_called_once()
     assert "ok" in capsys.readouterr().out
 
 

--- a/tests/unit/cli/test_sickbay.py
+++ b/tests/unit/cli/test_sickbay.py
@@ -714,30 +714,30 @@ class TestCheckShieldAnnotations:
 
 
 class TestCheckClearanceHub:
-    """Drift probe on the ``terok-dbus.service`` unit."""
+    """Drift probe on the ``terok-clearance-hub.service`` unit."""
 
     def test_current_version_is_ok(self) -> None:
         from terok.cli.commands.sickbay import _check_clearance_hub
 
         with (
             unittest.mock.patch(
-                "terok.cli.commands.sickbay._dbus_check_units_outdated", return_value=None
+                "terok.cli.commands.sickbay._clearance_check_units_outdated", return_value=None
             ),
             unittest.mock.patch(
-                "terok.cli.commands.sickbay._dbus_read_unit_version", return_value=1
+                "terok.cli.commands.sickbay._clearance_hub_unit_version", return_value=1
             ),
         ):
             sev, label, detail = _check_clearance_hub()
         assert sev == "ok"
         assert label == "Clearance hub"
-        assert "terok-dbus.service v1" in detail
+        assert "terok-clearance-hub.service v1" in detail
 
     def test_outdated_is_warn(self) -> None:
         from terok.cli.commands.sickbay import _check_clearance_hub
 
         with (
             unittest.mock.patch(
-                "terok.cli.commands.sickbay._dbus_check_units_outdated",
+                "terok.cli.commands.sickbay._clearance_check_units_outdated",
                 return_value="is outdated (installed unversioned, expected v1) — rerun `terok setup`.",
             ),
         ):
@@ -752,10 +752,10 @@ class TestCheckClearanceHub:
 
         with (
             unittest.mock.patch(
-                "terok.cli.commands.sickbay._dbus_check_units_outdated", return_value=None
+                "terok.cli.commands.sickbay._clearance_check_units_outdated", return_value=None
             ),
             unittest.mock.patch(
-                "terok.cli.commands.sickbay._dbus_read_unit_version", return_value=None
+                "terok.cli.commands.sickbay._clearance_hub_unit_version", return_value=None
             ),
         ):
             sev, _, detail = _check_clearance_hub()

--- a/tests/unit/lib/domain/test_facade.py
+++ b/tests/unit/lib/domain/test_facade.py
@@ -158,7 +158,7 @@ class TestSummarizeSshInit:
             {
                 "key_id": 3,
                 "key_type": "rsa",
-                "fingerprint": "abc123",
+                "fingerprint": "SHA256:abc123",
                 "comment": "tk-main:proj",
                 "public_line": "ssh-rsa AAAA… tk-main:proj",
             }


### PR DESCRIPTION
## Summary

Bumps the sibling pins to the current release chain *and* updates terok to consume the post-split clearance API surface:

| Sibling | Old | New |
|---|---|---|
| terok-clearance | v0.6.0 | v0.6.1 |
| terok-sandbox | v0.0.90 | v0.0.91 |
| terok-shield | v0.6.28 | v0.6.29 |
| terok-executor | v0.0.109 | v0.0.110 |

## What changed in terok-clearance v0.6.1 that forced the consumer churn

1. **Hub/verdict-helper split** — the single `terok-dbus.service` became `terok-clearance-hub.service` (hardened, bus-owning) + `terok-clearance-verdict.service` (unhardened, execs `terok-shield allow|deny`). NoNewPrivileges + seccomp + mount-ns isolation can now live on the hub while the helper keeps the unconfined surface that rootless podman's `nsenter` re-exec needs.
2. **New public `uninstall_service()`** — symmetric teardown for `install_service()`, owns the systemctl disable + unlink + daemon-reload sequence for both units and migrates a legacy pre-split `terok-dbus.service` on its way out.
3. **Screaming-architecture refactor** — the private `terok_clearance._registry` / `._install` / `._cli` modules moved to `terok_clearance.cli.registry` / `.runtime.installer` / `.cli.main` (public surface).

## terok-side consumer changes

* `cli/commands/setup.py::_ensure_dbus_hub` now installs + enables **both** units in the same pass; `check_only` treats a one-sided pair as not-installed so a half-broken install is visible in the stage line.
* `cli/commands/setup.py::_disable_dbus_bridge` and `cli/commands/uninstall.py::_uninstall_dbus_bridge` delegate to `terok_clearance.uninstall_service()` — no more bespoke `systemctl --user disable --now terok-dbus` in terok.
* `cli/commands/sickbay.py` imports `HUB_UNIT_NAME` from the new `runtime.installer` path; `check_units_outdated` already covers legacy-unit, half-installed, and stale-marker drift in a single call.
* `cli/commands/dbus.py` + `tests/unit/cli/test_cli_dbus.py` follow the module rename from `_registry` to `cli.registry`.
* Docstrings stop referencing `terok-dbus.service` except when the subject is specifically the pre-split legacy unit.

## Drive-by fix

`lib/domain/facade.summarize_ssh_init` printed `fingerprint: SHA256:{value}`, but terok-sandbox's current `fingerprint_of` already returns `SHA256:…` as a complete string, so the rendered line became `SHA256:SHA256:…` once the sandbox pin bumped. Removed the literal prefix; test fixture updated to pass a pre-prefixed fingerprint.

## Test plan

- [x] `make check` passes locally (ruff, unit tests, tach, import-linter, docstrings, reuse, bandit, dead-code)
- [x] `poetry run pytest tests/unit -q` → 2076 passed
- [ ] Container smoke test (user's test machine): clean `terok setup` installs both hub and verdict units, `terok uninstall --no-dbus-bridge` tears both down + reaps a legacy `terok-dbus.service` if present.
- [ ] Visual: `terok sickbay` reports "Clearance hub … terok-clearance-hub.service v1" on a fresh install.

🤖 Generated with [Claude Code](https://claude.com/claude-code)