### PR TITLE
feat(config): layer ssh.use_personal via ConfigStack

### DIFF
--- a/src/terok/lib/core/projects.py
+++ b/src/terok/lib/core/projects.py
@@ -39,7 +39,7 @@ from .project_model import (  # noqa: F401 — re-exported public API
     is_valid_project_id,
     validate_project_id,
 )
-from .yaml_schema import RawGlobalGitSection, RawProjectYaml
+from .yaml_schema import RawGlobalGitSection, RawProjectYaml, RawSSHSection
 
 logger = logging.getLogger(__name__)
 
@@ -153,6 +153,7 @@ def _resolve_hooks(raw: RawProjectYaml) -> tuple[str | None, str | None, str | N
 def _build_project_config(
     raw: RawProjectYaml,
     identity: dict[str, str | None],
+    ssh_resolved: dict[str, Any],
     root: Path,
     project_id: str,
 ) -> ProjectConfig:
@@ -211,7 +212,10 @@ def _build_project_config(
         gate_path=gate_path,
         gate_enabled=raw.gate.enabled,
         staging_root=staging_root,
-        ssh_use_personal=raw.ssh.use_personal,
+        # ``ssh_resolved`` carries the merged terok-global → project value.
+        # Both layers default to ``None`` (unset), so ``False`` is the
+        # final fallback when neither the user nor the global config opted in.
+        ssh_use_personal=ssh_resolved.get("use_personal") or False,
         expose_external_remote=raw.gatekeeping.expose_external_remote,
         human_name=identity.get("human_name") or "Nobody",
         human_email=identity.get("human_email") or "nobody@localhost",
@@ -479,6 +483,24 @@ def _validated_global_git_section() -> dict[str, Any]:
         return {}
 
 
+def _validated_global_ssh_section() -> dict[str, Any]:
+    """Return the global config ``ssh:`` section, validated through the schema.
+
+    Mirrors :func:`_validated_global_git_section` — same defensive pattern,
+    same fail-soft behaviour: a malformed section logs a warning and is
+    treated as empty, so a typo in ``config.yml`` doesn't take the whole
+    project load down.
+    """
+    raw = get_global_section("ssh")
+    if not raw:
+        return {}
+    try:
+        return RawSSHSection.model_validate(raw).model_dump(exclude_none=True)
+    except ValidationError:
+        logger.warning("Invalid ssh section in global config, ignoring", exc_info=True)
+        return {}
+
+
 def load_project(project_id: str) -> ProjectConfig:
     """Load and return a fully resolved :class:`ProjectConfig` from *project_id*."""
     root = _find_project_root(project_id)
@@ -496,8 +518,17 @@ def load_project(project_id: str) -> ProjectConfig:
     identity_stack.push(ConfigScope("project", cfg_path, git_dict))
     identity = identity_stack.resolve()
 
+    # SSH knobs resolved via the same ConfigStack: terok-global → project.yml.
+    # The CLI override (``--use-personal-ssh``) sits one tier above this and
+    # is applied in ``make_git_gate`` so it doesn't have to round-trip
+    # through ``ProjectConfig`` mutation.
+    ssh_stack = ConfigStack()
+    ssh_stack.push(ConfigScope("terok-global", None, _validated_global_ssh_section()))
+    ssh_stack.push(ConfigScope("project", cfg_path, raw.ssh.model_dump(exclude_none=True)))
+    ssh_resolved = ssh_stack.resolve()
+
     try:
-        return _build_project_config(raw, identity, root, project_id)
+        return _build_project_config(raw, identity, ssh_resolved, root, project_id)
     except ValidationError as exc:
         # Identity values come from merged sources (git config, global config,
         # project.yml).  Include provenance in the error so the user knows

--- a/src/terok/lib/core/yaml_schema.py
+++ b/src/terok/lib/core/yaml_schema.py
@@ -155,16 +155,25 @@ class RawGlobalGitSection(BaseModel):
 
 
 class RawSSHSection(BaseModel):
-    """The ``ssh:`` section of project.yml."""
+    """The ``ssh:`` section, valid in both ``project.yml`` and global ``config.yml``.
+
+    The default is ``None`` (not ``False``) so ``model_dump(exclude_none=True)``
+    can distinguish *unset* from *explicitly false* — the project layer
+    needs to leave the global value alone when the user omitted ``ssh:``,
+    not stomp it back to ``False``.  The effective ``False`` default
+    happens at the consumer end via ``ssh_resolved.get("use_personal",
+    False)``, so callers see the same behaviour as before.
+    """
 
     model_config = ConfigDict(extra="forbid")
 
-    use_personal: bool = Field(
-        default=False,
+    use_personal: bool | None = Field(
+        default=None,
         description=(
             "Opt in to the user's ``~/.ssh`` keys for host-side ``gate-sync``. "
             "Default ``false`` — terok uses only its vault-managed key. "
-            "See also the per-invocation override ``--use-personal-ssh``."
+            "Resolves through ConfigStack: ``terok-global config.yml`` → "
+            "``project.yml`` → CLI ``--use-personal-ssh`` (highest)."
         ),
     )
 
@@ -602,6 +611,7 @@ class RawGlobalConfig(BaseModel):
     network: RawNetworkSection = Field(default_factory=RawNetworkSection)
     tasks: RawTasksGlobalSection = Field(default_factory=RawTasksGlobalSection)
     git: RawGlobalGitSection = Field(default_factory=RawGlobalGitSection)
+    ssh: RawSSHSection = Field(default_factory=RawSSHSection)
     hooks: RawHooksSection = Field(default_factory=RawHooksSection)
     image: RawImageSection = Field(default_factory=RawImageSection)
     experimental: bool = False

--- a/tests/unit/lib/test_projects.py
+++ b/tests/unit/lib/test_projects.py
@@ -26,6 +26,7 @@ def project_yaml(
     shield_drop_on_task_run: bool | None = None,
     shield_on_task_restart: str | None = None,
     timezone: str | None = None,
+    ssh_use_personal: bool | None = None,
 ) -> str:
     """Build project YAML for tests with optional sections."""
     lines = ["project:", f"  id: {project_id}"]
@@ -43,6 +44,8 @@ def project_yaml(
         lines += ["shield:", *shield_lines]
     if timezone is not None:
         lines += ["run:", f"  timezone: {timezone}"]
+    if ssh_use_personal is not None:
+        lines += ["ssh:", f"  use_personal: {str(ssh_use_personal).lower()}"]
     return "\n".join(lines) + "\n"
 
 
@@ -100,6 +103,62 @@ class TestProject:
                 with unittest.mock.patch.dict(os.environ, {"TEROK_CONFIG_FILE": str(config_file)}):
                     project = load_project(project_id)
         assert project.git_authorship == expected
+
+    @pytest.mark.parametrize(
+        ("project_id", "yaml_text", "config_text", "expected"),
+        [
+            pytest.param(
+                "ssh-default",
+                project_yaml("ssh-default"),
+                None,
+                False,
+                id="default-false",
+            ),
+            pytest.param(
+                "ssh-project-on",
+                project_yaml("ssh-project-on", ssh_use_personal=True),
+                None,
+                True,
+                id="project-yaml-on",
+            ),
+            pytest.param(
+                "ssh-global-on",
+                project_yaml("ssh-global-on"),
+                "ssh:\n  use_personal: true\n",
+                True,
+                id="global-config-on",
+            ),
+            pytest.param(
+                "ssh-project-overrides-global",
+                project_yaml("ssh-project-overrides-global", ssh_use_personal=False),
+                "ssh:\n  use_personal: true\n",
+                False,
+                id="project-overrides-global",
+            ),
+        ],
+    )
+    def test_ssh_use_personal_resolution(
+        self,
+        project_id: str,
+        yaml_text: str,
+        config_text: str | None,
+        expected: bool,
+    ) -> None:
+        """``ssh.use_personal`` resolves through the same ConfigStack as git identity.
+
+        Order: terok-global ``config.yml`` → project ``project.yml``.  The
+        per-invocation CLI override (``--use-personal-ssh``) sits one tier
+        above this and is applied in :func:`make_git_gate`, not here.
+        """
+        with project_env(yaml_text, project_id=project_id) as ctx:
+            if config_text is None:
+                project = load_project(project_id)
+            else:
+                config_file = ctx.base / "config.yml"
+                config_file.write_text(config_text, encoding="utf-8")
+                with unittest.mock.patch.dict(os.environ, {"TEROK_CONFIG_FILE": str(config_file)}):
+                    project = load_project(project_id)
+        assert project.ssh_use_personal is expected
 
     def test_load_project_invalid_git_authorship_raises(self) -> None:
         with project_env(


### PR DESCRIPTION
## Summary

Adds an `ssh:` section to the global `~/.config/terok/config.yml` so a power user can opt every project's **host-side gate** into using their personal `~/.ssh` once, without per-project flags. Useful when an existing host is already configured with a working SSH agent + `~/.ssh/config` and re-issuing per-project deploy keys would just be ceremony.

The mechanism reuses the existing `ConfigStack` that already resolves git identity (`git-global → terok-global → project.yml`) — no new special-cased fallback chain in the gate code, no new `SandboxConfig` field. The new `ssh` section follows the exact same pattern as `git`, with the same defensive validation (`_validated_global_ssh_section()` mirrors `_validated_global_git_section()`).

**Final resolution order:**

```
CLI --use-personal-ssh           (highest — already implemented in make_git_gate)
  ↓
project.yml `ssh:` section
  ↓
global config.yml `ssh:` section  (NEW)
  ↓
False                             (default)
```

**In-container git stays untouched** — the in-container SSH path goes through the vault socket with `IdentityFile=none`, never through the host's `~/.ssh` regardless of this flag.

### One small model change

`RawSSHSection.use_personal` switches from `bool = False` to `bool | None = None`. Without this, `model_dump(exclude_none=True)` always emits `use_personal: False` for the project layer, which would stomp the global `True` value during `ConfigStack.resolve()`'s deep merge. With `None` as the default, "user omitted the section" is distinguishable from "user explicitly set false", and the effective `False` fallback happens at the consumer end (one line in `_build_project_config`). Same trick `RawGitSection.human_name: str | None` already uses for its identity fields.

## Test plan

- [x] `tests/unit/lib/test_projects.py::test_ssh_use_personal_resolution` — 4 parametrised cases:
  - `default-false` — neither layer sets it
  - `project-yaml-on` — only `project.yml` opts in
  - `global-config-on` — only global `config.yml` opts in (the new path this PR enables)
  - `project-overrides-global` — project explicitly sets `false` while global says `true`
- [x] Full unit suite: 2130 passed
- [x] `make lint` / `make tach` / `make lint-imports` / `make docstrings` / `make reuse` clean

## Closes

Closes #591 — the gate already does not depend on `~/.ssh/config`; the only thing missing was a host-wide opt-in to use it. Verified via code scan: `gate/mirror.py:_git_env_with_ssh` uses `GIT_SSH_COMMAND="ssh -o IdentityFile=none"` by default and only returns the env unmodified when `use_personal_ssh=True`. Zero references to `~/.ssh/config`, `ssh_config`, or `expanduser(.ssh)` in the gate path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * SSH personal key usage can now be configured at the global configuration level, enabling centralized settings that cascade down and can be overridden on a per-project basis.

* **Tests**
  * Added comprehensive tests to validate SSH configuration resolution across configuration layers, ensuring proper override behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->