### PR TITLE
fix(paths): honor paths.root for panic lock and terok log

### DIFF
--- a/.importlinter
+++ b/.importlinter
@@ -47,6 +47,7 @@ allowed_importers =
     terok.cli.main
     terok.cli.wiring
     terok.lib.core.config
+    terok.lib.core.paths
     terok.lib.core.projects
     terok.lib.core.runtime
     terok.lib.core.yaml_schema

--- a/src/terok/cli/commands/info.py
+++ b/src/terok/cli/commands/info.py
@@ -19,11 +19,11 @@ from ...lib.core.config import (
     global_config_path as _global_config_path,
     global_config_search_paths as _global_config_search_paths,
     projects_dir as _projects_dir,
-    state_dir as _state_dir,
     user_presets_dir as _user_presets_dir,
     user_projects_dir as _user_projects_dir,
     vault_dir as _vault_dir,
 )
+from ...lib.core.paths import core_state_dir as _core_state_dir
 from ...lib.core.projects import list_projects
 from ...ui_utils.terminal import (
     gray as _gray,
@@ -236,7 +236,7 @@ def _print_config() -> None:
 
     # WRITE PATHS
     print("Writable locations (write):")
-    sdir = _state_dir()
+    sdir = _core_state_dir()
     sdir_exists = Path(sdir).is_dir()
     print(
         f"- State dir: {_gray(str(sdir), color_enabled)} "

--- a/src/terok/lib/core/config.py
+++ b/src/terok/lib/core/config.py
@@ -196,11 +196,7 @@ def _resolve_path(
     config_key: tuple[str, str] | None,
     default: Callable[[], Path],
 ) -> Path:
-    """Resolve a path: env var → global config → computed default.
-
-    This replaces the repeated try/except + load_global_config() pattern
-    that was duplicated across ``state_dir``, ``build_dir``, etc.
-    """
+    """Resolve a path: env var → global config → computed default."""
     if env_var:
         env = os.environ.get(env_var)
         if env:
@@ -221,19 +217,6 @@ def _resolve_path(
             )
 
     return default().resolve()
-
-
-def state_dir() -> Path:
-    """Terok core state directory (host-only: build artifacts, task metadata).
-
-    Precedence:
-    - ``TEROK_STATE_DIR`` environment variable (per-package escape hatch).
-    - Namespace root (``TEROK_ROOT`` / ``config.yml`` ``paths.root``) + ``core/``.
-    - Platform default (``~/.local/share/terok/core``).
-    """
-    from terok_sandbox.paths import namespace_state_dir
-
-    return namespace_state_dir("core", "TEROK_STATE_DIR").resolve()
 
 
 def sandbox_live_dir() -> Path:
@@ -327,9 +310,11 @@ def build_dir() -> Path:
 
     Resolution order:
     - Global config: paths.build_dir
-    - Otherwise: state_dir()/build
+    - Otherwise: core_state_dir()/build
     """
-    return _resolve_path(None, ("paths", "build_dir"), lambda: state_dir() / "build")
+    from .paths import core_state_dir
+
+    return _resolve_path(None, ("paths", "build_dir"), lambda: core_state_dir() / "build")
 
 
 def archive_dir() -> Path:

--- a/src/terok/lib/core/paths.py
+++ b/src/terok/lib/core/paths.py
@@ -51,29 +51,29 @@ def config_root() -> Path:
 
 
 def state_root() -> Path:
-    """
-    Writable state (tasks, pods, caches).
+    """Namespace state root shared by every terok ecosystem package.
 
-    Priority:
-      1. TEROK_STATE_DIR
-      2. if root   → /var/lib/terok
-         else      → ${XDG_DATA_HOME:-~/.local/share}/terok
+    Single source of truth — delegates to :func:`terok_sandbox.paths.namespace_state_dir`,
+    which resolves ``TEROK_ROOT`` → ``config.yml`` ``paths.root`` (via the
+    layered config stack) → platform default (``/var/lib/terok`` or
+    ``${XDG_DATA_HOME:-~/.local/share}/terok``).
+    """
+    from terok_sandbox.paths import namespace_state_dir
+
+    return namespace_state_dir("").resolve()
+
+
+def core_state_dir() -> Path:
+    """Terok core state (build artifacts, task metadata, panic lock, log).
+
+    Resolves to ``$state_root/core`` unless ``TEROK_STATE_DIR`` overrides it
+    (per-package escape hatch, same convention as ``TEROK_SANDBOX_STATE_DIR``
+    etc.).
     """
     env = os.getenv("TEROK_STATE_DIR")
     if env:
-        return Path(env).expanduser()
-
-    if _is_root():
-        return Path("/var/lib") / APP_NAME
-
-    if _user_data_dir is not None:
-        return Path(_user_data_dir(APP_NAME))
-
-    # Fallback without platformdirs: honor XDG_DATA_HOME if set
-    xdg = os.getenv("XDG_DATA_HOME")
-    if xdg:
-        return Path(xdg) / APP_NAME
-    return Path.home() / ".local" / "share" / APP_NAME
+        return Path(env).expanduser().resolve()
+    return (state_root() / "core").resolve()
 
 
 def runtime_root() -> Path:

--- a/src/terok/lib/domain/panic.py
+++ b/src/terok/lib/domain/panic.py
@@ -19,7 +19,7 @@ from dataclasses import dataclass, field
 from datetime import UTC, datetime
 
 from ..core.config import get_shield_bypass_firewall_no_protection
-from ..core.paths import state_root
+from ..core.paths import core_state_dir
 from ..core.projects import list_projects
 from ..orchestration.tasks import (
     CONTAINER_MODES,
@@ -96,12 +96,12 @@ def panic_stop_containers() -> tuple[list[str], list[tuple[str, str]]]:
 
 def is_panicked() -> bool:
     """Return whether the panic lock file exists."""
-    return (state_root() / _LOCK_FILENAME).is_file()
+    return (core_state_dir() / _LOCK_FILENAME).is_file()
 
 
 def clear_panic_lock() -> None:
     """Remove the panic lock file if it exists."""
-    (state_root() / _LOCK_FILENAME).unlink(missing_ok=True)
+    (core_state_dir() / _LOCK_FILENAME).unlink(missing_ok=True)
 
 
 def format_panic_report(result: PanicResult) -> str:
@@ -260,6 +260,6 @@ def _stop_containers(targets: list[_Target]) -> tuple[list[str], list[tuple[str,
 
 def _write_panic_lock() -> None:
     """Write the panic lock file with current timestamp."""
-    path = state_root() / _LOCK_FILENAME
+    path = core_state_dir() / _LOCK_FILENAME
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(datetime.now(UTC).isoformat() + "\n")

--- a/src/terok/lib/domain/project.py
+++ b/src/terok/lib/domain/project.py
@@ -57,10 +57,10 @@ from ..core.config import (
     make_sandbox_config,
     projects_dir,
     sandbox_live_dir,
-    state_dir,
     user_projects_dir,
     vault_dir,
 )
+from ..core.paths import core_state_dir
 from ..core.project_model import ProjectConfig
 from ..core.projects import list_presets, load_project
 from ..orchestration.agent_config import resolve_agent_config
@@ -97,7 +97,7 @@ def _is_under_terok_root(path: Path) -> bool:
     managed_roots = [
         projects_dir(),
         user_projects_dir(),
-        state_dir(),
+        core_state_dir(),
         sandbox_live_dir(),
         make_sandbox_config().state_dir,
         vault_dir(),
@@ -247,7 +247,7 @@ def _archive_project(project_id: str) -> str | None:
             sources.append(("config", project.root))
 
         # Task metadata (core state)
-        project_state = state_dir() / "projects" / pid
+        project_state = core_state_dir() / "projects" / pid
         if project_state.is_dir():
             sources.append(("state", project_state))
 
@@ -346,7 +346,7 @@ def delete_project(project_id: str) -> DeleteProjectResult:
     _rmtree_managed(project.tasks_root, "Tasks root", deleted, skipped)
 
     # 3-4. Remove state dir, build artifacts, and any remaining task archives
-    for d in (state_dir() / "projects" / pid, build_dir() / pid, archive_dir() / pid):
+    for d in (core_state_dir() / "projects" / pid, build_dir() / pid, archive_dir() / pid):
         if d.is_dir():
             shutil.rmtree(d)
             deleted.append(str(d))

--- a/src/terok/lib/orchestration/environment.py
+++ b/src/terok/lib/orchestration/environment.py
@@ -65,7 +65,7 @@ def _gate_url(
             f"  Gate repo: {gate_repo}\n"
             f"  Gate base: {gate_base}\n"
             "Move the repo under the gate base directory, or adjust\n"
-            "gate_server.repos_dir / paths.state_dir in global config."
+            "gate_server.repos_dir / paths.root in global config."
         )
     host = f"localhost:{port}" if use_socket else f"host.containers.internal:{port}"
     return f"http://{token}@{host}/{gate_repo.name}"

--- a/src/terok/lib/orchestration/tasks.py
+++ b/src/terok/lib/orchestration/tasks.py
@@ -25,7 +25,8 @@ from pathlib import Path
 from terok_executor import AgentRunner
 
 from ..core import runtime as _rt
-from ..core.config import archive_dir, state_dir
+from ..core.config import archive_dir
+from ..core.paths import core_state_dir
 from ..core.projects import ProjectConfig, load_project
 from ..core.task_display import (
     CONTAINER_MODES,
@@ -429,7 +430,7 @@ def get_workspace_git_diff(project_id: str, task_id: str, against: str = "HEAD")
 
 def tasks_meta_dir(project_id: str) -> Path:
     """Return the directory containing task metadata YAML files for *project_id*."""
-    return state_dir() / "projects" / project_id / "tasks"
+    return core_state_dir() / "projects" / project_id / "tasks"
 
 
 def tasks_archive_dir(project_id: str) -> Path:

--- a/src/terok/lib/util/logging_utils.py
+++ b/src/terok/lib/util/logging_utils.py
@@ -10,7 +10,7 @@ All functions are exception-safe — they never raise or affect callers.
 import sys
 
 LOG_FILENAME = "terok.log"
-"""Filename for the best-effort terok library log (written under ``state_root()``)."""
+"""Filename for the best-effort terok library log (written under ``core_state_dir()``)."""
 
 
 def _log(message: str, *, level: str = "DEBUG") -> None:
@@ -19,14 +19,14 @@ def _log(message: str, *, level: str = "DEBUG") -> None:
     Best-effort, exception-safe: any IO error is silently ignored so this
     function never raises or affects callers.
 
-    Writes to ``state_root()/terok.log``.
+    Writes to ``core_state_dir()/terok.log``.
     """
     try:
         import time
 
-        from ..core.paths import state_root
+        from ..core.paths import core_state_dir
 
-        log_path = state_root() / LOG_FILENAME
+        log_path = core_state_dir() / LOG_FILENAME
         log_path.parent.mkdir(parents=True, exist_ok=True)
         timestamp = time.strftime("%Y-%m-%d %H:%M:%S", time.localtime())
         with open(log_path, "a", encoding="utf-8") as f:

--- a/src/terok/tui/app.py
+++ b/src/terok/tui/app.py
@@ -78,8 +78,8 @@ if _HAS_TEXTUAL:
     from ..lib.core.config import (
         get_tui_default_tmux,
         set_experimental,
-        state_dir,
     )
+    from ..lib.core.paths import core_state_dir
     from ..lib.core.projects import (
         BrokenProject,
         ProjectConfig,
@@ -419,7 +419,7 @@ if _HAS_TEXTUAL:
             not be visible even though the widgets exist.
             """
             try:
-                log_path = state_dir() / "terok.log"
+                log_path = core_state_dir() / "terok.log"
                 log_path.parent.mkdir(parents=True, exist_ok=True)
 
                 left_pane = self.query_one("#left-pane")
@@ -457,7 +457,7 @@ if _HAS_TEXTUAL:
             try:
                 from datetime import datetime as _dt
 
-                log_path = state_dir() / "terok.log"
+                log_path = core_state_dir() / "terok.log"
                 log_path.parent.mkdir(parents=True, exist_ok=True)
                 ts = _dt.now().isoformat(timespec="seconds")
                 with log_path.open("a", encoding="utf-8") as _f:
@@ -471,7 +471,7 @@ if _HAS_TEXTUAL:
             try:
                 import json
 
-                state_path = state_dir() / "terok-state.json"
+                state_path = core_state_dir() / "terok-state.json"
                 if state_path.exists():
                     with state_path.open("r", encoding="utf-8") as f:
                         state = json.load(f)
@@ -489,7 +489,7 @@ if _HAS_TEXTUAL:
             try:
                 import json
 
-                state_path = state_dir() / "terok-state.json"
+                state_path = core_state_dir() / "terok-state.json"
                 state_path.parent.mkdir(parents=True, exist_ok=True)
                 state = {
                     "last_project": self.current_project_id,

--- a/tach.toml
+++ b/tach.toml
@@ -837,7 +837,7 @@ expose = ["assign_web_port", "release_web_port"]
 from = ["terok.lib.orchestration.ports"]
 
 [[interfaces]]
-expose = ["config_root", "vault_root", "state_root", "runtime_root"]
+expose = ["config_root", "vault_root", "state_root", "core_state_dir", "runtime_root"]
 from = ["terok.lib.core.paths"]
 
 [[interfaces]]

--- a/tests/unit/cli/test_cli_config.py
+++ b/tests/unit/cli/test_cli_config.py
@@ -93,7 +93,7 @@ def patch_config_command(layout: SimpleNamespace) -> Iterator[None]:
             patch("terok.cli.commands.info._projects_dir", return_value=layout.system_root)
         )
         stack.enter_context(
-            patch("terok.cli.commands.info._state_dir", return_value=layout.state_root)
+            patch("terok.cli.commands.info._core_state_dir", return_value=layout.state_root)
         )
         stack.enter_context(
             patch("terok.cli.commands.info._build_dir", return_value=layout.build_root)

--- a/tests/unit/lib/test_config.py
+++ b/tests/unit/lib/test_config.py
@@ -12,8 +12,7 @@ from pathlib import Path
 import pytest
 from terok_sandbox import port_registry as reg
 
-from terok.lib.core import config as cfg
-from terok.lib.core import paths as _paths
+from terok.lib.core import config as cfg, paths as _paths
 
 
 @pytest.fixture(autouse=True)

--- a/tests/unit/lib/test_config.py
+++ b/tests/unit/lib/test_config.py
@@ -13,6 +13,7 @@ import pytest
 from terok_sandbox import port_registry as reg
 
 from terok.lib.core import config as cfg
+from terok.lib.core import paths as _paths
 
 
 @pytest.fixture(autouse=True)
@@ -54,7 +55,7 @@ def test_global_config_path_prefers_xdg(
 @pytest.mark.parametrize(
     ("env_var", "config_text", "resolver", "expected_name"),
     [
-        ("TEROK_STATE_DIR", None, cfg.state_dir, "state"),
+        ("TEROK_STATE_DIR", None, _paths.core_state_dir, "state"),
         (
             "TEROK_CONFIG_FILE",
             "paths:\n  user_projects_dir: {path}\n",
@@ -179,22 +180,29 @@ def test_projects_dir_appends_subdir(monkeypatch: pytest.MonkeyPatch, tmp_path: 
     assert cfg.projects_dir() == (tmp_path / "projects").resolve()
 
 
-def test_state_dir_via_env(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
-    """``state_dir()`` reads TEROK_STATE_DIR."""
+def test_core_state_dir_via_env(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """``core_state_dir()`` reads TEROK_STATE_DIR."""
     target = tmp_path / "my-state"
     monkeypatch.setenv("TEROK_STATE_DIR", str(target))
-    assert cfg.state_dir() == target.resolve()
+    assert _paths.core_state_dir() == target.resolve()
 
 
-def test_state_dir_via_config(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
-    """``state_dir()`` honors ``paths.root`` from config as namespace root."""
+def test_core_state_dir_via_config(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """``core_state_dir()`` honors ``paths.root`` from config as namespace root."""
+    from terok_sandbox import paths as sandbox_paths
+
+    sandbox_paths._config_section_cache.clear()
     target = tmp_path / "custom-root"
     monkeypatch.delenv("TEROK_STATE_DIR", raising=False)
+    monkeypatch.delenv("TEROK_ROOT", raising=False)
     monkeypatch.setenv(
         "TEROK_CONFIG_FILE",
         str(write_config(tmp_path, f"paths:\n  root: {target}\n")),
     )
-    assert cfg.state_dir() == (target / "core").resolve()
+    try:
+        assert _paths.core_state_dir() == (target / "core").resolve()
+    finally:
+        sandbox_paths._config_section_cache.clear()
 
 
 def test_build_dir_via_config(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:

--- a/tests/unit/lib/test_panic.py
+++ b/tests/unit/lib/test_panic.py
@@ -324,7 +324,7 @@ class TestStopGate:
 class TestPanicLock:
     """Tests for panic lock file lifecycle."""
 
-    @patch("terok.lib.domain.panic.state_root")
+    @patch("terok.lib.domain.panic.core_state_dir")
     def test_lock_lifecycle(self, mock_state, tmp_path):
         """Lock can be written, checked, and cleared."""
         mock_state.return_value = tmp_path
@@ -336,7 +336,7 @@ class TestPanicLock:
         clear_panic_lock()
         assert not is_panicked()
 
-    @patch("terok.lib.domain.panic.state_root")
+    @patch("terok.lib.domain.panic.core_state_dir")
     def test_clear_idempotent(self, mock_state, tmp_path):
         """Clearing when no lock exists is a no-op."""
         mock_state.return_value = tmp_path

--- a/tests/unit/lib/test_paths.py
+++ b/tests/unit/lib/test_paths.py
@@ -148,34 +148,48 @@ class TestConfigRoot:
 
 
 class TestStateRoot:
-    """Verify ``state_root()`` resolution."""
+    """Verify ``state_root()`` delegates to the sandbox namespace resolver."""
+
+    def test_terok_root_env_override(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+        """TEROK_ROOT pins the namespace root."""
+        monkeypatch.setenv("TEROK_ROOT", str(tmp_path))
+        monkeypatch.delenv("TEROK_CONFIG_FILE", raising=False)
+        assert paths.state_root() == tmp_path.resolve()
+
+    def test_paths_root_from_config(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+        """config.yml ``paths.root`` is honored when TEROK_ROOT is unset."""
+        from terok_sandbox import paths as sandbox_paths
+
+        sandbox_paths._config_section_cache.clear()
+        monkeypatch.delenv("TEROK_ROOT", raising=False)
+        custom_root = tmp_path / "custom-root"
+        cfg = tmp_path / "config.yml"
+        cfg.write_text(f"paths:\n  root: {custom_root}\n")
+        monkeypatch.setenv("TEROK_CONFIG_FILE", str(cfg))
+        try:
+            assert paths.state_root() == custom_root.resolve()
+        finally:
+            sandbox_paths._config_section_cache.clear()
+
+
+class TestCoreStateDir:
+    """Verify ``core_state_dir()`` derives from ``state_root()``."""
+
+    def test_defaults_under_state_root(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """Without TEROK_STATE_DIR, core state lives at ``$state_root/core``."""
+        monkeypatch.delenv("TEROK_STATE_DIR", raising=False)
+        monkeypatch.setenv("TEROK_ROOT", str(tmp_path))
+        monkeypatch.delenv("TEROK_CONFIG_FILE", raising=False)
+        assert paths.core_state_dir() == (tmp_path / "core").resolve()
 
     def test_env_override(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
-        """TEROK_STATE_DIR takes first priority."""
-        monkeypatch.setenv("TEROK_STATE_DIR", str(tmp_path))
-        assert paths.state_root() == tmp_path
-
-    def test_root_fallback(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        """Root user gets /var/lib/terok."""
-        monkeypatch.delenv("TEROK_STATE_DIR", raising=False)
-        monkeypatch.setattr(paths, "_is_root", lambda: True)
-        assert paths.state_root() == Path("/var/lib/terok")
-
-    def test_xdg_data_home_fallback(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        """Without platformdirs, XDG_DATA_HOME is honored."""
-        monkeypatch.delenv("TEROK_STATE_DIR", raising=False)
-        monkeypatch.setattr(paths, "_is_root", lambda: False)
-        monkeypatch.setattr(paths, "_user_data_dir", None)
-        monkeypatch.setenv("XDG_DATA_HOME", str(MOCK_BASE / "xdg-data"))
-        assert paths.state_root() == MOCK_BASE / "xdg-data" / "terok"
-
-    def test_bare_fallback(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        """Last resort: ~/.local/share/terok."""
-        monkeypatch.delenv("TEROK_STATE_DIR", raising=False)
-        monkeypatch.delenv("XDG_DATA_HOME", raising=False)
-        monkeypatch.setattr(paths, "_is_root", lambda: False)
-        monkeypatch.setattr(paths, "_user_data_dir", None)
-        assert paths.state_root() == Path.home() / ".local" / "share" / "terok"
+        """TEROK_STATE_DIR is the per-package escape hatch."""
+        override = tmp_path / "override"
+        monkeypatch.setenv("TEROK_STATE_DIR", str(override))
+        monkeypatch.setenv("TEROK_ROOT", str(tmp_path / "ignored"))
+        assert paths.core_state_dir() == override.resolve()
 
 
 class TestRuntimeRoot:

--- a/tests/unit/lib/test_project_archive.py
+++ b/tests/unit/lib/test_project_archive.py
@@ -15,7 +15,8 @@ from unittest.mock import patch
 
 import pytest
 
-from terok.lib.core.config import archive_dir, build_dir, state_dir
+from terok.lib.core.config import archive_dir, build_dir
+from terok.lib.core.paths import core_state_dir
 from terok.lib.core.projects import load_project
 from terok.lib.domain.facade import delete_project
 from terok.lib.domain.project import _archive_project
@@ -41,7 +42,7 @@ def archive_member_names(path: str) -> list[str]:
 
 def create_task_state(project_id: str) -> None:
     """Create a sample task metadata file for an archived project."""
-    meta_dir = state_dir() / "projects" / project_id / "tasks"
+    meta_dir = core_state_dir() / "projects" / project_id / "tasks"
     meta_dir.mkdir(parents=True, exist_ok=True)
     (meta_dir / "1.yml").write_text("task_id: '1'\nname: test\n")
 

--- a/tests/unit/lib/test_project_delete.py
+++ b/tests/unit/lib/test_project_delete.py
@@ -11,7 +11,8 @@ from types import SimpleNamespace
 
 import pytest
 
-from terok.lib.core.config import build_dir as cfg_build_dir, state_dir as cfg_state_dir
+from terok.lib.core.config import build_dir as cfg_build_dir
+from terok.lib.core.paths import core_state_dir as cfg_state_dir
 from terok.lib.core.projects import load_project
 from terok.lib.domain.facade import delete_project
 from tests.test_utils import project_env, write_project

--- a/tests/unit/lib/test_tasks.py
+++ b/tests/unit/lib/test_tasks.py
@@ -1186,9 +1186,9 @@ class TestTaskLogs:
         """Create a task and set its mode in metadata."""
         task_id = task_new(project_id)
         # Manually update metadata to set mode (normally done by task runners)
-        from terok.lib.core.config import state_dir
+        from terok.lib.core.paths import core_state_dir
 
-        meta_dir = state_dir() / "projects" / project_id / "tasks"
+        meta_dir = core_state_dir() / "projects" / project_id / "tasks"
         meta_path = meta_dir / f"{task_id}.yml"
         meta = yaml_load(meta_path.read_text()) or {}
         meta["mode"] = mode

--- a/tests/unit/test_error_surfacing.py
+++ b/tests/unit/test_error_surfacing.py
@@ -40,7 +40,7 @@ class TestWarnUser:
     @pytest.fixture(autouse=True)
     def _isolate_log(self, tmp_path: Path) -> None:
         """Redirect log writes so tests never touch the real state dir."""
-        with patch("terok.lib.core.paths.state_root", return_value=tmp_path):
+        with patch("terok.lib.core.paths.core_state_dir", return_value=tmp_path):
             yield
 
     def test_prints_structured_warning_to_stderr(self, capsys: pytest.CaptureFixture[str]) -> None:
@@ -85,8 +85,8 @@ class TestLogFunctions:
     """Tests for file-based logging utilities."""
 
     def test_log_warning_writes_warning_level(self, tmp_path: Path) -> None:
-        """log_warning() writes a WARNING-level line to state_root()/terok.log."""
-        with patch("terok.lib.core.paths.state_root", return_value=tmp_path):
+        """log_warning() writes a WARNING-level line to core_state_dir()/terok.log."""
+        with patch("terok.lib.core.paths.core_state_dir", return_value=tmp_path):
             log_warning("disk almost full")
         log_file = tmp_path / LOG_FILENAME
         assert log_file.exists()
@@ -95,14 +95,14 @@ class TestLogFunctions:
 
     def test_log_debug_writes_debug_level(self, tmp_path: Path) -> None:
         """_log_debug() writes a DEBUG-level line."""
-        with patch("terok.lib.core.paths.state_root", return_value=tmp_path):
+        with patch("terok.lib.core.paths.core_state_dir", return_value=tmp_path):
             _log_debug("resolved path /foo")
         content = (tmp_path / LOG_FILENAME).read_text(encoding="utf-8")
         assert "[DEBUG] resolved path /foo" in content
 
     def test_log_appends_multiple_lines(self, tmp_path: Path) -> None:
         """Successive calls append; they do not overwrite."""
-        with patch("terok.lib.core.paths.state_root", return_value=tmp_path):
+        with patch("terok.lib.core.paths.core_state_dir", return_value=tmp_path):
             log_warning("first")
             log_warning("second")
         lines = (tmp_path / LOG_FILENAME).read_text(encoding="utf-8").strip().splitlines()
@@ -113,14 +113,14 @@ class TestLogFunctions:
     def test_log_creates_parent_dirs(self, tmp_path: Path) -> None:
         """_log creates parent directories if they do not exist."""
         nested = tmp_path / "deep" / "nested"
-        with patch("terok.lib.core.paths.state_root", return_value=nested):
+        with patch("terok.lib.core.paths.core_state_dir", return_value=nested):
             _log("hello", level="INFO")
         assert (nested / LOG_FILENAME).exists()
 
     def test_log_never_raises_on_io_error(self) -> None:
-        """Exception safety: if state_root() raises, _log swallows it."""
+        """Exception safety: if core_state_dir() raises, _log swallows it."""
         with patch(
-            "terok.lib.core.paths.state_root",
+            "terok.lib.core.paths.core_state_dir",
             side_effect=OSError("permission denied"),
         ):
             # Must not raise
@@ -129,7 +129,7 @@ class TestLogFunctions:
     def test_log_warning_never_raises_on_io_error(self) -> None:
         """Exception safety for the convenience wrapper."""
         with patch(
-            "terok.lib.core.paths.state_root",
+            "terok.lib.core.paths.core_state_dir",
             side_effect=RuntimeError("boom"),
         ):
             log_warning("should not crash")
@@ -137,14 +137,14 @@ class TestLogFunctions:
     def test_log_debug_never_raises_on_io_error(self) -> None:
         """Exception safety for the debug convenience wrapper."""
         with patch(
-            "terok.lib.core.paths.state_root",
+            "terok.lib.core.paths.core_state_dir",
             side_effect=RuntimeError("boom"),
         ):
             _log_debug("should not crash")
 
     def test_log_line_contains_timestamp(self, tmp_path: Path) -> None:
         """Each log line starts with a bracketed timestamp."""
-        with patch("terok.lib.core.paths.state_root", return_value=tmp_path):
+        with patch("terok.lib.core.paths.core_state_dir", return_value=tmp_path):
             log_warning("ts check")
         line = (tmp_path / LOG_FILENAME).read_text(encoding="utf-8").strip()
         # Format: [YYYY-MM-DD HH:MM:SS] [WARNING] ts check
@@ -163,7 +163,7 @@ class TestLoadValidatedErrorPaths:
     @pytest.fixture(autouse=True)
     def _isolate_log(self, tmp_path: Path) -> None:
         """Redirect log writes to tmp_path so tests never touch the real state dir."""
-        with patch("terok.lib.core.paths.state_root", return_value=tmp_path):
+        with patch("terok.lib.core.paths.core_state_dir", return_value=tmp_path):
             yield
 
     def test_malformed_yaml_warns_and_returns_defaults(
@@ -273,7 +273,7 @@ class TestResolvePathFallback:
 
     @pytest.fixture(autouse=True)
     def _isolate_log(self, tmp_path: Path) -> None:
-        with patch("terok.lib.core.paths.state_root", return_value=tmp_path):
+        with patch("terok.lib.core.paths.core_state_dir", return_value=tmp_path):
             yield
 
     def test_value_error_falls_back_to_default(
@@ -284,7 +284,7 @@ class TestResolvePathFallback:
         bad_file = write_config(tmp_path, "paths:\n  build_dir: null\n")
         monkeypatch.setenv("TEROK_CONFIG_FILE", str(bad_file))
         # _resolve_path should fall back to default without raising
-        result = cfg.state_dir()
+        result = cfg.build_dir()
         assert result.is_absolute()
 
     def test_yaml_error_falls_back_to_default(
@@ -293,7 +293,7 @@ class TestResolvePathFallback:
         """YAMLError during config key lookup falls back to default path."""
         bad_file = write_config(tmp_path, ": [broken")
         monkeypatch.setenv("TEROK_CONFIG_FILE", str(bad_file))
-        result = cfg.state_dir()
+        result = cfg.build_dir()
         assert result.is_absolute()
 
 
@@ -307,7 +307,7 @@ class TestProjectStateWarnings:
 
     @pytest.fixture(autouse=True)
     def _isolate_log(self, tmp_path: Path) -> None:
-        with patch("terok.lib.core.paths.state_root", return_value=tmp_path):
+        with patch("terok.lib.core.paths.core_state_dir", return_value=tmp_path):
             yield
 
     def test_template_comparison_failure_logged(self, tmp_path: Path) -> None:
@@ -378,7 +378,7 @@ class TestImageCleanupWarning:
 
     @pytest.fixture(autouse=True)
     def _isolate_log(self, tmp_path: Path) -> None:
-        with patch("terok.lib.core.paths.state_root", return_value=tmp_path):
+        with patch("terok.lib.core.paths.core_state_dir", return_value=tmp_path):
             yield
 
     def test_project_discovery_failure_logged(self) -> None:
@@ -409,7 +409,7 @@ class TestEnvironmentWarnings:
 
     @pytest.fixture(autouse=True)
     def _isolate_log(self, tmp_path: Path) -> None:
-        with patch("terok.lib.core.paths.state_root", return_value=tmp_path):
+        with patch("terok.lib.core.paths.core_state_dir", return_value=tmp_path):
             yield
 
     def test_gate_fallback_warns(self, capsys: pytest.CaptureFixture[str]) -> None:


### PR DESCRIPTION
## Summary

- `state_root()` was an XDG-only fallback that bypassed the config stack, so `panic.lock` and `terok.log` always landed in `~/.local/share/terok/` even when `paths.root` was set in `config.yml`.
- `state_dir()` in `config.py` was the real namespace-aware resolver but lived in the wrong module and collided in name with `ShieldConfig.state_dir` (dataclass field) and the `terok.shield.state_dir` container annotation.
- Unifies on one codepath: `state_root()` delegates to `terok_sandbox.paths.namespace_state_dir("")` (env → `TEROK_ROOT` → `paths.root` → platform default), and new `core_state_dir()` = `$state_root/core` with `TEROK_STATE_DIR` as the per-package escape hatch.

## Changes

- `state_root()` in `lib/core/paths.py` now delegates to the sandbox namespace resolver — TEROK_ROOT → config.yml `paths.root` → platform default, via the sandbox's layered config stack.
- New `core_state_dir()` in `paths.py` derives from `state_root() / "core"` with `TEROK_STATE_DIR` override.
- `state_dir()` removed from `config.py`; `build_dir()` and every caller (panic, logging_utils, project, tasks, tui, info CLI) moved to `core_state_dir`.
- `tach.toml` exposes `core_state_dir` alongside the other public paths.

## Side effect

Also fixes a split-brain where `tui/app.py` wrote `terok.log` to `state_dir()` (config-stack aware) while `lib/util/logging_utils.py` wrote the *same filename* to `state_root()` (XDG default) — two writers, two different directories. Both now converge on `core_state_dir() / terok.log`.

## Test plan

- [x] `pytest tests/unit` — 2084 passed
- [x] `ruff check` + `ruff format --check`
- [x] `tach check`
- [x] `docstr-coverage` (98.5%)
- [x] `bandit -ll`
- [x] `reuse lint`
- [ ] Verify on a host with `paths.root` set: `panic.lock` now appears under `$root/core/` (manual)
- [ ] Verify `terok.log` is written to a single location regardless of whether the writer is the TUI or `logging_utils` (manual)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized state file storage with a dedicated core state directory. System files including logs, panic locks, project metadata, and task data are now stored in a more structured core state location, improving internal organization and clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->