### PR TITLE
fix(tui): fold-wrap the SSH pubkey so long keys stay visible

### DIFF
--- a/src/terok/tui/wizard_screens.py
+++ b/src/terok/tui/wizard_screens.py
@@ -30,6 +30,7 @@ import io
 from pathlib import Path
 from typing import Any
 
+from rich.text import Text
 from textual import on, work
 from textual.app import ComposeResult
 from textual.binding import Binding
@@ -375,8 +376,6 @@ class ShowSshKeyScreen(ModalScreen[None]):
 
     def compose(self) -> ComposeResult:
         """Build the hint + bare public key."""
-        from rich.text import Text
-
         yield Static(
             "Shift-drag to select the key below  ·  Esc, Enter or q to return",
             id="wizard-ssh-show-hint",
@@ -715,7 +714,18 @@ class InitProgressScreen(ModalScreen[InitOutcome]):
             log.write(f"[green]✓[/] SSH key minted: {result['comment']}")
 
             if project_needs_key_registration(self._project_id):
-                self.query_one("#wizard-init-ssh-pubkey", Static).update(result["public_line"])
+                # ``overflow="fold"`` is load-bearing: Static's default
+                # word-wrap can't break a base64 blob (no spaces), so
+                # long keys silently truncate at the right edge of the
+                # bordered box — the user doesn't see there's more key
+                # off-screen and might copy an incomplete key.  Folding
+                # forces a character-level wrap so the full key is
+                # visible, even if border chars sit alongside it; a
+                # byte-clean copy is still one click away via "Copy"
+                # or "Show full key".
+                self.query_one("#wizard-init-ssh-pubkey", Static).update(
+                    Text(result["public_line"], overflow="fold", no_wrap=False)
+                )
                 # Show the fingerprint beside the key so the user can
                 # check it matches what their remote (e.g. GitHub) shows
                 # *after* pasting — by then the pubkey is already gone


### PR DESCRIPTION
## Summary

- Renders the wizard's SSH public key through `Text(..., overflow="fold")` so the line wraps at character granularity instead of being silently truncated at the right edge of the bordered box.
- Promotes `from rich.text import Text` to a module-level import (was a local import inside `ShowSshKeyScreen.compose`).

## Why

`Static`'s default word-wrap can't break a base64 blob — there are no spaces to break on — so a key that exceeded the bordered box's inner width was cropped. Users who missed the crop could click **Copy** and walk away with an incomplete key, or never realise that **Show full key** existed to rescue them.

Folding forces a character-level wrap. The full key is always visible; a byte-clean copy is still one click away (**Copy** for clipboard, **Show full key** for terminal mouse-select).

Follow-up to #817.

## Test plan

- [ ] Launch `terok-tui`, run the new-project wizard with a project whose upstream requires SSH key registration.
- [ ] Verify the full pubkey is visible in the bordered box — no cropped ends — at both the default dialog width and a narrow terminal.
- [ ] Click **Copy**; paste into a scratch buffer; verify the pasted text is the full single-line key with no embedded line breaks.
- [ ] Click **Show full key** and confirm the borderless view still works.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * SSH key display in the registration wizard now wraps properly instead of truncating at the container edge, ensuring full visibility of public keys.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->