### PR TITLE
fix(release-chain): declare terok-sandbox → terok-clearance in DEPS

### DIFF
--- a/tools/terok-release-chain.py
+++ b/tools/terok-release-chain.py
@@ -81,7 +81,7 @@ CHAIN = ["terok-clearance", "terok-shield", "terok-sandbox", "terok-executor", "
 DEPS: dict[str, list[str]] = {
     "terok-clearance": [],
     "terok-shield": ["terok-clearance"],
-    "terok-sandbox": ["terok-shield"],
+    "terok-sandbox": ["terok-shield", "terok-clearance"],
     "terok-executor": ["terok-sandbox"],
     # terok pins terok-shield directly (src/terok/cli/commands/shield.py
     # imports from it), so it must be in this list even though shield would


### PR DESCRIPTION
## Summary

``terok-sandbox`` now directly imports from ``terok-clearance``, so its ``pyproject.toml`` declares the pin.  The release-chain verifier (added in #807) noticed the drift and blocked today's release attempt.  This one-line DEPS update closes the drift.

Stand-alone from #807 — branched off ``upstream/master`` so it can merge without waiting on the larger refactor.

## Test plan

- [ ] Re-run ``quick --from-prs sandbox:202,executor:224,terok:806 --open-top``; verifier should now pass for all three repos.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal dependency mapping to ensure correct package resolution during build processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->