### PR TITLE
fix(tui): clamp wizard dialogs to viewport width on narrow terminals

### DIFF
--- a/src/terok/tui/wizard_screens.py
+++ b/src/terok/tui/wizard_screens.py
@@ -68,6 +68,7 @@ class WizardFormScreen(ModalScreen["dict[str, str] | None"]):
 
     #wizard-form-dialog {
         width: 80;
+        max-width: 100%;
         height: 90%;
         border: heavy $primary;
         border-title-align: right;
@@ -260,6 +261,7 @@ class ProjectReviewScreen(ModalScreen["str | object | None"]):
 
     #wizard-review-dialog {
         width: 90;
+        max-width: 100%;
         height: 80%;
         border: heavy $primary;
         border-title-align: right;
@@ -427,6 +429,7 @@ class InitProgressScreen(ModalScreen[InitOutcome]):
 
     #wizard-init-dialog {
         width: 90;
+        max-width: 100%;
         height: 80%;
         border: heavy $primary;
         border-title-align: right;


### PR DESCRIPTION
## Summary

- Adds `max-width: 100%` to the three wizard dialogs (`#wizard-form-dialog`, `#wizard-review-dialog`, `#wizard-init-dialog`) so they shrink to the viewport when the terminal is narrower than the preferred width.

## Why

All three wizard screens ship with a fixed width (80 or 90) and no upper clamp. On an 80-column terminal the right border of the 90-wide dialogs disappears entirely — and with it, the last couple of columns of every line of content, including the SSH key row. A ``max-width: 100%`` clamp keeps the fixed preferred width on wider terminals (more readable than a full-width modal) while letting it shrink on narrower ones.

Follow-up to #817 / #820 — the SSH key already folds at character granularity (#820), so a narrower inner width just produces more wrap rows; nothing truncates.

## Test plan

- [ ] Resize a terminal to 80 cols and launch `terok-tui`; open the new-project wizard.
- [ ] Verify the form, review, and init dialogs all render with a visible right border and no clipped content.
- [ ] Resize to 120 cols; verify the dialogs still render at their preferred 80/90 width, centred.
- [ ] During the init step on the 80-col terminal, confirm the SSH pubkey wraps fully inside the bordered box.