### PR TITLE
fix(tui): wizard silent failure + build frame corruption + YAML robustness

### DIFF
--- a/src/terok/lib/core/projects.py
+++ b/src/terok/lib/core/projects.py
@@ -99,15 +99,32 @@ def _format_validation_error(exc: ValidationError, cfg_path: Path) -> str:
 
 
 def _parse_project_yaml(cfg_path: Path) -> RawProjectYaml:
-    """Parse and validate a project.yml file, returning a typed model."""
+    """Parse and validate a project.yml file, returning a typed model.
+
+    Any error reading or parsing the file — including internal crashes
+    from the YAML library itself — is converted into a single
+    ``SystemExit`` with the path embedded in the message.  The narrow
+    catch list (OSError, UnicodeDecodeError, YAMLError) would let
+    ruamel.yaml's own quirks (``IndexError`` on certain inputs,
+    ``AttributeError`` mid-scan, etc.) escape and crash whatever
+    called us — the TUI's project-list keypress handler was one such
+    path.  ``discover_projects`` already treats ``SystemExit`` from
+    this module as "broken project" and surfaces the entry in-UI, so
+    the robust policy is: no matter what goes wrong per file, the app
+    keeps running and the user sees a damaged project in the list.
+    """
     try:
         raw = _yaml_load(cfg_path.read_text(encoding="utf-8")) or {}
     except (OSError, UnicodeDecodeError, YAMLError) as exc:
         raise SystemExit(f"Failed to read {cfg_path}: {exc}")
+    except Exception as exc:  # noqa: BLE001 — YAML parsers can raise anything; quarantine it
+        raise SystemExit(f"Failed to read {cfg_path}: {type(exc).__name__}: {exc}") from exc
     try:
         return RawProjectYaml.model_validate(raw)
     except ValidationError as exc:
         raise SystemExit(_format_validation_error(exc, cfg_path))
+    except Exception as exc:  # noqa: BLE001 — defensive against non-Validation pydantic surprises
+        raise SystemExit(f"Failed to validate {cfg_path}: {type(exc).__name__}: {exc}") from exc
 
 
 def _resolve_shield_config(raw: RawProjectYaml) -> tuple[bool, str]:

--- a/src/terok/lib/core/projects.py
+++ b/src/terok/lib/core/projects.py
@@ -116,13 +116,13 @@ def _parse_project_yaml(cfg_path: Path) -> RawProjectYaml:
     try:
         raw = _yaml_load(cfg_path.read_text(encoding="utf-8")) or {}
     except (OSError, UnicodeDecodeError, YAMLError) as exc:
-        raise SystemExit(f"Failed to read {cfg_path}: {exc}")
+        raise SystemExit(f"Failed to read {cfg_path}: {exc}") from exc
     except Exception as exc:  # noqa: BLE001 — YAML parsers can raise anything; quarantine it
         raise SystemExit(f"Failed to read {cfg_path}: {type(exc).__name__}: {exc}") from exc
     try:
         return RawProjectYaml.model_validate(raw)
     except ValidationError as exc:
-        raise SystemExit(_format_validation_error(exc, cfg_path))
+        raise SystemExit(_format_validation_error(exc, cfg_path)) from exc
     except Exception as exc:  # noqa: BLE001 — defensive against non-Validation pydantic surprises
         raise SystemExit(f"Failed to validate {cfg_path}: {type(exc).__name__}: {exc}") from exc
 

--- a/src/terok/tui/project_actions.py
+++ b/src/terok/tui/project_actions.py
@@ -480,7 +480,7 @@ class ProjectActionsMixin:
         """
         self._run_wizard_flow()
 
-    @work(exclusive=True)
+    @work(exclusive=True, group="wizard-flow", exit_on_error=False)
     async def _run_wizard_flow(self) -> None:
         """Drive form → review → init-progress, refreshing the list at the end.
 
@@ -489,10 +489,28 @@ class ProjectActionsMixin:
         screen's ``REVIEW_BACK`` sentinel tells us to re-open the form
         with the user's previous input instead of starting fresh.
         ``None`` from either screen abandons the wizard.
+
+        Any unhandled exception is surfaced as a TUI notification —
+        ``exit_on_error=False`` on the decorator keeps errors from
+        killing the app, but we do not want them silently vanishing
+        either.
         """
+        try:
+            await self._run_wizard_flow_body()
+        except Exception as exc:  # noqa: BLE001 — last-resort wizard error surface
+            self.notify(
+                f"New-project wizard failed: {exc}",
+                severity="error",
+                timeout=15,
+            )
+            raise
+
+    async def _run_wizard_flow_body(self) -> None:
+        """Inner wizard orchestration — see the decorator wrapper for docs."""
         from ..lib.domain.wizards.new_project import render_project_yaml
         from .wizard_screens import (
             REVIEW_BACK,
+            InitOutcome,
             InitProgressScreen,
             ProjectReviewScreen,
             WizardFormScreen,
@@ -517,7 +535,6 @@ class ProjectActionsMixin:
             break
 
         outcome = await self.push_screen_wait(InitProgressScreen(values["project_id"], final_yaml))
-        from .wizard_screens import InitOutcome
 
         match outcome:
             case InitOutcome.SUCCESS:

--- a/src/terok/tui/wizard_screens.py
+++ b/src/terok/tui/wizard_screens.py
@@ -424,11 +424,21 @@ class InitProgressScreen(ModalScreen[InitOutcome]):
                         classes="wizard-init-step",
                         id=self._step_id(key),
                     )
-            # Hidden until ssh-init runs + upstream is SSH-scheme
+            # Hidden until ssh-init runs + upstream is SSH-scheme.  A
+            # ``Static`` (rather than ``TextArea``) renders selectable
+            # plain text without the editor's line-number gutter or
+            # cursor — copying from the terminal's mouse works cleanly,
+            # and the "Copy" button bypasses that path entirely via the
+            # shared clipboard helper.
             with Vertical(id="wizard-init-ssh-key"):
                 yield Label("SSH public key — register this on your git remote:")
-                yield TextArea("", id="wizard-init-ssh-pubkey", read_only=True)
-                with Horizontal():
+                yield Static("", id="wizard-init-ssh-pubkey")
+                with Horizontal(id="wizard-init-ssh-buttons"):
+                    yield Button(
+                        "Copy",
+                        id="wizard-init-ssh-copy",
+                        variant="default",
+                    )
                     yield Button(
                         "I've registered the key — continue",
                         id="wizard-init-ssh-continue",
@@ -451,32 +461,48 @@ class InitProgressScreen(ModalScreen[InitOutcome]):
         """
         self._run_init_with_confirm()
 
-    @work(exclusive=True)
+    # Distinct ``group`` from the outer wizard flow is essential:
+    # ``@work(exclusive=True)`` cancels every running worker sharing the
+    # same group, so inheriting the default "default" group would have
+    # the init worker cancel its own parent the moment it started —
+    # symptom: click "Initialize" on the review screen, the init modal
+    # pops off immediately, and the wizard silently completes with no
+    # project created.  Keep these two groups isolated.
+    @work(exclusive=True, group="wizard-init", exit_on_error=False)
     async def _run_init_with_confirm(self) -> None:
-        """Top-level coroutine that sequences overwrite-confirm → write → run."""
-        log = self.query_one("#wizard-init-log", RichLog)
-        existing = self._existing_project_yaml_path()
-        if existing is not None:
-            if not await self._confirm_overwrite(existing):
-                log.write(
-                    "[yellow]Keeping existing project.yml — nothing written, "
-                    "nothing initialised.[/]"
-                )
-                # A declined overwrite is the user's deliberate choice —
-                # not a failure — so the screen dismisses with a distinct
-                # outcome the caller can branch on.
-                self._outcome = InitOutcome.DECLINED
-                self._finish_with_close_button()
-                return
+        """Top-level coroutine that sequences overwrite-confirm → write → run.
 
-        log.write(f"[dim]Writing project.yml for {self._project_id}…[/]")
+        The outer try/except is a safety net: any unexpected exception
+        from confirm/write/run is logged and the Close button is
+        enabled, so a user is never stuck in front of a frozen modal
+        wondering why nothing is happening.
+        """
+        log = self.query_one("#wizard-init-log", RichLog)
         try:
-            write_project_yaml(self._project_id, self._rendered_yaml, overwrite=True)
-        except (OSError, SystemExit) as exc:
-            log.write(f"[red]Failed to write project.yml: {exc}[/]")
+            existing = self._existing_project_yaml_path()
+            if existing is not None:
+                if not await self._confirm_overwrite(existing):
+                    log.write(
+                        "[yellow]Keeping existing project.yml — nothing written, "
+                        "nothing initialised.[/]"
+                    )
+                    # A declined overwrite is the user's deliberate choice —
+                    # not a failure — so the screen dismisses with a distinct
+                    # outcome the caller can branch on.
+                    self._outcome = InitOutcome.DECLINED
+                    return
+
+            log.write(f"[dim]Writing project.yml for {self._project_id}…[/]")
+            try:
+                write_project_yaml(self._project_id, self._rendered_yaml, overwrite=True)
+            except (OSError, SystemExit) as exc:
+                log.write(f"[red]Failed to write project.yml: {exc}[/]")
+                return
+            await self._run_init()
+        except Exception as exc:  # noqa: BLE001 — modal must never freeze silently
+            log.write(f"[red]Unexpected wizard error: {exc}[/]")
+        finally:
             self._finish_with_close_button()
-            return
-        await self._run_init()
 
     def _existing_project_yaml_path(self) -> Path | None:
         """Return the on-disk ``project.yml`` path if it already exists, else None."""
@@ -561,7 +587,6 @@ class InitProgressScreen(ModalScreen[InitOutcome]):
 
         from terok.lib.core.projects import load_project
         from terok.lib.domain.facade import (
-            build_images,
             generate_dockerfiles,
             make_git_gate,
             provision_ssh_key,
@@ -579,7 +604,10 @@ class InitProgressScreen(ModalScreen[InitOutcome]):
             log.write(f"[green]✓[/] SSH key minted: {result['comment']}")
 
             if project_needs_key_registration(self._project_id):
-                self.query_one("#wizard-init-ssh-pubkey", TextArea).text = result["public_line"]
+                self.query_one("#wizard-init-ssh-pubkey", Static).update(result["public_line"])
+                # Stash for the Copy button handler — Static doesn't keep
+                # the raw text the way TextArea.text does.
+                self._ssh_pub_line = result["public_line"]
                 self.query_one("#wizard-init-ssh-key").styles.display = "block"
                 log.write(
                     "[yellow]Register the public key on the git remote, then click Continue.[/]"
@@ -600,13 +628,20 @@ class InitProgressScreen(ModalScreen[InitOutcome]):
                 await asyncio.to_thread(generate_dockerfiles, self._project_id)
             self._mark("generate", "done")
 
-            # Step 3: Build
+            # Step 3: Build.  ``build_images`` invokes ``podman build``
+            # subprocesses that inherit terok's stdout/stderr file
+            # descriptors; left alone, their raw output *corrupts the
+            # TUI frame* (colour codes, cursor moves, et al.).  Redirect
+            # fd 1 and 2 to /dev/null for the duration of the build so
+            # the TUI keeps rendering cleanly.  A proper log-tailer
+            # widget that streams subprocess output into this pane is
+            # tracked in issue #473.
             self._mark("build", "running", "this can take several minutes")
             log.write(
-                "[dim]Running image build in the background — podman's output goes to the "
-                "terminal that launched terok, not this pane.[/]"
+                "[dim]Running image build (output suppressed to keep the TUI intact; "
+                "watch `podman images` or see #473 for the planned log-tailer widget).[/]"
             )
-            await asyncio.to_thread(build_images, self._project_id)
+            await asyncio.to_thread(_build_with_silenced_fds, self._project_id)
             self._mark("build", "done")
 
             # Step 4: Gate sync — load_project to read gate_enabled
@@ -644,8 +679,10 @@ class InitProgressScreen(ModalScreen[InitOutcome]):
                 if "⋯" in str(widget.renderable):
                     self._mark(key, "failed", str(exc))
                     break
-        finally:
-            self._finish_with_close_button()
+        # Close-button enabling is consolidated in the outer
+        # ``_run_init_with_confirm`` finally — keeping it there prevents
+        # the button from flashing enabled then disabled between the
+        # two coroutines.
 
     # ── Button handlers ───────────────────────────────────────────────
 
@@ -653,6 +690,25 @@ class InitProgressScreen(ModalScreen[InitOutcome]):
     def _on_ssh_continue(self) -> None:
         if self._ssh_continue is not None:
             self._ssh_continue.set()
+
+    @on(Button.Pressed, "#wizard-init-ssh-copy")
+    def _on_ssh_copy(self) -> None:
+        """Copy the SSH public key to the system clipboard via the shared helper."""
+        from .clipboard import copy_to_clipboard_detailed
+
+        key = getattr(self, "_ssh_pub_line", "")
+        if not key:
+            return
+        result = copy_to_clipboard_detailed(key)
+        if result.ok:
+            self.notify("SSH public key copied to clipboard.")
+        else:
+            hint = result.hint or result.error or "no clipboard helper found"
+            self.notify(
+                f"Copy failed: {hint}",
+                severity="warning",
+                timeout=10,
+            )
 
     @on(Button.Pressed, "#wizard-init-close")
     def _on_close(self) -> None:
@@ -685,3 +741,34 @@ def _log_capture(log: RichLog):
             text = buffer.getvalue().rstrip()
             if text:
                 log.write(text)
+
+
+def _build_with_silenced_fds(project_id: str) -> None:
+    """Call :func:`build_images` with fd 1/2 redirected to ``/dev/null``.
+
+    ``build_images`` delegates to ``podman build`` via ``subprocess.run``
+    without ``capture_output``; the subprocess inherits the parent's
+    stdout/stderr file descriptors and writes TTY escape sequences that
+    scramble the Textual frame.  Redirecting at the fd level is the
+    minimum-viable fix for v1 — the trade-off is that build progress
+    stops being visible during the wizard's init step.  Users who want
+    the raw output can still run ``terok project init`` from the CLI,
+    and the proper log-tailer widget (issue #473) will reclaim it.
+    """
+    import os
+
+    from ..lib.domain.facade import build_images
+
+    devnull_fd = os.open(os.devnull, os.O_WRONLY)
+    saved_out = os.dup(1)
+    saved_err = os.dup(2)
+    try:
+        os.dup2(devnull_fd, 1)
+        os.dup2(devnull_fd, 2)
+        build_images(project_id)
+    finally:
+        os.dup2(saved_out, 1)
+        os.dup2(saved_err, 2)
+        os.close(saved_out)
+        os.close(saved_err)
+        os.close(devnull_fd)

--- a/src/terok/tui/wizard_screens.py
+++ b/src/terok/tui/wizard_screens.py
@@ -629,19 +629,21 @@ class InitProgressScreen(ModalScreen[InitOutcome]):
             self._mark("generate", "done")
 
             # Step 3: Build.  ``build_images`` invokes ``podman build``
-            # subprocesses that inherit terok's stdout/stderr file
+            # subprocesses that inherit the caller's stdout/stderr file
             # descriptors; left alone, their raw output *corrupts the
-            # TUI frame* (colour codes, cursor moves, et al.).  Redirect
-            # fd 1 and 2 to /dev/null for the duration of the build so
-            # the TUI keeps rendering cleanly.  A proper log-tailer
-            # widget that streams subprocess output into this pane is
-            # tracked in issue #473.
+            # TUI frame* (colour codes, cursor moves, et al.).  We run
+            # the whole build in a fresh Python subprocess whose fds
+            # are captured by ``subprocess.run`` — parent-side fds stay
+            # untouched no matter what the build crashes on.  A proper
+            # log-tailer widget that streams subprocess output into
+            # this pane is tracked in issue #473.
             self._mark("build", "running", "this can take several minutes")
             log.write(
-                "[dim]Running image build (output suppressed to keep the TUI intact; "
-                "watch `podman images` or see #473 for the planned log-tailer widget).[/]"
+                "[dim]Running image build in a subprocess (output suppressed to keep "
+                "the TUI intact; watch `podman images`, or see #473 for the planned "
+                "log-tailer widget).[/]"
             )
-            await asyncio.to_thread(_build_with_silenced_fds, self._project_id)
+            await asyncio.to_thread(_build_in_subprocess, self._project_id)
             self._mark("build", "done")
 
             # Step 4: Gate sync — load_project to read gate_enabled
@@ -743,32 +745,33 @@ def _log_capture(log: RichLog):
                 log.write(text)
 
 
-def _build_with_silenced_fds(project_id: str) -> None:
-    """Call :func:`build_images` with fd 1/2 redirected to ``/dev/null``.
+def _build_in_subprocess(project_id: str) -> None:
+    """Run :func:`build_images` in a child Python process.
 
-    ``build_images`` delegates to ``podman build`` via ``subprocess.run``
-    without ``capture_output``; the subprocess inherits the parent's
-    stdout/stderr file descriptors and writes TTY escape sequences that
-    scramble the Textual frame.  Redirecting at the fd level is the
-    minimum-viable fix for v1 — the trade-off is that build progress
-    stops being visible during the wizard's init step.  Users who want
-    the raw output can still run ``terok project init`` from the CLI,
-    and the proper log-tailer widget (issue #473) will reclaim it.
+    Isolating the build in a subprocess is the robust way to keep
+    ``podman build``'s inherited stdout/stderr from scrambling the
+    Textual frame: the child gets its own fds, ``capture_output``
+    swallows them, and the parent's terminal is untouched regardless
+    of what the build prints (or crashes with).
+
+    Any non-zero exit propagates as ``RuntimeError`` carrying the last
+    few KiB of the child's stderr, which the wizard's worker already
+    logs as the failed-step's detail.  Proper streaming (subprocess
+    stdout → RichLog via a reader thread) is tracked in issue #473 —
+    this is the minimum-viable isolation, not the final UX.
     """
-    import os
+    import subprocess  # noqa: S404 — launching a known python interpreter with fixed argv
+    import sys
 
-    from ..lib.domain.facade import build_images
-
-    devnull_fd = os.open(os.devnull, os.O_WRONLY)
-    saved_out = os.dup(1)
-    saved_err = os.dup(2)
-    try:
-        os.dup2(devnull_fd, 1)
-        os.dup2(devnull_fd, 2)
-        build_images(project_id)
-    finally:
-        os.dup2(saved_out, 1)
-        os.dup2(saved_err, 2)
-        os.close(saved_out)
-        os.close(saved_err)
-        os.close(devnull_fd)
+    # Literal repr keeps project_id safely escaped into the -c body.
+    child_body = f"from terok.lib.domain.facade import build_images; build_images({project_id!r})"
+    result = subprocess.run(  # noqa: S603 — argv is sys.executable + -c + terok code we control
+        [sys.executable, "-c", child_body],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        tail = (result.stderr or result.stdout or "").strip().splitlines()
+        snippet = "\n".join(tail[-20:]) if tail else "(no output)"
+        raise RuntimeError(f"build_images exited with code {result.returncode}:\n{snippet}")

--- a/tests/unit/lib/test_projects.py
+++ b/tests/unit/lib/test_projects.py
@@ -270,6 +270,27 @@ class TestProject:
             with pytest.raises(SystemExit, match="Failed to read"):
                 load_project("bad-yaml")
 
+    def test_load_project_catches_non_yaml_exceptions(self) -> None:
+        """Parser internal crashes (e.g. ruamel.yaml ``IndexError``) become SystemExit.
+
+        Users have tripped ruamel.yaml's scanner into ``IndexError`` with
+        inputs that *look* syntactically valid but hit a reader edge
+        case.  Without a broad catch, the exception would bubble all the
+        way up to the Textual keypress handler and take down the TUI —
+        instead the file becomes a "broken project" visible in the list.
+        """
+        import terok.lib.core.projects as projects_mod
+
+        def _raise_index_error(text: str) -> object:
+            raise IndexError("string index out of range")
+
+        with project_env(project_yaml("weird"), project_id="weird"):
+            with unittest.mock.patch.object(
+                projects_mod, "_yaml_load", side_effect=_raise_index_error
+            ):
+                with pytest.raises(SystemExit, match="Failed to read"):
+                    load_project("weird")
+
     @pytest.mark.parametrize(
         ("project_id", "yaml_text", "expected"),
         [

--- a/tests/unit/lib/test_projects.py
+++ b/tests/unit/lib/test_projects.py
@@ -278,6 +278,11 @@ class TestProject:
         case.  Without a broad catch, the exception would bubble all the
         way up to the Textual keypress handler and take down the TUI —
         instead the file becomes a "broken project" visible in the list.
+
+        The assertion checks the *full* shape of the surfaced message
+        — the "Failed to read" prefix **and** the original exception's
+        type and details — so future refactors can't silently drop the
+        parser diagnostics on the floor.
         """
         import terok.lib.core.projects as projects_mod
 
@@ -288,8 +293,15 @@ class TestProject:
             with unittest.mock.patch.object(
                 projects_mod, "_yaml_load", side_effect=_raise_index_error
             ):
-                with pytest.raises(SystemExit, match="Failed to read"):
+                with pytest.raises(SystemExit) as exc_info:
                     load_project("weird")
+        message = str(exc_info.value)
+        assert "Failed to read" in message
+        assert "IndexError" in message
+        assert "string index out of range" in message
+        # Chained cause is preserved so `__cause__` gives debuggers the
+        # full traceback of the underlying scanner crash.
+        assert isinstance(exc_info.value.__cause__, IndexError)
 
     @pytest.mark.parametrize(
         ("project_id", "yaml_text", "expected"),


### PR DESCRIPTION
## Field report from master

After #797 landed, real-world use turned up a cluster of bugs.  Fixes are generalisable, not one-offs.

### 1. Wizard silent failure (the critical one)

**Symptom:** click Initialize on the review screen → back to the main screen, no error, no project written.  Second attempt refuses every project ID as "must start with lowercase" even on valid input.  Restart fixes it.

**Cause:** both ``_run_wizard_flow`` and ``_run_init_with_confirm`` were decorated ``@work(exclusive=True)`` with the default ``group="default"``.  ``exclusive=True`` cancels every running worker in the same group — so the moment ``InitProgressScreen.on_mount`` kicked off the init worker, it cancelled *its own parent*.  The parent's ``push_screen_wait`` unwound mid-await, the modal popped, and the user landed on a stale widget state the next wizard picked up piecemeal.

**Fix:** distinct groups — ``wizard-flow`` for the outer orchestrator, ``wizard-init`` for the inner worker.  Both get ``exit_on_error=False`` plus a try/except safety net that surfaces any remaining exception as a TUI notification, so the next silent-fail class is caught and named.

### 2. ``project.yml`` load crashes the TUI on ``ruamel.yaml`` internal bugs

**Symptom:** pressing arrow-up in the project list killed terok with an ``IndexError: string index out of range`` from ``ruamel.yaml.reader.peek``.  User correctly flagged: \"we had similar issues before — these must be solved in a generally robust way.\"

**Cause:** ``_parse_project_yaml`` caught only ``(OSError, UnicodeDecodeError, YAMLError)``.  ruamel.yaml can raise arbitrary exceptions for edge-case inputs — ``IndexError`` from the scanner, ``AttributeError`` mid-compose, etc.  Anything outside the narrow catch escaped to the Textual keypress handler and took the whole TUI down.

**Fix:** widen the catch to ``Exception`` with a preserved cause chain.  Any per-file crash becomes a single ``SystemExit`` the existing ``discover_projects`` turns into a \"broken project\" row — the TUI keeps running, the damaged project is visible, the user can fix it.  Same treatment applied to the pydantic validation path defensively.

### 3. SSH pubkey copy/paste

**Symptom:** the pubkey ``TextArea`` in the init screen fought both the Textual copy action and the terminal's mouse selection (which picked up modal border chars).

**Fix:** replaced ``TextArea`` with a plain ``Static`` (selectable, no gutter/cursor) plus a ``Copy`` button routing through the existing ``copy_to_clipboard_detailed`` helper.  Either path works cleanly.

### 4. Image build scrambles the TUI frame

**Symptom:** the build step's ``podman build`` output bled through the Textual render.

**Cause:** ``build_images`` shells out without ``capture_output``; the subprocess inherits terok's stdout/stderr file descriptors.

**Fix:** a ``_build_with_silenced_fds`` helper redirects fd 1/2 to ``/dev/null`` around the build call.  Trade-off: wizard users don't see the raw build progress.  The proper streaming widget (subprocess pipe + RichLog) is #473.

### 5. Safety net around ``_run_init_with_confirm``

Added an outer try/except that always enables the Close button in ``finally``.  A user cannot end up staring at a frozen modal.  The inner ``_run_init``'s redundant ``finally`` was removed — button state lives in one place now.

## Known issues *not* addressed here

- **Project doesn't appear until TUI restart** — should be fixed as a side-effect of the worker-group fix (the ``refresh_projects`` call at the end of ``_run_wizard_flow`` was never reached because the worker had been cancelled).  Manual smoke welcome.
- **``~/.local/share/terok/terok.log`` shows up in wrong location** — pre-existing bug: ``state_root()`` and ``state_dir()`` honour the env override but not the ``config.yml`` root setting.  Orthogonal; not touched here.

## Test plan

- [x] New ``test_load_project_catches_non_yaml_exceptions`` covers the ``IndexError``-from-scanner path, asserting it's converted to ``SystemExit``.
- [x] Existing wizard suite (Pilot-driven) still passes.
- [x] 2106 unit tests pass; lint / tach / lint-imports / docstrings / reuse / security all clean.
- [ ] Manual smoke on the user's machine — required to confirm the silent-failure and arrow-up-crash fixes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Copy button for SSH public key display in the setup wizard.

* **Bug Fixes**
  * Improved user-facing error notifications when wizard steps fail.
  * Prevented build output from disrupting the UI during image builds.
  * Strengthened project file parsing to surface unexpected parser errors clearly.

* **Tests**
  * Added a unit test ensuring parser crashes are reported as user-visible errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->