### PR TITLE
feat(task): script-readable exit codes for setup-needed (3) / downgrade (4)

### DIFF
--- a/.importlinter
+++ b/.importlinter
@@ -40,6 +40,7 @@ allowed_importers =
     terok.cli.commands.setup
     terok.cli.commands.shield
     terok.cli.commands.sickbay
+    terok.cli.commands.task
     terok.cli.commands.uninstall
     terok.tui.clearance_screen
     terok.cli.commands.vault_local

--- a/src/terok/cli/commands/task.py
+++ b/src/terok/cli/commands/task.py
@@ -319,6 +319,7 @@ def dispatch(args: argparse.Namespace) -> bool:
 
 def _cmd_task_run(args: argparse.Namespace) -> None:
     """Dispatch ``terok task run`` to the runner for the chosen mode."""
+    _setup_verdict_or_exit()
     mode = getattr(args, "mode", "cli")
     if mode == "headless":
         _cmd_task_run_headless(args)
@@ -326,6 +327,92 @@ def _cmd_task_run(args: argparse.Namespace) -> None:
         _cmd_task_run_interactive(args, runner=task_run_toad, attach=False)
     else:  # mode == "cli"
         _cmd_task_run_interactive(args, runner=task_run_cli, attach=_resolve_attach(args))
+
+
+def _setup_verdict_or_exit() -> None:
+    """Bounce the user to ``terok setup`` before spawning task containers.
+
+    Mirrors ``terok-executor run``'s phase-4 exit-code contract so
+    scripts see the same signal whether they drive terok or executor
+    directly:
+
+    - ``OK`` → silent return, task runner proceeds.
+    - ``FIRST_RUN`` / ``STALE_AFTER_UPDATE`` / ``STAMP_CORRUPT`` →
+      exit 3 with ``"Fix: terok setup"`` on stderr.
+    - ``STALE_AFTER_DOWNGRADE`` → exit 4 after a multi-line refusal
+      naming the downgraded packages.  Downgrades aren't tested;
+      refusing is deliberate per epic terok-ai/terok#685.
+
+    Cheap enough to call on every ``task run`` / ``task restart``
+    invocation — one ``Path.is_file``, one JSON decode, a handful
+    of ``importlib.metadata.version`` lookups.
+    """
+    from terok_sandbox import SetupVerdict, needs_setup
+    from terok_sandbox.setup_stamp import _installed_versions, _read_stamp, stamp_path
+
+    verdict = needs_setup()
+    if verdict is SetupVerdict.OK:
+        return
+
+    if verdict is SetupVerdict.STALE_AFTER_DOWNGRADE:
+        downgraded = _name_downgraded_packages(stamp_path(), _read_stamp, _installed_versions)
+        names = ", ".join(downgraded) or "one or more packages"
+        print(
+            f"terok: refusing to run — downgrade detected ({names}).\n"
+            "  Downgrades aren't supported; older code may not read newer state correctly.\n"
+            "  Either upgrade back to the stamped version, or "
+            "remove the stamp at your own risk:\n"
+            f"    rm {stamp_path()}",
+            file=sys.stderr,
+        )
+        raise SystemExit(4)
+
+    nudge = {
+        SetupVerdict.FIRST_RUN: "no setup stamp found — terok hasn't been initialised",
+        SetupVerdict.STALE_AFTER_UPDATE: (
+            "package versions changed since the last setup — re-run to apply"
+        ),
+        SetupVerdict.STAMP_CORRUPT: "setup stamp is unreadable — re-run setup to refresh it",
+    }[verdict]
+    print(
+        f"terok: {nudge}.\n  Fix:    terok setup",
+        file=sys.stderr,
+    )
+    raise SystemExit(3)
+
+
+def _name_downgraded_packages(
+    path: Any,
+    read_stamp_fn: Any,
+    installed_fn: Any,
+) -> list[str]:
+    """Return ``[pkg]`` whose installed version is < stamped, or missing entirely.
+
+    Best-effort: if the stamp can't be re-read (race with a parallel
+    setup overwrite) we return an empty list so the caller falls back
+    to a generic "downgrade detected" message instead of crashing.
+    """
+    from packaging.version import InvalidVersion, Version
+
+    try:
+        stamped = read_stamp_fn(path)
+    except Exception:  # noqa: BLE001 — diagnostic helper, never the source of truth
+        return []
+    installed = installed_fn()
+
+    out: list[str] = []
+    for pkg, stamp_ver in stamped.items():
+        if pkg not in installed:
+            out.append(f"{pkg} (uninstalled)")
+            continue
+        cur = installed[pkg]
+        try:
+            if Version(cur) < Version(stamp_ver):
+                out.append(f"{pkg} {stamp_ver} → {cur}")
+        except InvalidVersion:
+            if cur < stamp_ver:
+                out.append(f"{pkg} {stamp_ver} → {cur}")
+    return out
 
 
 def _cmd_task_run_interactive(args: argparse.Namespace, *, runner: Any, attach: bool) -> None:
@@ -492,8 +579,10 @@ def _dispatch_task_sub(args: argparse.Namespace) -> bool:
     elif args.task_cmd == "stop":
         task_stop(pid, tid, timeout=getattr(args, "timeout", None))
     elif args.task_cmd == "restart":
+        _setup_verdict_or_exit()
         task_restart(pid, tid)
     elif args.task_cmd == "followup":
+        _setup_verdict_or_exit()
         task_followup_headless(
             pid,
             tid,

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -395,6 +395,22 @@ def terok_env(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> TerokIntegrati
     sandbox_state.mkdir(parents=True, exist_ok=True)
     monkeypatch.setenv("TEROK_SANDBOX_LIVE_DIR", str(sandbox_live))
     monkeypatch.setenv("TEROK_SANDBOX_STATE_DIR", str(sandbox_state))
+
+    # Seed a valid setup.stamp so subprocess CLIs don't exit 3 at the
+    # verdict gate on ``terok task run`` / ``terok-executor run``.  Real
+    # operators run ``terok setup`` once before tasks; the integration
+    # harness simulates that completed state without running the full
+    # installer.  Tests that specifically exercise the gate's response
+    # to FIRST_RUN / STALE_* verdicts should manipulate the stamp
+    # themselves (or use unit tests which don't rely on this fixture).
+    #
+    # ``TEROK_ROOT`` is set via subprocess env in ``TerokIntegrationEnv.cli_env``
+    # (helpers.py), so we also mirror it into the pytest process so the
+    # in-process ``write_stamp()`` call below targets the same path.
+    monkeypatch.setenv("TEROK_ROOT", str(tmp_path))
+    from terok_sandbox import write_stamp
+
+    write_stamp()
     return env
 
 

--- a/tests/unit/cli/test_cli_autopilot.py
+++ b/tests/unit/cli/test_cli_autopilot.py
@@ -15,6 +15,20 @@ from tests.testcli import run_cli
 from tests.testfs import NONEXISTENT_MARKDOWN_PATH
 
 
+@pytest.fixture(autouse=True)
+def _bypass_setup_verdict_gate():
+    """Skip the stamp-based gate in task-CLI unit tests — covered separately.
+
+    ``_cmd_task_run`` now calls :func:`terok.cli.commands.task._setup_verdict_or_exit`
+    at entry which raises exit 3 when the setup stamp is absent.  These
+    tests run in a stamp-free tmp env and assert behaviour downstream
+    of that gate; the gate's own behaviour is pinned by
+    ``test_cli_task_verdict_gate.py``.
+    """
+    with patch("terok.cli.commands.task._setup_verdict_or_exit"):
+        yield
+
+
 def capture_headless_request(project: str, prompt: str, *extra_args: str) -> HeadlessRunRequest:
     """Run ``terok task run --mode headless`` and capture the forwarded request."""
     with (

--- a/tests/unit/cli/test_cli_task_verdict_gate.py
+++ b/tests/unit/cli/test_cli_task_verdict_gate.py
@@ -1,0 +1,130 @@
+# SPDX-FileCopyrightText: 2026 Jiri Vyskocil
+# SPDX-License-Identifier: Apache-2.0
+
+"""Cheap stamp-based gate that runs before ``terok task run`` / ``task restart``.
+
+Mirrors the executor-side contract (``terok-executor run`` exit codes
+3 / 4; see sandbox setup-stamp primitive and epic terok-ai/terok#685
+phase 6): scripts driving either entry point see the same signal for
+"setup needed" vs "real task failure".
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+from terok_sandbox import SetupVerdict
+
+from terok.cli.commands.task import _setup_verdict_or_exit
+
+# ── Verdict → exit-code mapping ───────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    ("verdict", "expected_fragment"),
+    [
+        pytest.param(SetupVerdict.FIRST_RUN, "no setup stamp found", id="first-run-exits-3"),
+        pytest.param(
+            SetupVerdict.STALE_AFTER_UPDATE,
+            "package versions changed",
+            id="stale-after-update-exits-3",
+        ),
+        pytest.param(SetupVerdict.STAMP_CORRUPT, "stamp is unreadable", id="stamp-corrupt-exits-3"),
+    ],
+)
+def test_setup_needed_verdicts_all_exit_three(
+    verdict: SetupVerdict,
+    expected_fragment: str,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """FIRST_RUN / STALE_AFTER_UPDATE / STAMP_CORRUPT all collapse to exit 3 with a fix hint."""
+    with patch("terok_sandbox.needs_setup", return_value=verdict):
+        with pytest.raises(SystemExit) as excinfo:
+            _setup_verdict_or_exit()
+    assert excinfo.value.code == 3
+    err = capsys.readouterr().err
+    assert expected_fragment in err
+    # Every "setup needed" path points at the canonical terok-side fix.
+    assert "terok setup" in err
+
+
+def test_downgrade_exits_four_with_named_packages(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """STALE_AFTER_DOWNGRADE refuses with exit 4, names the offending packages."""
+    with (
+        patch(
+            "terok_sandbox.needs_setup",
+            return_value=SetupVerdict.STALE_AFTER_DOWNGRADE,
+        ),
+        patch(
+            "terok.cli.commands.task._name_downgraded_packages",
+            return_value=["terok 0.8.1 → 0.8.0"],
+        ),
+    ):
+        with pytest.raises(SystemExit) as excinfo:
+            _setup_verdict_or_exit()
+    assert excinfo.value.code == 4
+    err = capsys.readouterr().err
+    assert "downgrade detected" in err
+    assert "terok 0.8.1 → 0.8.0" in err
+    # The refusal points at the deliberate-override path, not the easy fix.
+    assert "rm" in err and "stamp" in err
+
+
+def test_downgrade_falls_back_to_generic_when_diff_unavailable(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """When the stamp can't be re-read for diffing, surface a generic refusal — never crash."""
+    with (
+        patch(
+            "terok_sandbox.needs_setup",
+            return_value=SetupVerdict.STALE_AFTER_DOWNGRADE,
+        ),
+        patch("terok.cli.commands.task._name_downgraded_packages", return_value=[]),
+    ):
+        with pytest.raises(SystemExit) as excinfo:
+            _setup_verdict_or_exit()
+    assert excinfo.value.code == 4
+    assert "one or more packages" in capsys.readouterr().err
+
+
+def test_ok_verdict_returns_silently() -> None:
+    """OK is the happy path — no print, no exit, control flows back to the task runner."""
+    with patch("terok_sandbox.needs_setup", return_value=SetupVerdict.OK):
+        assert _setup_verdict_or_exit() is None
+
+
+# ── _name_downgraded_packages helper ──────────────────────────────────
+
+
+def test_name_downgraded_packages_lists_each_offender(tmp_path) -> None:
+    """Helper compares stamped vs installed and names every package that regressed."""
+    from terok.cli.commands.task import _name_downgraded_packages
+
+    stamp = tmp_path / "setup.stamp"
+
+    def fake_read(_path):
+        return {"terok": "0.8.1", "terok-sandbox": "0.0.98", "terok-shield": "0.6.31"}
+
+    def fake_installed():
+        # terok downgraded, sandbox kept its version, shield gone entirely.
+        return {"terok": "0.8.0", "terok-sandbox": "0.0.98"}
+
+    out = _name_downgraded_packages(stamp, fake_read, fake_installed)
+    assert "terok 0.8.1 → 0.8.0" in out
+    assert "terok-shield (uninstalled)" in out
+    # Equal versions don't get listed.
+    assert not any(entry.startswith("terok-sandbox ") for entry in out)
+
+
+def test_name_downgraded_packages_swallows_read_error(tmp_path) -> None:
+    """A racing setup overwriting the stamp can't crash the diagnostic helper."""
+    from terok.cli.commands.task import _name_downgraded_packages
+
+    def boom(_path):
+        raise RuntimeError("stamp went away mid-diff")
+
+    out = _name_downgraded_packages(tmp_path / "x", boom, lambda: {})
+    assert out == []

--- a/tests/unit/cli/test_cli_workflows.py
+++ b/tests/unit/cli/test_cli_workflows.py
@@ -13,6 +13,18 @@ import pytest
 from tests.testfs import FAKE_GATE_DIR
 
 
+@pytest.fixture(autouse=True)
+def _bypass_setup_verdict_gate():
+    """Skip the stamp-based gate — covered separately in ``test_cli_task_verdict_gate.py``.
+
+    Workflow tests assert the command-dispatch shape downstream of the
+    gate; they run in a stamp-free tmp env where the real gate would
+    always raise exit 3 before dispatch ever happens.
+    """
+    with unittest.mock.patch("terok.cli.commands.task._setup_verdict_or_exit"):
+        yield
+
+
 def _patch_init_steps[T](func: Callable[..., T]) -> Callable[..., T]:
     """Apply project-init step mocks to a test method.
 


### PR DESCRIPTION
## Summary

Phase 6 of [epic terok-ai/terok#685](https://github.com/terok-ai/terok/issues/685) — mirrors phase 4 (executor [PR #231](https://github.com/terok-ai/terok-executor/pull/231)) on the terok side so scripts driving ``terok task run`` / ``terok task restart`` see the same signal as ``terok-executor run``.

## Exit-code contract

| Code | Meaning |
|---|---|
| 0 | success |
| 1 | task-level failure (e.g. runner crash) |
| 2 | argparse / generic CLI error |
| **3** | **setup needed** ← NEW on terok |
| **4** | **downgrade detected, refuses** ← NEW on terok |

Matches the executor-side codes exactly — driver scripts don't have to know which entry point spawned the task.

## Verdict routing

New ``_setup_verdict_or_exit()`` helper in ``src/terok/cli/commands/task.py`` reads ``terok_sandbox.needs_setup``:

- ``OK`` → silent return, runner proceeds.
- ``FIRST_RUN`` / ``STALE_AFTER_UPDATE`` / ``STAMP_CORRUPT`` → exit 3 with ``"Fix: terok setup"`` on stderr.
- ``STALE_AFTER_DOWNGRADE`` → exit 4 with the downgraded packages named explicitly (e.g. ``terok 0.8.1 → 0.8.0``) and a pointer at the deliberate-override path (``rm <stamp>``).  Downgrades aren't tested; refusing is deliberate per the epic.

## Where it's wired

- ``_cmd_task_run`` (covers all three modes: cli / toad / headless)
- ``_dispatch_task_sub`` restart branch
- ``_dispatch_task_sub`` followup branch

Read-only commands (``status``, ``logs``, ``archive list``, ``task new`` metadata creation) stay ungated — they don't need a ready sandbox to work.

## Cost

Sub-millisecond on the OK path: one ``Path.is_file``, one JSON decode, ~5 ``importlib.metadata.version`` lookups. Same budget as the executor-side gate.

## Test plan

- [x] ``tests/unit/cli/test_cli_task_verdict_gate.py`` — 8 new tests:
  - All 3 "setup needed" verdicts → exit 3 + canonical fix hint (parametrised)
  - Downgrade → exit 4, named packages in stderr, points at ``rm <stamp>``
  - Downgrade with unavailable diff → graceful generic message, still exit 4
  - OK → silent return, no exit
  - ``_name_downgraded_packages`` helper: lists each offender, swallows read errors
- [x] ``test_cli_autopilot.py`` + ``test_cli_workflows.py`` get autouse fixtures that bypass the gate so downstream-dispatch assertions still see the same behaviour in a stamp-free test env.
- [x] ``terok.cli.commands.task`` added to the sandbox-boundary import-linter allow-list.
- [x] ``make lint`` / ``make tach`` / ``make lint-imports`` / ``make docstrings`` / full unit suite (2084 pass) all clean.

## Remaining epic phases

- 3b — structured ``CheckResult.suggest`` for per-check ``--fix-X`` hints (skipped per user direction)
- 7 — TUI ``needs_setup()`` verdict dispatch (holding — other dev on adjacent TUI work)
- 8 — command-palette "Terok: Run setup" (holding — TUI-adjacent)

After phase 7/8, the epic body is fully closed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * CLI now enforces a preflight setup check before running/restarting tasks, guides users to run setup when missing/corrupt, and reports downgrade refusals with affected package details.

* **Tests**
  * Added unit tests for setup-verdict behavior and helpers; several test suites mock the verdict gate to focus on command dispatch; integration fixture seeds a completed-setup state.

* **Chores**
  * Updated import policy configuration to permit the CLI task command to import the sandbox.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->