### PR TITLE
fix(tui): detach wizard subprocesses from controlling tty

### DIFF
--- a/src/terok/tui/wizard_screens.py
+++ b/src/terok/tui/wizard_screens.py
@@ -947,6 +947,15 @@ def _run_isolated(child_body: str, *, label: str) -> None:
     terminal stays pristine regardless of what the step prints or
     crashes with.
 
+    ``capture_output=True`` only intercepts stdout/stderr, not
+    ``/dev/tty``.  Tools like OpenSSH open ``/dev/tty`` directly to
+    read passphrases, which would land on the Textual frame despite
+    the captured fds.  ``start_new_session=True`` detaches the child
+    from its controlling terminal so ``/dev/tty`` has nothing to
+    resolve to, and ``stdin=DEVNULL`` closes the last input channel.
+    Combined, no subprocess below this call — however badly behaved —
+    can prompt the user over the TUI.
+
     *label* is the human-friendly step name used in the error message.
     Any non-zero exit propagates as :class:`RuntimeError` carrying the
     last few KiB of the child's combined output, which the wizard's
@@ -964,6 +973,8 @@ def _run_isolated(child_body: str, *, label: str) -> None:
         capture_output=True,
         text=True,
         check=False,
+        stdin=subprocess.DEVNULL,
+        start_new_session=True,
     )
     if result.returncode != 0:
         tail = (result.stderr or result.stdout or "").strip().splitlines()

--- a/tests/unit/tui/test_wizard_screens.py
+++ b/tests/unit/tui/test_wizard_screens.py
@@ -344,6 +344,31 @@ def test_run_isolated_propagates_nonzero_as_runtime_error() -> None:
     assert "kaboom" in msg
 
 
+def test_run_isolated_detaches_child_from_controlling_tty() -> None:
+    """The child is its own session leader and has an empty stdin.
+
+    Without this isolation, a misbehaving grandchild (e.g. OpenSSH asking
+    for a passphrase) can open ``/dev/tty`` and write prompts onto the
+    Textual frame that the TUI can't catch via ``capture_output``.  The
+    invariants below prove the belt-and-braces:
+
+    * ``os.getsid(0) == os.getpid()`` — child was ``setsid()``-ed, so it
+      has no controlling tty at all.
+    * reading stdin returns empty — ``DEVNULL`` severed the last input
+      channel, so any tool that falls back to stdin also fails cleanly.
+    """
+    from terok.tui.wizard_screens import _run_isolated
+
+    probe = (
+        "import os, sys;"
+        " is_leader = os.getsid(0) == os.getpid();"
+        " stdin_empty = sys.stdin.read() == '';"
+        " sys.exit(0 if (is_leader and stdin_empty) else 1)"
+    )
+    # Raises if either invariant fails.
+    _run_isolated(probe, label="tty-isolation probe")
+
+
 def test_gate_sync_in_subprocess_returns_result_dict() -> None:
     """The helper shuttles the child's result dict back to the parent verbatim.
 


### PR DESCRIPTION
## Summary

- The new-project wizard's ``_run_isolated`` helper only captured stdout/stderr of the child subprocess. OpenSSH (and other tools) open ``/dev/tty`` directly for passphrase prompts, bypassing captured fds and writing over the Textual frame.
- Triggered in practice by the first gate-sync during wizard setup when the freshly minted key wasn't registered on the remote yet — ssh fell through to the user's ambient config, picked up a personal key, and prompted for *that* passphrase on the TUI.
- Fix: ``start_new_session=True`` detaches the child from its controlling terminal (so ``/dev/tty`` has nothing to resolve to) and ``stdin=subprocess.DEVNULL`` closes the last input channel. Belt-and-braces for any subprocess the wizard spawns, present or future — also covers the ``terok-web serve`` path where no TUI is even attached.

Pairs with terok-ai/terok-sandbox#212 which fixes the *root cause* (``BatchMode=yes`` + ``IdentityAgent=<sock>`` + ``-F /dev/null`` on the vault branch of ``_git_env_with_ssh``). Either change alone would have prevented the observed symptom; having both ensures the invariant holds even if a future subprocess does something unexpected.

## Test plan

- [x] New ``test_run_isolated_detaches_child_from_controlling_tty`` asserts in a real child: ``os.getsid(0) == os.getpid()`` (child is session leader → no controlling tty) and ``sys.stdin.read() == ''`` (DEVNULL).
- [x] ``poetry run pytest tests/unit/tui/test_wizard_screens.py`` — 18 passed.
- [x] ``poetry run pytest tests/unit/`` — 2055 passed.
- [x] ``ruff check`` + ``ruff format --check`` — clean on changed files.
- [x] ``tach check`` — clean.
- [x] ``docstr-coverage`` — 98.6% project-wide.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where interactive prompts could interfere with the text-based user interface by improving subprocess isolation.

* **Tests**
  * Added unit tests to verify subprocess isolation guarantees are maintained.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->