### PR TITLE
fix(tui): slugify project IDs, wrap errors, isolate gate sync

### DIFF
--- a/src/terok/lib/domain/wizards/new_project.py
+++ b/src/terok/lib/domain/wizards/new_project.py
@@ -21,6 +21,7 @@ the TUI presenter lives in :mod:`terok.tui.wizard_screens`.
 
 from __future__ import annotations
 
+import re
 import sys
 import tempfile
 from collections.abc import Callable
@@ -115,6 +116,29 @@ def _validate_project_id(project_id: str) -> str | None:
     return None
 
 
+_SLUG_ALLOWED = re.compile(r"[a-z0-9_-]+")
+_SLUG_RUNS = re.compile(r"-{2,}")
+
+
+def _slugify_project_id(raw: str) -> str:
+    """Best-effort-normalise *raw* into a valid project ID.
+
+    Meets users halfway: ``"terok pages"`` → ``"terok-pages"`` rather than
+    bouncing them back with a regex error.  Drops characters outside the
+    project-ID alphabet (``[a-z0-9_-]``), collapses runs of hyphens, and
+    strips leading/trailing punctuation.  When the input is already
+    hopeless (e.g. ``"!!!"``) the result is empty and validation gives
+    the user the usual "must start with a lowercase letter…" message.
+    """
+    lowered = raw.casefold()
+    # Whitespace → single hyphen before dropping out-of-alphabet chars so
+    # word boundaries survive ("terok pages" shouldn't glue into "terokpages").
+    hyphenated = re.sub(r"\s+", "-", lowered)
+    kept = "".join(_SLUG_ALLOWED.findall(hyphenated))
+    collapsed = _SLUG_RUNS.sub("-", kept)
+    return collapsed.strip("-_")
+
+
 QUESTIONS: tuple[Question, ...] = (
     Question(
         key="security_class",
@@ -135,7 +159,7 @@ QUESTIONS: tuple[Question, ...] = (
         kind="text",
         prompt="Project ID",
         required=True,
-        transform=str.lower,
+        transform=_slugify_project_id,
         validate=_validate_project_id,
         placeholder="lowercase; letters, digits, hyphens, underscores",
     ),
@@ -316,10 +340,10 @@ def collect_wizard_inputs() -> dict | None:
                     return None
                 value, error = validate_answer(question, raw)
                 if error is None:
-                    if question.transform and value != raw:
+                    if question.transform and value != raw.strip():
                         # Surface the normalisation so the user sees *what*
-                        # their answer became (e.g. uppercase → lowercase).
-                        print(f"Note: {question.prompt.lower()} lowercased to '{value}'")
+                        # their answer became (e.g. ``"My Proj"`` → ``"my-proj"``).
+                        print(f"Note: {question.prompt.lower()} normalised to '{value}'")
                     values[question.key] = value
                     break
                 print(error, file=sys.stderr)

--- a/src/terok/tui/wizard_screens.py
+++ b/src/terok/tui/wizard_screens.py
@@ -84,10 +84,12 @@ class WizardFormScreen(ModalScreen["dict[str, str] | None"]):
 
     .wizard-help {
         color: $text-muted;
+        height: auto;
     }
 
     .wizard-error {
         color: $error;
+        height: auto;
     }
 
     #wizard-form-buttons {
@@ -382,6 +384,20 @@ class InitProgressScreen(ModalScreen[InitOutcome]):
         display: none;
     }
 
+    .wizard-init-ssh-spacer {
+        height: 1;
+    }
+
+    #wizard-init-ssh-pubkey {
+        color: $accent;
+        height: auto;
+    }
+
+    #wizard-init-ssh-fingerprint {
+        color: $text-muted;
+        height: auto;
+    }
+
     #wizard-init-buttons {
         height: auto;
         align-horizontal: right;
@@ -429,10 +445,16 @@ class InitProgressScreen(ModalScreen[InitOutcome]):
             # plain text without the editor's line-number gutter or
             # cursor — copying from the terminal's mouse works cleanly,
             # and the "Copy" button bypasses that path entirely via the
-            # shared clipboard helper.
+            # shared clipboard helper.  The fingerprint is shown
+            # alongside the key so the user can verify what GitHub etc.
+            # will display *after* they paste the key — the comparison
+            # has to be possible with both halves on screen at once.
             with Vertical(id="wizard-init-ssh-key"):
                 yield Label("SSH public key — register this on your git remote:")
+                yield Static("", classes="wizard-init-ssh-spacer")
                 yield Static("", id="wizard-init-ssh-pubkey")
+                yield Static("", classes="wizard-init-ssh-spacer")
+                yield Static("", id="wizard-init-ssh-fingerprint")
                 with Horizontal(id="wizard-init-ssh-buttons"):
                     yield Button(
                         "Copy",
@@ -588,7 +610,6 @@ class InitProgressScreen(ModalScreen[InitOutcome]):
         from terok.lib.core.projects import load_project
         from terok.lib.domain.facade import (
             generate_dockerfiles,
-            make_git_gate,
             provision_ssh_key,
             summarize_ssh_init,
         )
@@ -605,6 +626,13 @@ class InitProgressScreen(ModalScreen[InitOutcome]):
 
             if project_needs_key_registration(self._project_id):
                 self.query_one("#wizard-init-ssh-pubkey", Static).update(result["public_line"])
+                # Show the fingerprint beside the key so the user can
+                # check it matches what their remote (e.g. GitHub) shows
+                # *after* pasting — by then the pubkey is already gone
+                # from that page and only the SHA256 digest remains.
+                self.query_one("#wizard-init-ssh-fingerprint", Static).update(
+                    f"Fingerprint: {result['fingerprint']}  ·  Comment: {result['comment']}"
+                )
                 # Stash for the Copy button handler — Static doesn't keep
                 # the raw text the way TextArea.text does.
                 self._ssh_pub_line = result["public_line"]
@@ -646,14 +674,17 @@ class InitProgressScreen(ModalScreen[InitOutcome]):
             await asyncio.to_thread(_build_in_subprocess, self._project_id)
             self._mark("build", "done")
 
-            # Step 4: Gate sync — load_project to read gate_enabled
+            # Step 4: Gate sync — load_project to read gate_enabled.
+            # Sync itself runs in a subprocess for the same reason as
+            # the build: ``git clone --mirror`` and friends inherit
+            # stdout/stderr and would otherwise overwrite the TUI frame.
             project = load_project(self._project_id)
             if not project.gate_enabled:
                 self._mark("gate", "skipped", "gate.enabled: false")
                 log.write("[dim]Gate disabled in project.yml — skipping gate-sync.[/]")
             else:
                 self._mark("gate", "running")
-                res = await asyncio.to_thread(lambda: make_git_gate(project).sync())
+                res = await asyncio.to_thread(_gate_sync_in_subprocess, self._project_id)
                 if res["success"]:
                     upstream_hint = (
                         f"upstream {res['upstream_url']}"
@@ -745,26 +776,31 @@ def _log_capture(log: RichLog):
                 log.write(text)
 
 
-def _build_in_subprocess(project_id: str) -> None:
-    """Run :func:`build_images` in a child Python process.
+def _run_isolated(child_body: str, *, label: str) -> None:
+    """Run *child_body* as a ``python -c`` subprocess with captured fds.
 
-    Isolating the build in a subprocess is the robust way to keep
-    ``podman build``'s inherited stdout/stderr from scrambling the
-    Textual frame: the child gets its own fds, ``capture_output``
-    swallows them, and the parent's terminal is untouched regardless
-    of what the build prints (or crashes with).
+    Several init steps shell out to long-running commands (``podman
+    build``, ``git clone --mirror``) that inherit the caller's
+    stdout/stderr file descriptors.  Left alone, their raw output
+    *corrupts the TUI frame* — colour codes, cursor moves, and progress
+    bars land directly on the terminal underneath Textual.  Running the
+    whole step in a child Python process moves those fds one layer
+    away: ``capture_output=True`` swallows them, and the parent's
+    terminal stays pristine regardless of what the step prints or
+    crashes with.
 
-    Any non-zero exit propagates as ``RuntimeError`` carrying the last
-    few KiB of the child's stderr, which the wizard's worker already
-    logs as the failed-step's detail.  Proper streaming (subprocess
-    stdout → RichLog via a reader thread) is tracked in issue #473 —
-    this is the minimum-viable isolation, not the final UX.
+    *label* is the human-friendly step name used in the error message.
+    Any non-zero exit propagates as :class:`RuntimeError` carrying the
+    last few KiB of the child's combined output, which the wizard's
+    worker already logs as the failed step's detail.
+
+    Proper streaming (subprocess output → ``RichLog`` via a reader
+    thread) is tracked in issue #473 — this is the minimum-viable
+    isolation, not the final UX.
     """
     import subprocess  # noqa: S404 — launching a known python interpreter with fixed argv
     import sys
 
-    # Literal repr keeps project_id safely escaped into the -c body.
-    child_body = f"from terok.lib.domain.facade import build_images; build_images({project_id!r})"
     result = subprocess.run(  # noqa: S603 — argv is sys.executable + -c + terok code we control
         [sys.executable, "-c", child_body],
         capture_output=True,
@@ -774,4 +810,39 @@ def _build_in_subprocess(project_id: str) -> None:
     if result.returncode != 0:
         tail = (result.stderr or result.stdout or "").strip().splitlines()
         snippet = "\n".join(tail[-20:]) if tail else "(no output)"
-        raise RuntimeError(f"build_images exited with code {result.returncode}:\n{snippet}")
+        raise RuntimeError(f"{label} exited with code {result.returncode}:\n{snippet}")
+
+
+def _build_in_subprocess(project_id: str) -> None:
+    """Run :func:`build_images` in a child Python process."""
+    # Literal repr keeps project_id safely escaped into the -c body.
+    child_body = f"from terok.lib.domain.facade import build_images; build_images({project_id!r})"
+    _run_isolated(child_body, label="build_images")
+
+
+def _gate_sync_in_subprocess(project_id: str) -> dict[str, Any]:
+    """Run the gate sync in a child Python process and return its result dict.
+
+    The result dict is serialised to a tempfile (rather than captured
+    stdout) so any ``git`` progress noise can't be mistaken for the
+    payload.  The tempfile is cleaned up regardless of subprocess
+    outcome.
+    """
+    import json
+    import tempfile
+
+    with tempfile.NamedTemporaryFile(suffix=".json", prefix="terok-gate-sync-", delete=False) as f:
+        result_path = Path(f.name)
+    try:
+        child_body = (
+            "import json\n"
+            "from terok.lib.core.projects import load_project\n"
+            "from terok.lib.domain.facade import make_git_gate\n"
+            f"_project = load_project({project_id!r})\n"
+            "_result = make_git_gate(_project).sync()\n"
+            f"json.dump(_result, open({str(result_path)!r}, 'w'))\n"
+        )
+        _run_isolated(child_body, label="gate sync")
+        return json.loads(result_path.read_text(encoding="utf-8"))
+    finally:
+        result_path.unlink(missing_ok=True)

--- a/tests/unit/lib/test_wizard.py
+++ b/tests/unit/lib/test_wizard.py
@@ -16,6 +16,7 @@ from terok.lib.domain.wizards.new_project import (
     QUESTIONS,
     SECURITY_CLASSES,
     Question,
+    _slugify_project_id,
     _validate_project_id,
     collect_wizard_inputs,
     generate_config,
@@ -108,7 +109,7 @@ def test_validate_project_id(project_id: str, valid: bool) -> None:
             id="custom-branch",
         ),
         pytest.param(
-            ["1", "1", "bad project", "good-id", "https://example.com/r.git", "main", "n"],
+            ["1", "1", "!!!", "good-id", "https://example.com/r.git", "main", "n"],
             wizard_values(project_id="good-id", upstream_url="https://example.com/r.git"),
             id="retry-invalid-project-id",
         ),
@@ -149,7 +150,7 @@ def test_collect_wizard_inputs_cancellation_paths(
 
 
 def test_collect_wizard_inputs_lowercases_project_id() -> None:
-    """Uppercase project IDs are lowercased with a friendly note."""
+    """Uppercase project IDs are normalised with a friendly note."""
     with (
         patch(
             "builtins.input",
@@ -161,7 +162,26 @@ def test_collect_wizard_inputs_lowercases_project_id() -> None:
 
     assert result == wizard_values(project_id="myproject", upstream_url="https://example.com/r.git")
     printed = [" ".join(str(arg) for arg in call.args) for call in mock_print.call_args_list]
-    assert any("lowercased to 'myproject'" in line for line in printed)
+    assert any("normalised to 'myproject'" in line for line in printed)
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        pytest.param("terok", "terok", id="already-valid-passthrough"),
+        pytest.param("My Project", "my-project", id="spaces-to-hyphens"),
+        pytest.param("MyProject", "myproject", id="camelcase-lowercased"),
+        pytest.param("proj!!@#", "proj", id="special-chars-dropped"),
+        pytest.param("foo   ---   bar", "foo-bar", id="runs-collapsed"),
+        pytest.param("   edgy   ", "edgy", id="surrounding-whitespace-stripped"),
+        pytest.param("-_proj_-", "proj", id="leading-and-trailing-punctuation-trimmed"),
+        pytest.param("!!!", "", id="nothing-salvageable"),
+        pytest.param("terok pages", "terok-pages", id="the-field-report-case"),
+    ],
+)
+def test_slugify_project_id(raw: str, expected: str) -> None:
+    """``_slugify_project_id`` meets users halfway without silently mangling intent."""
+    assert _slugify_project_id(raw) == expected
 
 
 def generate_into_tmp(values: dict[str, object]) -> tuple[str, str, str]:
@@ -396,15 +416,29 @@ class TestValidateAnswer:
         assert err is None
 
     def test_transform_runs_before_validation(self) -> None:
-        """str.lower on project_id normalises before the regex check fires."""
+        """Slugify + lowercase on project_id normalises before the regex check fires."""
         value, err = validate_answer(_q("project_id"), "MyProject")
         assert value == "myproject"
         assert err is None
 
+    def test_transform_slugifies_spaces_and_specials(self) -> None:
+        """Whitespace turns into hyphens and stray punctuation is dropped."""
+        value, err = validate_answer(_q("project_id"), "My Fancy Project!!")
+        assert value == "my-fancy-project"
+        assert err is None
+
+    def test_transform_collapses_hyphen_runs(self) -> None:
+        """Consecutive delimiters collapse into one hyphen."""
+        value, err = validate_answer(_q("project_id"), "foo   ---   bar")
+        assert value == "foo-bar"
+        assert err is None
+
     def test_validator_surfaces_error(self) -> None:
-        """The project-id validator rejects malformed slugs verbatim."""
-        value, err = validate_answer(_q("project_id"), "has spaces")
+        """A slug that can't be salvaged by slugification surfaces the regex error."""
+        # Only punctuation — nothing in the allowed alphabet survives.
+        value, err = validate_answer(_q("project_id"), "!!!")
         assert err is not None
+        assert "Invalid project ID" in err or "required" in err
 
     def test_editor_kind_accepts_arbitrary_text(self) -> None:
         """Editor-style questions have no validator; any string goes through."""

--- a/tests/unit/tui/test_wizard_screens.py
+++ b/tests/unit/tui/test_wizard_screens.py
@@ -18,7 +18,7 @@ from unittest.mock import patch
 
 import pytest
 from textual.app import App
-from textual.widgets import Input, Label, RadioButton, RadioSet, TextArea
+from textual.widgets import Input, Label, RadioButton, RadioSet, Static, TextArea
 
 from terok.lib.domain.wizards.new_project import QUESTIONS, Question
 from terok.tui.wizard_screens import ProjectReviewScreen, WizardFormScreen
@@ -325,3 +325,105 @@ async def test_form_prefill_populates_widgets() -> None:
         pressed = sec_rs.pressed_button
         assert pressed is not None
         assert pressed.name == initial["security_class"]
+
+
+# ── Subprocess isolation helpers ──────────────────────────────────────
+
+
+def test_run_isolated_propagates_nonzero_as_runtime_error() -> None:
+    """A crashing child surfaces its stderr tail in the raised message."""
+    from terok.tui.wizard_screens import _run_isolated
+
+    with pytest.raises(RuntimeError) as excinfo:
+        _run_isolated(
+            "import sys; sys.stderr.write('kaboom\\n'); sys.exit(3)",
+            label="toy step",
+        )
+    msg = str(excinfo.value)
+    assert "toy step exited with code 3" in msg
+    assert "kaboom" in msg
+
+
+def test_gate_sync_in_subprocess_returns_result_dict() -> None:
+    """The helper shuttles the child's result dict back to the parent verbatim.
+
+    We patch the facade's ``make_git_gate`` inside the *child* process by
+    pre-seeding a ``conftest``-style sitecustomize — not worth the
+    trouble.  Instead, we verify the helper's tempfile-roundtrip path
+    with a trivial child body that writes a known dict to the result
+    file directly.
+    """
+    from unittest.mock import patch as upatch
+
+    from terok.tui.wizard_screens import _gate_sync_in_subprocess
+
+    sentinel = {"success": True, "upstream_url": "https://example.com/r.git", "errors": []}
+
+    def _fake_run_isolated(body: str, *, label: str) -> None:  # noqa: ARG001
+        # Extract the result path from the body — it's the last argument
+        # passed to ``open(...)``.
+        import json
+        import re
+
+        match = re.search(r"open\((['\"])(?P<p>[^'\"]+)\1, 'w'\)", body)
+        assert match, f"body missing result path: {body!r}"
+        Path(match.group("p")).write_text(json.dumps(sentinel), encoding="utf-8")
+
+    with upatch("terok.tui.wizard_screens._run_isolated", side_effect=_fake_run_isolated):
+        assert _gate_sync_in_subprocess("demo") == sentinel
+
+
+# ── SSH fingerprint display ───────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_ssh_panel_shows_fingerprint_alongside_pubkey() -> None:
+    """When the ssh panel pops up, fingerprint + comment render beside the pubkey.
+
+    GitHub and friends only show the SHA256 fingerprint on the deploy
+    key settings page once the key is pasted — by then the raw pubkey
+    is hidden.  Displaying the fingerprint at mint time is what lets
+    the user verify they registered the right key.
+    """
+    import asyncio as _asyncio
+
+    from terok.tui.wizard_screens import InitProgressScreen
+
+    # Stub every downstream step so ``_run_init`` gets as far as
+    # populating the SSH panel, then parks on ``_ssh_continue``.
+    minted = {
+        "key_id": 42,
+        "key_type": "ed25519",
+        "fingerprint": "SHA256:abcdefGHIJKLmnop1234567890",
+        "comment": "terok@demo",
+        "public_line": "ssh-ed25519 AAAAFAKE terok@demo",
+    }
+    app = _WizardHost(InitProgressScreen("demo", "project:\n  id: demo\n"))
+    with (
+        patch.object(InitProgressScreen, "_existing_project_yaml_path", return_value=None),
+        patch("terok.tui.wizard_screens.write_project_yaml"),
+        patch("terok.tui.wizard_screens.project_needs_key_registration", return_value=True),
+        patch("terok.lib.domain.facade.provision_ssh_key", return_value=minted),
+        patch("terok.lib.domain.facade.summarize_ssh_init"),
+    ):
+        async with app.run_test() as pilot:
+            # Give the worker a chance to reach the ssh_continue wait.
+            for _ in range(20):
+                await pilot.pause()
+                await _asyncio.sleep(0)
+                screen = app.screen
+                if not isinstance(screen, InitProgressScreen):
+                    break
+                panel = screen.query_one("#wizard-init-ssh-key")
+                if panel.styles.display == "block":
+                    break
+            screen = app.screen
+            assert isinstance(screen, InitProgressScreen)
+            pubkey = screen.query_one("#wizard-init-ssh-pubkey", Static)
+            fingerprint = screen.query_one("#wizard-init-ssh-fingerprint", Static)
+            assert minted["public_line"] in str(pubkey.render())
+            assert "SHA256:abcdefGHIJKLmnop1234567890" in str(fingerprint.render())
+            assert "terok@demo" in str(fingerprint.render())
+            # Unblock the worker so the test exits cleanly.
+            screen._ssh_continue.set()
+            await pilot.pause()


### PR DESCRIPTION
## Summary

Four field-report fixes after PR #797 (Textual wizard) and #802 (first round of fixes) landed on master:

- **Wrap validation errors**: long messages like `Invalid project ID 'terok pages': must start with a lowercase letter or digit…` were truncating mid-sentence. `.wizard-error` / `.wizard-help` now use `height: auto` so the label expands and pushes the other form elements down.
- **Slugify project IDs**: `str.lower` transform replaced with `_slugify_project_id` — whitespace becomes hyphens, characters outside `[a-z0-9_-]` drop, hyphen runs collapse. So `"terok pages"` → `"terok-pages"` (no error), while hopeless input like `"!!!"` still falls through to the usual regex message.
- **SSH panel formatting + fingerprint**: blank spacers around the pubkey so it's visually obvious what to copy; the SHA256 fingerprint and key comment render beside the pubkey at mint time. GitHub etc. only show the fingerprint on the deploy-key settings page *after* the key is pasted (the raw pubkey is hidden there) — displaying it now lets the user verify the match.
- **Gate sync frame corruption**: `git clone --mirror` and friends inherit the caller's stdout/stderr and were spewing onto the Textual frame. Gate sync now runs in a Python subprocess with `capture_output=True`, sharing the `_run_isolated` helper with the existing build-in-subprocess path. The step's result dict is shuttled back via a tempfile so `git`'s progress chatter can't be mistaken for the payload.

Fixes tracked alongside the smooth-first-run UX pass.

## Test plan

- [x] `tests/unit/lib/test_wizard.py` — 63 passed (new slugify param tests cover field-report case + edge cases)
- [x] `tests/unit/tui/test_wizard_screens.py` — 16 passed (new tests for `_run_isolated` error propagation, `_gate_sync_in_subprocess` roundtrip, SSH fingerprint render)
- [x] `make lint` / `make tach` / `make lint-imports` / `make docstrings` / `make reuse` / `make security` all clean
- [ ] Manual smoke: fresh project wizard with `"My Project"` → normalises, with `"!!!"` → rejects, SSH panel shows fingerprint + comment, gate sync step doesn't corrupt the frame

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * SSH key fingerprint and metadata now displayed in the initialization wizard for verification
  * Project ID input field now accepts and intelligently normalizes spaces and special characters into valid project IDs

* **Bug Fixes**
  * Gate synchronization and critical operations now execute in isolated subprocesses for improved stability

<!-- end of auto-generated comment: release notes by coderabbit.ai -->