### PR TITLE
feat(cli): accept Crockford surface-form variants for task IDs

### DIFF
--- a/src/terok/cli/commands/_completers.py
+++ b/src/terok/cli/commands/_completers.py
@@ -18,6 +18,7 @@ from typing import Any
 
 from ...lib.core.projects import list_presets, list_projects
 from ...lib.domain.facade import get_tasks
+from ...lib.orchestration.tasks import normalize_task_id_input
 
 
 def complete_project_ids(
@@ -41,6 +42,11 @@ def complete_task_ids(
     Returns an empty list when the project arg hasn't been typed yet —
     argcomplete uses the partially-parsed namespace, which is exactly
     what we want to scope task-ID suggestions.
+
+    The prefix is run through :func:`normalize_task_id_input`, so
+    ``K3V<TAB>`` or ``k3-v<TAB>`` rewrite to the canonical lowercase
+    form — the same surface-form tolerance ``resolve_task_id`` gives
+    at dispatch time.
     """
     project_id = getattr(parsed_args, "project_id", None)
     if not project_id:
@@ -49,8 +55,9 @@ def complete_task_ids(
         tids = [t.task_id for t in get_tasks(project_id) if t.task_id]
     except Exception:
         return []
-    if prefix:
-        tids = [t for t in tids if t.startswith(prefix)]
+    normalized = normalize_task_id_input(prefix)
+    if normalized:
+        tids = [t for t in tids if t.startswith(normalized)]
     return tids
 
 

--- a/src/terok/lib/orchestration/tasks.py
+++ b/src/terok/lib/orchestration/tasks.py
@@ -89,6 +89,28 @@ _LEGACY_HEX_TASK_ID_PREFIX_RE = re.compile(r"[0-9a-f]{1,8}")
 _LEGACY_HEX_TASK_ID_FULL_RE = re.compile(r"[0-9a-f]{8}")
 """Full-form validator for pre-0.8.0 hex task IDs.  Deprecated; removal in 0.9.0."""
 
+_TASK_ID_AMBIGUOUS_LETTERS = "ilo"
+"""Crockford's visually ambiguous letters: ``I``/``L`` → ``1`` and ``O`` → ``0``.
+
+See https://www.crockford.com/base32.html.  We encode only in canonical
+lowercase, but accept these substitutions at user-facing entry points to
+widen the input surface.
+"""
+
+_TASK_ID_INPUT_TRANSLATE = str.maketrans(_TASK_ID_AMBIGUOUS_LETTERS, "110")
+"""Translate table matching :data:`_TASK_ID_AMBIGUOUS_LETTERS`."""
+
+
+def normalize_task_id_input(raw: str) -> str:
+    """Collapse user-input variants to the canonical lowercase form.
+
+    Strips hyphens, lowercases, and applies the Crockford
+    ``I/L → 1``, ``O → 0`` substitutions.  The result is still subject
+    to :data:`_TASK_ID_PREFIX_RE` downstream — this only widens what
+    we accept, never what we emit.
+    """
+    return raw.replace("-", "").lower().translate(_TASK_ID_INPUT_TRANSLATE)
+
 
 def is_task_id(text: str) -> bool:
     """Return True if *text* is a well-formed task ID (current or legacy)."""
@@ -147,8 +169,25 @@ def _validate_task_id_prefix(prefix: str) -> None:
 def resolve_task_id(project_id: str, prefix: str) -> str:
     """Resolve a (possibly partial) task ID to its full form.
 
+    The *prefix* is first run through :func:`normalize_task_id_input`,
+    so callers may pass uppercase, hyphenated, or ambiguous-letter
+    variants (``K3-V8H``, ``k3v8I``) — they collapse to the canonical
+    lowercase form before validation and lookup.
+
     Raises ``SystemExit`` with an actionable message on zero or multiple matches.
     """
+    # Head position is letter-only, so an ``I/L/O`` there can't be a
+    # Crockford body substitution — surface that as a specific error
+    # instead of normalising it into a digit and letting downstream
+    # mistake it for a legacy-hex prefix.
+    stripped = prefix.replace("-", "").lower()
+    if stripped[:1] in _TASK_ID_AMBIGUOUS_LETTERS:
+        raise SystemExit(
+            f"Invalid task ID prefix {prefix!r}; "
+            f"task IDs never start with I, L, or O — "
+            f"expected one of {_TASK_ID_HEAD_CHARS!r}"
+        )
+    prefix = stripped.translate(_TASK_ID_INPUT_TRANSLATE)
     _validate_task_id_prefix(prefix)
     meta_dir = tasks_meta_dir(project_id)
     if not meta_dir.is_dir():

--- a/tach.toml
+++ b/tach.toml
@@ -607,6 +607,7 @@ expose = [
     "tasks_archive_dir",
     "resolve_task_id",
     "is_task_id",
+    "normalize_task_id_input",
 ]
 from = ["terok.lib.orchestration.tasks"]
 

--- a/tests/unit/cli/test_completers.py
+++ b/tests/unit/cli/test_completers.py
@@ -77,6 +77,28 @@ class TestCompleteTaskIds:
             result = complete_task_ids("k", argparse.Namespace(project_id="p"))
         assert result == ["k3v8h"]
 
+    @pytest.mark.parametrize(
+        "typed, expected",
+        [
+            ("K3V8", ["k3v8h"]),  # uppercase → lowercase
+            ("k3-v8", ["k3v8h"]),  # hyphen separator
+            ("K3VO", ["k3v01"]),  # O → 0 on a body position
+            ("K3-V-I", ["k3v1m"]),  # hyphens + I → 1
+            ("P7F", ["p7fmn"]),  # sanity: no ambiguous letters
+        ],
+    )
+    def test_normalises_typed_prefix(self, typed: str, expected: list[str]) -> None:
+        """Typed-prefix variants resolve to canonical IDs (bash then rewrites the word)."""
+        tasks = [
+            SimpleNamespace(task_id="k3v8h"),
+            SimpleNamespace(task_id="k3v01"),
+            SimpleNamespace(task_id="k3v1m"),
+            SimpleNamespace(task_id="p7fmn"),
+        ]
+        with patch("terok.cli.commands._completers.get_tasks", return_value=tasks):
+            result = complete_task_ids(typed, argparse.Namespace(project_id="p"))
+        assert result == expected
+
     def test_skips_tasks_without_ids(self) -> None:
         """Tasks with a falsy ``task_id`` (defensive: shouldn't happen) are skipped."""
         tasks = [SimpleNamespace(task_id="k3v8h"), SimpleNamespace(task_id="")]

--- a/tests/unit/lib/test_task_ids.py
+++ b/tests/unit/lib/test_task_ids.py
@@ -15,6 +15,7 @@ from terok.lib.orchestration.tasks import (
     _TASK_ID_HEAD_CHARS,
     _TASK_ID_LEN,
     _generate_unique_id,
+    normalize_task_id_input,
     resolve_task_id,
     tasks_meta_dir,
 )
@@ -76,6 +77,30 @@ class TestGenerateUniqueId:
                 _generate_unique_id({ID_A})
 
 
+# ---------- normalize_task_id_input ----------
+
+
+class TestNormalizeTaskIdInput:
+    """Surface-form input sanitiser — Crockford-style I/L→1, O→0 substitutions."""
+
+    @pytest.mark.parametrize(
+        "raw, expected",
+        [
+            ("K3V8H", "k3v8h"),
+            ("k3-v8h", "k3v8h"),
+            ("K3-V8-H", "k3v8h"),
+            ("K3VOH", "k3v0h"),  # O → 0 at body position
+            ("k3vIh", "k3v1h"),  # I → 1 at body position
+            ("k3vLh", "k3v1h"),  # L → 1 at body position
+            ("g1V0L", "g1v01"),  # mixed case + L → 1
+            ("", ""),
+        ],
+    )
+    def test_canonical_form(self, raw: str, expected: str) -> None:
+        """Normalisation collapses case, hyphens, and ambiguous Crockford letters."""
+        assert normalize_task_id_input(raw) == expected
+
+
 # ---------- resolve_task_id ----------
 
 
@@ -134,11 +159,25 @@ class TestResolveTaskId:
             with pytest.raises(SystemExit, match="Invalid task ID prefix"):
                 resolve_task_id("test-proj", "../../etc")
 
-    def test_rejects_uppercase(self) -> None:
-        """Should reject uppercase letters (IDs are always lowercase)."""
+    def test_accepts_uppercase(self) -> None:
+        """Uppercase input should be normalised to the canonical lowercase ID."""
         with project_env(MINIMAL_PROJECT) as _ctx:
-            with pytest.raises(SystemExit, match="Invalid task ID prefix"):
-                resolve_task_id("test-proj", ID_A.upper())
+            self._write_meta("test-proj", ID_A)
+            assert resolve_task_id("test-proj", ID_A.upper()) == ID_A
+
+    def test_accepts_hyphenated_input(self) -> None:
+        """Hyphens (Crockford group separators) should be stripped."""
+        with project_env(MINIMAL_PROJECT) as _ctx:
+            self._write_meta("test-proj", ID_A)
+            assert resolve_task_id("test-proj", f"{ID_A[:2]}-{ID_A[2:]}") == ID_A
+
+    def test_accepts_ambiguous_body_letters(self) -> None:
+        """``I/L → 1`` and ``O → 0`` substitutions resolve in body positions."""
+        # ID_A = "k3v8h"; insert a fake ambiguous variant and check it maps back.
+        tid = "g1v01"  # body positions contain '1' and '0'
+        with project_env(MINIMAL_PROJECT) as _ctx:
+            self._write_meta("test-proj", tid)
+            assert resolve_task_id("test-proj", "G1-VOL") == tid
 
     def test_rejects_empty_string(self) -> None:
         """Should reject an empty prefix."""


### PR DESCRIPTION
## Summary

Thin input sanitiser at the user-facing task-ID boundaries — accept what
Crockford base32 [defines as equivalent](https://www.crockford.com/base32.html),
emit only the canonical lowercase form. We still encode in our existing
lowercase Crockford-4.5; this only widens what we *accept* on input.

- New helper `normalize_task_id_input(raw)` (strips hyphens, lowercases,
  `I/L → 1`, `O → 0`). Exposed via the tach interface.
- Wired into `resolve_task_id`: `K3-V8H`, `k3v8I`, `K3VO` all resolve
  to their canonical IDs before validation and filesystem lookup.
  A head-position guard rejects `I`/`L`/`O` at position 1 with a
  Crockford-specific error — task IDs are letter-headed, so silently
  remapping would mislead the legacy-hex fallback.
- Wired into `complete_task_ids` (argcomplete): typed prefix is
  normalised before filtering, so `K3V<TAB>` rewrites the partial
  word to the canonical `k3v8h` the same way `~<TAB>` rewrites to
  `$HOME`.

## Test plan

- [x] `pytest tests/unit/lib/test_task_ids.py tests/unit/cli/test_completers.py` — new direct coverage of the normaliser + parametrised completer cases (uppercase, hyphens, `I→1`, `O→0`)
- [x] Flipped `test_rejects_uppercase` → `test_accepts_uppercase`; added `test_accepts_hyphenated_input` and `test_accepts_ambiguous_body_letters`
- [x] `make check` passes (2141 tests, lint, tach, docstrings 98.6%, reuse, vulture, bandit)
- [ ] Manual tab-completion sanity: `terok task login <proj> K3V<TAB>` rewrites to canonical lowercase (requires an installed shell; untested locally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)