### PR TITLE
fix(setup): image build is opt-in via --with-images=BASE; default is skip

### DIFF
--- a/src/terok/cli/commands/setup.py
+++ b/src/terok/cli/commands/setup.py
@@ -7,12 +7,18 @@ Thin wrapper over :func:`terok_executor.ensure_sandbox_ready` — the
 executor-level composer that generates vault routes from the agent
 roster and then runs the sandbox aggregator (shield hooks + reader +
 vault + gate + clearance hub/verdict/notifier with a full
-stop → uninstall → install → verify cycle per service).  After the
-service stack we build the L0/L1 base images via
-:func:`terok_executor.build_base_images` so a fresh ``terok setup``
-leaves the host ready to run tasks without a separate image-build
-step.  On top, terok adds its own desktop-entry install for
-``terok-tui``.  Safe to re-run; every phase is idempotent.
+stop → uninstall → install → verify cycle per service).  On top,
+terok adds its own desktop-entry install for ``terok-tui``.  Safe
+to re-run; every phase is idempotent.
+
+Base images are **not** built by default: each project declares its
+own ``image.base_image`` in ``project.yml`` (ubuntu, fedora,
+nvidia/cuda, …), so at setup time there's nothing sensible to
+pre-build.  L0/L1 build happens lazily on first ``terok task run``
+keyed by the project's declared base, or explicitly via
+``terok project init``.  The ``--with-images=<BASE>`` flag is the
+expert escape hatch for operators who *know* a fleet-wide base
+image and want to pay the build cost once up front.
 
 Per-project operations live under the ``project`` group in
 :mod:`project.py`; :func:`cmd_project_init` stays here because
@@ -62,22 +68,26 @@ def register(subparsers: argparse._SubParsersAction[argparse.ArgumentParser]) ->
         ),
     )
     p_setup.add_argument(
-        "--no-images",
-        action="store_true",
+        "--with-images",
+        metavar="BASE_IMAGE",
+        default=None,
         help=(
-            "Skip the L0/L1 base-image build.  Use on hosts that will "
-            "never run tasks locally (e.g. management-only installs)."
+            "Pre-build L0/L1 for BASE_IMAGE (e.g. ``ubuntu:24.04``, "
+            "``fedora:43``, ``nvidia/cuda:12.6.0-runtime-ubuntu24.04``).  "
+            "Normally images build lazily on first ``terok task run`` or "
+            "``terok project init``, keyed by each project's declared "
+            "base — so this flag is only useful when you *know* your "
+            "fleet will use one base and want to pay the cost once up "
+            "front.  No default: omit the flag to skip the build."
         ),
-    )
-    p_setup.add_argument(
-        "--base",
-        default="ubuntu:24.04",
-        help="Base image for the L0/L1 build (default: ubuntu:24.04).",
     )
     p_setup.add_argument(
         "--family",
         default=None,
-        help="Override auto-detected package family (``deb`` or ``rpm``).",
+        help=(
+            "Package family override for ``--with-images`` (``deb`` or "
+            "``rpm``).  Auto-detected from the base image name otherwise."
+        ),
     )
 
 
@@ -87,8 +97,7 @@ def dispatch(args: argparse.Namespace) -> bool:
         return False
     cmd_setup(
         no_desktop_entry=getattr(args, "no_desktop_entry", False),
-        no_images=getattr(args, "no_images", False),
-        base=getattr(args, "base", "ubuntu:24.04"),
+        with_images=getattr(args, "with_images", None),
         family=getattr(args, "family", None),
     )
     return True
@@ -100,20 +109,23 @@ def dispatch(args: argparse.Namespace) -> bool:
 def cmd_setup(
     *,
     no_desktop_entry: bool = False,
-    no_images: bool = False,
-    base: str = "ubuntu:24.04",
+    with_images: str | None = None,
     family: str | None = None,
 ) -> None:
-    """Install the sandbox stack via the executor composer, build base images, then desktop entry.
+    """Install the sandbox stack + desktop entry; optionally pre-build one L0/L1 pair.
 
     Exits non-zero if the sandbox aggregator fails (one or more service
-    phases unreachable) or if the image build fails.  The desktop entry
-    step is non-fatal when xdg-utils is missing — the built-in fallback
-    covers spec-compliant hosts and the warning is a WARN, not a FAIL.
+    phases unreachable) or if a requested image build fails.  The
+    desktop entry step is non-fatal when xdg-utils is missing — the
+    built-in fallback covers spec-compliant hosts and the warning is
+    a WARN, not a FAIL.
 
-    ``no_images`` skips the L0/L1 build for management-only hosts that
-    never run tasks locally; ``base`` + ``family`` are forwarded to the
-    image factory when the build does run.
+    When ``with_images`` is ``None`` (the default) the L0/L1 build is
+    *skipped entirely* — image-build decisions are per-project and
+    happen on first ``terok task run`` / ``terok project init``.  Pass
+    a base image (e.g. ``"ubuntu:24.04"``) to eagerly build once up
+    front for a known fleet.  ``family`` overrides package-family
+    detection for that build.
     """
     from terok_executor import ensure_sandbox_ready
 
@@ -128,11 +140,11 @@ def cmd_setup(
             print(_bold(_red(f"Sandbox aggregator reported failures (exit {exc.code}).")))
 
     images_failed = False
-    if not no_images and not sandbox_failed:
+    if with_images and not sandbox_failed:
         # Skip the (slow) image build when the service stack is already
         # broken — the user needs to fix setup before anything that
         # depends on images will be useful anyway.
-        images_failed = not _run_image_build(base=base, family=family)
+        images_failed = not _run_image_build(base=with_images, family=family)
 
     print()
     desktop_ok = no_desktop_entry or _ensure_desktop_entry()

--- a/tests/unit/cli/test_cli_setup_global.py
+++ b/tests/unit/cli/test_cli_setup_global.py
@@ -33,37 +33,33 @@ def test_dispatch_invokes_cmd_setup_with_flag() -> None:
     ns = argparse.Namespace(
         cmd="setup",
         no_desktop_entry=True,
-        no_images=False,
-        base="ubuntu:24.04",
+        with_images=None,
         family=None,
     )
     with patch("terok.cli.commands.setup.cmd_setup") as mock:
         assert dispatch(ns) is True
     mock.assert_called_once_with(
         no_desktop_entry=True,
-        no_images=False,
-        base="ubuntu:24.04",
+        with_images=None,
         family=None,
     )
 
 
-def test_dispatch_forwards_image_flags() -> None:
-    """``--no-images`` / ``--base`` / ``--family`` travel through the dispatcher as kwargs."""
+def test_dispatch_forwards_with_images_and_family() -> None:
+    """``--with-images`` + ``--family`` travel through the dispatcher as kwargs."""
     import argparse
 
     ns = argparse.Namespace(
         cmd="setup",
         no_desktop_entry=False,
-        no_images=True,
-        base="fedora:43",
+        with_images="fedora:43",
         family="rpm",
     )
     with patch("terok.cli.commands.setup.cmd_setup") as mock:
         dispatch(ns)
     mock.assert_called_once_with(
         no_desktop_entry=False,
-        no_images=True,
-        base="fedora:43",
+        with_images="fedora:43",
         family="rpm",
     )
 
@@ -72,9 +68,16 @@ def test_dispatch_forwards_image_flags() -> None:
 
 
 class TestCmdSetup:
-    """``cmd_setup`` composes sandbox-ready + image build + desktop-entry in that order."""
+    """``cmd_setup`` runs sandbox-ready + desktop-entry by default; images are opt-in."""
 
-    def test_happy_path_runs_all_phases(self, capsys: pytest.CaptureFixture[str]) -> None:
+    def test_default_skips_image_build(self, capsys: pytest.CaptureFixture[str]) -> None:
+        """Normal ``terok setup`` doesn't touch the image factory.
+
+        Base images are a per-project decision (each ``project.yml``
+        declares its own ``image.base_image``); at host-setup time
+        there's nothing sensible to pre-build.  L0/L1 materialises
+        lazily on first ``terok task run`` / ``terok project init``.
+        """
         with (
             patch("terok_executor.ensure_sandbox_ready") as sandbox,
             patch("terok_executor.build_base_images") as images,
@@ -82,7 +85,7 @@ class TestCmdSetup:
         ):
             cmd_setup()
         sandbox.assert_called_once()
-        images.assert_called_once_with(base_image="ubuntu:24.04", family=None)
+        images.assert_not_called()
         desktop.assert_called_once()
         assert "Setup complete" in capsys.readouterr().out
 
@@ -95,25 +98,27 @@ class TestCmdSetup:
             cmd_setup(no_desktop_entry=True)
         desktop.assert_not_called()
 
-    def test_no_images_skips_image_phase(self, capsys: pytest.CaptureFixture[str]) -> None:
-        """``--no-images`` keeps setup fast on management-only hosts."""
+    def test_with_images_builds_requested_base(self) -> None:
+        """``--with-images=ubuntu:24.04`` triggers the factory with that base + auto-detected family."""
         with (
             patch("terok_executor.ensure_sandbox_ready"),
             patch("terok_executor.build_base_images") as images,
             patch("terok.cli.commands.setup._ensure_desktop_entry", return_value=True),
         ):
-            cmd_setup(no_images=True)
-        images.assert_not_called()
+            cmd_setup(with_images="ubuntu:24.04")
+        images.assert_called_once_with(base_image="ubuntu:24.04", family=None)
 
-    def test_base_and_family_forwarded_to_factory(self) -> None:
-        """``--base`` + ``--family`` thread through to :func:`build_base_images`."""
+    def test_with_images_plus_family_override(self) -> None:
+        """``--family`` overrides auto-detection when paired with ``--with-images``."""
         with (
             patch("terok_executor.ensure_sandbox_ready"),
             patch("terok_executor.build_base_images") as images,
             patch("terok.cli.commands.setup._ensure_desktop_entry", return_value=True),
         ):
-            cmd_setup(base="fedora:43", family="rpm")
-        images.assert_called_once_with(base_image="fedora:43", family="rpm")
+            cmd_setup(with_images="my-registry.example.com/odd-base:1.0", family="rpm")
+        images.assert_called_once_with(
+            base_image="my-registry.example.com/odd-base:1.0", family="rpm"
+        )
 
     def test_image_build_error_exits_nonzero(self, capsys: pytest.CaptureFixture[str]) -> None:
         """A ``BuildError`` from the factory surfaces as a FAIL stage line and exit 1."""
@@ -128,19 +133,23 @@ class TestCmdSetup:
             patch("terok.cli.commands.setup._ensure_desktop_entry", return_value=True),
         ):
             with pytest.raises(SystemExit) as exc:
-                cmd_setup()
+                cmd_setup(with_images="ubuntu:24.04")
         assert exc.value.code == 1
         assert "Image build failed" in capsys.readouterr().out
 
-    def test_sandbox_failure_skips_image_phase(self) -> None:
-        """When the service stack breaks, don't spend minutes building images on a broken host."""
+    def test_sandbox_failure_skips_requested_image_phase(self) -> None:
+        """``--with-images`` is still suppressed when the service stack is broken.
+
+        No point burning minutes on L0/L1 against a host that can't
+        yet mount it; the user needs to fix the sandbox install first.
+        """
         with (
             patch("terok_executor.ensure_sandbox_ready", side_effect=SystemExit(1)),
             patch("terok_executor.build_base_images") as images,
             patch("terok.cli.commands.setup._ensure_desktop_entry", return_value=True),
         ):
             with pytest.raises(SystemExit):
-                cmd_setup()
+                cmd_setup(with_images="ubuntu:24.04")
         images.assert_not_called()
 
     def test_sandbox_failure_exits_nonzero(self, capsys: pytest.CaptureFixture[str]) -> None:


### PR DESCRIPTION
## Summary

Walks back #816's eager image build.  ``terok setup`` no longer pre-builds L0/L1 by default — it's behind an expert flag instead.

## Why

#816 pre-built a single ``terok-l0``/``terok-l1-cli`` pair at host-setup time, defaulting to ``ubuntu:24.04``.  But:

- Each ``project.yml`` declares its own ``image.base_image`` — projects can ask for ubuntu, fedora, ``nvidia/cuda:*``, and so on.
- At setup time the host doesn't know what any project will need.  If the user's first project declares ``fedora:43`` the ubuntu pre-build is wasted; the executor rebuilds from fedora on first ``terok task run`` anyway.
- The right model is **lazy, per-project** — and the executor already does that via ``check_images`` + interactive fix during ``terok task run`` / ``terok project init``.

Terok's ``terok setup`` should therefore **default to skip** the image build.  Keep an escape hatch for operators who *know* a fleet-wide base and want to pay the cost once up front.

## Flag changes

Removed (default-on path):

```
--no-images       opt-out of the default build
--base BASE       what to build (defaulted to ubuntu:24.04)
```

Added (expert path):

```
--with-images BASE_IMAGE      pre-build L0/L1 for BASE_IMAGE, nothing otherwise
--family deb|rpm              (kept; still pairs with --with-images)
--no-desktop-entry            (kept)
```

New UX:

```bash
# Normal — fast, guess-free, matches the lazy per-project model
terok setup

# Expert — pay the image build now for a known fleet-wide base
terok setup --with-images=ubuntu:24.04
terok setup --with-images=fedora:43 --family=rpm
```

Sandbox aggregator + desktop entry still always run — nothing changed there.  Image build is also suppressed when the sandbox stack itself fails (unchanged from #816).

## Executor side

terok-executor's own ``terok-executor setup`` still builds a default image — that's the right choice for a standalone single-task runner where the base *is* known per-invocation.  Only terok's top-level ``setup`` walks back the eager default.

## Test plan

- [x] ``tests/unit/cli/test_cli_setup_global.py`` — 16 tests pass:
  - ``test_default_skips_image_build`` — new; pins the guess-free default
  - ``test_with_images_builds_requested_base`` — opt-in happy path
  - ``test_with_images_plus_family_override`` — family override pairs with opt-in
  - ``test_image_build_error_exits_nonzero`` — BuildError still exits 1
  - ``test_sandbox_failure_skips_requested_image_phase`` — even an explicit opt-in is suppressed when services broken
  - Plus the existing sandbox / desktop / dispatch wiring tests updated to the new signature.
- [x] ``make lint`` / ``make tach`` / ``make lint-imports`` / ``make docstrings`` / full unit suite — all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated `terok setup` command interface: base image building is now off by default. Replaced `--no-images` and `--base` flags with a single optional `--with-images` parameter to enable per-project image builds on demand.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->