### PR TITLE
feat(cli): route shield + sickbay task IDs through resolve_task_id

### DIFF
--- a/src/terok/cli/commands/shield.py
+++ b/src/terok/cli/commands/shield.py
@@ -19,6 +19,7 @@ from terok_sandbox import make_shield
 from terok_shield import COMMANDS, ArgDef, CommandDef, ExecError
 
 from ...lib.core.config import make_sandbox_config
+from ...lib.orchestration.tasks import resolve_task_id
 
 
 def _add_arg(parser: argparse.ArgumentParser, arg: ArgDef) -> None:
@@ -168,10 +169,12 @@ def dispatch(args: argparse.Namespace) -> bool:
         print("Error: provide both <project_id> and <task_id>, or neither", file=sys.stderr)
         sys.exit(1)
     has_task = project_id is not None and task_id is not None
+    if has_task:
+        task_id = resolve_task_id(project_id, task_id)
 
     try:
         if has_task:
-            cname, task_dir = _resolve_task(args.project_id, args.task_id)
+            cname, task_dir = _resolve_task(project_id, task_id)
             shield = make_shield(task_dir, cfg=make_sandbox_config())
             kwargs = _extract_handler_kwargs(args, cmd_def)
             if cmd_def.needs_container:
@@ -190,7 +193,7 @@ def dispatch(args: argparse.Namespace) -> bool:
                 cmd_def.handler(shield, **kwargs)
     except ExecError as exc:
         print(
-            f"Error: shield operation failed for task {args.task_id}: {exc}"
+            f"Error: shield operation failed for task {task_id}: {exc}"
             if has_task
             else f"Error: shield operation failed: {exc}",
             file=sys.stderr,

--- a/src/terok/cli/commands/sickbay.py
+++ b/src/terok/cli/commands/sickbay.py
@@ -55,7 +55,12 @@ from ...lib.core.project_model import ProjectConfig, is_valid_project_id
 from ...lib.core.projects import list_projects, load_project
 from ...lib.orchestration.container_doctor import run_container_doctor
 from ...lib.orchestration.hooks import run_hook
-from ...lib.orchestration.tasks import container_name, is_task_id, tasks_meta_dir
+from ...lib.orchestration.tasks import (
+    container_name,
+    is_task_id,
+    resolve_task_id,
+    tasks_meta_dir,
+)
 from ...lib.util.check_reporter import CheckReporter
 from ...lib.util.yaml import load as _yaml_load
 
@@ -85,9 +90,13 @@ def dispatch(args: argparse.Namespace) -> bool:
     """Handle the sickbay command.  Returns True if handled."""
     if args.cmd != "sickbay":
         return False
+    project_id = getattr(args, "project_id", None)
+    task_id = getattr(args, "task_id", None)
+    if project_id and task_id:
+        task_id = resolve_task_id(project_id, task_id)
     _cmd_sickbay(
-        project_id=getattr(args, "project_id", None),
-        task_id=getattr(args, "task_id", None),
+        project_id=project_id,
+        task_id=task_id,
         fix=getattr(args, "fix", False),
     )
     return True

--- a/src/terok/lib/orchestration/tasks.py
+++ b/src/terok/lib/orchestration/tasks.py
@@ -108,6 +108,14 @@ def normalize_task_id_input(raw: str) -> str:
     ``I/L → 1``, ``O → 0`` substitutions.  The result is still subject
     to :data:`_TASK_ID_PREFIX_RE` downstream — this only widens what
     we accept, never what we emit.
+
+    **Call-site discipline:** only call this at user-interactive CLI
+    boundaries — argparse dispatch handlers and argcomplete completers.
+    Internal code paths (``lib/*``, ``tui/*``, TUI pickers, clearance,
+    anything reading task IDs from disk, OCI annotations, or runtime
+    state) always work with canonical lowercase IDs and must *never*
+    re-normalise.  Leaking this tolerance inward quietly defeats the
+    "we encode only in canonical form" invariant.
     """
     return raw.replace("-", "").lower().translate(_TASK_ID_INPUT_TRANSLATE)
 

--- a/tests/unit/cli/test_cli_shield.py
+++ b/tests/unit/cli/test_cli_shield.py
@@ -28,6 +28,16 @@ def shield_parser() -> argparse.ArgumentParser:
     return parser
 
 
+@pytest.fixture(autouse=True)
+def _stub_resolve_task_id() -> object:
+    """Bypass filesystem-backed ``resolve_task_id`` — these tests mock ``_resolve_task``."""
+    with patch(
+        "terok.cli.commands.shield.resolve_task_id",
+        side_effect=lambda _pid, tid: tid,
+    ) as stub:
+        yield stub
+
+
 @pytest.mark.parametrize(
     ("argv", "expected"),
     [


### PR DESCRIPTION
## Summary

Follow-up to #811 (stack base). Extends the same input-tolerance
pattern to the two remaining CLI entry points that accepted raw
`args.task_id`:

- **`shield`** — normalises + resolves at `dispatch`, before the
  internal `_resolve_task` helper is called.
- **`sickbay`** — same, when both `project_id` and `task_id` are
  given. Unknown / ambiguous IDs now raise instead of silently
  scoping to nothing and reporting "all clear" — much better UX
  for a diagnostic tool.

Also documents the scope invariant on `normalize_task_id_input`:
only callable from argparse dispatch handlers and argcomplete
completers. Internal code paths (`lib/*`, `tui/*`, disk, OCI
annotations, runtime state) must work with canonical lowercase
IDs and must never re-normalise — that's how we keep the "encode
only in canonical form" rule intact.

## Stack

Depends on #811. Both can land in either order; there's no code
conflict, just a dependency on `normalize_task_id_input` /
`resolve_task_id` continuing to exist.

## Test plan

- [x] `pytest tests/unit/cli/test_cli_shield.py tests/unit/cli/test_cli_sickbay.py` — all existing cases pass under the new dispatch path
- [x] Replaced scattered per-test `@patch` of `resolve_task_id` in the shield suite with one autouse fixture (simpler seam — tests already mock `_resolve_task`)
- [x] `make check` passes (2141 tests, lint, tach, docstrings 98.6%, reuse, vulture, bandit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Task IDs now accept flexible input formats (case-insensitive, optional hyphens, character ambiguity handling) in CLI commands and autocompletion.

* **Improvements**
  * Task dispatch and resolution now normalize inputs for consistent behavior across all related commands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->