### PR TITLE
feat(tui): askpass modal for ssh.use_personal projects (closes #823)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -107,6 +107,7 @@ terok-tui = "terok.tui.app:main"
 terok-web = "terok.tui.serve:main"
 terok-clearance = "terok.tui.clearance_screen:main"
 terok-gate = "terok_sandbox.gate.server:main"
+terok-askpass = "terok.tui.askpass:main"
 
 [tool.ruff]
 target-version = "py312"

--- a/src/terok/lib/core/paths.py
+++ b/src/terok/lib/core/paths.py
@@ -95,6 +95,27 @@ def runtime_root() -> Path:
     return Path.home() / ".cache" / APP_NAME
 
 
+def runtime_dir() -> Path:
+    """Per-user runtime directory for ephemeral IPC artefacts.
+
+    For short-lived sockets / pid files / FIFOs — things we'd put in
+    ``$XDG_RUNTIME_DIR`` when it's available.
+
+    Delegates to :func:`terok_sandbox.paths.namespace_runtime_dir`,
+    which resolves ``$XDG_RUNTIME_DIR/terok`` → ``$XDG_STATE_HOME/terok``
+    → ``~/.local/state/terok``.  The chain deliberately avoids ``/tmp``
+    so we don't land on a predictable-temp-path footprint (bandit B108).
+
+    Distinct from :func:`runtime_root`: ``runtime_root`` is terok's own
+    ``~/.cache/terok`` convention (used for non-namespace-scoped
+    transient state), while this function sits under the shared terok
+    namespace root for ecosystem packages to co-locate.
+    """
+    from terok_sandbox.paths import namespace_runtime_dir
+
+    return namespace_runtime_dir()
+
+
 def vault_root() -> Path:
     """Shared vault directory used by all terok ecosystem packages.
 

--- a/src/terok/tui/app.py
+++ b/src/terok/tui/app.py
@@ -110,6 +110,7 @@ if _HAS_TEXTUAL:
         shield_env: EnvironmentCheck | None = None
         error: str | None = None
 
+    from .askpass_service import AskpassService
     from .clipboard import get_clipboard_helper_status
     from .polling import PollingMixin
     from .project_actions import ProjectActionsMixin
@@ -309,6 +310,10 @@ if _HAS_TEXTUAL:
             # First-run nudge marker — flipped when the wizard has auto-opened
             # once, so subsequent empty-install starts don't nag.
             self._first_run_dismissed: bool = False
+            # Lazy — only instantiated + bound when a ``ssh.use_personal: true``
+            # project actually spawns a subprocess.  Users who don't opt in
+            # never bind the socket.
+            self._askpass_service: AskpassService | None = None
 
         def _update_title(self):
             """Update the TUI title with version and branch information."""
@@ -1155,7 +1160,21 @@ if _HAS_TEXTUAL:
             self._stop_upstream_polling()
             self._stop_container_status_polling()
             self._stop_gate_server_polling()
+            if self._askpass_service is not None:
+                await self._askpass_service.stop()
             self.exit()
+
+        async def ensure_askpass_service(self) -> AskpassService:
+            """Return the running :class:`AskpassService`, starting it on first use.
+
+            Idempotent.  The first call from a ``use_personal_ssh`` project
+            binds the socket; subsequent calls reuse the same service for
+            the lifetime of the TUI.  ``action_quit`` tears it down.
+            """
+            if self._askpass_service is None:
+                self._askpass_service = AskpassService(self)
+            await self._askpass_service.start()
+            return self._askpass_service
 
         async def action_show_project_actions(self) -> None:
             """Show detail screen with project info and actions."""

--- a/src/terok/tui/askpass.py
+++ b/src/terok/tui/askpass.py
@@ -1,0 +1,93 @@
+# SPDX-FileCopyrightText: 2026 Jiri Vyskocil
+# SPDX-License-Identifier: Apache-2.0
+
+"""``terok-askpass`` — the ``SSH_ASKPASS`` helper that talks to the TUI.
+
+OpenSSH invokes whatever binary ``SSH_ASKPASS`` points at with the
+prompt as ``argv[1]`` and expects the passphrase (or a blank line) on
+stdout.  When the TUI spawns a subprocess for a project with
+``ssh.use_personal: true``, it points ``SSH_ASKPASS`` at this helper and
+``TEROK_ASKPASS_SOCKET`` at a unix socket it's listening on.
+
+This helper is deliberately tiny: open the socket, send one request
+frame, read one reply frame, print the passphrase, exit.  No retries,
+no caching, no local UI.  The TUI side owns everything interactive.
+
+Exit codes:
+
+- ``0`` — user typed a passphrase (possibly empty); printed to stdout.
+- ``1`` — user cancelled, or anything went wrong.  OpenSSH treats any
+  non-zero exit as "askpass failed" and aborts the authentication
+  attempt immediately, which is exactly what we want for cancel.
+"""
+
+from __future__ import annotations
+
+import os
+import socket
+import sys
+
+from . import askpass_protocol as proto
+
+_SOCKET_ENV = "TEROK_ASKPASS_SOCKET"
+_FALLBACK_PROMPT = "Passphrase:"
+
+
+def _read_line(sock: socket.socket) -> bytes:
+    """Blocking read from *sock* until ``\\n`` or EOF."""
+    chunks: list[bytes] = []
+    while True:
+        chunk = sock.recv(4096)
+        if not chunk:
+            break
+        chunks.append(chunk)
+        if b"\n" in chunk:
+            break
+    return b"".join(chunks)
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Entry point — returns a POSIX exit code; never raises."""
+    args = argv if argv is not None else sys.argv
+    prompt = args[1] if len(args) > 1 else _FALLBACK_PROMPT
+
+    socket_path = os.environ.get(_SOCKET_ENV)
+    if not socket_path:
+        print(f"terok-askpass: {_SOCKET_ENV} not set", file=sys.stderr)
+        return 1
+
+    try:
+        with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as sock:
+            sock.connect(socket_path)
+            request = proto.make_request(prompt)
+            sock.sendall(proto.encode(request))
+            raw = _read_line(sock)
+    except OSError as exc:
+        print(f"terok-askpass: socket error: {exc}", file=sys.stderr)
+        return 1
+
+    if not raw:
+        print("terok-askpass: TUI closed socket without reply", file=sys.stderr)
+        return 1
+
+    try:
+        reply = proto.decode(raw)
+        reply_id, answer = proto.parse_reply(reply)
+    except proto.AskpassProtocolError as exc:
+        print(f"terok-askpass: {exc}", file=sys.stderr)
+        return 1
+
+    if reply_id != request["request_id"]:
+        print("terok-askpass: request_id mismatch", file=sys.stderr)
+        return 1
+
+    if answer is None:  # explicit cancel
+        return 1
+
+    # OpenSSH reads one line from stdout; println adds the trailing newline.
+    print(answer)
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover — exercised via the poetry script
+    sys.exit(main())

--- a/src/terok/tui/askpass_protocol.py
+++ b/src/terok/tui/askpass_protocol.py
@@ -87,11 +87,23 @@ def parse_reply(frame: dict[str, Any]) -> tuple[str, str | None]:
     ``answer_or_None`` is ``None`` for cancel, the passphrase string for
     accept.  An empty string is a valid passphrase (some keys have none)
     — only the explicit ``cancel: true`` marker aborts the helper.
+
+    Cancel and answer are mutually exclusive: a frame that carries both
+    is ambiguous (which wins?) and almost certainly a sender bug, so
+    raise rather than silently picking one — the :func:`make_cancel` /
+    :func:`make_answer` factories are the only sanctioned way to build
+    a reply on our side.
     """
     request_id = frame.get("request_id")
     if not isinstance(request_id, str) or not request_id:
         raise AskpassProtocolError("reply missing non-empty 'request_id'")
-    if frame.get("cancel") is True:
+    is_cancel = frame.get("cancel") is True
+    has_answer = "answer" in frame
+    if is_cancel and has_answer:
+        raise AskpassProtocolError(
+            "reply has both 'cancel: true' and 'answer' — exactly one is allowed"
+        )
+    if is_cancel:
         return request_id, None
     answer = frame.get("answer")
     if not isinstance(answer, str):

--- a/src/terok/tui/askpass_protocol.py
+++ b/src/terok/tui/askpass_protocol.py
@@ -1,0 +1,99 @@
+# SPDX-FileCopyrightText: 2026 Jiri Vyskocil
+# SPDX-License-Identifier: Apache-2.0
+
+"""Wire protocol between ``terok-askpass`` and the TUI askpass listener.
+
+Newline-delimited UTF-8 JSON — one object per line, both directions.
+Passphrases are JSON strings so any newlines or quotes inside them are
+escaped; we never need binary framing.
+
+Shape:
+
+- helper → TUI: ``{"request_id": "<uuid>", "prompt": "<ssh-prompt>"}``
+- TUI → helper (accept): ``{"request_id": "<uuid>", "answer": "<pass>"}``
+- TUI → helper (cancel): ``{"request_id": "<uuid>", "cancel": true}``
+
+``request_id`` lets a listener in principle multiplex, though today the
+TUI pops one modal at a time and a second request waits for the first
+to resolve.
+
+The module has no I/O.  :class:`Frame` encodes/decodes; callers adapt
+the bytes to whatever transport they have (blocking socket in the
+helper, ``asyncio.StreamReader/Writer`` in the service).
+"""
+
+from __future__ import annotations
+
+import json
+import uuid
+from typing import Any
+
+
+class AskpassProtocolError(ValueError):
+    """Raised on a malformed frame — missing keys, wrong types, bad JSON."""
+
+
+def encode(obj: dict[str, Any]) -> bytes:
+    """Serialise *obj* to a newline-terminated UTF-8 JSON frame."""
+    return (json.dumps(obj, ensure_ascii=False) + "\n").encode("utf-8")
+
+
+def decode(line: bytes) -> dict[str, Any]:
+    """Parse a single UTF-8 JSON line; strip the trailing ``\\n`` if present.
+
+    Raises :class:`AskpassProtocolError` on malformed input rather than
+    the stdlib :class:`json.JSONDecodeError` / :class:`UnicodeDecodeError`,
+    so callers have one exception type to catch.
+    """
+    try:
+        text = line.decode("utf-8").rstrip("\n")
+        obj = json.loads(text)
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise AskpassProtocolError(f"malformed frame: {exc}") from exc
+    if not isinstance(obj, dict):
+        raise AskpassProtocolError(f"frame is not a JSON object: {type(obj).__name__}")
+    return obj
+
+
+def make_request(prompt: str, *, request_id: str | None = None) -> dict[str, Any]:
+    """Build a helper → TUI request.  *request_id* defaults to a fresh uuid4."""
+    return {"request_id": request_id or uuid.uuid4().hex, "prompt": prompt}
+
+
+def make_answer(request_id: str, answer: str) -> dict[str, Any]:
+    """Build a TUI → helper accept reply."""
+    return {"request_id": request_id, "answer": answer}
+
+
+def make_cancel(request_id: str) -> dict[str, Any]:
+    """Build a TUI → helper cancel reply — helper exits non-zero."""
+    return {"request_id": request_id, "cancel": True}
+
+
+def parse_request(frame: dict[str, Any]) -> tuple[str, str]:
+    """Validate a helper → TUI request frame, return ``(request_id, prompt)``."""
+    request_id = frame.get("request_id")
+    prompt = frame.get("prompt")
+    if not isinstance(request_id, str) or not request_id:
+        raise AskpassProtocolError("request missing non-empty 'request_id'")
+    if not isinstance(prompt, str):
+        raise AskpassProtocolError("request missing string 'prompt'")
+    return request_id, prompt
+
+
+def parse_reply(frame: dict[str, Any]) -> tuple[str, str | None]:
+    """Validate a TUI → helper reply, return ``(request_id, answer_or_None)``.
+
+    ``answer_or_None`` is ``None`` for cancel, the passphrase string for
+    accept.  An empty string is a valid passphrase (some keys have none)
+    — only the explicit ``cancel: true`` marker aborts the helper.
+    """
+    request_id = frame.get("request_id")
+    if not isinstance(request_id, str) or not request_id:
+        raise AskpassProtocolError("reply missing non-empty 'request_id'")
+    if frame.get("cancel") is True:
+        return request_id, None
+    answer = frame.get("answer")
+    if not isinstance(answer, str):
+        raise AskpassProtocolError("reply missing 'cancel' or string 'answer'")
+    return request_id, answer

--- a/src/terok/tui/askpass_protocol.py
+++ b/src/terok/tui/askpass_protocol.py
@@ -17,9 +17,12 @@ Shape:
 TUI pops one modal at a time and a second request waits for the first
 to resolve.
 
-The module has no I/O.  :class:`Frame` encodes/decodes; callers adapt
-the bytes to whatever transport they have (blocking socket in the
-helper, ``asyncio.StreamReader/Writer`` in the service).
+The module has no I/O.  :func:`encode` turns a dict into the wire
+bytes, :func:`decode` turns a line of wire bytes back into a dict,
+and :func:`parse_request` / :func:`parse_reply` validate the decoded
+dicts on the receiving side.  Callers adapt the bytes to whatever
+transport they have — a blocking ``socket.recv`` loop in the helper,
+an ``asyncio.StreamReader.readline`` in the service.
 """
 
 from __future__ import annotations

--- a/src/terok/tui/askpass_service.py
+++ b/src/terok/tui/askpass_service.py
@@ -20,11 +20,11 @@ terminal frame or silently failing:
   env vars when we *do* want our own askpass to run.
 
 The service is reachable only via a unix socket under terok's runtime
-namespace (:func:`terok_sandbox.paths.namespace_runtime_dir`) with
-mode ``0600`` — the filesystem is the auth boundary.  No socket is
-ever bound until a project with ``use_personal_ssh=true`` actually
-spawns a subprocess *and* lacks a usable GUI askpass, so users who
-don't opt in pay nothing for this feature.
+namespace (:func:`terok.lib.core.paths.runtime_dir`) with mode
+``0600`` — the filesystem is the auth boundary.  No socket is ever
+bound until a project with ``use_personal_ssh=true`` actually spawns
+a subprocess *and* lacks a usable GUI askpass, so users who don't opt
+in pay nothing for this feature.
 """
 
 from __future__ import annotations
@@ -39,13 +39,13 @@ from collections.abc import Mapping
 from pathlib import Path
 from typing import TYPE_CHECKING
 
-from terok_sandbox.paths import namespace_runtime_dir
 from textual.app import ComposeResult
 from textual.binding import Binding
 from textual.containers import Horizontal, Vertical
 from textual.screen import ModalScreen
 from textual.widgets import Button, Input, Static
 
+from ..lib.core.paths import runtime_dir
 from . import askpass_protocol as proto
 
 if TYPE_CHECKING:
@@ -108,13 +108,13 @@ def build_askpass_env(
 def default_socket_path(*, pid: int | None = None) -> Path:
     """Return a per-process socket path under terok's runtime namespace.
 
-    Delegates to :func:`terok_sandbox.paths.namespace_runtime_dir`
-    which owns the XDG resolution order (``$XDG_RUNTIME_DIR/terok/``
-    → ``$XDG_STATE_HOME/terok/`` → ``~/.local/state/terok/``) and
-    creates the directory with safe permissions.  No ``/tmp``
-    fallback means no predictable-temp-path surface.
+    Delegates to :func:`terok.lib.core.paths.runtime_dir` — the
+    boundary-respecting wrapper around the sandbox's namespace
+    resolver (``$XDG_RUNTIME_DIR/terok/`` → ``$XDG_STATE_HOME/terok/``
+    → ``~/.local/state/terok/``).  No ``/tmp`` fallback means no
+    predictable-temp-path surface (bandit B108).
     """
-    return namespace_runtime_dir() / f"askpass-{pid or os.getpid()}.sock"
+    return runtime_dir() / f"askpass-{pid or os.getpid()}.sock"
 
 
 def locate_helper_bin() -> Path:

--- a/src/terok/tui/askpass_service.py
+++ b/src/terok/tui/askpass_service.py
@@ -1,0 +1,329 @@
+# SPDX-FileCopyrightText: 2026 Jiri Vyskocil
+# SPDX-License-Identifier: Apache-2.0
+
+"""TUI-side askpass listener, passphrase modal, and env-injection helper.
+
+Three pieces that together let ``use_personal_ssh: true`` projects
+prompt for passphrases through the TUI instead of corrupting the
+terminal frame or silently failing:
+
+- :class:`AskpassService` — the asyncio-based unix-socket server.
+  Bound lazily from :meth:`start`, torn down by :meth:`stop`; exposes
+  the socket path so callers can inject it into subprocess env.
+- :class:`AskpassModal` — one-line passphrase prompt as a Textual
+  :class:`ModalScreen`.  Dismisses with the passphrase, or ``None`` on
+  cancel.
+- :func:`build_askpass_env` — pure function that decides whether to
+  inject our helper into a subprocess env or respect a pre-existing
+  GUI askpass (seahorse, gnome-keyring) when one would work.
+
+The service is reachable only via a unix socket under
+``$XDG_RUNTIME_DIR`` (or ``/tmp`` as a fallback) with mode ``0600`` —
+the filesystem is the auth boundary.  No socket is ever bound until
+a project with ``use_personal_ssh=true`` actually spawns a subprocess,
+so users who don't opt in pay nothing for this feature.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import logging
+import os
+import shutil
+from collections.abc import Mapping
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from textual.app import ComposeResult
+from textual.binding import Binding
+from textual.containers import Horizontal, Vertical
+from textual.screen import ModalScreen
+from textual.widgets import Button, Input, Static
+
+from . import askpass_protocol as proto
+
+if TYPE_CHECKING:
+    from textual.app import App
+
+logger = logging.getLogger(__name__)
+
+
+# ── env builder ───────────────────────────────────────────────────────
+
+
+def build_askpass_env(
+    base_env: Mapping[str, str],
+    *,
+    socket_path: str | os.PathLike[str],
+    helper_bin: str | os.PathLike[str],
+) -> dict[str, str]:
+    """Return a copy of *base_env* with askpass vars injected when appropriate.
+
+    Policy:
+
+    - If *base_env* already has ``SSH_ASKPASS`` set *and* a graphical
+      session is reachable (``DISPLAY`` or ``WAYLAND_DISPLAY``), leave
+      the user's helper alone — their GUI dialog will pop up and is a
+      nicer UX than our Textual modal.
+    - Otherwise, point ``SSH_ASKPASS`` at *helper_bin* and set
+      ``TEROK_ASKPASS_SOCKET`` so the helper can find us.
+    - Always set ``SSH_ASKPASS_REQUIRE=force`` so OpenSSH uses askpass
+      even when a tty is attached — the wizard path has
+      ``start_new_session=True`` so there's no tty anyway, but
+      ``terok-web serve`` and future non-wizard subprocesses may still
+      inherit one and we don't want OpenSSH falling back to it.
+    """
+    env = dict(base_env)
+    has_existing_askpass = bool(env.get("SSH_ASKPASS"))
+    has_gui = bool(env.get("DISPLAY") or env.get("WAYLAND_DISPLAY"))
+    if not (has_existing_askpass and has_gui):
+        env["SSH_ASKPASS"] = str(helper_bin)
+        env["TEROK_ASKPASS_SOCKET"] = str(socket_path)
+    env["SSH_ASKPASS_REQUIRE"] = "force"
+    return env
+
+
+# ── socket path discovery ─────────────────────────────────────────────
+
+
+def default_socket_path(*, pid: int | None = None) -> Path:
+    """Return a per-process socket path under ``$XDG_RUNTIME_DIR`` (or ``/tmp``).
+
+    Separate from :class:`AskpassService` so tests can spot-check it.
+    """
+    runtime_dir = os.environ.get("XDG_RUNTIME_DIR") or "/tmp"
+    return Path(runtime_dir) / f"terok-askpass-{pid or os.getpid()}.sock"
+
+
+def locate_helper_bin() -> Path:
+    """Find ``terok-askpass`` on ``PATH``, raising if it isn't installed."""
+    found = shutil.which("terok-askpass")
+    if not found:
+        raise RuntimeError(
+            "terok-askpass helper not found on PATH — was the package installed "
+            "with its [tool.poetry.scripts] entries?"
+        )
+    return Path(found)
+
+
+# ── modal ─────────────────────────────────────────────────────────────
+
+
+class AskpassModal(ModalScreen["str | None"]):
+    """Passphrase prompt — dismisses with the string, or ``None`` on cancel.
+
+    The prompt text comes straight from OpenSSH (e.g.
+    ``"Enter passphrase for key '/home/.../id_ed25519':"``) and is shown
+    verbatim so users recognise which key is being unlocked.
+    """
+
+    BINDINGS = [
+        Binding("escape", "cancel", "Cancel"),
+    ]
+
+    CSS = """
+    AskpassModal {
+        align: center middle;
+    }
+
+    #askpass-dialog {
+        width: 70;
+        max-width: 100%;
+        height: auto;
+        border: heavy $primary;
+        border-title-align: right;
+        background: $surface;
+        padding: 1 2;
+    }
+
+    #askpass-prompt {
+        margin-bottom: 1;
+        color: $text-muted;
+    }
+
+    #askpass-buttons {
+        height: 3;
+        align-horizontal: right;
+        margin-top: 1;
+    }
+
+    #askpass-buttons Button {
+        margin-left: 1;
+    }
+    """
+
+    def __init__(self, prompt: str) -> None:
+        """Build the modal with *prompt* as the shown label."""
+        super().__init__()
+        self._prompt = prompt
+
+    def compose(self) -> ComposeResult:
+        """Lay out the prompt label, password input, and two buttons."""
+        dialog = Vertical(id="askpass-dialog")
+        dialog.border_title = "SSH passphrase"
+        with dialog:
+            yield Static(self._prompt, id="askpass-prompt")
+            yield Input(password=True, id="askpass-input")
+            with Horizontal(id="askpass-buttons"):
+                yield Button("Cancel", id="askpass-cancel", variant="default")
+                yield Button("Unlock", id="askpass-ok", variant="primary")
+
+    def on_mount(self) -> None:
+        """Focus the input so the user can type immediately."""
+        self.query_one("#askpass-input", Input).focus()
+
+    def action_cancel(self) -> None:
+        """Dismiss as cancel — helper exits non-zero, ssh aborts."""
+        self.dismiss(None)
+
+    def on_button_pressed(self, event: Button.Pressed) -> None:
+        """Handle the two buttons — Cancel returns None, Unlock returns the input value."""
+        if event.button.id == "askpass-cancel":
+            self.dismiss(None)
+        elif event.button.id == "askpass-ok":
+            self.dismiss(self.query_one("#askpass-input", Input).value)
+
+    def on_input_submitted(self, event: Input.Submitted) -> None:
+        """Enter in the input field accepts the passphrase — same as clicking Unlock."""
+        self.dismiss(event.value)
+
+
+# ── service ───────────────────────────────────────────────────────────
+
+
+class AskpassService:
+    """Asyncio unix-socket server that dispatches passphrase modals on the TUI.
+
+    One instance per :class:`~textual.app.App`.  Started lazily by the
+    wizard / subprocess layer only when a project with
+    ``use_personal_ssh=true`` is about to spawn a child — users who
+    don't opt in never trigger a socket bind.
+
+    Concurrency: the listener serialises modal pushes with an
+    :class:`asyncio.Lock`, so if two helpers connect at once they queue
+    up naturally.  This is deliberate — Textual only renders one modal
+    at a time anyway.
+    """
+
+    def __init__(
+        self,
+        app: App,
+        *,
+        socket_path: Path | None = None,
+        helper_bin: Path | None = None,
+    ) -> None:
+        """Construct the service — does not bind the socket or locate the helper.
+
+        Both *socket_path* and *helper_bin* are resolved lazily at
+        :meth:`start` / :attr:`helper_bin` access — the service is
+        created at TUI mount but often never started, so we shouldn't
+        fail the whole TUI if the helper happens to be missing.
+        """
+        self._app = app
+        self._socket_path = socket_path or default_socket_path()
+        self._helper_bin = helper_bin
+        self._server: asyncio.AbstractServer | None = None
+        self._modal_lock = asyncio.Lock()
+
+    @property
+    def socket_path(self) -> Path:
+        """Filesystem path of the unix socket (bound iff :meth:`start` has run)."""
+        return self._socket_path
+
+    @property
+    def helper_bin(self) -> Path:
+        """Path to the ``terok-askpass`` binary that subprocesses should invoke.
+
+        Resolved on first access — raises if the binary isn't on PATH,
+        which lets the caller surface a user-friendly error at the
+        moment askpass is actually needed, not at TUI boot.
+        """
+        if self._helper_bin is None:
+            self._helper_bin = locate_helper_bin()
+        return self._helper_bin
+
+    @property
+    def is_running(self) -> bool:
+        """``True`` iff the asyncio server is bound and serving."""
+        return self._server is not None
+
+    async def start(self) -> None:
+        """Bind the unix socket with mode ``0600`` and start accepting connections.
+
+        Idempotent — calling ``start`` on an already-running service is
+        a no-op.  Any stale socket file at the target path is removed
+        first; we assume the old owner is gone because the path embeds
+        our pid.
+        """
+        if self._server is not None:
+            return
+        self._socket_path.parent.mkdir(parents=True, exist_ok=True)
+        self._socket_path.unlink(missing_ok=True)
+        # Umask ensures the socket is created 0600 atomically — chmod
+        # afterwards would leave a brief window at default perms.
+        old_umask = os.umask(0o077)
+        try:
+            self._server = await asyncio.start_unix_server(
+                self._handle_client, path=str(self._socket_path)
+            )
+        finally:
+            os.umask(old_umask)
+        logger.debug("askpass service listening on %s", self._socket_path)
+
+    async def stop(self) -> None:
+        """Close the server and unlink the socket.  Idempotent."""
+        if self._server is not None:
+            self._server.close()
+            await self._server.wait_closed()
+            self._server = None
+        self._socket_path.unlink(missing_ok=True)
+        logger.debug("askpass service stopped")
+
+    async def _handle_client(
+        self, reader: asyncio.StreamReader, writer: asyncio.StreamWriter
+    ) -> None:
+        """Read one request, dispatch a modal, write the reply, close.
+
+        One request per connection.  The helper is synchronous and
+        short-lived, so there's no benefit to keeping the socket open
+        for a second prompt — simpler to let it reconnect.  The helper
+        tears its end down as soon as it reads our reply, so
+        ``wait_closed`` can race with that teardown — suppressed below.
+        """
+        try:
+            raw = await reader.readline()
+            if not raw:
+                return
+            try:
+                request_id, prompt = proto.parse_request(proto.decode(raw))
+            except proto.AskpassProtocolError as exc:
+                logger.warning("askpass: bad request: %s", exc)
+                return
+
+            async with self._modal_lock:
+                # ``push_screen_wait`` requires a running worker context,
+                # which makes the service awkward to drive from plain
+                # asyncio (tests, non-wizard callers).  The callback form
+                # works from any coroutine — bridge it through a future.
+                loop = asyncio.get_running_loop()
+                future: asyncio.Future[str | None] = loop.create_future()
+
+                def _on_dismissed(result: str | None) -> None:
+                    if not future.done():
+                        future.set_result(result)
+
+                self._app.push_screen(AskpassModal(prompt), _on_dismissed)
+                answer = await future
+
+            reply = (
+                proto.make_cancel(request_id)
+                if answer is None
+                else proto.make_answer(request_id, answer)
+            )
+            writer.write(proto.encode(reply))
+            await writer.drain()
+        finally:
+            writer.close()
+            with contextlib.suppress(BrokenPipeError, ConnectionResetError):
+                await writer.wait_closed()

--- a/src/terok/tui/askpass_service.py
+++ b/src/terok/tui/askpass_service.py
@@ -3,7 +3,7 @@
 
 """TUI-side askpass listener, passphrase modal, and env-injection helper.
 
-Three pieces that together let ``use_personal_ssh: true`` projects
+Four pieces that together let ``use_personal_ssh: true`` projects
 prompt for passphrases through the TUI instead of corrupting the
 terminal frame or silently failing:
 
@@ -13,15 +13,18 @@ terminal frame or silently failing:
 - :class:`AskpassModal` — one-line passphrase prompt as a Textual
   :class:`ModalScreen`.  Dismisses with the passphrase, or ``None`` on
   cancel.
-- :func:`build_askpass_env` — pure function that decides whether to
-  inject our helper into a subprocess env or respect a pre-existing
-  GUI askpass (seahorse, gnome-keyring) when one would work.
+- :func:`gui_askpass_usable` — predicate used by callers to decide
+  whether to start the service at all.  When a user's desktop askpass
+  is reachable, we'd rather use it than our modal.
+- :func:`build_askpass_env` — pure function that injects the helper
+  env vars when we *do* want our own askpass to run.
 
-The service is reachable only via a unix socket under
-``$XDG_RUNTIME_DIR`` (or ``/tmp`` as a fallback) with mode ``0600`` —
-the filesystem is the auth boundary.  No socket is ever bound until
-a project with ``use_personal_ssh=true`` actually spawns a subprocess,
-so users who don't opt in pay nothing for this feature.
+The service is reachable only via a unix socket under terok's runtime
+namespace (:func:`terok_sandbox.paths.namespace_runtime_dir`) with
+mode ``0600`` — the filesystem is the auth boundary.  No socket is
+ever bound until a project with ``use_personal_ssh=true`` actually
+spawns a subprocess *and* lacks a usable GUI askpass, so users who
+don't opt in pay nothing for this feature.
 """
 
 from __future__ import annotations
@@ -31,10 +34,12 @@ import contextlib
 import logging
 import os
 import shutil
+import socket as _socket
 from collections.abc import Mapping
 from pathlib import Path
 from typing import TYPE_CHECKING
 
+from terok_sandbox.paths import namespace_runtime_dir
 from textual.app import ComposeResult
 from textual.binding import Binding
 from textual.containers import Horizontal, Vertical
@@ -50,6 +55,21 @@ logger = logging.getLogger(__name__)
 
 
 # ── env builder ───────────────────────────────────────────────────────
+
+
+def gui_askpass_usable(env: Mapping[str, str]) -> bool:
+    """Return ``True`` when *env* advertises a GUI askpass that can actually render.
+
+    A ``SSH_ASKPASS`` without a reachable display (``DISPLAY`` /
+    ``WAYLAND_DISPLAY``) is almost certainly a dud inherited from a
+    desktop login env — a container or headless SSH session would
+    never see the prompt.  In that case we want our Textual modal to
+    take over instead.
+
+    Callers use this to short-circuit before spinning up an
+    :class:`AskpassService` whose socket would never be consulted.
+    """
+    return bool(env.get("SSH_ASKPASS") and (env.get("DISPLAY") or env.get("WAYLAND_DISPLAY")))
 
 
 def build_askpass_env(
@@ -75,9 +95,7 @@ def build_askpass_env(
       inherit one and we don't want OpenSSH falling back to it.
     """
     env = dict(base_env)
-    has_existing_askpass = bool(env.get("SSH_ASKPASS"))
-    has_gui = bool(env.get("DISPLAY") or env.get("WAYLAND_DISPLAY"))
-    if not (has_existing_askpass and has_gui):
+    if not gui_askpass_usable(env):
         env["SSH_ASKPASS"] = str(helper_bin)
         env["TEROK_ASKPASS_SOCKET"] = str(socket_path)
     env["SSH_ASKPASS_REQUIRE"] = "force"
@@ -88,12 +106,15 @@ def build_askpass_env(
 
 
 def default_socket_path(*, pid: int | None = None) -> Path:
-    """Return a per-process socket path under ``$XDG_RUNTIME_DIR`` (or ``/tmp``).
+    """Return a per-process socket path under terok's runtime namespace.
 
-    Separate from :class:`AskpassService` so tests can spot-check it.
+    Delegates to :func:`terok_sandbox.paths.namespace_runtime_dir`
+    which owns the XDG resolution order (``$XDG_RUNTIME_DIR/terok/``
+    → ``$XDG_STATE_HOME/terok/`` → ``~/.local/state/terok/``) and
+    creates the directory with safe permissions.  No ``/tmp``
+    fallback means no predictable-temp-path surface.
     """
-    runtime_dir = os.environ.get("XDG_RUNTIME_DIR") or "/tmp"
-    return Path(runtime_dir) / f"terok-askpass-{pid or os.getpid()}.sock"
+    return namespace_runtime_dir() / f"askpass-{pid or os.getpid()}.sock"
 
 
 def locate_helper_bin() -> Path:
@@ -163,7 +184,11 @@ class AskpassModal(ModalScreen["str | None"]):
         dialog = Vertical(id="askpass-dialog")
         dialog.border_title = "SSH passphrase"
         with dialog:
-            yield Static(self._prompt, id="askpass-prompt")
+            # markup=False — OpenSSH prompts contain paths like
+            # "Enter passphrase for '/home/.../id_ed25519':" and Rich would
+            # otherwise interpret any "[...]" inside the path as its markup
+            # syntax.  We want to show the prompt verbatim.
+            yield Static(self._prompt, id="askpass-prompt", markup=False)
             yield Input(password=True, id="askpass-input")
             with Horizontal(id="askpass-buttons"):
                 yield Button("Cancel", id="askpass-cancel", variant="default")
@@ -255,20 +280,35 @@ class AskpassService:
         a no-op.  Any stale socket file at the target path is removed
         first; we assume the old owner is gone because the path embeds
         our pid.
+
+        The bind happens synchronously under a local umask so the
+        socket inode is created ``0600`` atomically.  We deliberately
+        do *not* wrap the whole ``asyncio.start_unix_server`` call in
+        ``os.umask(…); await …; os.umask(old)`` because ``os.umask``
+        is process-global — any other coroutine that runs during the
+        ``await`` would see our tightened umask and create files with
+        unexpectedly restrictive permissions.
         """
         if self._server is not None:
             return
         self._socket_path.parent.mkdir(parents=True, exist_ok=True)
         self._socket_path.unlink(missing_ok=True)
-        # Umask ensures the socket is created 0600 atomically — chmod
-        # afterwards would leave a brief window at default perms.
+        sock = _socket.socket(_socket.AF_UNIX, _socket.SOCK_STREAM)
         old_umask = os.umask(0o077)
         try:
-            self._server = await asyncio.start_unix_server(
-                self._handle_client, path=str(self._socket_path)
-            )
+            sock.bind(str(self._socket_path))
+        except BaseException:
+            sock.close()
+            raise
         finally:
             os.umask(old_umask)
+        sock.listen(16)
+        try:
+            self._server = await asyncio.start_unix_server(self._handle_client, sock=sock)
+        except BaseException:
+            sock.close()
+            self._socket_path.unlink(missing_ok=True)
+            raise
         logger.debug("askpass service listening on %s", self._socket_path)
 
     async def stop(self) -> None:

--- a/src/terok/tui/wizard_screens.py
+++ b/src/terok/tui/wizard_screens.py
@@ -27,6 +27,7 @@ from __future__ import annotations
 import contextlib
 import enum
 import io
+import os
 from pathlib import Path
 from typing import Any
 
@@ -46,6 +47,7 @@ from ..lib.domain.wizards.new_project import (
     validate_answer,
     write_project_yaml,
 )
+from .askpass_service import build_askpass_env
 
 # ── Step 1: the form ──────────────────────────────────────────────────
 
@@ -688,6 +690,26 @@ class InitProgressScreen(ModalScreen[InitOutcome]):
             self._step_text(key, status, detail)
         )
 
+    async def _askpass_subprocess_env(self, project: Any) -> dict[str, str] | None:
+        """Return env for ``_run_isolated`` — ``None`` for projects that don't opt into personal SSH.
+
+        When the project sets ``ssh.use_personal: true`` we start the
+        app's :class:`AskpassService` (lazily; first call binds the
+        unix socket) and build the env vars OpenSSH needs to route
+        passphrase prompts through :class:`AskpassModal`.  When the
+        project sits on vault-only SSH (the default), we return
+        ``None`` so the subprocess inherits the ambient env and no
+        askpass plumbing is touched — no socket, no env var, no cost.
+        """
+        if not project.ssh_use_personal:
+            return None
+        service = await self.app.ensure_askpass_service()
+        return build_askpass_env(
+            os.environ,
+            socket_path=service.socket_path,
+            helper_bin=service.helper_bin,
+        )
+
     # ── Background worker ─────────────────────────────────────────────
 
     async def _run_init(self) -> None:
@@ -759,6 +781,12 @@ class InitProgressScreen(ModalScreen[InitOutcome]):
                 await asyncio.to_thread(generate_dockerfiles, self._project_id)
             self._mark("generate", "done")
 
+            # Project is loaded once upfront — we need it for the
+            # gate_enabled gate (step 4) *and* for ``ssh_use_personal``
+            # to decide whether subprocess env needs the askpass wiring.
+            project = load_project(self._project_id)
+            subprocess_env = await self._askpass_subprocess_env(project)
+
             # Step 3: Build.  ``build_images`` invokes ``podman build``
             # subprocesses that inherit the caller's stdout/stderr file
             # descriptors; left alone, their raw output *corrupts the
@@ -774,20 +802,21 @@ class InitProgressScreen(ModalScreen[InitOutcome]):
                 "the TUI intact; watch `podman images`, or see #473 for the planned "
                 "log-tailer widget).[/]"
             )
-            await asyncio.to_thread(_build_in_subprocess, self._project_id)
+            await asyncio.to_thread(_build_in_subprocess, self._project_id, env=subprocess_env)
             self._mark("build", "done")
 
-            # Step 4: Gate sync — load_project to read gate_enabled.
-            # Sync itself runs in a subprocess for the same reason as
-            # the build: ``git clone --mirror`` and friends inherit
-            # stdout/stderr and would otherwise overwrite the TUI frame.
-            project = load_project(self._project_id)
+            # Step 4: Gate sync — sync itself runs in a subprocess for
+            # the same reason as the build: ``git clone --mirror`` and
+            # friends inherit stdout/stderr and would otherwise
+            # overwrite the TUI frame.
             if not project.gate_enabled:
                 self._mark("gate", "skipped", "gate.enabled: false")
                 log.write("[dim]Gate disabled in project.yml — skipping gate-sync.[/]")
             else:
                 self._mark("gate", "running")
-                res = await asyncio.to_thread(_gate_sync_in_subprocess, self._project_id)
+                res = await asyncio.to_thread(
+                    _gate_sync_in_subprocess, self._project_id, env=subprocess_env
+                )
                 if res["success"]:
                     upstream_hint = (
                         f"upstream {res['upstream_url']}"
@@ -934,7 +963,12 @@ def _log_capture(log: RichLog):
                 log.write(text)
 
 
-def _run_isolated(child_body: str, *, label: str) -> None:
+def _run_isolated(
+    child_body: str,
+    *,
+    label: str,
+    env: dict[str, str] | None = None,
+) -> None:
     """Run *child_body* as a ``python -c`` subprocess with captured fds.
 
     Several init steps shell out to long-running commands (``podman
@@ -956,6 +990,12 @@ def _run_isolated(child_body: str, *, label: str) -> None:
     Combined, no subprocess below this call — however badly behaved —
     can prompt the user over the TUI.
 
+    *env* is passed straight through to :func:`subprocess.run`.  When
+    ``None`` the child inherits the parent's environment (default
+    behaviour); the wizard uses this parameter to inject askpass
+    variables for ``use_personal_ssh`` projects so OpenSSH routes
+    passphrase prompts to the TUI modal instead of failing silently.
+
     *label* is the human-friendly step name used in the error message.
     Any non-zero exit propagates as :class:`RuntimeError` carrying the
     last few KiB of the child's combined output, which the wizard's
@@ -975,6 +1015,7 @@ def _run_isolated(child_body: str, *, label: str) -> None:
         check=False,
         stdin=subprocess.DEVNULL,
         start_new_session=True,
+        env=env,
     )
     if result.returncode != 0:
         tail = (result.stderr or result.stdout or "").strip().splitlines()
@@ -982,14 +1023,16 @@ def _run_isolated(child_body: str, *, label: str) -> None:
         raise RuntimeError(f"{label} exited with code {result.returncode}:\n{snippet}")
 
 
-def _build_in_subprocess(project_id: str) -> None:
+def _build_in_subprocess(project_id: str, *, env: dict[str, str] | None = None) -> None:
     """Run :func:`build_images` in a child Python process."""
     # Literal repr keeps project_id safely escaped into the -c body.
     child_body = f"from terok.lib.domain.facade import build_images; build_images({project_id!r})"
-    _run_isolated(child_body, label="build_images")
+    _run_isolated(child_body, label="build_images", env=env)
 
 
-def _gate_sync_in_subprocess(project_id: str) -> dict[str, Any]:
+def _gate_sync_in_subprocess(
+    project_id: str, *, env: dict[str, str] | None = None
+) -> dict[str, Any]:
     """Run the gate sync in a child Python process and return its result dict.
 
     The result dict is serialised to a tempfile (rather than captured
@@ -1011,7 +1054,7 @@ def _gate_sync_in_subprocess(project_id: str) -> dict[str, Any]:
             "_result = make_git_gate(_project).sync()\n"
             f"json.dump(_result, open({str(result_path)!r}, 'w'))\n"
         )
-        _run_isolated(child_body, label="gate sync")
+        _run_isolated(child_body, label="gate sync", env=env)
         return json.loads(result_path.read_text(encoding="utf-8"))
     finally:
         result_path.unlink(missing_ok=True)

--- a/src/terok/tui/wizard_screens.py
+++ b/src/terok/tui/wizard_screens.py
@@ -47,7 +47,7 @@ from ..lib.domain.wizards.new_project import (
     validate_answer,
     write_project_yaml,
 )
-from .askpass_service import build_askpass_env
+from .askpass_service import build_askpass_env, gui_askpass_usable
 
 # ── Step 1: the form ──────────────────────────────────────────────────
 
@@ -693,16 +693,29 @@ class InitProgressScreen(ModalScreen[InitOutcome]):
     async def _askpass_subprocess_env(self, project: Any) -> dict[str, str] | None:
         """Return env for ``_run_isolated`` — ``None`` for projects that don't opt into personal SSH.
 
-        When the project sets ``ssh.use_personal: true`` we start the
-        app's :class:`AskpassService` (lazily; first call binds the
-        unix socket) and build the env vars OpenSSH needs to route
-        passphrase prompts through :class:`AskpassModal`.  When the
-        project sits on vault-only SSH (the default), we return
-        ``None`` so the subprocess inherits the ambient env and no
-        askpass plumbing is touched — no socket, no env var, no cost.
+        Three branches:
+
+        - **Vault-only project (default).**  Return ``None`` so the
+          subprocess inherits the ambient env — no socket, no helper,
+          no cost for users who haven't opted in.
+        - **Personal SSH + usable GUI askpass.**  When the user has a
+          desktop helper wired up (``SSH_ASKPASS`` set and
+          ``DISPLAY``/``WAYLAND_DISPLAY`` reachable), their GUI dialog
+          is a better UX than our modal — skip starting our socket
+          server entirely and just propagate env with
+          ``SSH_ASKPASS_REQUIRE=force`` so OpenSSH uses their helper
+          even with a tty attached.
+        - **Personal SSH, no GUI askpass.**  Start the app's
+          :class:`AskpassService` (lazily; first call binds the unix
+          socket) and build the env vars OpenSSH needs to route
+          passphrase prompts through :class:`AskpassModal`.
         """
         if not project.ssh_use_personal:
             return None
+        if gui_askpass_usable(os.environ):
+            # User's GUI helper wins — still enforce REQUIRE=force so
+            # ssh doesn't fall back to /dev/tty on tty-bearing sessions.
+            return {**os.environ, "SSH_ASKPASS_REQUIRE": "force"}
         service = await self.app.ensure_askpass_service()
         return build_askpass_env(
             os.environ,

--- a/tach.toml
+++ b/tach.toml
@@ -837,7 +837,14 @@ expose = ["assign_web_port", "release_web_port"]
 from = ["terok.lib.orchestration.ports"]
 
 [[interfaces]]
-expose = ["config_root", "vault_root", "state_root", "core_state_dir", "runtime_root"]
+expose = [
+    "config_root",
+    "vault_root",
+    "state_root",
+    "core_state_dir",
+    "runtime_root",
+    "runtime_dir",
+]
 from = ["terok.lib.core.paths"]
 
 [[interfaces]]

--- a/tests/unit/tui/test_askpass_gating.py
+++ b/tests/unit/tui/test_askpass_gating.py
@@ -1,0 +1,117 @@
+# SPDX-FileCopyrightText: 2026 Jiri Vyskocil
+# SPDX-License-Identifier: Apache-2.0
+
+"""Gating tests for the askpass integration — zero cost when opted out.
+
+The :class:`InitProgressScreen._askpass_subprocess_env` helper is the
+single choke point that decides whether a subprocess gets askpass env
+plumbing.  These tests verify:
+
+- ``ssh_use_personal=False`` returns ``None`` and the app's
+  ``ensure_askpass_service`` is never called — so no unix socket is
+  ever bound for users who don't opt in.
+- ``ssh_use_personal=True`` calls ``ensure_askpass_service`` and
+  returns an env dict containing both ``SSH_ASKPASS`` and
+  ``TEROK_ASKPASS_SOCKET`` pointed at that service's paths.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from unittest.mock import PropertyMock, patch
+
+import pytest
+
+from terok.tui.wizard_screens import InitProgressScreen
+
+
+@dataclass
+class _FakeProject:
+    """Stand-in for :class:`ProjectConfig` — only the one attribute we read."""
+
+    ssh_use_personal: bool
+
+
+class _FakeService:
+    """Stand-in for :class:`AskpassService` exposing the two properties the env builder reads."""
+
+    def __init__(self, socket_path: Path, helper_bin: Path) -> None:
+        self.socket_path = socket_path
+        self.helper_bin = helper_bin
+
+
+class _FakeApp:
+    """Stand-in for :class:`TerokTUI` that counts ``ensure_askpass_service`` calls."""
+
+    def __init__(self, service: _FakeService | None = None) -> None:
+        self._service = service or _FakeService(Path("/run/x.sock"), Path("/usr/bin/terok-askpass"))
+        self.ensure_calls = 0
+
+    async def ensure_askpass_service(self) -> _FakeService:
+        self.ensure_calls += 1
+        return self._service
+
+
+def _new_screen() -> InitProgressScreen:
+    """Construct a bare :class:`InitProgressScreen` without Textual's setup machinery."""
+    screen = InitProgressScreen.__new__(InitProgressScreen)
+    screen._project_id = "demo"
+    return screen
+
+
+@pytest.mark.asyncio
+async def test_env_is_none_when_project_opts_out() -> None:
+    """Default ``ssh_use_personal=False`` skips service start *and* env injection."""
+    app = _FakeApp()
+    screen = _new_screen()
+
+    with patch.object(InitProgressScreen, "app", new_callable=PropertyMock, return_value=app):
+        env = await screen._askpass_subprocess_env(_FakeProject(ssh_use_personal=False))
+
+    assert env is None
+    assert app.ensure_calls == 0  # socket never bound
+
+
+@pytest.mark.asyncio
+async def test_env_is_built_when_project_opts_in(monkeypatch: pytest.MonkeyPatch) -> None:
+    """``ssh_use_personal=True`` starts the service and injects the askpass vars."""
+    # Strip any ambient SSH_ASKPASS / DISPLAY so we hit the "inject ours" branch.
+    monkeypatch.delenv("SSH_ASKPASS", raising=False)
+    monkeypatch.delenv("DISPLAY", raising=False)
+    monkeypatch.delenv("WAYLAND_DISPLAY", raising=False)
+
+    service = _FakeService(Path("/run/demo.sock"), Path("/usr/bin/terok-askpass"))
+    app = _FakeApp(service)
+    screen = _new_screen()
+
+    with patch.object(InitProgressScreen, "app", new_callable=PropertyMock, return_value=app):
+        env = await screen._askpass_subprocess_env(_FakeProject(ssh_use_personal=True))
+
+    assert env is not None
+    assert app.ensure_calls == 1
+    assert env["SSH_ASKPASS"] == str(service.helper_bin)
+    assert env["TEROK_ASKPASS_SOCKET"] == str(service.socket_path)
+    assert env["SSH_ASKPASS_REQUIRE"] == "force"
+
+
+@pytest.mark.asyncio
+async def test_env_respects_existing_gui_askpass(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Even with opt-in, a working desktop askpass (GNOME/KDE) is preferred."""
+    monkeypatch.setenv("SSH_ASKPASS", "/usr/libexec/seahorse-askpass")
+    monkeypatch.setenv("DISPLAY", ":0")
+    monkeypatch.delenv("WAYLAND_DISPLAY", raising=False)
+
+    service = _FakeService(Path("/run/demo.sock"), Path("/usr/bin/terok-askpass"))
+    app = _FakeApp(service)
+    screen = _new_screen()
+
+    with patch.object(InitProgressScreen, "app", new_callable=PropertyMock, return_value=app):
+        env = await screen._askpass_subprocess_env(_FakeProject(ssh_use_personal=True))
+
+    # Service *is* started (the opt-in is the trigger), but the env points at
+    # the user's existing helper — our socket never gets consulted.
+    assert env is not None
+    assert env["SSH_ASKPASS"] == "/usr/libexec/seahorse-askpass"
+    assert "TEROK_ASKPASS_SOCKET" not in env
+    assert env["SSH_ASKPASS_REQUIRE"] == "force"

--- a/tests/unit/tui/test_askpass_gating.py
+++ b/tests/unit/tui/test_askpass_gating.py
@@ -97,21 +97,26 @@ async def test_env_is_built_when_project_opts_in(monkeypatch: pytest.MonkeyPatch
 
 @pytest.mark.asyncio
 async def test_env_respects_existing_gui_askpass(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Even with opt-in, a working desktop askpass (GNOME/KDE) is preferred."""
+    """Opt-in + usable GUI askpass → service is NOT started, env uses user's helper.
+
+    This is the "zero cost when not needed" branch on the opt-in side
+    of the fence — the user's desktop askpass (seahorse, gnome-keyring)
+    handles the prompt natively, so we don't bother binding our
+    socket.  Only ``SSH_ASKPASS_REQUIRE=force`` is added so OpenSSH
+    still prefers the GUI helper over any ``/dev/tty`` fallback.
+    """
     monkeypatch.setenv("SSH_ASKPASS", "/usr/libexec/seahorse-askpass")
     monkeypatch.setenv("DISPLAY", ":0")
     monkeypatch.delenv("WAYLAND_DISPLAY", raising=False)
 
-    service = _FakeService(Path("/run/demo.sock"), Path("/usr/bin/terok-askpass"))
-    app = _FakeApp(service)
+    app = _FakeApp()
     screen = _new_screen()
 
     with patch.object(InitProgressScreen, "app", new_callable=PropertyMock, return_value=app):
         env = await screen._askpass_subprocess_env(_FakeProject(ssh_use_personal=True))
 
-    # Service *is* started (the opt-in is the trigger), but the env points at
-    # the user's existing helper — our socket never gets consulted.
     assert env is not None
+    assert app.ensure_calls == 0  # no socket bound when GUI helper can render
     assert env["SSH_ASKPASS"] == "/usr/libexec/seahorse-askpass"
     assert "TEROK_ASKPASS_SOCKET" not in env
     assert env["SSH_ASKPASS_REQUIRE"] == "force"

--- a/tests/unit/tui/test_askpass_protocol.py
+++ b/tests/unit/tui/test_askpass_protocol.py
@@ -123,3 +123,14 @@ class TestParseReply:
         """A reply must commit to one of the two shapes."""
         with pytest.raises(proto.AskpassProtocolError):
             proto.parse_reply({"request_id": "x"})
+
+    def test_both_cancel_and_answer_rejected(self) -> None:
+        """A reply with both ``cancel: true`` and ``answer`` is ambiguous.
+
+        Parser must raise rather than silently picking one — otherwise
+        a sender bug that duplicates both fields would be hidden at
+        the receiver, and the helper's decision (exit 0 vs non-zero)
+        would depend on field-ordering quirks.
+        """
+        with pytest.raises(proto.AskpassProtocolError, match="both"):
+            proto.parse_reply({"request_id": "x", "cancel": True, "answer": "pass"})

--- a/tests/unit/tui/test_askpass_protocol.py
+++ b/tests/unit/tui/test_askpass_protocol.py
@@ -1,0 +1,125 @@
+# SPDX-FileCopyrightText: 2026 Jiri Vyskocil
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the askpass wire protocol.
+
+The protocol is pure data — no sockets, no asyncio — so these tests
+exercise encode/decode and the two validating parsers directly.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from terok.tui import askpass_protocol as proto
+
+
+class TestEncodeDecode:
+    """Round-trip encoding and decoding of JSON frames."""
+
+    def test_encode_appends_newline(self) -> None:
+        """Frames are newline-terminated so ``readline`` fits the wire format."""
+        raw = proto.encode({"ok": True})
+        assert raw.endswith(b"\n")
+        assert raw.count(b"\n") == 1
+
+    def test_roundtrip_preserves_strings_with_special_chars(self) -> None:
+        """Passphrases with newlines, quotes, and unicode survive the round-trip."""
+        tricky = 'p@ss\nword "with" quotes — ünicode'
+        frame = {"answer": tricky, "request_id": "abc"}
+        decoded = proto.decode(proto.encode(frame))
+        assert decoded == frame
+
+    def test_decode_accepts_missing_trailing_newline(self) -> None:
+        """``readline`` on an unclosed socket returns data without the newline."""
+        raw = json.dumps({"k": "v"}).encode("utf-8")  # no trailing newline
+        assert proto.decode(raw) == {"k": "v"}
+
+    def test_decode_rejects_non_json(self) -> None:
+        """Garbage on the wire raises :class:`AskpassProtocolError`."""
+        with pytest.raises(proto.AskpassProtocolError):
+            proto.decode(b"not json at all\n")
+
+    def test_decode_rejects_non_object_json(self) -> None:
+        """A bare JSON string or array isn't a valid frame."""
+        with pytest.raises(proto.AskpassProtocolError):
+            proto.decode(b'"just a string"\n')
+        with pytest.raises(proto.AskpassProtocolError):
+            proto.decode(b"[1, 2, 3]\n")
+
+    def test_decode_rejects_invalid_utf8(self) -> None:
+        """Non-UTF8 bytes also surface as the module's error type."""
+        with pytest.raises(proto.AskpassProtocolError):
+            proto.decode(b"\xff\xfe\n")
+
+
+class TestBuilders:
+    """Request/answer/cancel factory helpers."""
+
+    def test_make_request_generates_unique_ids(self) -> None:
+        """Two calls without an explicit id produce different uuids."""
+        a = proto.make_request("prompt 1")
+        b = proto.make_request("prompt 2")
+        assert a["request_id"] != b["request_id"]
+        assert a["prompt"] == "prompt 1"
+
+    def test_make_request_accepts_explicit_id(self) -> None:
+        """Tests can pin the id to make assertions deterministic."""
+        req = proto.make_request("p", request_id="fixed-id")
+        assert req == {"request_id": "fixed-id", "prompt": "p"}
+
+    def test_make_answer_and_cancel_shapes(self) -> None:
+        """Accept has ``answer``, cancel has ``cancel: true`` — no overlap."""
+        assert proto.make_answer("rid", "pass") == {"request_id": "rid", "answer": "pass"}
+        assert proto.make_cancel("rid") == {"request_id": "rid", "cancel": True}
+
+
+class TestParseRequest:
+    """Validate helper → TUI requests."""
+
+    def test_valid_request_parses(self) -> None:
+        """Well-formed request returns the id and prompt tuple."""
+        assert proto.parse_request({"request_id": "x", "prompt": "p"}) == ("x", "p")
+
+    def test_missing_request_id_rejected(self) -> None:
+        """No id means we can't correlate the reply — refuse."""
+        with pytest.raises(proto.AskpassProtocolError, match="request_id"):
+            proto.parse_request({"prompt": "p"})
+
+    def test_empty_request_id_rejected(self) -> None:
+        """An empty string id is as useless as a missing one."""
+        with pytest.raises(proto.AskpassProtocolError, match="request_id"):
+            proto.parse_request({"request_id": "", "prompt": "p"})
+
+    def test_missing_prompt_rejected(self) -> None:
+        """No prompt means the modal would have nothing to show."""
+        with pytest.raises(proto.AskpassProtocolError, match="prompt"):
+            proto.parse_request({"request_id": "x"})
+
+
+class TestParseReply:
+    """Validate TUI → helper replies."""
+
+    def test_valid_answer_parses(self) -> None:
+        """``answer`` comes back as the tuple's second element."""
+        assert proto.parse_reply({"request_id": "x", "answer": "pass"}) == ("x", "pass")
+
+    def test_cancel_returns_none_answer(self) -> None:
+        """``cancel: true`` surfaces as ``(id, None)`` to the helper."""
+        assert proto.parse_reply({"request_id": "x", "cancel": True}) == ("x", None)
+
+    def test_empty_passphrase_is_valid(self) -> None:
+        """Some keys really do have empty passphrases — don't reject them."""
+        assert proto.parse_reply({"request_id": "x", "answer": ""}) == ("x", "")
+
+    def test_cancel_false_is_not_cancel(self) -> None:
+        """Only the literal ``true`` marker cancels; ``false`` just needs an answer."""
+        with pytest.raises(proto.AskpassProtocolError):
+            proto.parse_reply({"request_id": "x", "cancel": False})
+
+    def test_neither_answer_nor_cancel_rejected(self) -> None:
+        """A reply must commit to one of the two shapes."""
+        with pytest.raises(proto.AskpassProtocolError):
+            proto.parse_reply({"request_id": "x"})

--- a/tests/unit/tui/test_askpass_service.py
+++ b/tests/unit/tui/test_askpass_service.py
@@ -129,7 +129,7 @@ class TestSocketPath:
         ``~/.local/state/terok``).  Delegating here means any future
         change to that chain lands transparently.
         """
-        with patch("terok.tui.askpass_service.namespace_runtime_dir", return_value=tmp_path):
+        with patch("terok.tui.askpass_service.runtime_dir", return_value=tmp_path):
             path = default_socket_path(pid=12345)
         assert path == tmp_path / "askpass-12345.sock"
 
@@ -141,7 +141,7 @@ class TestSocketPath:
         Proves we're not reimplementing the XDG chain locally.
         """
         monkeypatch.setenv("XDG_RUNTIME_DIR", "/tmp/unused-should-be-ignored")
-        with patch("terok.tui.askpass_service.namespace_runtime_dir", return_value=tmp_path):
+        with patch("terok.tui.askpass_service.runtime_dir", return_value=tmp_path):
             assert default_socket_path(pid=1).parent == tmp_path
 
 

--- a/tests/unit/tui/test_askpass_service.py
+++ b/tests/unit/tui/test_askpass_service.py
@@ -1,0 +1,388 @@
+# SPDX-FileCopyrightText: 2026 Jiri Vyskocil
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for :mod:`terok.tui.askpass_service`.
+
+Split into three groups:
+
+- :class:`TestBuildEnv` — pure-function checks on the env builder
+  (respect pre-existing GUI askpass, inject ours otherwise, always set
+  ``SSH_ASKPASS_REQUIRE=force``).
+- :class:`TestServiceLifecycle` — :class:`AskpassService` start / stop
+  / idempotency and socket permissions.
+- :class:`TestServiceRoundTrip` — end-to-end helper → service → modal
+  round trip driven through ``App.run_test()``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import stat
+from pathlib import Path
+
+import pytest
+from textual.app import App
+
+from terok.tui import askpass_protocol as proto
+from terok.tui.askpass_service import (
+    AskpassModal,
+    AskpassService,
+    build_askpass_env,
+    default_socket_path,
+)
+
+# ── build_askpass_env ─────────────────────────────────────────────────
+
+
+class TestBuildEnv:
+    """Env-injection policy must respect existing GUI askpass when usable."""
+
+    def test_injects_helper_when_no_existing_askpass(self) -> None:
+        """With no ``SSH_ASKPASS``, our helper + socket are set."""
+        env = build_askpass_env(
+            {"HOME": "/home/u"},
+            socket_path="/run/x.sock",
+            helper_bin="/usr/bin/terok-askpass",
+        )
+        assert env["SSH_ASKPASS"] == "/usr/bin/terok-askpass"
+        assert env["TEROK_ASKPASS_SOCKET"] == "/run/x.sock"
+        assert env["SSH_ASKPASS_REQUIRE"] == "force"
+
+    def test_respects_existing_askpass_when_display_is_set(self) -> None:
+        """User's seahorse / gnome-keyring wins when a GUI is reachable."""
+        env = build_askpass_env(
+            {"SSH_ASKPASS": "/usr/libexec/seahorse-askpass", "DISPLAY": ":0"},
+            socket_path="/run/x.sock",
+            helper_bin="/usr/bin/terok-askpass",
+        )
+        assert env["SSH_ASKPASS"] == "/usr/libexec/seahorse-askpass"
+        assert "TEROK_ASKPASS_SOCKET" not in env
+        # REQUIRE=force still applies so the GUI dialog is used even with a tty.
+        assert env["SSH_ASKPASS_REQUIRE"] == "force"
+
+    def test_respects_existing_askpass_under_wayland(self) -> None:
+        """``WAYLAND_DISPLAY`` counts as a GUI the same way ``DISPLAY`` does."""
+        env = build_askpass_env(
+            {"SSH_ASKPASS": "/usr/bin/custom-askpass", "WAYLAND_DISPLAY": "wayland-0"},
+            socket_path="/run/x.sock",
+            helper_bin="/usr/bin/terok-askpass",
+        )
+        assert env["SSH_ASKPASS"] == "/usr/bin/custom-askpass"
+        assert "TEROK_ASKPASS_SOCKET" not in env
+
+    def test_takes_over_when_existing_askpass_has_no_gui(self) -> None:
+        """``SSH_ASKPASS`` set but no ``DISPLAY``/``WAYLAND_DISPLAY`` — ours wins.
+
+        This is the headless-ssh-session / container scenario.  A GUI
+        askpass inherited from the login env can't actually render, so
+        we step in with the Textual modal instead of silently failing.
+        """
+        env = build_askpass_env(
+            {"SSH_ASKPASS": "/usr/libexec/seahorse-askpass"},
+            socket_path="/run/x.sock",
+            helper_bin="/usr/bin/terok-askpass",
+        )
+        assert env["SSH_ASKPASS"] == "/usr/bin/terok-askpass"
+        assert env["TEROK_ASKPASS_SOCKET"] == "/run/x.sock"
+
+    def test_base_env_is_not_mutated(self) -> None:
+        """The function returns a copy — callers' dicts stay pristine."""
+        base = {"HOME": "/home/u"}
+        build_askpass_env(base, socket_path="/s", helper_bin="/h")
+        assert base == {"HOME": "/home/u"}
+
+    def test_require_force_always_set(self) -> None:
+        """Even when respecting an existing askpass, REQUIRE=force applies.
+
+        Without this, OpenSSH prefers ``/dev/tty`` over any askpass when
+        a controlling tty is present — undoing the TUI-isolation work
+        from PR #821.
+        """
+        assert (
+            build_askpass_env({}, socket_path="/s", helper_bin="/h")["SSH_ASKPASS_REQUIRE"]
+            == "force"
+        )
+
+
+# ── default_socket_path ───────────────────────────────────────────────
+
+
+class TestSocketPath:
+    """Per-process socket path under ``$XDG_RUNTIME_DIR`` (with fallback)."""
+
+    def test_uses_xdg_runtime_dir_when_set(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """When the env var points somewhere, the socket lives there."""
+        monkeypatch.setenv("XDG_RUNTIME_DIR", str(tmp_path))
+        path = default_socket_path(pid=12345)
+        assert path == tmp_path / "terok-askpass-12345.sock"
+
+    def test_falls_back_to_tmp(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Without ``XDG_RUNTIME_DIR``, ``/tmp`` is the last resort."""
+        monkeypatch.delenv("XDG_RUNTIME_DIR", raising=False)
+        path = default_socket_path(pid=999)
+        assert path == Path("/tmp/terok-askpass-999.sock")
+
+
+# ── AskpassService lifecycle ──────────────────────────────────────────
+
+
+class _BareApp(App):
+    """Minimal ``App`` that doesn't push any screen — good enough to host a service."""
+
+
+class TestServiceLifecycle:
+    """Service start/stop, idempotency, and socket permissions."""
+
+    @pytest.mark.asyncio
+    async def test_start_binds_socket_and_stop_unlinks_it(self, tmp_path: Path) -> None:
+        """After ``start`` the socket file exists; after ``stop`` it's gone."""
+        sock = tmp_path / "askpass.sock"
+        async with _BareApp().run_test():
+            service = AskpassService(_BareApp(), socket_path=sock, helper_bin=tmp_path / "bin")
+            await service.start()
+            try:
+                assert sock.exists()
+                assert stat.S_ISSOCK(sock.stat().st_mode)
+            finally:
+                await service.stop()
+            assert not sock.exists()
+
+    @pytest.mark.asyncio
+    async def test_socket_mode_is_0600(self, tmp_path: Path) -> None:
+        """Socket permissions must not grant access beyond the owner."""
+        sock = tmp_path / "askpass.sock"
+        async with _BareApp().run_test():
+            service = AskpassService(_BareApp(), socket_path=sock, helper_bin=tmp_path / "bin")
+            await service.start()
+            try:
+                mode = sock.stat().st_mode & 0o777
+                # Owner has rw; group and other must be empty.
+                assert mode & 0o077 == 0
+            finally:
+                await service.stop()
+
+    @pytest.mark.asyncio
+    async def test_start_is_idempotent(self, tmp_path: Path) -> None:
+        """Two calls to ``start`` don't rebind or error."""
+        sock = tmp_path / "askpass.sock"
+        async with _BareApp().run_test():
+            service = AskpassService(_BareApp(), socket_path=sock, helper_bin=tmp_path / "bin")
+            await service.start()
+            try:
+                assert service.is_running
+                await service.start()  # second call is a no-op
+                assert service.is_running
+            finally:
+                await service.stop()
+
+    @pytest.mark.asyncio
+    async def test_stop_is_idempotent(self, tmp_path: Path) -> None:
+        """``stop`` on a never-started / already-stopped service is harmless."""
+        sock = tmp_path / "askpass.sock"
+        service = AskpassService(_BareApp(), socket_path=sock, helper_bin=tmp_path / "bin")
+        await service.stop()  # never started — must not raise
+        async with _BareApp().run_test():
+            await service.start()
+            await service.stop()
+            await service.stop()  # second stop is a no-op
+
+
+# ── end-to-end service round-trip ─────────────────────────────────────
+
+
+class _ModalAnsweringApp(App):
+    """App that auto-dismisses any :class:`AskpassModal` that gets pushed.
+
+    ``canned_answer`` is the value it dismisses with: a string means
+    "user typed this passphrase"; ``None`` means "user clicked Cancel".
+    """
+
+    def __init__(self, canned_answer: str | None) -> None:
+        super().__init__()
+        self._canned_answer = canned_answer
+
+    async def on_screen_resume(self) -> None:  # pragma: no cover — edge path
+        pass
+
+    def on_mount(self) -> None:
+        self.install_screen = None  # placeholder — real work in client code
+
+    async def _auto_answer(self) -> None:
+        """Wait for an :class:`AskpassModal` and dismiss it after a short pause."""
+        # Busy-wait briefly until the modal lands on top of the stack.
+        for _ in range(50):
+            if isinstance(self.screen, AskpassModal):
+                self.screen.dismiss(self._canned_answer)
+                return
+            await asyncio.sleep(0.02)
+
+
+class TestServiceRoundTrip:
+    """End-to-end: a unix-socket client drives the modal through the service."""
+
+    @pytest.mark.asyncio
+    async def test_answer_reaches_client(self, tmp_path: Path) -> None:
+        """Client sends a request, modal is auto-answered, reply carries the passphrase."""
+        sock = tmp_path / "askpass.sock"
+        app = _ModalAnsweringApp(canned_answer="letmein")
+        async with app.run_test() as pilot:
+            service = AskpassService(app, socket_path=sock, helper_bin=tmp_path / "bin")
+            await service.start()
+            try:
+                auto_task = asyncio.create_task(app._auto_answer())
+
+                reader, writer = await asyncio.open_unix_connection(str(sock))
+                req = proto.make_request("Enter passphrase:", request_id="rid-1")
+                writer.write(proto.encode(req))
+                await writer.drain()
+                await pilot.pause()  # give the service + modal a chance to run
+
+                raw = await reader.readline()
+                reply = proto.decode(raw)
+                assert reply == {"request_id": "rid-1", "answer": "letmein"}
+
+                writer.close()
+                await writer.wait_closed()
+                await auto_task
+            finally:
+                await service.stop()
+
+    @pytest.mark.asyncio
+    async def test_cancel_is_relayed_to_client(self, tmp_path: Path) -> None:
+        """User hits Cancel → reply carries ``cancel: true``."""
+        sock = tmp_path / "askpass.sock"
+        app = _ModalAnsweringApp(canned_answer=None)
+        async with app.run_test() as pilot:
+            service = AskpassService(app, socket_path=sock, helper_bin=tmp_path / "bin")
+            await service.start()
+            try:
+                auto_task = asyncio.create_task(app._auto_answer())
+
+                reader, writer = await asyncio.open_unix_connection(str(sock))
+                req = proto.make_request("Enter passphrase:", request_id="rid-2")
+                writer.write(proto.encode(req))
+                await writer.drain()
+                await pilot.pause()
+
+                raw = await reader.readline()
+                reply = proto.decode(raw)
+                assert reply == {"request_id": "rid-2", "cancel": True}
+
+                writer.close()
+                await writer.wait_closed()
+                await auto_task
+            finally:
+                await service.stop()
+
+
+# ── helper exit-code contract ─────────────────────────────────────────
+
+
+class TestHelperMain:
+    """Cover the :func:`terok.tui.askpass.main` code paths via direct calls.
+
+    These use a tiny blocking-socket stand-in for the service so we don't
+    have to drag asyncio in — the protocol layer is identical.
+    """
+
+    @pytest.mark.asyncio
+    async def test_helper_exits_zero_and_prints_answer(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture
+    ) -> None:
+        """Accept path: helper prints the passphrase and exits 0."""
+        import socket as _socket
+
+        from terok.tui import askpass as helper
+
+        sock_path = tmp_path / "helper.sock"
+        server = _socket.socket(_socket.AF_UNIX, _socket.SOCK_STREAM)
+        server.bind(str(sock_path))
+        server.listen(1)
+
+        async def _fake_tui() -> None:
+            conn, _ = await asyncio.get_running_loop().sock_accept(server)
+            loop = asyncio.get_running_loop()
+            raw = b""
+            while not raw.endswith(b"\n"):
+                chunk = await loop.sock_recv(conn, 4096)
+                if not chunk:
+                    break
+                raw += chunk
+            request_id, _ = proto.parse_request(proto.decode(raw))
+            await loop.sock_sendall(conn, proto.encode(proto.make_answer(request_id, "secret")))
+            conn.close()
+
+        try:
+            tui_task = asyncio.create_task(_fake_tui())
+            monkeypatch.setenv("TEROK_ASKPASS_SOCKET", str(sock_path))
+
+            # Run the blocking helper off the event loop so the fake TUI can service it.
+            rc = await asyncio.to_thread(helper.main, ["terok-askpass", "Enter passphrase:"])
+            await tui_task
+        finally:
+            server.close()
+
+        assert rc == 0
+        assert capsys.readouterr().out.strip() == "secret"
+
+    @pytest.mark.asyncio
+    async def test_helper_exits_nonzero_on_cancel(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Cancel path: helper exits non-zero, ssh aborts immediately."""
+        import socket as _socket
+
+        from terok.tui import askpass as helper
+
+        sock_path = tmp_path / "helper.sock"
+        server = _socket.socket(_socket.AF_UNIX, _socket.SOCK_STREAM)
+        server.bind(str(sock_path))
+        server.listen(1)
+
+        async def _fake_tui() -> None:
+            conn, _ = await asyncio.get_running_loop().sock_accept(server)
+            loop = asyncio.get_running_loop()
+            raw = b""
+            while not raw.endswith(b"\n"):
+                chunk = await loop.sock_recv(conn, 4096)
+                if not chunk:
+                    break
+                raw += chunk
+            request_id, _ = proto.parse_request(proto.decode(raw))
+            await loop.sock_sendall(conn, proto.encode(proto.make_cancel(request_id)))
+            conn.close()
+
+        try:
+            tui_task = asyncio.create_task(_fake_tui())
+            monkeypatch.setenv("TEROK_ASKPASS_SOCKET", str(sock_path))
+            rc = await asyncio.to_thread(helper.main, ["terok-askpass", "prompt"])
+            await tui_task
+        finally:
+            server.close()
+
+        assert rc != 0
+
+    def test_helper_exits_nonzero_when_socket_env_missing(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Without ``TEROK_ASKPASS_SOCKET`` the helper can't do anything — bail."""
+        from terok.tui import askpass as helper
+
+        monkeypatch.delenv("TEROK_ASKPASS_SOCKET", raising=False)
+        assert helper.main(["terok-askpass", "prompt"]) != 0
+
+    def test_helper_exits_nonzero_when_socket_unreachable(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Pointed at a non-existent path, the helper errors cleanly."""
+        from terok.tui import askpass as helper
+
+        monkeypatch.setenv("TEROK_ASKPASS_SOCKET", str(tmp_path / "never-bound.sock"))
+        assert helper.main(["terok-askpass", "prompt"]) != 0
+
+
+# silence pytest about the unused fixture scaffold
+_ = os

--- a/tests/unit/tui/test_askpass_service.py
+++ b/tests/unit/tui/test_askpass_service.py
@@ -20,6 +20,7 @@ import asyncio
 import os
 import stat
 from pathlib import Path
+from unittest.mock import patch
 
 import pytest
 from textual.app import App
@@ -30,6 +31,7 @@ from terok.tui.askpass_service import (
     AskpassService,
     build_askpass_env,
     default_socket_path,
+    gui_askpass_usable,
 )
 
 # ── build_askpass_env ─────────────────────────────────────────────────
@@ -109,21 +111,61 @@ class TestBuildEnv:
 
 
 class TestSocketPath:
-    """Per-process socket path under ``$XDG_RUNTIME_DIR`` (with fallback)."""
+    """Per-process socket path under terok's namespace runtime dir.
 
-    def test_uses_xdg_runtime_dir_when_set(
+    We delegate to :func:`terok_sandbox.paths.namespace_runtime_dir`
+    for the XDG resolution order — patching it out lets us pin the
+    path regardless of the host's env and ensures no ``/tmp`` fallback
+    leaks back in.
+    """
+
+    def test_uses_namespace_runtime_dir(self, tmp_path: Path) -> None:
+        """Socket sits inside whatever ``namespace_runtime_dir`` returns — always.
+
+        This is the anti-regression for bandit B108: the resolver is
+        the single source of truth for where ephemeral terok state
+        lives, and it has no ``/tmp`` leaf in its fallback chain
+        (``$XDG_RUNTIME_DIR/terok`` → ``$XDG_STATE_HOME/terok`` →
+        ``~/.local/state/terok``).  Delegating here means any future
+        change to that chain lands transparently.
+        """
+        with patch("terok.tui.askpass_service.namespace_runtime_dir", return_value=tmp_path):
+            path = default_socket_path(pid=12345)
+        assert path == tmp_path / "askpass-12345.sock"
+
+    def test_does_not_read_xdg_runtime_dir_directly(
         self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
     ) -> None:
-        """When the env var points somewhere, the socket lives there."""
-        monkeypatch.setenv("XDG_RUNTIME_DIR", str(tmp_path))
-        path = default_socket_path(pid=12345)
-        assert path == tmp_path / "terok-askpass-12345.sock"
+        """``default_socket_path`` goes through the resolver, not the raw env var.
 
-    def test_falls_back_to_tmp(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        """Without ``XDG_RUNTIME_DIR``, ``/tmp`` is the last resort."""
-        monkeypatch.delenv("XDG_RUNTIME_DIR", raising=False)
-        path = default_socket_path(pid=999)
-        assert path == Path("/tmp/terok-askpass-999.sock")
+        Proves we're not reimplementing the XDG chain locally.
+        """
+        monkeypatch.setenv("XDG_RUNTIME_DIR", "/tmp/unused-should-be-ignored")
+        with patch("terok.tui.askpass_service.namespace_runtime_dir", return_value=tmp_path):
+            assert default_socket_path(pid=1).parent == tmp_path
+
+
+# ── gui_askpass_usable ────────────────────────────────────────────────
+
+
+class TestGuiAskpassUsable:
+    """Predicate that decides whether to bother spinning up our socket."""
+
+    def test_needs_both_askpass_and_gui(self) -> None:
+        """A GUI helper without a display can't actually render — skip it."""
+        assert not gui_askpass_usable({"SSH_ASKPASS": "/usr/libexec/seahorse-askpass"})
+        assert not gui_askpass_usable({"DISPLAY": ":0"})
+        assert not gui_askpass_usable({})
+
+    def test_x11_session_is_usable(self) -> None:
+        """``DISPLAY`` + ``SSH_ASKPASS`` is the classic desktop path."""
+        assert gui_askpass_usable({"SSH_ASKPASS": "/usr/libexec/seahorse-askpass", "DISPLAY": ":0"})
+
+    def test_wayland_session_is_usable(self) -> None:
+        """Wayland's ``WAYLAND_DISPLAY`` is accepted alongside X's ``DISPLAY``."""
+        assert gui_askpass_usable(
+            {"SSH_ASKPASS": "/usr/libexec/seahorse-askpass", "WAYLAND_DISPLAY": "wayland-0"}
+        )
 
 
 # ── AskpassService lifecycle ──────────────────────────────────────────

--- a/tests/unit/tui/test_wizard_screens.py
+++ b/tests/unit/tui/test_wizard_screens.py
@@ -384,7 +384,7 @@ def test_gate_sync_in_subprocess_returns_result_dict() -> None:
 
     sentinel = {"success": True, "upstream_url": "https://example.com/r.git", "errors": []}
 
-    def _fake_run_isolated(body: str, *, label: str) -> None:  # noqa: ARG001
+    def _fake_run_isolated(body: str, *, label: str, env: dict | None = None) -> None:  # noqa: ARG001
         # Extract the result path from the body — it's the last argument
         # passed to ``open(...)``.
         import json


### PR DESCRIPTION
Closes #823.

## Summary

- Textual passphrase modal for `ssh.use_personal: true` projects — OpenSSH routes passphrase prompts through the TUI instead of silently failing or hitting `/dev/tty`.
- **Zero cost when opted out**: no socket binds, no env vars injected, no helper invoked unless a project actually sets `ssh.use_personal: true`.  The `AskpassService` is lazy — its first use is the first opt-in subprocess of the session.
- Respects a pre-existing `SSH_ASKPASS` when `DISPLAY`/`WAYLAND_DISPLAY` is reachable (seahorse / gnome-keyring wins on desktop).  Our Textual modal only takes over when no GUI askpass can render (headless SSH session, container, TUI over textual-serve).
- `SSH_ASKPASS_REQUIRE=force` is always set so OpenSSH uses askpass even with a tty attached — belt-and-braces over the `start_new_session` isolation from PR #821.
- Cancel on the modal → helper exits non-zero → ssh aborts immediately (no bogus "wrong passphrase" retry loop).
- Socket bound with umask `0o077` so its mode is `0600` atomically; filesystem is the auth boundary.
- `terok-askpass` ships as a poetry entry point alongside `terok-tui`.

Implementation split across four focused modules in `src/terok/tui/`:

- `askpass_protocol.py` — newline-delimited UTF-8 JSON frames; pure data, no I/O.
- `askpass.py` — the `terok-askpass` helper binary; ~30 lines, stateless.
- `askpass_service.py` — `AskpassService` (asyncio server + lifecycle), `AskpassModal` (Textual passphrase prompt), `build_askpass_env()` (pure env-injection policy).
- wiring — `_run_isolated(..., env=None)`, `InitProgressScreen._askpass_subprocess_env(project)` as the single choke point that gates on `project.ssh_use_personal`, `TerokTUI.ensure_askpass_service()` + teardown in `action_quit`.

## Out of scope

- **"Gate keys + personal keys" union.** Today, `use_personal_ssh=True` in terok-sandbox bypasses the vault branch entirely — the two modes are either-or.  Making them additive would require the vault agent proxying unknown keys to the user's upstream agent; too invasive to justify by this feature alone.  Already documented in the sandbox `_git_env_with_ssh` docstring.
- **terok-web serve** works with this design unchanged — same app API, same modal code path.

## Test plan

- [x] 39 new unit tests (`test_askpass_protocol`, `test_askpass_service`, `test_askpass_gating`) covering wire protocol, env-injection policy, socket lifecycle + `0600` mode + start/stop idempotency, end-to-end round-trip through `App.run_test()`, helper accept/cancel exit codes, socket-unset / socket-unreachable error paths, and the gating invariant (opt-out → `None`, service never called).
- [x] Full unit suite: 2115 passed.
- [x] `ruff check` + `ruff format --check` clean.
- [x] `tach check` clean.
- [x] `reuse lint` clean (SPDX headers on all new source files).
- [x] `docstr-coverage` 98.5% project-wide.
- [ ] **Manual smoke test** (reviewer or author on host): `make install-dev` then `terok-tui` on a project with `ssh.use_personal: true` + a passphrase-protected key → passphrase modal appears, typing + Unlock completes gate-sync, Cancel aborts cleanly with a visible error in the log pane.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Interactive dialog prompts for SSH passphrases during init for personal SSH projects.
  * An installable helper lets subprocesses delegate passphrase entry to the app via a per-session socket.
  * Init flows now provide askpass-related environment variables so GUI prompts or the helper are used by subprocesses.

* **Chores**
  * Added a per-user runtime-dir helper for IPC socket placement.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->