### PR TITLE
refactor(setup): narrative-readability polish

### DIFF
--- a/src/terok/cli/commands/_setup_ui.py
+++ b/src/terok/cli/commands/_setup_ui.py
@@ -73,5 +73,8 @@ def _stage_begin(label: str) -> None:
     a network round-trip.  The matching terminator is the regular
     ``print(...)`` that writes the status suffix and newline.
     """
-    # 21 chars wide = longest label ("Clearance notifier" = 18) + 3 space gutter.
+    # Column width is load-bearing: setup and uninstall both align
+    # their status markers at this offset, so the two commands read
+    # as one continuous log when run back-to-back.  Recompute when a
+    # new phase ships with a label longer than the current widest.
     print(f"  {label:<21}", end="", flush=True)

--- a/src/terok/cli/commands/sickbay.py
+++ b/src/terok/cli/commands/sickbay.py
@@ -147,12 +147,11 @@ def _check_shield() -> _CheckResult:
 
 
 def _check_clearance_stack() -> _CheckResult:
-    """Detect drift across the clearance hub/verdict/notifier triple.
+    """Surface stale or half-installed clearance units — pipx upgrade hygiene.
 
-    ``terok_clearance.check_units_outdated`` covers all three units in
-    one probe: a pre-split monolithic ``terok-dbus.service`` on disk,
-    a half-installed hub/verdict pair, and a stale version marker on
-    any of the three surface as a single ``warn`` here.
+    Delegates drift detection to the clearance package so sickbay
+    tracks whatever new units terok-clearance ships next without
+    knowing the triple's shape itself.
     """
     label = "Clearance stack"
     outdated = _clearance_check_units_outdated()

--- a/src/terok/lib/orchestration/task_runners.py
+++ b/src/terok/lib/orchestration/task_runners.py
@@ -438,13 +438,19 @@ def _run_container(
     command: list[str] | None = None,
     hooks: LifecycleHooks | None = None,
 ) -> None:
-    """Launch a detached task container via the executor's public API.
+    """Launch a detached task container, annotated for clearance enrichment.
 
-    Delegates all podman command assembly (userns, shield/bypass, GPU,
-    env redaction, CDI detection) to :meth:`AgentRunner.launch_prepared`,
-    which in turn drives the sandbox.  In sealed isolation mode
-    (``project.is_sealed``), the sandbox splits into create → copy → start
-    instead of a single ``podman run -d``.
+    Three ``ai.terok.*`` OCI annotations bind the container to its task
+    identity so clearance popups can render "Task: project/task_id ·
+    name" instead of raw short IDs: project, task_id, and
+    task_meta_path.  The meta-path annotation carries the YAML path
+    (not a snapshot of the name) so a rename mid-run surfaces the
+    fresh label in the next popup.
+
+    Podman command assembly (userns, shield/bypass, GPU, env redaction,
+    CDI detection) is delegated to :meth:`AgentRunner.launch_prepared`.
+    In sealed isolation mode (``project.is_sealed``) the sandbox splits
+    into create → copy → start instead of a single ``podman run -d``.
 
     Args:
         cname: Container name (``--name``).
@@ -452,9 +458,8 @@ def _run_container(
         env: Environment variables to pass via ``-e``.
         volumes: Typed volume specs (sandbox decides mount vs inject).
         project: The resolved :class:`ProjectConfig` (used for GPU flag).
-        task_id: Task identifier, used for the ``ai.terok.task`` OCI
-            annotation so clearance clients can render popups as
-            "Task: project/task_id" instead of raw container IDs.
+        task_id: Task identifier — the second component of the clearance
+            annotation triple.
         task_dir: Per-task directory (used for per-task shield state).
         extra_args: Additional ``podman run`` flags inserted after the GPU
             args (e.g. ``["-p", "127.0.0.1:8080:7860"]``).


### PR DESCRIPTION
## Summary

Three small readability touches after the big thin-setup landed in #813:

- **``sickbay.py``** — ``_check_clearance_stack`` docstring trimmed.  The old version narrated which scenarios ``terok_clearance.check_units_outdated`` produces a warn for — implementation detail that belongs in the clearance package's own docstring, not in a consumer check.  Replaced with a one-line domain intent + the delegation rationale.
- **``_setup_ui.py``** — the ``_stage_begin`` column-width constant had an arithmetic comment (``21 chars = 18 + 3 gutter``) describing *what* it computes.  Rewrote as *why* it's shared: setup and uninstall align their markers at the same offset so the two commands read as one continuous log when run back-to-back.
- **``task_runners.py``** — ``_run_container`` docstring now leads with the domain intent (``Launch a detached task container, annotated for clearance enrichment``) instead of delegation mechanics.  The three-annotation contract (``project`` + ``task`` + ``task_meta_path``) gets its own paragraph since that's the non-obvious behaviour; podman command-assembly delegation follows.  ``task_id`` arg docstring shrunk — the "clearance renders popups as..." expansion now lives in the overview once.

No behaviour change.  All 2052 unit tests pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated internal documentation and comments for enhanced clarity on setup output formatting and clearance detection mechanisms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->