### PR TITLE
feat(tui): top-level "Authenticate agents and tools" entry

### DIFF
--- a/src/terok/tui/app.py
+++ b/src/terok/tui/app.py
@@ -272,6 +272,7 @@ if _HAS_TEXTUAL:
 
         BINDINGS = [
             ("q", "quit", "Quit"),
+            ("a", "authenticate", "Auth"),
             ("P", "panic", "PANIC"),
         ]
 
@@ -1388,6 +1389,39 @@ if _HAS_TEXTUAL:
                 "Monitor blocked connections and send verdicts via D-Bus",
                 self.action_show_clearance,
             )
+            yield SystemCommand(
+                "Authenticate agents and tools",
+                "Run the host-wide auth flow for an agent or tool — no project required",
+                self.action_authenticate,
+            )
+
+        async def action_authenticate(self) -> None:
+            """Open the host-wide ``Authenticate agents and tools`` modal.
+
+            Reuses :class:`AuthActionsScreen`, but the result handler
+            forces a host-wide auth flow (``project_id=None``) regardless
+            of what's selected in the main pane — the per-project entry
+            lives on the project-details screen.
+            """
+            from .screens import AuthActionsScreen
+
+            await self.push_screen(AuthActionsScreen(), self._on_authenticate_result)
+
+        async def _on_authenticate_result(self, result: str | None) -> None:
+            """Route the host-wide auth modal's selection.
+
+            ``auth_<provider>`` lands in :meth:`_action_auth_host_wide`
+            (forced ``project_id=None``); ``import_opencode_config``
+            shares the project-screen handler since the import is
+            project-agnostic anyway.
+            """
+            if not result:
+                return
+            if result.startswith("auth_"):
+                await self._action_auth_host_wide(result[5:])
+                return
+            if result == "import_opencode_config":
+                await self._action_import_opencode_config()
 
         async def action_show_gate_server(self) -> None:
             """Open the gate server management screen."""

--- a/src/terok/tui/project_actions.py
+++ b/src/terok/tui/project_actions.py
@@ -274,13 +274,33 @@ class ProjectActionsMixin:
     # ---------- Authentication actions ----------
 
     async def _action_auth(self, provider: str) -> None:
-        """Run auth flow for the given provider."""
+        """Run the auth flow for *provider* against the selected project.
+
+        Reached from the project-details screen, where a project is
+        always selected.  The top-level "Authenticate agents and tools"
+        entry uses :meth:`_action_auth_host_wide` instead — it bypasses
+        ``current_project_id`` so a stray selection in the main pane
+        doesn't silently scope a host-wide intent to one project.
+        """
         if not self.current_project_id:
             self.notify("No project selected.")
             return
         await self._run_suspended(
             lambda: authenticate(provider, self.current_project_id),
             success_msg=f"Auth completed for {provider}",
+            refresh=None,
+        )
+
+    async def _action_auth_host_wide(self, provider: str) -> None:
+        """Run the host-wide auth flow for *provider* — no project context.
+
+        Resolves a shared L1 image (or builds one) and writes credentials
+        provider-scoped to the vault, so a later switch to per-project
+        auth doesn't duplicate or overwrite anything.
+        """
+        await self._run_suspended(
+            lambda: authenticate(provider, None),
+            success_msg=f"Auth completed for {provider} (host-wide)",
             refresh=None,
         )
 

--- a/tests/unit/tui/test_detail_screens.py
+++ b/tests/unit/tui/test_detail_screens.py
@@ -777,6 +777,53 @@ class TestSSHKeyRegistration:
             m_summarize.assert_called_once_with(_FAKE_SSH_INIT_RESULT)
 
 
+class TestActionAuth:
+    """Per-project ``_action_auth`` and host-wide ``_action_auth_host_wide``."""
+
+    def _get_mixin(self):
+        from terok.tui.project_actions import ProjectActionsMixin
+
+        return ProjectActionsMixin
+
+    def test_per_project_calls_authenticate_with_project_id(self) -> None:
+        """``_action_auth`` is the project-details path — passes the selection."""
+        mixin = self._get_mixin()
+        instance = mock.Mock(spec=mixin)
+        instance.current_project_id = "myproj"
+        instance._run_suspended = mock.AsyncMock(side_effect=lambda fn, **kw: fn())
+
+        with mock.patch("terok.tui.project_actions.authenticate") as m_auth:
+            run(mixin._action_auth(instance, "claude"))
+        m_auth.assert_called_once_with("claude", "myproj")
+
+    def test_per_project_without_selection_notifies_and_skips(self) -> None:
+        """Without a selection ``_action_auth`` is a no-op — host-wide path is separate."""
+        mixin = self._get_mixin()
+        instance = mock.Mock(spec=mixin)
+        instance.current_project_id = None
+        # ``notify`` lives on the App parent, not the mixin spec — wire it
+        # explicitly so the early-return path can call it without erroring.
+        instance.notify = mock.Mock()
+        instance._run_suspended = mock.AsyncMock()
+
+        with mock.patch("terok.tui.project_actions.authenticate") as m_auth:
+            run(mixin._action_auth(instance, "claude"))
+        m_auth.assert_not_called()
+        instance._run_suspended.assert_not_called()
+        instance.notify.assert_called_once()
+
+    def test_host_wide_passes_none_regardless_of_selection(self) -> None:
+        """``_action_auth_host_wide`` ignores ``current_project_id`` by design."""
+        mixin = self._get_mixin()
+        instance = mock.Mock(spec=mixin)
+        instance.current_project_id = "selected-but-irrelevant"
+        instance._run_suspended = mock.AsyncMock(side_effect=lambda fn, **kw: fn())
+
+        with mock.patch("terok.tui.project_actions.authenticate") as m_auth:
+            run(mixin._action_auth_host_wide(instance, "claude"))
+        m_auth.assert_called_once_with("claude", None)
+
+
 class TestActionSelection:
     """Tests for task selection after task creation flows."""
 
@@ -981,6 +1028,64 @@ class TestCommandPalette:
             commands = list(app_class.get_system_commands(instance, screen=mock.Mock()))
         titles = [cmd.title for cmd in commands]
         assert "Git Gate Server" in titles
+
+    def test_get_system_commands_includes_authenticate(self) -> None:
+        """The host-wide auth flow is reachable from the command palette."""
+        from tests.unit.tui.tui_test_helpers import build_textual_stubs
+
+        stubs = build_textual_stubs()
+        _, app_class = import_app(stubs)
+        instance = app_class()
+        with mock.patch.dict(sys.modules, stubs):
+            commands = list(app_class.get_system_commands(instance, screen=mock.Mock()))
+        titles = [cmd.title for cmd in commands]
+        assert "Authenticate agents and tools" in titles
+
+
+class TestGlobalAuthBinding:
+    """The top-level ``a`` shortcut + ``action_authenticate`` route."""
+
+    def test_app_binds_a_to_authenticate(self) -> None:
+        """``a`` on the main screen opens the auth modal — no project required."""
+        _, app_class = import_app()
+        bindings = {(b[0], b[1]) for b in app_class.BINDINGS}
+        assert ("a", "authenticate") in bindings
+
+    def test_action_authenticate_pushes_auth_actions_screen(self) -> None:
+        """``action_authenticate`` opens :class:`AuthActionsScreen`."""
+        _, app_class = import_app()
+        # No spec — ``push_screen`` is inherited from the Textual ``App``
+        # stub and isn't present on the inner ``TerokTUI`` class itself.
+        instance = mock.MagicMock()
+        instance.push_screen = mock.AsyncMock()
+        run(app_class.action_authenticate(instance))
+        instance.push_screen.assert_awaited_once()
+        pushed_screen, callback = instance.push_screen.await_args.args
+        assert type(pushed_screen).__name__ == "AuthActionsScreen"
+        assert callback == instance._on_authenticate_result
+
+    def test_on_authenticate_result_routes_to_host_wide(self) -> None:
+        """``auth_<provider>`` from the global modal lands in the host-wide handler."""
+        _, app_class = import_app()
+        instance = mock.Mock(spec=app_class)
+        run(app_class._on_authenticate_result(instance, "auth_claude"))
+        instance._action_auth_host_wide.assert_awaited_once_with("claude")
+        instance._action_auth.assert_not_called()
+
+    def test_on_authenticate_result_routes_opencode_import(self) -> None:
+        """OpenCode import from the global modal reuses the project-screen handler."""
+        _, app_class = import_app()
+        instance = mock.Mock(spec=app_class)
+        run(app_class._on_authenticate_result(instance, "import_opencode_config"))
+        instance._action_import_opencode_config.assert_awaited_once()
+
+    def test_on_authenticate_result_ignores_cancel(self) -> None:
+        """Esc on the modal returns ``None`` — handler is a no-op."""
+        _, app_class = import_app()
+        instance = mock.Mock(spec=app_class)
+        run(app_class._on_authenticate_result(instance, None))
+        instance._action_auth_host_wide.assert_not_called()
+        instance._action_import_opencode_config.assert_not_called()
 
 
 class TestRenderGateServerStatus:


### PR DESCRIPTION
## Summary

The host-wide ``terok auth <provider>`` flow no longer requires a project, but the TUI still hid auth behind project-details — so a freshly-installed user with no project yet had no way to reach the auth flow without dropping back to the CLI.

Add a top-level entry that opens the existing ``AuthActionsScreen``:

- ``a`` keybinding on the main screen (footer shows "Auth")
- "Authenticate agents and tools" entry in the command palette (Ctrl-P)
- Both route through a new ``_action_auth_host_wide(provider)`` which calls ``authenticate(provider, None)``

The host-wide handler **explicitly ignores ``current_project_id``** — a stray project selection in the main pane can't silently scope what the user intended as host-wide auth. The per-project path on ``ProjectDetailsScreen`` is unchanged.

## Test plan

- [x] ``make check`` passes (2151 tests; +9 new)
- [x] ``a`` is bound to ``authenticate`` in the main BINDINGS
- [x] ``action_authenticate`` opens ``AuthActionsScreen`` with the new callback
- [x] ``_on_authenticate_result`` routes ``auth_<provider>`` to ``_action_auth_host_wide`` (not the per-project handler) and ``import_opencode_config`` to the existing handler; ``None`` is a no-op
- [x] ``_action_auth_host_wide`` always calls ``authenticate(provider, None)`` even with a project selected
- [x] Per-project ``_action_auth`` still notifies + bails when no project is selected (project-details path)
- [x] Command palette includes the new entry

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added keyboard shortcut (`a`) to quickly authenticate agents and tools at the host level
  * New command palette entry for host-wide agent and tool authentication
  * Expanded authentication capabilities to support system-wide setup in addition to project-specific authentication
  * Added ability to import OpenCode configuration through the authentication flow

<!-- end of auto-generated comment: release notes by coderabbit.ai -->