### PR TITLE
feat(tui): drive terok setup before the new-project wizard on first run

### DIFF
--- a/.importlinter
+++ b/.importlinter
@@ -66,6 +66,7 @@ allowed_importers =
     terok.tui.polling
     terok.tui.project_actions
     terok.tui.screens
+    terok.tui.setup_screen
     terok.tui.task_actions
     terok.tui.widgets.project_state
 

--- a/src/terok/tui/app.py
+++ b/src/terok/tui/app.py
@@ -63,13 +63,15 @@ if _HAS_TEXTUAL:
         EnvironmentCheck,
         GateServerStatus,
         GateStalenessInfo,
+        SetupVerdict,
         VaultStatus,
         check_environment as _shield_check_environment,
         get_server_status,
         get_vault_status,
+        needs_setup,
         state as _shield_state,
     )
-    from textual import on
+    from textual import on, work
     from textual.app import App, ComposeResult
     from textual.containers import Horizontal, Vertical
     from textual.widgets import Footer, Header, Static
@@ -122,6 +124,7 @@ if _HAS_TEXTUAL:
         TaskDetailsScreen,
         VaultScreen,
     )
+    from .setup_screen import SetupOutcome, SetupScreen
     from .task_actions import TaskActionsMixin
     from .widgets import (
         PanicButton,
@@ -132,6 +135,7 @@ if _HAS_TEXTUAL:
         TaskListItem,
         TaskMeta,
     )
+    from .worker_log_screen import WorkerLogScreen
 
     # -- Dispatch tables mapping action IDs to handler method names ----------
     # These are the single source of truth for action routing.  Both
@@ -400,22 +404,117 @@ if _HAS_TEXTUAL:
             # Start periodic gate server polling
             self._start_gate_server_polling()
 
-            # First-run nudge: zero projects *and* zero broken configs on
-            # a fresh install → auto-open the wizard so the user never
-            # lands on a blank TUI wondering what to do next.  The
-            # dismissed flag persists through ``terok-state.json`` so a
-            # user who closes the wizard once isn't nagged again.
-            if not self._projects_by_id and not self._broken_by_id:
-                await self._maybe_show_first_run_wizard()
+            # First-run nudge: drive setup → wizard on a fresh install,
+            # but also re-prompt for setup whenever a stale stamp is
+            # detected (e.g. after a package upgrade).  The dismissed
+            # flag persists through ``terok-state.json`` so a user who
+            # closes both screens isn't nagged again — but a non-OK
+            # verdict overrides the flag, since a stale stamp is
+            # actionable feedback the user shouldn't be allowed to mute
+            # indefinitely.
+            await self._maybe_show_first_run_flow()
 
-        async def _maybe_show_first_run_wizard(self) -> None:
-            """Auto-open the wizard on a genuinely-empty install, once per user."""
-            if getattr(self, "_first_run_dismissed", False):
+        async def _maybe_show_first_run_flow(self) -> None:
+            """Probe the setup verdict and decide whether to drive the first-run flow."""
+            empty_install = not self._projects_by_id and not self._broken_by_id
+            try:
+                verdict = needs_setup()
+            except Exception:
+                verdict = SetupVerdict.OK  # keep the TUI usable on probe failure
+
+            already_dismissed = getattr(self, "_first_run_dismissed", False)
+            if verdict is SetupVerdict.OK and (already_dismissed or not empty_install):
                 return
+
             self._first_run_dismissed = True
             self._save_selection_state()
-            # The action kicks off a worker; no need to await.
-            self.action_new_project_wizard()
+            self._run_first_run_flow(verdict=verdict, empty_install=empty_install)
+
+        @work(exclusive=True, group="first-run-flow", exit_on_error=False)
+        async def _run_first_run_flow(self, *, verdict: SetupVerdict, empty_install: bool) -> None:
+            """Drive setup → wizard sequencing on a single worker.
+
+            Runs the setup flow first when the verdict is non-OK, then
+            chains into the new-project wizard *only* if setup
+            succeeded (or wasn't needed) and the install is empty.
+            Surfaces unexpected exceptions as a TUI notification so a
+            crash in either screen can never silently swallow the
+            user's first impression.
+            """
+            try:
+                proceed = await self._run_setup_flow(verdict)
+                if proceed and empty_install:
+                    self.action_new_project_wizard()
+            except Exception as exc:  # noqa: BLE001 — last-resort surface
+                self.notify(
+                    f"First-run flow failed: {exc}",
+                    severity="error",
+                    timeout=15,
+                )
+                raise
+
+        async def _run_setup_flow(self, verdict: SetupVerdict) -> bool:
+            """Show the setup screen + worker log; return True if the wizard may follow.
+
+            ``True`` covers both "setup completed cleanly" and "verdict
+            was already OK so we skipped the screen" — either way the
+            host stack is in a state where the project wizard makes
+            sense.  ``False`` covers user-initiated skip / refusal /
+            failure: the wizard is gated behind a working sandbox stack,
+            so chaining into it on a known-broken host would just
+            produce confusing follow-on errors.
+            """
+            if verdict is SetupVerdict.OK:
+                return True
+
+            outcome = await self.push_screen_wait(SetupScreen(verdict=verdict))
+            match outcome:
+                case SetupOutcome.SHOULD_RUN:
+                    return await self._run_setup_subprocess()
+                case SetupOutcome.SKIPPED | SetupOutcome.CANCELLED:
+                    self.notify(
+                        "Skipped terok setup.  Run it any time from the command "
+                        "palette → Run terok setup.",
+                        severity="warning",
+                        timeout=10,
+                    )
+                case SetupOutcome.REFUSED:
+                    self.notify(
+                        "Setup refused due to a downgrade.  Re-upgrade or remove "
+                        "the setup stamp; see ``terok setup`` from a shell for "
+                        "details.",
+                        severity="error",
+                        timeout=15,
+                    )
+            return False
+
+        async def _run_setup_subprocess(self) -> bool:
+            """Stream ``terok setup`` through :class:`WorkerLogScreen`; True on exit 0."""
+            result = await self.push_screen_wait(
+                WorkerLogScreen(["terok", "setup"], title="Running terok setup…")
+            )
+            if result.ok:
+                return True
+            self.notify(
+                "terok setup reported errors.  Re-run from the command palette "
+                "once the underlying issue is fixed.",
+                severity="error",
+                timeout=15,
+            )
+            return False
+
+        async def action_run_setup(self) -> None:
+            """Open the setup flow on demand (command palette / re-run).
+
+            Always probes the current verdict so the user sees the live
+            state — useful even on a healthy install when they want to
+            re-apply the (idempotent) systemd cycle after an upgrade.
+            """
+            try:
+                verdict = needs_setup()
+            except Exception:
+                verdict = SetupVerdict.FIRST_RUN
+            await self._run_setup_flow(verdict)
 
         def _log_layout_debug(self) -> None:
             """Write a one-shot snapshot of key widget sizes to the state dir.
@@ -1259,6 +1358,11 @@ if _HAS_TEXTUAL:
             from textual.app import SystemCommand
 
             yield from super().get_system_commands(screen)
+            yield SystemCommand(
+                "Run terok setup",
+                "Install or re-apply the host services (shield, vault, gate, clearance) + desktop entry",
+                self.action_run_setup,
+            )
             yield SystemCommand(
                 "Git Gate Server",
                 "Manage gate server status and operations",

--- a/src/terok/tui/setup_screen.py
+++ b/src/terok/tui/setup_screen.py
@@ -1,0 +1,195 @@
+# SPDX-FileCopyrightText: 2026 Jiri Vyskocil
+# SPDX-License-Identifier: Apache-2.0
+
+"""Verdict + decision modal for the first-run / re-run host setup flow.
+
+Renders the current :class:`terok_sandbox.SetupVerdict` with a
+contextual blurb and a Run / Skip choice — no subprocess plumbing here.
+The actual ``terok setup`` invocation rides on top of
+:class:`~terok.tui.worker_log_screen.WorkerLogScreen`, pushed by the
+TUI's first-run flow worker after this screen dismisses with
+:data:`SetupOutcome.SHOULD_RUN`.
+
+The verdict probe (``terok_sandbox.needs_setup``) is the same one
+``terok task run`` enforces in
+:func:`terok.cli.commands.task._setup_verdict_or_exit` — so a verdict
+of ``OK`` short-circuits with a banner instead of nudging the user
+toward a slow re-run, and a ``STALE_AFTER_DOWNGRADE`` refuses outright
+with the same wording the CLI uses.
+"""
+
+from __future__ import annotations
+
+import enum
+from collections.abc import Iterator
+
+from terok_sandbox import SetupVerdict, needs_setup
+from textual.app import ComposeResult
+from textual.binding import Binding
+from textual.containers import Horizontal, Vertical
+from textual.screen import ModalScreen
+from textual.widgets import Button, Label, Static
+
+
+class SetupOutcome(enum.Enum):
+    """User's decision on :class:`SetupScreen`.
+
+    The screen does *not* run setup itself; it only collects intent.
+    Translating the outcome to host-state changes is the caller's job:
+
+    - ``SHOULD_RUN`` — user clicked Run; caller should push
+      :class:`~terok.tui.worker_log_screen.WorkerLogScreen` with
+      ``["terok", "setup"]``.
+    - ``SKIPPED`` — user dismissed before running; the caller leaves
+      the host alone.
+    - ``REFUSED`` — verdict is ``STALE_AFTER_DOWNGRADE``; the only
+      available exit, mirroring the CLI exit-4 contract.
+    - ``CANCELLED`` — Esc on the pre-run screen; treated as a soft
+      skip but distinguishable for telemetry.
+    """
+
+    SHOULD_RUN = "should_run"
+    SKIPPED = "skipped"
+    REFUSED = "refused"
+    CANCELLED = "cancelled"
+
+
+_VERDICT_HEADLINE: dict[SetupVerdict, str] = {
+    SetupVerdict.OK: "Host services are already set up — re-running is safe but optional.",
+    SetupVerdict.FIRST_RUN: "First run detected — host services have not been initialised yet.",
+    SetupVerdict.STALE_AFTER_UPDATE: (
+        "Package versions changed since the last setup — re-run to apply."
+    ),
+    SetupVerdict.STAMP_CORRUPT: "Setup stamp is unreadable — re-run setup to refresh it.",
+    SetupVerdict.STALE_AFTER_DOWNGRADE: (
+        "Downgrade detected — terok refuses to run until the stamp is reconciled."
+    ),
+}
+
+
+class SetupScreen(ModalScreen[SetupOutcome]):
+    """Modal that surfaces the current setup verdict and asks whether to run it.
+
+    Two button layouts:
+
+    1. *Healthy / non-OK verdict* — Skip + Run buttons.  Clicking Run
+       dismisses with :data:`SetupOutcome.SHOULD_RUN` so the parent
+       can push the :class:`WorkerLogScreen` that owns the actual
+       subprocess streaming.
+    2. *Downgrade verdict* — Run is hidden; the only exit dismisses
+       with :data:`SetupOutcome.REFUSED`.  The CLI refuses with exit
+       code 4 here; this mirrors that contract by *not* offering an
+       option that would make the contract meaningless.
+    """
+
+    BINDINGS = [
+        Binding("escape", "close", "Close"),
+    ]
+
+    CSS = """
+    SetupScreen {
+        align: center middle;
+    }
+
+    #setup-dialog {
+        width: 80;
+        max-width: 100%;
+        height: auto;
+        max-height: 80%;
+        border: heavy $primary;
+        border-title-align: right;
+        background: $surface;
+        padding: 1 2;
+    }
+
+    #setup-headline {
+        height: auto;
+        margin-bottom: 1;
+    }
+
+    #setup-blurb {
+        color: $text-muted;
+        height: auto;
+        margin-bottom: 1;
+    }
+
+    #setup-buttons {
+        height: auto;
+        align-horizontal: right;
+    }
+
+    #setup-buttons Button {
+        margin-left: 1;
+    }
+    """
+
+    def __init__(self, verdict: SetupVerdict | None = None) -> None:
+        """Build the screen with an optional pre-fetched verdict.
+
+        Verdict probing is normally done on the main thread before the
+        screen is pushed (so the caller can decide whether to show it
+        at all).  Falling back to a fresh probe inside the screen
+        keeps direct invocations from the command palette working
+        when no caller pre-fetched it.
+        """
+        super().__init__()
+        self._verdict = verdict if verdict is not None else needs_setup()
+
+    # ── Layout ──────────────────────────────────────────────────────────
+
+    def compose(self) -> ComposeResult:
+        """Build the dialog: headline, blurb, action buttons."""
+        dialog = Vertical(id="setup-dialog")
+        dialog.border_title = "Terok host setup"
+        with dialog:
+            yield Static(_VERDICT_HEADLINE[self._verdict], id="setup-headline")
+            yield Label(self._blurb_for(self._verdict), id="setup-blurb")
+            with Horizontal(id="setup-buttons"):
+                yield from self._buttons_for(self._verdict)
+
+    @staticmethod
+    def _blurb_for(verdict: SetupVerdict) -> str:
+        """Return the per-verdict explanation rendered below the headline."""
+        if verdict is SetupVerdict.STALE_AFTER_DOWNGRADE:
+            return (
+                "Older code may not read newer state correctly.  Either "
+                "re-upgrade terok, or remove the setup stamp at your own "
+                "risk and re-run setup manually from a shell."
+            )
+        return (
+            "Installs the sandbox stack (shield + vault + gate + clearance) "
+            "and the XDG desktop entry for terok-tui.  Idempotent — safe to "
+            "re-run.  Image builds are deferred to first task run."
+        )
+
+    @staticmethod
+    def _buttons_for(verdict: SetupVerdict) -> Iterator[Button]:
+        """Render the button row, refusing the run on a downgrade."""
+        if verdict is SetupVerdict.STALE_AFTER_DOWNGRADE:
+            yield Button("Refused", id="setup-refused", variant="error", disabled=True)
+            yield Button("Close", id="setup-close", variant="default")
+            return
+        yield Button("Skip", id="setup-skip", variant="default")
+        yield Button("Run setup", id="setup-run", variant="primary")
+
+    # ── Actions ─────────────────────────────────────────────────────────
+
+    def action_close(self) -> None:
+        """Esc dismisses with :data:`SetupOutcome.CANCELLED` (or REFUSED on a downgrade)."""
+        self.dismiss(self._cancel_outcome())
+
+    def _cancel_outcome(self) -> SetupOutcome:
+        """Pick the right outcome for an Esc / Close press given the verdict."""
+        if self._verdict is SetupVerdict.STALE_AFTER_DOWNGRADE:
+            return SetupOutcome.REFUSED
+        return SetupOutcome.CANCELLED
+
+    def on_button_pressed(self, event: Button.Pressed) -> None:
+        """Route the three button IDs to their dismissal outcomes."""
+        match event.button.id:
+            case "setup-run":
+                self.dismiss(SetupOutcome.SHOULD_RUN)
+            case "setup-skip":
+                self.dismiss(SetupOutcome.SKIPPED)
+            case "setup-close":
+                self.dismiss(self._cancel_outcome())

--- a/tests/unit/tui/tui_test_helpers.py
+++ b/tests/unit/tui/tui_test_helpers.py
@@ -231,10 +231,14 @@ def build_textual_stubs() -> dict[str, types.ModuleType]:
         def __class_getitem__(cls, item: type) -> type:
             return cls
 
+    class Label(_StubObject):
+        """Stub label widget that only captures construction args."""
+
     widgets_mod.Button = Button
     widgets_mod.Input = Input
     widgets_mod.Footer = Footer
     widgets_mod.Header = Header
+    widgets_mod.Label = Label
     widgets_mod.ListItem = ListItem
     widgets_mod.ListView = ListView
     widgets_mod.Static = Static


### PR DESCRIPTION
## Summary

- Fresh TUI installs landed straight on the new-project wizard before the host services (shield, vault, gate, clearance) were initialised, leaving every gate/vault action broken until the user discovered ``terok setup`` from a shell.
- TUI now probes ``terok_sandbox.needs_setup()`` on mount.  On any verdict other than ``OK`` it pushes a new ``SetupScreen`` with the verdict context + Run / Skip choice; the actual subprocess streaming rides on the shared ``WorkerLogScreen`` from #828.  The new-project wizard auto-opens only after setup either completed cleanly or wasn't needed.
- Adds a "Run terok setup" entry to the command palette so the same flow is reachable on demand after a package upgrade flips the verdict to ``STALE_AFTER_UPDATE``.  ``STALE_AFTER_DOWNGRADE`` refuses outright, mirroring the CLI exit-4 contract from #826.

## Design notes

- ``SetupScreen`` is verdict + decision only — no subprocess plumbing.  Dismisses with ``SetupOutcome.SHOULD_RUN`` so the orchestrator (``_run_first_run_flow`` worker on ``TerokTUI``) can push ``WorkerLogScreen`` directly.  Keeps the two screens single-purpose and reuses the existing live-stream infrastructure.
- The orchestrator is a dedicated ``@work``-decorated coroutine so ``push_screen_wait`` always has a worker context, mirroring the wizard-flow pattern in ``project_actions.py``.
- ``_first_run_dismissed`` is honoured only when ``needs_setup()`` already returns ``OK`` — a stale stamp from a package upgrade re-prompts even after the user previously dismissed the screen, which they shouldn't be able to mute indefinitely.
- ``WorkerLogScreen`` is invoked with the simple ``["terok", "setup"]`` argv; on hosts where ``terok`` is on ``PATH`` (the common case) this just works and the modal title makes it clear what's running.

## Test plan

- [x] ``make lint``  ·  ``make tach``  ·  ``make lint-imports``  ·  ``make reuse`` — all clean
- [x] ``make docstrings`` — 98.5% (Excellent)
- [x] ``poetry run pytest tests/unit/`` — 2133 passed
- [ ] Manual: launch on a host with ``terok setup`` not yet run; verify the SetupScreen appears with the FIRST_RUN headline, Run streams output via WorkerLogScreen, and the wizard opens after a clean exit.
- [ ] Manual: launch on a populated install after a package upgrade simulating ``STALE_AFTER_UPDATE``; verify the SetupScreen still appears (overrides ``_first_run_dismissed``) and the wizard does *not* auto-open afterwards.
- [ ] Manual: open the command palette → "Run terok setup" on a healthy install; verify the OK headline and that Skip dismisses cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Implemented setup-aware first-run flow that probes system requirements on startup and guides users through setup if needed
  * Added new "Run terok setup" system command for manual setup verification and execution
  * Introduced setup outcome notifications to inform users of setup results (skipped, cancelled, refused, or completed)
  * Added interactive setup screen for handling different setup scenarios with Skip and Run options

<!-- end of auto-generated comment: release notes by coderabbit.ai -->