### PR TITLE
feat(tui): WorkerLogScreen — reusable modal that streams a subprocess live

### DIFF
--- a/src/terok/tui/worker_log_screen.py
+++ b/src/terok/tui/worker_log_screen.py
@@ -1,0 +1,247 @@
+# SPDX-FileCopyrightText: 2026 Jiri Vyskocil
+# SPDX-License-Identifier: Apache-2.0
+
+"""Reusable modal that streams a child process's output into a RichLog.
+
+Retires the ``app.suspend()`` + "run it in the underlying terminal"
+pattern for long-running shell-outs (podman build, git clone --mirror,
+terok setup, etc.) so they work identically over ``terok-web`` /
+textual-serve where there's no terminal to suspend *to*.
+
+Scope for this first cut (tracked in
+[terok-ai/terok#473](https://github.com/terok-ai/terok/issues/473)):
+
+- Run an arbitrary ``argv`` as a subprocess via
+  :func:`asyncio.create_subprocess_exec`.
+- Stream ``stdout`` + ``stderr`` (merged) line by line into a
+  ``RichLog``.
+- Dismiss with :class:`WorkerResult` carrying the exit code; a
+  ``Close`` button enables when the process finishes and is coloured
+  by success / failure.
+- ``Hide`` button and "running tasks" drawer are **not** in this
+  PR — the modal blocks until the subprocess exits.  Adding them
+  later is additive (the worker structure is already decoupled via
+  ``@work``).
+
+Not in scope:
+
+- Python-level callables running in a thread.  Kept intentionally
+  out of the first cut because fd-1 / fd-2 redirection for a
+  whole-process capture risks interfering with Textual's own output.
+  Callers with Python work should wrap it in a ``python -c`` argv
+  (same pattern ``wizard_screens._run_isolated`` already uses).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import shlex
+from dataclasses import dataclass
+
+from textual import on, work
+from textual.app import ComposeResult
+from textual.binding import Binding
+from textual.containers import Horizontal, Vertical
+from textual.screen import ModalScreen
+from textual.widgets import Button, Label, RichLog
+
+
+@dataclass(frozen=True)
+class WorkerResult:
+    """Outcome of a :class:`WorkerLogScreen` run.
+
+    ``exit_code`` is the subprocess's exit status (0 on success,
+    non-zero on failure).  A screen dismissed before the subprocess
+    finished resolves to ``exit_code=None`` — distinguishable from
+    an exit-0 completion.
+    """
+
+    exit_code: int | None
+    """Subprocess exit status, or ``None`` if the screen was dismissed early."""
+
+    @property
+    def ok(self) -> bool:
+        """``True`` when the subprocess completed with a zero exit code."""
+        return self.exit_code == 0
+
+
+class WorkerLogScreen(ModalScreen[WorkerResult]):
+    """Modal that runs *argv* as a subprocess and streams its output live.
+
+    Example::
+
+        result = await app.push_screen_wait(
+            WorkerLogScreen(
+                ["terok", "setup"],
+                title="Running terok setup…",
+            )
+        )
+        if result.ok:
+            ...
+
+    The widget is deliberately generic — callers that want to run a
+    Python function inline should shell out with ``[sys.executable,
+    "-c", "..."]`` (the same isolation pattern the wizard's build +
+    gate-sync steps already use for TUI-frame hygiene).
+    """
+
+    BINDINGS = [
+        Binding("escape", "maybe_cancel", "Close"),
+    ]
+
+    CSS = """
+    WorkerLogScreen {
+        align: center middle;
+    }
+
+    #worker-log-dialog {
+        width: 90%;
+        height: 80%;
+        border: heavy $primary;
+        border-title-align: right;
+        background: $surface;
+        padding: 1 2;
+    }
+
+    #worker-log-command {
+        color: $text-muted;
+        margin-bottom: 1;
+        height: auto;
+    }
+
+    #worker-log-output {
+        height: 1fr;
+        border: round $primary-darken-2;
+        margin-bottom: 1;
+    }
+
+    #worker-log-buttons {
+        height: 3;
+        align-horizontal: right;
+    }
+
+    #worker-log-buttons Button {
+        margin-left: 1;
+    }
+    """
+
+    def __init__(
+        self,
+        argv: list[str],
+        *,
+        title: str = "Running…",
+        env: dict[str, str] | None = None,
+        cwd: str | None = None,
+    ) -> None:
+        """Create the modal for an about-to-run subprocess.
+
+        Args:
+            argv: The command to run.  Passed straight to
+                :func:`asyncio.create_subprocess_exec` — no shell.
+            title: Border-title text shown above the log pane.
+            env: Optional environment override.  ``None`` inherits
+                the parent's env (the common case).
+            cwd: Optional working directory.  ``None`` inherits.
+        """
+        super().__init__()
+        self._argv = list(argv)
+        self._title = title
+        self._env = env
+        self._cwd = cwd
+        # Default pessimistic — the worker flips this to the real code on clean
+        # exit; an escape-key dismissal mid-run leaves it None so the caller
+        # can tell "user bailed out" from "process exited 0".
+        self._result: WorkerResult = WorkerResult(exit_code=None)
+        self._proc: asyncio.subprocess.Process | None = None
+
+    def compose(self) -> ComposeResult:
+        """Lay out the log pane and single-action button row."""
+        dialog = Vertical(id="worker-log-dialog")
+        dialog.border_title = self._title
+        with dialog:
+            # Render argv via shlex.join so the operator knows which
+            # command is producing the output they're about to watch.
+            yield Label(f"$ {shlex.join(self._argv)}", id="worker-log-command")
+            yield RichLog(id="worker-log-output", markup=False, wrap=True)
+            with Horizontal(id="worker-log-buttons"):
+                yield Button(
+                    "Close",
+                    id="worker-log-close",
+                    variant="default",
+                    disabled=True,
+                )
+
+    async def on_mount(self) -> None:
+        """Kick off the subprocess as soon as the screen is on stage."""
+        self._run_subprocess()
+
+    # ── Worker ────────────────────────────────────────────────────────
+
+    @work(exclusive=False, group="worker-log", exit_on_error=False)
+    async def _run_subprocess(self) -> None:
+        """Drive the subprocess lifecycle: spawn, stream, finalise.
+
+        The outer try/except is a safety net: an exec failure (command
+        not on PATH, permission denied, cwd missing) needs to surface
+        as a visible line rather than freezing the modal silently.
+        """
+        log = self.query_one("#worker-log-output", RichLog)
+        try:
+            self._proc = await asyncio.create_subprocess_exec(
+                *self._argv,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.STDOUT,
+                env=self._env,
+                cwd=self._cwd,
+            )
+        except (OSError, FileNotFoundError) as exc:
+            log.write(f"[failed to launch] {exc}")
+            self._result = WorkerResult(exit_code=127)
+            self._finish_with_close_button()
+            return
+
+        assert self._proc.stdout is not None
+        async for raw in self._proc.stdout:
+            # Strip only the trailing newline — keep whitespace-preserving
+            # indentation on each line (podman build's output uses it
+            # for STEP 1/n / STEP 2/n markers).
+            log.write(raw.decode(errors="replace").rstrip("\n"))
+
+        exit_code = await self._proc.wait()
+        self._result = WorkerResult(exit_code=exit_code)
+        log.write("")
+        if exit_code == 0:
+            log.write(f"[✓] {self._argv[0]} exited 0")
+        else:
+            log.write(f"[✗] {self._argv[0]} exited with code {exit_code}")
+        self._finish_with_close_button()
+
+    def _finish_with_close_button(self) -> None:
+        """Enable the Close button and colour it by the outcome."""
+        button = self.query_one("#worker-log-close", Button)
+        button.disabled = False
+        if self._result.ok:
+            button.label = "Done"
+            button.variant = "success"
+        else:
+            button.label = "Close"
+            button.variant = "warning"
+
+    # ── Actions ───────────────────────────────────────────────────────
+
+    def action_maybe_cancel(self) -> None:
+        """Escape only dismisses once the worker has finished.
+
+        Mid-run Escape is deliberately ignored — an in-flight
+        ``podman build`` or ``terok setup`` spanning minutes shouldn't
+        be killable by an accidental keypress.  A future ``Cancel``
+        button (with explicit SIGTERM + confirm) is the place for
+        abort semantics.
+        """
+        if not self.query_one("#worker-log-close", Button).disabled:
+            self.dismiss(self._result)
+
+    @on(Button.Pressed, "#worker-log-close")
+    def _on_close(self) -> None:
+        """User-driven dismiss — passes the worker's result back to the caller."""
+        self.dismiss(self._result)

--- a/tests/unit/tui/test_worker_log_screen.py
+++ b/tests/unit/tui/test_worker_log_screen.py
@@ -1,0 +1,168 @@
+# SPDX-FileCopyrightText: 2026 Jiri Vyskocil
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for :class:`WorkerLogScreen` — the reusable subprocess-streaming modal.
+
+Drives the screen via Textual's ``Pilot`` harness — spawns real
+(short-lived) subprocesses rather than mocking ``asyncio.subprocess``
+so the fd / pipe plumbing gets exercised end-to-end.
+"""
+
+from __future__ import annotations
+
+import sys
+
+import pytest
+from textual.app import App
+from textual.widgets import Button, RichLog
+
+from terok.tui.worker_log_screen import WorkerLogScreen, WorkerResult
+
+_SENTINEL_PENDING = object()
+
+
+class _WorkerHost(App):
+    """Minimal app that pushes a :class:`WorkerLogScreen` and stashes the result."""
+
+    def __init__(self, argv: list[str]) -> None:
+        super().__init__()
+        self._argv = argv
+        self.result: object = _SENTINEL_PENDING
+
+    def on_mount(self) -> None:
+        self.push_screen(WorkerLogScreen(self._argv, title="test"), self._capture)
+
+    def _capture(self, result: object) -> None:
+        self.result = result
+
+
+async def _wait_until_close_enabled(pilot, timeout_ticks: int = 200) -> None:
+    """Pump the event loop until the Close button enables (subprocess finished).
+
+    ``Pilot.pause()`` processes one iteration of the Textual tick; 200
+    * default pause (few ms each) gives us ~2–4 s of real wait, enough
+    for even a cold Python startup + an echo.
+    """
+    for _ in range(timeout_ticks):
+        await pilot.pause()
+        button = pilot.app.screen.query_one("#worker-log-close", Button)
+        if not button.disabled:
+            return
+    raise AssertionError("Close button never enabled — subprocess stuck or screen wedged")
+
+
+# ── Happy path ────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_zero_exit_streams_output_and_marks_done() -> None:
+    """A clean subprocess completes, enables Close with ``success`` variant, captures stdout."""
+    argv = [sys.executable, "-c", "print('hello from worker'); print('line two')"]
+    app = _WorkerHost(argv)
+    async with app.run_test() as pilot:
+        await _wait_until_close_enabled(pilot)
+        screen = pilot.app.screen
+        assert isinstance(screen, WorkerLogScreen)
+        # Both printed lines should have made it into the log widget.
+        log = screen.query_one("#worker-log-output", RichLog)
+        rendered = "\n".join(str(line) for line in log.lines)
+        assert "hello from worker" in rendered
+        assert "line two" in rendered
+        # Close is green and relabelled "Done" when the run succeeded.
+        button = screen.query_one("#worker-log-close", Button)
+        assert button.variant == "success"
+        assert str(button.label) == "Done"
+        # Click Close and confirm the screen dismisses with exit 0.
+        await pilot.click("#worker-log-close")
+        await pilot.pause()
+    assert isinstance(app.result, WorkerResult)
+    assert app.result.exit_code == 0
+    assert app.result.ok is True
+
+
+@pytest.mark.asyncio
+async def test_nonzero_exit_surfaces_exit_code_and_warns() -> None:
+    """A subprocess that exits non-zero reports the code and styles Close as ``warning``."""
+    argv = [sys.executable, "-c", "import sys; print('oops'); sys.exit(7)"]
+    app = _WorkerHost(argv)
+    async with app.run_test() as pilot:
+        await _wait_until_close_enabled(pilot)
+        screen = pilot.app.screen
+        assert isinstance(screen, WorkerLogScreen)
+        log = screen.query_one("#worker-log-output", RichLog)
+        rendered = "\n".join(str(line) for line in log.lines)
+        assert "oops" in rendered
+        assert "exited with code 7" in rendered
+        button = screen.query_one("#worker-log-close", Button)
+        assert button.variant == "warning"
+        await pilot.click("#worker-log-close")
+        await pilot.pause()
+    assert isinstance(app.result, WorkerResult)
+    assert app.result.exit_code == 7
+    assert app.result.ok is False
+
+
+# ── Exec failure ──────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_missing_executable_surfaces_in_log_with_exit_127() -> None:
+    """Command-not-found is caught and printed — the modal doesn't freeze silently."""
+    argv = ["/nonexistent/command/terok-never-existed", "--help"]
+    app = _WorkerHost(argv)
+    async with app.run_test() as pilot:
+        await _wait_until_close_enabled(pilot)
+        screen = pilot.app.screen
+        assert isinstance(screen, WorkerLogScreen)
+        log = screen.query_one("#worker-log-output", RichLog)
+        rendered = "\n".join(str(line) for line in log.lines)
+        assert "failed to launch" in rendered
+        # 127 matches the shell convention for "command not found".
+        await pilot.click("#worker-log-close")
+        await pilot.pause()
+    assert isinstance(app.result, WorkerResult)
+    assert app.result.exit_code == 127
+    assert app.result.ok is False
+
+
+# ── Escape binding ────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_escape_before_completion_is_ignored() -> None:
+    """Escape mid-run can't dismiss — Close-button enablement is the only exit.
+
+    Prevents an accidental Escape from killing the view of a long-
+    running ``podman build`` / ``terok setup`` before it finishes.
+    """
+    # A subprocess that takes a moment — long enough to send Escape to.
+    argv = [sys.executable, "-c", "import time; time.sleep(0.3); print('done')"]
+    app = _WorkerHost(argv)
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        # Subprocess is in flight; Escape action runs but should be a no-op.
+        screen = pilot.app.screen
+        assert isinstance(screen, WorkerLogScreen)
+        screen.action_maybe_cancel()
+        await pilot.pause()
+        # The modal is still up, the Close button still disabled.
+        assert isinstance(pilot.app.screen, WorkerLogScreen)
+        assert pilot.app.screen.query_one("#worker-log-close", Button).disabled is True
+        # Wait for natural completion, then dismiss.
+        await _wait_until_close_enabled(pilot)
+        await pilot.click("#worker-log-close")
+        await pilot.pause()
+    assert isinstance(app.result, WorkerResult)
+    assert app.result.ok is True
+
+
+# ── WorkerResult sanity ───────────────────────────────────────────────
+
+
+def test_worker_result_ok_flag_matches_exit_zero() -> None:
+    """``WorkerResult.ok`` is syntactic sugar for ``exit_code == 0``."""
+    assert WorkerResult(exit_code=0).ok is True
+    assert WorkerResult(exit_code=1).ok is False
+    assert WorkerResult(exit_code=127).ok is False
+    # Dismissed-before-completion sentinel is explicitly not ok.
+    assert WorkerResult(exit_code=None).ok is False


### PR DESCRIPTION
## Summary

First cut of the log-tailer widget tracked in [#473](https://github.com/terok-ai/terok/issues/473).  Replaces the ``app.suspend() → run-in-underlying-terminal`` pattern with a Textual-native modal so long shell-outs (podman build, git clone --mirror, terok setup, …) work identically over ``terok-web`` / ``textual-serve`` where there's no terminal to suspend *to*.

Also prerequisite scaffolding for epic [#685](https://github.com/terok-ai/terok/issues/685) phases 7+8 — the first-run / stale-after-update modals will need exactly this subprocess-streaming shape, so doing it once here keeps the phase-7 PR half the size.

## What this PR ships

- New ``terok.tui.worker_log_screen`` module exporting ``WorkerLogScreen`` (``ModalScreen[WorkerResult]``) and the ``WorkerResult`` dataclass.
- ``WorkerLogScreen(argv, *, title, env, cwd)`` runs the argv via ``asyncio.create_subprocess_exec`` (no shell), merges stdout+stderr, streams lines live into a ``RichLog`` pane.
- Close button stays disabled until the subprocess exits, then colours by outcome (``success`` / ``Done`` on exit 0, ``warning`` / ``Close`` otherwise).
- Escape mid-run is a deliberate no-op — prevents an accidental key from killing the view of a 5-minute podman build before it finishes.  A real ``Cancel`` (SIGTERM + confirm) is a follow-up.

## Usage shape

```python
result = await app.push_screen_wait(
    WorkerLogScreen(
        ["terok", "setup"],
        title="Running terok setup…",
    )
)
if result.ok:
    ...
```

Python-level callables can use the same ``[sys.executable, "-c", "..."]`` wrapping ``wizard_screens._run_isolated`` already uses for the build + gate-sync steps.

## Deliberately out of scope

- **Dismiss-to-background** ("Hide" button + "running tasks" drawer).  The modal blocks until completion for now; adding the drawer later is additive since the worker is already isolated via ``@work``.
- **Python-callable form** (run a function in-thread with fd-redirection).  Kept out of the first cut because whole-process fd-1 / fd-2 redirection risks interfering with Textual's own output.  The subprocess path (via ``python -c``) covers every use case currently in the 23 ``_run_suspended`` call sites.
- **Porting existing call sites**.  Those become follow-up PRs once the widget is landed — each one is a small mechanical swap (``await self._run_suspended(fn)`` → ``await app.push_screen_wait(WorkerLogScreen([sys.executable, "-c", ...]))``).

## Test plan

5 pilot-driven tests running real short-lived ``python -c`` subprocesses so the pipe / streaming path gets exercised end-to-end:

- [x] zero exit → output captured + Close shows ``Done`` (success variant)
- [x] non-zero exit → exit code surfaces in log + Close shows warning
- [x] missing executable → ``failed to launch`` + exit 127
- [x] Escape mid-run is a no-op; normal completion still works
- [x] ``WorkerResult.ok`` parity with exit-code checks
- [x] ``make lint`` / ``make tach`` / ``make lint-imports`` / ``make docstrings`` / full unit suite (2089 passed) all clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)