### PR TITLE
fix(tui): keep Tab on the focus ring in the project review editor

### DIFF
--- a/src/terok/tui/wizard_screens.py
+++ b/src/terok/tui/wizard_screens.py
@@ -300,6 +300,13 @@ class ProjectReviewScreen(ModalScreen["str | object | None"]):
             yield TextArea.code_editor(
                 self._rendered,
                 language="yaml",
+                theme="vscode_dark",
+                # Keep Tab on the focus ring — the project template uses
+                # 2-space indent, so a literal tab here would yield an
+                # invalid YAML on save.  Shift-Tab to reach "Initialize"
+                # was a UX wart; Tab now cycles widgets like everywhere
+                # else, and indentation comes from the renderer.
+                tab_behavior="focus",
                 id="wizard-review-yaml",
             )
             with Horizontal(id="wizard-review-buttons"):

--- a/tests/unit/tui/test_wizard_screens.py
+++ b/tests/unit/tui/test_wizard_screens.py
@@ -185,6 +185,25 @@ async def test_review_screen_initialize_returns_edited_yaml() -> None:
     assert app.result == "project:\n  id: demo\n  edited: true\n"
 
 
+@pytest.mark.asyncio
+async def test_review_screen_textarea_keeps_tab_on_focus_ring() -> None:
+    """Tab cycles widgets — the project template uses 2-space indent.
+
+    A literal tab inside the YAML would silently corrupt the file, and
+    Shift-Tab to escape the editor was a UX wart that hid the
+    "Initialize project" button from new users.  YAML language +
+    coloured theme are also asserted here so a dependency upgrade
+    that drops either is caught.
+    """
+    app = _WizardHost(ProjectReviewScreen("demo", "project:\n  id: demo\n"))
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        ta = app.screen.query_one("#wizard-review-yaml", TextArea)
+        assert ta.tab_behavior == "focus"
+        assert ta.language == "yaml"
+        assert ta.theme == "vscode_dark"
+
+
 # ── Registry-level smoke ──────────────────────────────────────────────
 
 


### PR DESCRIPTION
## Summary

The "Review project.yml" wizard screen used the default ``TextArea`` ``tab_behavior``, which had two problems:

1. **Tab inserted a literal tab into the YAML buffer.** The project template uses 2-space indent, so a stray tab made the file invalid on save.
2. **Shift-Tab was the only way to reach "Initialize project".** The primary action of the screen was hidden behind a non-obvious key combo for any first-time user.

Flip ``tab_behavior="focus"`` so Tab cycles widgets like the rest of the TUI; indentation comes from the renderer. While in there, swap the editor theme to ``vscode_dark`` — monokai's YAML colouring barely distinguished keys from values, which the user reported as "looks quite boring".

## Test plan

- [x] ``make check`` passes (2142 tests; +1 new)
- [x] New ``test_review_screen_textarea_keeps_tab_on_focus_ring`` asserts ``tab_behavior == "focus"``, ``language == "yaml"``, and ``theme == "vscode_dark"`` — guards against a Textual upgrade silently dropping any of those

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Review YAML editor now features a dark VSCode-compatible theme for improved readability.
  * Tab key navigation updated to focus and cycle through interface widgets rather than inserting literal tab characters, while preserving valid YAML indentation in edited configuration files.

* **Tests**
  * Added unit tests to verify YAML editor configuration, including theme application and tab navigation behavior validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->