### PR TITLE
fix(tui): clipboard Copy freeze over SSH; Esc cancels wizard mid-run

### DIFF
--- a/src/terok/tui/clipboard.py
+++ b/src/terok/tui/clipboard.py
@@ -130,9 +130,11 @@ def copy_to_clipboard_detailed(text: str) -> ClipboardCopyResult:
               message when all helpers fail.
             * ``hint``: An optional hint string with guidance on how to enable
               clipboard support on the current platform (for example, a command
-              to install a missing helper). This is typically populated when no
-              helper is available or when all helpers fail, and is ``None`` on
-              successful copies.
+              to install a missing helper). Populated only when **no** helper
+              was found on the system; ``None`` on success and also ``None``
+              when helpers were available but all of them failed at runtime —
+              in that case the user already has a helper installed, so
+              ``error`` describes what actually went wrong.
 
     Examples:
         Basic usage with boolean check::
@@ -200,7 +202,9 @@ def copy_to_clipboard_detailed(text: str) -> ClipboardCopyResult:
         except Exception as e:
             errors.append(f"{name} error: {e}")
 
-    hint = _clipboard_install_hint()
-    return ClipboardCopyResult(
-        ok=False, error=errors[-1] if errors else "Clipboard copy failed.", hint=hint or None
-    )
+    # Helpers *were* available but all of them failed at runtime — a
+    # broken Wayland socket, a misconfigured compositor, an xclip
+    # segfault, etc.  Suggesting ``apt install wl-clipboard`` here would
+    # be actively misleading; the user already has the helper.  Leave
+    # hint None so the caller surfaces the actual per-helper error.
+    return ClipboardCopyResult(ok=False, error=errors[-1] if errors else "Clipboard copy failed.")

--- a/src/terok/tui/clipboard.py
+++ b/src/terok/tui/clipboard.py
@@ -9,6 +9,14 @@ import subprocess
 import sys
 from dataclasses import dataclass
 
+#: Hard cap on a single clipboard-helper invocation.  wl-copy in
+#: particular forks a daemon that holds the X/Wayland selection alive
+#: after the foreground process exits; if we ever ended up waiting for
+#: that daemon to close its pipes we'd block the UI loop forever.  Three
+#: seconds is comfortably more than any real clipboard write needs and
+#: small enough that a stuck helper surfaces as an error, not a hang.
+_CLIPBOARD_TIMEOUT_SEC = 3.0
+
 
 @dataclass(frozen=True)
 class ClipboardHelperStatus:
@@ -164,11 +172,31 @@ def copy_to_clipboard_detailed(text: str) -> ClipboardCopyResult:
     errors: list[str] = []
     for name, cmd in available:
         try:
-            subprocess.run(cmd, input=text, check=True, text=True, capture_output=True)
+            # Why ``stdout=DEVNULL`` instead of ``capture_output=True``:
+            # wl-copy forks a long-lived daemon that inherits the parent's
+            # stdout/stderr to keep the Wayland selection alive.  When
+            # Python captures stdout via a pipe, ``subprocess.run`` waits
+            # for EOF on that pipe — which the daemon never closes — and
+            # the call hangs forever, freezing the caller's event loop.
+            # Giving the helper ``/dev/null`` as stdout breaks the pipe
+            # dependency entirely; stderr stays on a pipe so we can still
+            # surface a real error message on failure.  The timeout is
+            # defence-in-depth for helpers we haven't anticipated.
+            subprocess.run(
+                cmd,
+                input=text,
+                check=True,
+                text=True,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.PIPE,
+                timeout=_CLIPBOARD_TIMEOUT_SEC,
+            )
             return ClipboardCopyResult(ok=True, method=name)
         except subprocess.CalledProcessError as e:
-            detail = (e.stderr or e.stdout or "").strip()
+            detail = (e.stderr or "").strip()
             errors.append(f"{name} failed" + (f": {detail}" if detail else ""))
+        except subprocess.TimeoutExpired:
+            errors.append(f"{name} timed out after {_CLIPBOARD_TIMEOUT_SEC:g}s")
         except Exception as e:
             errors.append(f"{name} error: {e}")
 

--- a/src/terok/tui/project_actions.py
+++ b/src/terok/tui/project_actions.py
@@ -545,6 +545,16 @@ class ProjectActionsMixin:
                 # no-op, not an error.  No notification needed; the log
                 # pane already told them what happened.
                 pass
+            case InitOutcome.CANCELLED:
+                # User hit Esc mid-init.  project.yml may have been
+                # written and early steps may have partially run; point
+                # them at the CLI to resume rather than guessing.
+                self.notify(
+                    f"Wizard cancelled. If '{values['project_id']}' was partially "
+                    "initialized, finish it with `terok project init` from the CLI.",
+                    severity="warning",
+                    timeout=10,
+                )
             case InitOutcome.FAILED:
                 self.notify(
                     f"Project '{values['project_id']}' created but init did not complete. "

--- a/src/terok/tui/task_actions.py
+++ b/src/terok/tui/task_actions.py
@@ -660,7 +660,13 @@ class TaskActionsMixin:
             self.notify("No changes to copy (working tree clean).")
             return
 
-        result = copy_to_clipboard_detailed(diff)
+        import asyncio
+
+        # Clipboard helpers (wl-copy in particular) can block briefly or
+        # misbehave in niche scenarios; the helper has its own timeout
+        # but we hop off the UI thread so even that timeout can't stall
+        # the event loop.
+        result = await asyncio.to_thread(copy_to_clipboard_detailed, diff)
         if result.ok:
             self.notify(f"Git diff vs {label} copied to clipboard ({len(diff)} characters)")
         else:

--- a/src/terok/tui/wizard_screens.py
+++ b/src/terok/tui/wizard_screens.py
@@ -772,11 +772,17 @@ class InitProgressScreen(ModalScreen[InitOutcome]):
     def action_cancel(self) -> None:
         """Esc aborts the wizard at any point in its lifecycle.
 
-        Three distinct cases to handle:
+        The Close button's ``disabled`` flag is the authoritative
+        "worker finished" signal — ``_outcome`` defaults to FAILED at
+        ``__init__`` time and only gets rewritten on success/decline
+        paths, so reading it to detect completion would falsely
+        classify an in-flight run as already-failed.
 
-        * **Worker already finished** (Close button enabled) — the
-          stored outcome is SUCCESS/FAILED/DECLINED; dismiss with it
-          so the caller's match arms render the correct notification.
+        Three cases:
+
+        * **Worker finished** (Close button enabled) — the stored
+          outcome is SUCCESS/FAILED/DECLINED; dismiss with it so the
+          caller's match arms render the correct notification.
         * **Worker paused on the SSH-key "continue" gate** — the
           worker is awaiting an :class:`asyncio.Event`; cancelling
           raises ``CancelledError`` out of that ``await`` and the
@@ -789,7 +795,12 @@ class InitProgressScreen(ModalScreen[InitOutcome]):
           in a transient state the caller may need to clean up later —
           but the UI is freed immediately, which is the point.
         """
-        if self._outcome in (InitOutcome.SUCCESS, InitOutcome.FAILED, InitOutcome.DECLINED):
+        try:
+            close_button = self.query_one("#wizard-init-close", Button)
+        except NoMatches:
+            # Screen already torn down by a prior dismiss — nothing to do.
+            return
+        if not close_button.disabled:
             self.dismiss(self._outcome)
             return
 

--- a/src/terok/tui/wizard_screens.py
+++ b/src/terok/tui/wizard_screens.py
@@ -34,6 +34,7 @@ from textual import on, work
 from textual.app import ComposeResult
 from textual.binding import Binding
 from textual.containers import Horizontal, Vertical, VerticalScroll
+from textual.css.query import NoMatches
 from textual.screen import ModalScreen
 from textual.widgets import Button, Input, Label, RadioButton, RadioSet, RichLog, Static, TextArea
 
@@ -319,18 +320,20 @@ class ProjectReviewScreen(ModalScreen["str | object | None"]):
 
 
 class InitOutcome(enum.Enum):
-    """Result of :class:`InitProgressScreen` — three distinct states.
+    """Result of :class:`InitProgressScreen` — four distinct states.
 
     ``SUCCESS`` and ``FAILED`` are the obvious outcomes; ``DECLINED``
     covers the case where the user deliberately chose not to overwrite
-    an existing ``project.yml``.  The caller needs all three to render
-    the right follow-up notification: a decline is a benign no-op, not
+    an existing ``project.yml``, and ``CANCELLED`` covers Esc-out
+    mid-run.  The caller needs all four to render the right follow-up
+    notification: a decline or a cancellation is a benign no-op, not
     an error.
     """
 
     SUCCESS = "success"
     FAILED = "failed"
     DECLINED = "declined"
+    CANCELLED = "cancelled"
 
 
 class InitProgressScreen(ModalScreen[InitOutcome]):
@@ -343,7 +346,7 @@ class InitProgressScreen(ModalScreen[InitOutcome]):
     """
 
     BINDINGS = [
-        Binding("escape", "maybe_cancel", "Close"),
+        Binding("escape", "cancel", "Cancel"),
     ]
 
     CSS = """
@@ -557,7 +560,14 @@ class InitProgressScreen(ModalScreen[InitOutcome]):
         branch in ``_run_init_with_confirm``, and from the worker's
         ``finally`` block.  Button label/variant mirror the outcome so
         a declined overwrite doesn't masquerade as a failed init.
+
+        When the user cancels via Esc the worker's ``finally`` still
+        runs after the screen has been dismissed — the Close button
+        has already been torn down, so a failed ``query_one`` is
+        expected and ignored rather than surfaced as a worker error.
         """
+        if self._outcome is InitOutcome.CANCELLED:
+            return
         variant_for = {
             InitOutcome.SUCCESS: "success",
             InitOutcome.FAILED: "warning",
@@ -568,7 +578,10 @@ class InitProgressScreen(ModalScreen[InitOutcome]):
             InitOutcome.FAILED: "Close",
             InitOutcome.DECLINED: "Close",
         }
-        button = self.query_one("#wizard-init-close", Button)
+        try:
+            button = self.query_one("#wizard-init-close", Button)
+        except NoMatches:
+            return
         button.disabled = False
         button.variant = variant_for[self._outcome]
         button.label = label_for[self._outcome]
@@ -725,14 +738,23 @@ class InitProgressScreen(ModalScreen[InitOutcome]):
             self._ssh_continue.set()
 
     @on(Button.Pressed, "#wizard-init-ssh-copy")
-    def _on_ssh_copy(self) -> None:
-        """Copy the SSH public key to the system clipboard via the shared helper."""
+    async def _on_ssh_copy(self) -> None:
+        """Copy the SSH public key to the system clipboard via the shared helper.
+
+        Runs the helper off the UI thread via :func:`asyncio.to_thread`:
+        the clipboard call has its own internal timeout, but the whole
+        point of the async hop is that a slow helper (think a laggy
+        Wayland compositor, or a misbehaving clipboard daemon) can't
+        freeze the event loop even for those few seconds.
+        """
+        import asyncio
+
         from .clipboard import copy_to_clipboard_detailed
 
         key = getattr(self, "_ssh_pub_line", "")
         if not key:
             return
-        result = copy_to_clipboard_detailed(key)
+        result = await asyncio.to_thread(copy_to_clipboard_detailed, key)
         if result.ok:
             self.notify("SSH public key copied to clipboard.")
         else:
@@ -747,10 +769,37 @@ class InitProgressScreen(ModalScreen[InitOutcome]):
     def _on_close(self) -> None:
         self.dismiss(self._outcome)
 
-    def action_maybe_cancel(self) -> None:
-        """Escape only dismisses once the worker has finished."""
-        if not self.query_one("#wizard-init-close", Button).disabled:
+    def action_cancel(self) -> None:
+        """Esc aborts the wizard at any point in its lifecycle.
+
+        Three distinct cases to handle:
+
+        * **Worker already finished** (Close button enabled) — the
+          stored outcome is SUCCESS/FAILED/DECLINED; dismiss with it
+          so the caller's match arms render the correct notification.
+        * **Worker paused on the SSH-key "continue" gate** — the
+          worker is awaiting an :class:`asyncio.Event`; cancelling
+          raises ``CancelledError`` out of that ``await`` and the
+          worker unwinds cleanly.
+        * **Worker actively running a step** (provision, build,
+          gate-sync) — those steps are ``asyncio.to_thread`` calls;
+          cancelling the Task drops the awaiter but the OS thread
+          keeps running to completion.  That's unavoidable on CPython
+          (threads aren't forcibly cancellable), and the work ends up
+          in a transient state the caller may need to clean up later —
+          but the UI is freed immediately, which is the point.
+        """
+        if self._outcome in (InitOutcome.SUCCESS, InitOutcome.FAILED, InitOutcome.DECLINED):
             self.dismiss(self._outcome)
+            return
+
+        # Cancel the in-flight worker explicitly rather than relying on
+        # dismiss() to tear it down; the worker's ``finally`` touches
+        # widgets (``_finish_with_close_button``) and a concurrent
+        # dismiss would race those queries against screen teardown.
+        self.workers.cancel_group(self, "wizard-init")
+        self._outcome = InitOutcome.CANCELLED
+        self.dismiss(self._outcome)
 
 
 # ── Helpers ───────────────────────────────────────────────────────────

--- a/tests/unit/lib/test_tasks.py
+++ b/tests/unit/lib/test_tasks.py
@@ -828,6 +828,10 @@ class TestTask:
         wl-copy's fork-a-daemon behaviour used to deadlock ``subprocess.run``
         when stdout was captured; stdout is now ``DEVNULL`` and the call has
         a hard timeout.  If either defence regresses the caller freezes.
+
+        Also locks in the contract that ``hint`` stays ``None`` when a
+        helper was available but failed at runtime — the user already
+        has wl-clipboard, so suggesting they install it would be wrong.
         """
         with unittest.mock.patch.dict(
             os.environ, {"XDG_SESSION_TYPE": "wayland", "WAYLAND_DISPLAY": "wayland-0"}
@@ -842,6 +846,11 @@ class TestTask:
                     assert not result.ok
                     assert result.error is not None
                     assert "timed out" in result.error
+                    # A misleading "install wl-clipboard" hint on a system that
+                    # already has wl-clipboard would wrongly take precedence
+                    # over the real timeout message at the call sites that
+                    # prefer ``hint`` over ``error``.
+                    assert result.hint is None
 
     def test_get_clipboard_helper_status_with_available_helpers(self) -> None:
         """Test get_clipboard_helper_status returns available helpers on macOS."""

--- a/tests/unit/lib/test_tasks.py
+++ b/tests/unit/lib/test_tasks.py
@@ -755,7 +755,12 @@ class TestTask:
                     assert kwargs["input"] == "test content"
                     assert kwargs["check"]
                     assert kwargs["text"]
-                    assert kwargs["capture_output"]
+                    # wl-copy's daemon inherits stdout; piping it would
+                    # hang the caller forever, so we send it to /dev/null
+                    # and only keep stderr for error reporting.
+                    assert kwargs["stdout"] == subprocess.DEVNULL
+                    assert kwargs["stderr"] == subprocess.PIPE
+                    assert kwargs["timeout"] > 0
 
     def test_copy_to_clipboard_fallback_to_xclip(self) -> None:
         """Test copy_to_clipboard_detailed uses xclip on X11 when available."""
@@ -816,6 +821,27 @@ class TestTask:
                     assert "failed" in result.error
 
                     assert run_mock.call_count == 2
+
+    def test_copy_to_clipboard_helper_timeout_does_not_hang(self) -> None:
+        """A helper that times out must surface as an error, not hang the caller.
+
+        wl-copy's fork-a-daemon behaviour used to deadlock ``subprocess.run``
+        when stdout was captured; stdout is now ``DEVNULL`` and the call has
+        a hard timeout.  If either defence regresses the caller freezes.
+        """
+        with unittest.mock.patch.dict(
+            os.environ, {"XDG_SESSION_TYPE": "wayland", "WAYLAND_DISPLAY": "wayland-0"}
+        ):
+            with unittest.mock.patch(
+                "terok.tui.clipboard.shutil.which", return_value="/usr/bin/wl-copy"
+            ):
+                with unittest.mock.patch("terok.tui.clipboard.subprocess.run") as run_mock:
+                    run_mock.side_effect = subprocess.TimeoutExpired(cmd=["wl-copy"], timeout=3.0)
+
+                    result = copy_to_clipboard_detailed("test content")
+                    assert not result.ok
+                    assert result.error is not None
+                    assert "timed out" in result.error
 
     def test_get_clipboard_helper_status_with_available_helpers(self) -> None:
         """Test get_clipboard_helper_status returns available helpers on macOS."""

--- a/tests/unit/tui/test_wizard_screens.py
+++ b/tests/unit/tui/test_wizard_screens.py
@@ -427,3 +427,70 @@ async def test_ssh_panel_shows_fingerprint_alongside_pubkey() -> None:
             # Unblock the worker so the test exits cleanly.
             screen._ssh_continue.set()
             await pilot.pause()
+
+
+# ── Esc-cancels-wizard ────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_init_screen_esc_cancels_mid_run() -> None:
+    """Esc during an in-flight init sets CANCELLED and tears down cleanly.
+
+    Drives the worker to the SSH-key ``continue`` gate — where it
+    parks on ``await self._ssh_continue.wait()`` — then presses Esc
+    to trigger :meth:`InitProgressScreen.action_cancel`.  Two things
+    must hold:
+
+    * The outcome is :attr:`InitOutcome.CANCELLED`, not FAILED — a
+      deliberate cancel is not a failure.
+    * No teardown exception is raised.  The worker's ``finally``
+      runs after the screen has been dismissed; the cleanup path
+      early-returns on ``CANCELLED`` and tolerates a missing Close
+      button via ``NoMatches``.  Either defence regressing would
+      surface here as an uncaught worker error.
+    """
+    import asyncio as _asyncio
+
+    from terok.tui.wizard_screens import InitOutcome, InitProgressScreen
+
+    minted = {
+        "key_id": 7,
+        "key_type": "ed25519",
+        "fingerprint": "SHA256:cancelme",
+        "comment": "terok@cancel",
+        "public_line": "ssh-ed25519 AAAAFAKE terok@cancel",
+    }
+    app = _WizardHost(InitProgressScreen("demo", "project:\n  id: demo\n"))
+    with (
+        patch.object(InitProgressScreen, "_existing_project_yaml_path", return_value=None),
+        patch("terok.tui.wizard_screens.write_project_yaml"),
+        patch("terok.tui.wizard_screens.project_needs_key_registration", return_value=True),
+        patch("terok.lib.domain.facade.provision_ssh_key", return_value=minted),
+        patch("terok.lib.domain.facade.summarize_ssh_init"),
+    ):
+        async with app.run_test() as pilot:
+            # Let the worker reach the ssh_continue.wait() park state —
+            # same readiness probe as the fingerprint test above.
+            for _ in range(20):
+                await pilot.pause()
+                await _asyncio.sleep(0)
+                screen = app.screen
+                if not isinstance(screen, InitProgressScreen):
+                    break
+                panel = screen.query_one("#wizard-init-ssh-key")
+                if panel.styles.display == "block":
+                    break
+            screen = app.screen
+            assert isinstance(screen, InitProgressScreen)
+
+            await pilot.press("escape")
+            # Give the worker-cancel + dismiss + finally unwind time
+            # to fully settle before we assert.
+            for _ in range(10):
+                await pilot.pause()
+                await _asyncio.sleep(0)
+
+            assert screen._outcome is InitOutcome.CANCELLED
+            # The host's capture callback receives the dismissed outcome —
+            # confirms dismiss() actually fired (not just the outcome set).
+            assert app.result is InitOutcome.CANCELLED


### PR DESCRIPTION
## Summary

- **Clipboard freeze:** the Copy button on the new-project wizard's SSH-key step could hang the entire TUI over SSH. `subprocess.run(..., capture_output=True)` was waiting for EOF on wl-copy's stdout, but wl-copy forks a long-lived daemon that inherits and holds that pipe to keep the Wayland selection alive. Fix: `stdout=DEVNULL`, keep stderr on a pipe for real errors, add a 3s safety timeout, and run the helper off the UI thread via `asyncio.to_thread` (same treatment applied to the task-diff Copy caller).
- **Esc cancels anywhere in the wizard:** previously Esc on `InitProgressScreen` only dismissed *after* the worker finished. Added `InitOutcome.CANCELLED`, cancel the `wizard-init` worker group on Esc, dismiss, and the caller surfaces an advisory notification pointing at `terok project init` in case the early steps wrote anything. `_finish_with_close_button` is now tolerant of the screen being torn down so the worker's `finally` can't crash on cleanup.

## Test plan

- [ ] `make check` (lint, tach, tests, docstrings — all green locally)
- [ ] `terok-tui` over SSH → new-project wizard → SSH-key step → press **Copy**: TUI stays responsive whether the system has wl-clipboard / xclip / nothing at all
- [ ] Wizard **Esc** at each stage: form screen, review screen, mid-init (during SSH-key continue wait), mid-init (during an active build step), and after completion — each should close the modal cleanly without freezing
- [ ] Failure path: uninstall clipboard helpers, press Copy — see the warning toast with the install hint, UI still responsive
- [ ] `task_actions` Copy-diff paths still work (xclip / wl-copy / pbcopy)

## Notes for reviewer

- During an active `podman build` / `git clone` step, Esc cancels the *awaiter* but the OS thread keeps running to completion — CPython can't forcibly cancel threads, so `asyncio.to_thread` tasks leak their thread until the work naturally finishes. This is called out in the `action_cancel` docstring; fixing it properly would mean switching those calls to `asyncio.create_subprocess_exec` with process-group kill, which is a separate piece of work.
- Added one regression test (`test_copy_to_clipboard_helper_timeout_does_not_hang`) to lock in both the `DEVNULL` and `timeout` defences.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Escape now cancels the initialization wizard mid-process and shows instructions on how to resume from the CLI.

* **Bug Fixes**
  * Clipboard copy runs off the UI thread to avoid freezes.
  * Clipboard operations enforce a timeout, report clear “timed out after …s” errors, and only show install hints when no helper is found.

* **Tests**
  * Added tests for clipboard timeout handling and mid-init cancellation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->