### PR TITLE
fix(ux): OSC 8 hyperlinks for wrapped URLs; clearer web-mode login notice

### DIFF
--- a/src/terok/lib/orchestration/task_runners.py
+++ b/src/terok/lib/orchestration/task_runners.py
@@ -43,6 +43,7 @@ from ..core.task_display import has_gpu
 from ..util.ansi import (
     blue as _blue,
     green as _green,
+    hyperlink as _hyperlink,
     red as _red,
     supports_color as _supports_color,
     yellow as _yellow,
@@ -195,7 +196,7 @@ def _resume_toad_container(
     url = _toad_browser_url(pub_host, saved_port, saved_token)
     if container_state == "running":
         print(f"Container {_green(cname, color_enabled)} is already running.")
-        print(f"Toad: {_blue(url, color_enabled)}")
+        print(f"Toad: {_hyperlink(_blue(url, color_enabled), url, enabled=color_enabled)}")
         return
     print(f"Starting existing container {_green(cname, color_enabled)}...")
     task_dir = project.tasks_root / str(task_id)
@@ -214,7 +215,7 @@ def _resume_toad_container(
     )
     _apply_shield_policy(project, cname, task_dir, is_restart=True)
     print("Container started.")
-    print(f"Toad: {_blue(url, color_enabled)}")
+    print(f"Toad: {_hyperlink(_blue(url, color_enabled), url, enabled=color_enabled)}")
 
 
 @dataclass(frozen=True)
@@ -816,7 +817,7 @@ def task_run_toad(
     print(
         f"\n>> Toad is serving."
         f"\n- Name: {_green(cname, color_enabled)}"
-        f"\n- URL:  {_blue(url, color_enabled)}"
+        f"\n- URL:  {_hyperlink(_blue(url, color_enabled), url, enabled=color_enabled)}"
         f"\n- Logs: {_yellow(f'podman logs -f {cname}', color_enabled)}"
         f"\n- Stop: {_red(f'podman stop {cname}', color_enabled)}"
     )
@@ -1243,7 +1244,8 @@ def task_restart(project_id: str, task_id: str) -> None:
             port = meta.get("web_port")
             token = meta.get("web_token")
             if isinstance(port, int) and isinstance(token, str):
-                print(f"Toad: {_toad_browser_url(get_public_host(), port, token)}")
+                url = _toad_browser_url(get_public_host(), port, token)
+                print(f"Toad: {_hyperlink(_blue(url, color_enabled), url, enabled=color_enabled)}")
     else:
         # Container is gone — restart can't recreate it.  User must start
         # a fresh task with ``task run``.

--- a/src/terok/lib/util/ansi.py
+++ b/src/terok/lib/util/ansi.py
@@ -64,3 +64,30 @@ def green(text: str, enabled: bool) -> str:
 def red(text: str, enabled: bool) -> str:
     """Return *text* in red (ANSI 31) when *enabled*."""
     return color(text, "31", enabled)
+
+
+def hyperlink(text: str, url: str, *, enabled: bool) -> str:
+    """Wrap *text* in an OSC 8 hyperlink to *url*, or return it unchanged.
+
+    Modern terminals (foot, WezTerm, Kitty, GNOME Terminal, iTerm2,
+    foot, Konsole…) recognise the ``\\e]8;id=...;URL\\e\\\\TEXT\\e]8;;\\e\\\\``
+    sequence as a clickable hyperlink — even when the visible text wraps
+    across lines, because the shared ``id=`` attribute tells the
+    terminal that the segments belong to one link.  Without it the
+    terminal's own URL auto-detector kicks in instead, which is
+    single-line-only and tends to slurp adjacent border characters.
+
+    Gated on the same ``enabled`` flag the colour helpers use: a user
+    who set ``NO_COLOR=1`` likely also wants plain output, and most
+    no-colour terminals don't honour OSC 8 either.  Composes cleanly
+    with the colour helpers (``hyperlink(blue(url, c), url, enabled=c)``)
+    because the OSC 8 wrapper sits *outside* the SGR escape.
+    """
+    if not enabled:
+        return text
+    # 32-bit positive id keeps the sequence short and matches what Rich
+    # emits.  ``hash`` mod 2**32 is fine — collisions across links would
+    # only mis-stitch wraps if two different URLs landed in the same
+    # render, which the project never does.
+    link_id = hash(url) & 0xFFFFFFFF
+    return f"\x1b]8;id={link_id};{url}\x1b\\{text}\x1b]8;;\x1b\\"

--- a/src/terok/tui/project_actions.py
+++ b/src/terok/tui/project_actions.py
@@ -149,8 +149,9 @@ class ProjectActionsMixin:
             self.notify(f"{label} in browser: {cname}")
         elif is_web_mode():
             self.notify(
-                f"No terminal available in web mode.  Open a host shell and run: "
-                f"terok login {cname}",
+                f"No terminal available in web mode.  Open a host shell and run "
+                f"`terok login {cname}`, or start a new task in toad mode "
+                f"(toad runs in the browser, no host shell needed).",
                 severity="warning",
                 timeout=15,
             )

--- a/src/terok/tui/widgets/task_detail.py
+++ b/src/terok/tui/widgets/task_detail.py
@@ -35,8 +35,17 @@ def render_task_details(
     css_variables: dict[str, str] | None = None,
     show_workspace: bool = True,
     shield_hooks_ok: bool | None = None,
+    is_web: bool = False,
 ) -> Text:
-    """Render task details as a Rich Text object."""
+    """Render task details as a Rich Text object.
+
+    *is_web* is the caller's ``app.is_web`` — when False (the TUI is
+    running in a real terminal) we emit OSC 8 hyperlinks so wrapped
+    URL lines stay one clickable link.  In web mode we skip OSC 8
+    because xterm.js's link handler shows a "could be dangerous"
+    confirmation dialog for every click; the ``@click`` meta below
+    keeps that path working without the dialog.
+    """
     if task is None:
         return Text(empty_message or "")
 
@@ -73,11 +82,17 @@ def render_task_details(
         # Render the full URL verbatim so users without OSC-8 support
         # (and copy-paste) still get the tokenised URL.
         link_url = f"{base_url}?token={task.web_token}" if task.web_token else base_url
-        # Route clicks through Textual's ``open_url`` action instead of
-        # an OSC-8 hyperlink — xterm.js's OSC handler shows a "could be
-        # dangerous" confirm dialog for every click, but the ``open_url``
-        # meta-message goes straight to ``window.open`` on the client.
+        # ``@click`` meta is the in-Textual click dispatcher — it routes
+        # through ``open_url`` and avoids xterm.js's OSC 8 confirm
+        # dialog when the TUI is served via textual-serve.  Outside web
+        # mode (real terminal underneath) we *also* attach Rich's
+        # ``link=`` so the host terminal sees the OSC 8 hyperlink: with
+        # the shared ``id=`` Rich emits, wrapped URL segments stitch
+        # back into one clickable link instead of breaking at the panel
+        # edge.
         click_style = accent_style + Style.from_meta({"@click": f"open_link({link_url!r})"})
+        if not is_web:
+            click_style = click_style + Style(link=link_url)
         lines.append(Text.assemble("Web URL:   ", Text(link_url, style=click_style)))
     if task.mode == "cli" and project_id:
         lines.append(
@@ -181,6 +196,7 @@ class TaskDetails(Static):
             _get_css_variables(self),
             show_workspace=False,
             shield_hooks_ok=hooks_ok,
+            is_web=bool(self.app and self.app.is_web),
         )
         content.update(rendered)
 

--- a/src/terok/ui_utils/terminal.py
+++ b/src/terok/ui_utils/terminal.py
@@ -14,6 +14,7 @@ from terok.lib.util.ansi import (  # noqa: F401  -- re-exports
     bold,
     color,
     green,
+    hyperlink,
     red,
     supports_color,
     yellow,

--- a/tests/unit/lib/util/test_ansi.py
+++ b/tests/unit/lib/util/test_ansi.py
@@ -1,0 +1,53 @@
+# SPDX-FileCopyrightText: 2026 Jiri Vyskocil
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for ANSI helpers — focused on the OSC 8 hyperlink escape.
+
+The colour helpers (``blue``, ``green`` …) are trivial wrappers around
+:func:`color`; their only logic is the on/off gate.  The hyperlink
+helper is the new, less-obvious one — it produces an OSC 8 sequence
+with a stable ``id=`` so terminals stitch wrapped link segments back
+into one clickable hyperlink.
+"""
+
+from terok.lib.util.ansi import blue, hyperlink
+
+
+def test_hyperlink_disabled_returns_text_unchanged() -> None:
+    """When *enabled* is False the helper is a pass-through — no escapes leak."""
+    assert hyperlink("toad URL", "http://example.com/", enabled=False) == "toad URL"
+
+
+def test_hyperlink_emits_osc8_with_id_and_url() -> None:
+    """Enabled output wraps text in the canonical OSC 8 sequence with an id."""
+    out = hyperlink("click me", "http://example.com/x?y=1", enabled=True)
+    # The opening sequence carries an ``id=`` so wrap-split segments stitch.
+    assert out.startswith("\x1b]8;id=")
+    assert ";http://example.com/x?y=1\x1b\\" in out
+    assert out.endswith("\x1b]8;;\x1b\\")
+    # The visible text sits between the wrappers, untouched.
+    assert "click me" in out
+
+
+def test_hyperlink_id_is_stable_for_same_url() -> None:
+    """Two calls with the same URL produce the same id — so wrap segments link."""
+    a = hyperlink("part 1", "http://example.com/", enabled=True)
+    b = hyperlink("part 2", "http://example.com/", enabled=True)
+    # Both sequences must share the id prefix, otherwise the terminal would
+    # treat the wrapped halves as two separate links.
+    id_a = a.split(";", 2)[1]
+    id_b = b.split(";", 2)[1]
+    assert id_a == id_b
+
+
+def test_hyperlink_composes_with_color() -> None:
+    """OSC 8 wraps *outside* the SGR escape — the colour reset doesn't break the link."""
+    url = "http://example.com/"
+    out = hyperlink(blue("toad URL", True), url, enabled=True)
+    # The OSC 8 brackets sit at the outermost edges; the SGR colour
+    # codes nest inside them — that's the only ordering terminals
+    # accept for a coloured-clickable link.
+    assert out.startswith("\x1b]8;id=")
+    assert out.endswith("\x1b]8;;\x1b\\")
+    assert "\x1b[34m" in out  # blue
+    assert "\x1b[0m" in out  # reset

--- a/tests/unit/tui/test_detail_screens.py
+++ b/tests/unit/tui/test_detail_screens.py
@@ -245,6 +245,39 @@ class TestRenderHelpers:
         text_str = str(result)
         assert "Exit code: 0" in text_str
 
+    def test_web_url_emits_osc8_link_outside_web_mode(self) -> None:
+        """In a real terminal the URL style carries an OSC 8 link for cross-line wrap."""
+        import io
+
+        from rich.console import Console
+
+        widgets = import_widgets()
+        task = make_task(widgets, task_id="42", mode="toad", web_port=8123, web_token="t0k")
+        result = widgets.render_task_details(task, project_id="proj1", is_web=False)
+        # Render to a buffer with ``force_terminal`` so styles serialise
+        # to ANSI; the plain ``str(result)`` projection drops styling.
+        buf = io.StringIO()
+        Console(file=buf, width=80, force_terminal=True, color_system="standard").print(result)
+        ansi = buf.getvalue()
+        assert "\x1b]8;" in ansi  # OSC 8 sequence present
+        assert "id=" in ansi  # shared id for cross-line stitching
+
+    def test_web_url_skips_osc8_when_web_mode(self) -> None:
+        """In web mode (xterm.js) we omit OSC 8 to avoid the dangerous-link dialog."""
+        import io
+
+        from rich.console import Console
+
+        widgets = import_widgets()
+        task = make_task(widgets, task_id="42", mode="toad", web_port=8123, web_token="t0k")
+        result = widgets.render_task_details(task, project_id="proj1", is_web=True)
+        buf = io.StringIO()
+        Console(file=buf, width=80, force_terminal=True, color_system="standard").print(result)
+        ansi = buf.getvalue()
+        assert "\x1b]8;" not in ansi  # no OSC 8 — Textual @click handles the click
+        # The URL itself is still in the rendered text so users can copy it.
+        assert "8123" in ansi
+
     @pytest.mark.parametrize(
         ("overrides", "present", "absent"),
         [


### PR DESCRIPTION
## Summary

Two unrelated polish items from field testing.

### URL wrapping

When a toad URL wraps across terminal lines (narrow window, narrow Textual panel) the terminal's single-line URL auto-detector breaks: only the first line is clickable, and it greedily slurps the trailing panel border too.

Fix: emit OSC 8 hyperlinks (`\e]8;id=…;URL\e\\TEXT\e]8;;\e\\`). The shared `id=` attribute tells terminals that wrapped segments belong to one link, so cross-line clicks work everywhere OSC 8 is supported (foot, WezTerm, Kitty, GNOME Terminal, iTerm2…).

- New `hyperlink` helper in `terok.lib.util.ansi` (re-exported from `ui_utils.terminal`) composes cleanly with the colour helpers: `hyperlink(blue(url, c), url, enabled=c)`. Three CLI toad-URL print sites in `task_runners.py` now use it.
- Textual `task_detail.py` adds Rich's `Style(link=…)` to the URL style — but **only when `app.is_web` is False**. In web mode (textual-serve via xterm.js) we keep just the existing `@click` meta: xterm.js's OSC 8 handler shows a "could be dangerous" confirm dialog for every click, which we originally avoided on purpose. `app.is_web` is the built-in Textual property that delegates to the active driver, so no env sniffing.

### Login notification

Pressing `l` (login) on a CLI-mode task while the TUI is served via terok-web previously surfaced "Open a host shell and run …" as the only path forward. iPad / Chromebook users without easy host shell access were stuck. The notice now also mentions the alternative that *does* work in the browser: a new task in toad mode runs in the browser, no host shell required.

## Test plan

- [x] `tests/unit/lib/util/test_ansi.py` — new (4 tests covering disabled passthrough, OSC 8 shape, stable id across calls, color composition)
- [x] `tests/unit/tui/test_detail_screens.py` — two new tests assert OSC 8 escape is present in the URL render when `is_web=False` and absent when `is_web=True`
- [x] `make lint` / `make tach` / `make lint-imports` / `make docstrings` / `make reuse` / `make security` all clean
- [x] Full unit suite: 2126 passed
- [ ] Manual: paste a long toad URL into a narrow window, confirm cross-line click works in foot/WezTerm/Kitty
- [ ] Manual: confirm xterm.js (terok-web) does NOT show the "dangerous link" dialog when clicking the Web URL in task detail
- [ ] Manual: in web mode, press `l` on a CLI-mode task and confirm the new notice mentions the toad-mode alternative

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Toad serving URLs are now rendered as clickable terminal hyperlinks when color output is enabled.
  * Web-mode fallback messaging now includes an alternative workflow to start a new task in toad mode.

* **Improvements**
  * Enhanced URL rendering behavior to properly differentiate between web and terminal display modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->