### PR TITLE
fix: keep shared codex oauth routing in sync

### DIFF
--- a/examples/terok-config.yml
+++ b/examples/terok-config.yml
@@ -97,3 +97,15 @@ tui:
 #     # via the shared .credentials.json mount. Claude manages its own refresh.
 #     # Shield must allow api.anthropic.com and platform.claude.com.
 #     # expose_oauth_token: false
+#   codex:
+#     # Allow secure vaulted Codex OAuth. The user logs in once via the auth
+#     # container; real tokens stay in the host vault and task containers receive
+#     # synthetic shared ~/.codex/auth.json plus managed vault URL config.
+#     # Currently requires experimental; the secure path has a single code switch
+#     # for lifting that gate. The exposed-token path below remains experimental.
+#     # allow_oauth: false
+#     #
+#     # Insecure escape hatch: expose the real Codex auth.json in the shared
+#     # ~/.codex mount. This breaks terok's "no real credentials in containers"
+#     # promise and should stay behind the experimental gate indefinitely.
+#     # expose_oauth_token: false

--- a/poetry.lock
+++ b/poetry.lock
@@ -3061,13 +3061,13 @@ tomli-w = ">=1.0,<2.0"
 
 [[package]]
 name = "terok-clearance"
-version = "0.6.7"
+version = "0.6.8"
 description = "Shield clearance and desktop notifications for terok"
 optional = false
 python-versions = ">=3.12,<4.0"
 groups = ["main"]
 files = [
-    {file = "terok_clearance-0.6.7-py3-none-any.whl", hash = "sha256:463dfaebfbb8408f4f9b1cb327edba0f5c75f16a0dfce8750ffe2c174724ee7f"},
+    {file = "terok_clearance-0.6.8-py3-none-any.whl", hash = "sha256:e07f9683e7c6089591f254e9b01b121f71814681c383dfbd45f7d887540eff55"},
 ]
 
 [package.dependencies]
@@ -3077,41 +3077,41 @@ pyyaml = ">=6.0,<7.0"
 
 [package.source]
 type = "url"
-url = "https://github.com/terok-ai/terok-clearance/releases/download/v0.6.7/terok_clearance-0.6.7-py3-none-any.whl"
+url = "https://github.com/terok-ai/terok-clearance/releases/download/v0.6.8/terok_clearance-0.6.8-py3-none-any.whl"
 
 [[package]]
 name = "terok-executor"
-version = "0.0.126"
+version = "0.0.127"
 description = "Single-agent task runner for hardened Podman containers"
 optional = false
 python-versions = ">=3.12,<4.0"
 groups = ["main"]
-files = []
-develop = false
+files = [
+    {file = "terok_executor-0.0.127-py3-none-any.whl", hash = "sha256:7cfdcc6295ed3a7cc368eac1c18e933acf2753d485b4d165c81f26c2e3e49a9b"},
+]
 
 [package.dependencies]
 Jinja2 = ">=3.1"
 pwinput = ">=1.0.3"
 pydantic = ">=2.9"
 "ruamel.yaml" = ">=0.18"
-terok-sandbox = {git = "https://github.com/sliwowitz/terok-sandbox.git", branch = "feat/codex-shared-oauth-vault"}
+terok_sandbox = {url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.0.106/terok_sandbox-0.0.106-py3-none-any.whl"}
 tomli-w = ">=1.0"
 
 [package.source]
-type = "git"
-url = "https://github.com/sliwowitz/terok-executor.git"
-reference = "feat/codex-oauth-expose-dispatch"
-resolved_reference = "a87b8ebb949b703f4c8d251fe3fb1498bb16bf85"
+type = "url"
+url = "https://github.com/terok-ai/terok-executor/releases/download/v0.0.127/terok_executor-0.0.127-py3-none-any.whl"
 
 [[package]]
 name = "terok-sandbox"
-version = "0.0.105"
+version = "0.0.106"
 description = "Hardened Podman container runner with gate server and shield integration"
 optional = false
 python-versions = ">=3.12,<4.0"
 groups = ["main"]
-files = []
-develop = false
+files = [
+    {file = "terok_sandbox-0.0.106-py3-none-any.whl", hash = "sha256:8d4ad1ce0986b8175df04fd8b30b00e4c582f3b76956d39f8dc16944fa126edd"},
+]
 
 [package.dependencies]
 aiohttp = ">=3.9"
@@ -3119,24 +3119,22 @@ cryptography = ">=46.0.7"
 packaging = ">=24"
 platformdirs = ">=4.9.6"
 pydantic = ">=2.9"
-terok-clearance = {url = "https://github.com/terok-ai/terok-clearance/releases/download/v0.6.7/terok_clearance-0.6.7-py3-none-any.whl"}
-terok-shield = {url = "https://github.com/terok-ai/terok-shield/releases/download/v0.6.35/terok_shield-0.6.35-py3-none-any.whl"}
+terok_clearance = {url = "https://github.com/terok-ai/terok-clearance/releases/download/v0.6.8/terok_clearance-0.6.8-py3-none-any.whl"}
+terok_shield = {url = "https://github.com/terok-ai/terok-shield/releases/download/v0.6.36/terok_shield-0.6.36-py3-none-any.whl"}
 
 [package.source]
-type = "git"
-url = "https://github.com/sliwowitz/terok-sandbox.git"
-reference = "feat/codex-shared-oauth-vault"
-resolved_reference = "949d50e504e5cb1083b035ad50f28b56ea321bae"
+type = "url"
+url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.0.106/terok_sandbox-0.0.106-py3-none-any.whl"
 
 [[package]]
 name = "terok-shield"
-version = "0.6.35"
+version = "0.6.36"
 description = "nftables-based egress firewalling for Podman containers"
 optional = false
 python-versions = ">=3.12,<4.0"
 groups = ["main"]
 files = [
-    {file = "terok_shield-0.6.35-py3-none-any.whl", hash = "sha256:611c7756a54658131c172d115de9bc7f315320c7ee0dd223af1219acc27c4933"},
+    {file = "terok_shield-0.6.36-py3-none-any.whl", hash = "sha256:21f86400ae9f2e333fb88a6da3d8c26d5a6efd3beb2596fcfb1cf28f8e1d86e3"},
 ]
 
 [package.dependencies]
@@ -3145,7 +3143,7 @@ PyYAML = ">=6.0"
 
 [package.source]
 type = "url"
-url = "https://github.com/terok-ai/terok-shield/releases/download/v0.6.35/terok_shield-0.6.35-py3-none-any.whl"
+url = "https://github.com/terok-ai/terok-shield/releases/download/v0.6.36/terok_shield-0.6.36-py3-none-any.whl"
 
 [[package]]
 name = "textual"
@@ -4025,4 +4023,4 @@ propcache = ">=0.2.1"
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.12,<4.0"
-content-hash = "1e0c7bfab04ae41851962c30aec96742ef78edb321bd7f6184391bb251bb1759"
+content-hash = "b2c4292d718116a481410dd843a02e772d2f7b691dd5f4060849dcef1dd141a3"

--- a/poetry.lock
+++ b/poetry.lock
@@ -3101,7 +3101,7 @@ tomli-w = ">=1.0"
 type = "git"
 url = "https://github.com/sliwowitz/terok-executor.git"
 reference = "feat/codex-oauth-expose-dispatch"
-resolved_reference = "a34316cb046d97518866eda358ff5441ceeaa427"
+resolved_reference = "a87b8ebb949b703f4c8d251fe3fb1498bb16bf85"
 
 [[package]]
 name = "terok-sandbox"

--- a/poetry.lock
+++ b/poetry.lock
@@ -269,19 +269,18 @@ dev = ["backports.zoneinfo ; python_version < \"3.9\"", "freezegun (>=1.0,<2.0)"
 
 [[package]]
 name = "backrefs"
-version = "6.2"
+version = "7.0"
 description = "A wrapper around re and regex that adds additional back references."
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 groups = ["docs"]
 files = [
-    {file = "backrefs-6.2-py310-none-any.whl", hash = "sha256:0fdc7b012420b6b144410342caeb8adc54c6866cf12064abc9bb211302e496f8"},
-    {file = "backrefs-6.2-py311-none-any.whl", hash = "sha256:08aa7fae530c6b2361d7bdcbda1a7c454e330cc9dbcd03f5c23205e430e5c3be"},
-    {file = "backrefs-6.2-py312-none-any.whl", hash = "sha256:c3f4b9cb2af8cda0d87ab4f57800b57b95428488477be164dd2b47be54db0c90"},
-    {file = "backrefs-6.2-py313-none-any.whl", hash = "sha256:12df81596ab511f783b7d87c043ce26bc5b0288cf3bb03610fe76b8189282b2b"},
-    {file = "backrefs-6.2-py314-none-any.whl", hash = "sha256:e5f805ae09819caa1aa0623b4a83790e7028604aa2b8c73ba602c4454e665de7"},
-    {file = "backrefs-6.2-py39-none-any.whl", hash = "sha256:664e33cd88c6840b7625b826ecf2555f32d491800900f5a541f772c485f7cda7"},
-    {file = "backrefs-6.2.tar.gz", hash = "sha256:f44ff4d48808b243b6c0cdc6231e22195c32f77046018141556c66f8bab72a49"},
+    {file = "backrefs-7.0-py310-none-any.whl", hash = "sha256:b57cd227ea556b0aed3dc9b8da4628db4eabc0402c6d7fcfc69283a93955f7e9"},
+    {file = "backrefs-7.0-py311-none-any.whl", hash = "sha256:a0fa7360c63509e9e077e174ef4e6d3c21c8db94189b9d957289ae6d794b9475"},
+    {file = "backrefs-7.0-py312-none-any.whl", hash = "sha256:ca42ce6a49ace3d75684dfa9937f3373902a63284ecb385ce36d15e5dcb41c12"},
+    {file = "backrefs-7.0-py313-none-any.whl", hash = "sha256:f2c52955d631b9e1ac4cd56209f0a3a946d592b98e7790e77699339ae01c102a"},
+    {file = "backrefs-7.0-py314-none-any.whl", hash = "sha256:a6448b28180e3ca01134c9cf09dcebafad8531072e09903c5451748a05f24bc9"},
+    {file = "backrefs-7.0.tar.gz", hash = "sha256:4989bb9e1e99eb23647c7160ed51fb21d0b41b5d200f2d3017da41e023097e82"},
 ]
 
 [package.extras]
@@ -843,75 +842,68 @@ toml = ["tomli ; python_full_version <= \"3.11.0a6\""]
 
 [[package]]
 name = "cryptography"
-version = "46.0.7"
+version = "47.0.0"
 description = "cryptography is a package which provides cryptographic recipes and primitives to Python developers."
 optional = false
 python-versions = "!=3.9.0,!=3.9.1,>=3.8"
 groups = ["main"]
 files = [
-    {file = "cryptography-46.0.7-cp311-abi3-macosx_10_9_universal2.whl", hash = "sha256:ea42cbe97209df307fdc3b155f1b6fa2577c0defa8f1f7d3be7d31d189108ad4"},
-    {file = "cryptography-46.0.7-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:b36a4695e29fe69215d75960b22577197aca3f7a25b9cf9d165dcfe9d80bc325"},
-    {file = "cryptography-46.0.7-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:5ad9ef796328c5e3c4ceed237a183f5d41d21150f972455a9d926593a1dcb308"},
-    {file = "cryptography-46.0.7-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:73510b83623e080a2c35c62c15298096e2a5dc8d51c3b4e1740211839d0dea77"},
-    {file = "cryptography-46.0.7-cp311-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:cbd5fb06b62bd0721e1170273d3f4d5a277044c47ca27ee257025146c34cbdd1"},
-    {file = "cryptography-46.0.7-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:420b1e4109cc95f0e5700eed79908cef9268265c773d3a66f7af1eef53d409ef"},
-    {file = "cryptography-46.0.7-cp311-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:24402210aa54baae71d99441d15bb5a1919c195398a87b563df84468160a65de"},
-    {file = "cryptography-46.0.7-cp311-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:8a469028a86f12eb7d2fe97162d0634026d92a21f3ae0ac87ed1c4a447886c83"},
-    {file = "cryptography-46.0.7-cp311-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:9694078c5d44c157ef3162e3bf3946510b857df5a3955458381d1c7cfc143ddb"},
-    {file = "cryptography-46.0.7-cp311-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:42a1e5f98abb6391717978baf9f90dc28a743b7d9be7f0751a6f56a75d14065b"},
-    {file = "cryptography-46.0.7-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:91bbcb08347344f810cbe49065914fe048949648f6bd5c2519f34619142bbe85"},
-    {file = "cryptography-46.0.7-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:5d1c02a14ceb9148cc7816249f64f623fbfee39e8c03b3650d842ad3f34d637e"},
-    {file = "cryptography-46.0.7-cp311-abi3-win32.whl", hash = "sha256:d23c8ca48e44ee015cd0a54aeccdf9f09004eba9fc96f38c911011d9ff1bd457"},
-    {file = "cryptography-46.0.7-cp311-abi3-win_amd64.whl", hash = "sha256:397655da831414d165029da9bc483bed2fe0e75dde6a1523ec2fe63f3c46046b"},
-    {file = "cryptography-46.0.7-cp314-cp314t-macosx_10_9_universal2.whl", hash = "sha256:d151173275e1728cf7839aaa80c34fe550c04ddb27b34f48c232193df8db5842"},
-    {file = "cryptography-46.0.7-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:db0f493b9181c7820c8134437eb8b0b4792085d37dbb24da050476ccb664e59c"},
-    {file = "cryptography-46.0.7-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:ebd6daf519b9f189f85c479427bbd6e9c9037862cf8fe89ee35503bd209ed902"},
-    {file = "cryptography-46.0.7-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:b7b412817be92117ec5ed95f880defe9cf18a832e8cafacf0a22337dc1981b4d"},
-    {file = "cryptography-46.0.7-cp314-cp314t-manylinux_2_28_ppc64le.whl", hash = "sha256:fbfd0e5f273877695cb93baf14b185f4878128b250cc9f8e617ea0c025dfb022"},
-    {file = "cryptography-46.0.7-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:ffca7aa1d00cf7d6469b988c581598f2259e46215e0140af408966a24cf086ce"},
-    {file = "cryptography-46.0.7-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:60627cf07e0d9274338521205899337c5d18249db56865f943cbe753aa96f40f"},
-    {file = "cryptography-46.0.7-cp314-cp314t-manylinux_2_34_aarch64.whl", hash = "sha256:80406c3065e2c55d7f49a9550fe0c49b3f12e5bfff5dedb727e319e1afb9bf99"},
-    {file = "cryptography-46.0.7-cp314-cp314t-manylinux_2_34_ppc64le.whl", hash = "sha256:c5b1ccd1239f48b7151a65bc6dd54bcfcc15e028c8ac126d3fada09db0e07ef1"},
-    {file = "cryptography-46.0.7-cp314-cp314t-manylinux_2_34_x86_64.whl", hash = "sha256:d5f7520159cd9c2154eb61eb67548ca05c5774d39e9c2c4339fd793fe7d097b2"},
-    {file = "cryptography-46.0.7-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:fcd8eac50d9138c1d7fc53a653ba60a2bee81a505f9f8850b6b2888555a45d0e"},
-    {file = "cryptography-46.0.7-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:65814c60f8cc400c63131584e3e1fad01235edba2614b61fbfbfa954082db0ee"},
-    {file = "cryptography-46.0.7-cp314-cp314t-win32.whl", hash = "sha256:fdd1736fed309b4300346f88f74cd120c27c56852c3838cab416e7a166f67298"},
-    {file = "cryptography-46.0.7-cp314-cp314t-win_amd64.whl", hash = "sha256:e06acf3c99be55aa3b516397fe42f5855597f430add9c17fa46bf2e0fb34c9bb"},
-    {file = "cryptography-46.0.7-cp38-abi3-macosx_10_9_universal2.whl", hash = "sha256:462ad5cb1c148a22b2e3bcc5ad52504dff325d17daf5df8d88c17dda1f75f2a4"},
-    {file = "cryptography-46.0.7-cp38-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:84d4cced91f0f159a7ddacad249cc077e63195c36aac40b4150e7a57e84fffe7"},
-    {file = "cryptography-46.0.7-cp38-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:128c5edfe5e5938b86b03941e94fac9ee793a94452ad1365c9fc3f4f62216832"},
-    {file = "cryptography-46.0.7-cp38-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:5e51be372b26ef4ba3de3c167cd3d1022934bc838ae9eaad7e644986d2a3d163"},
-    {file = "cryptography-46.0.7-cp38-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:cdf1a610ef82abb396451862739e3fc93b071c844399e15b90726ef7470eeaf2"},
-    {file = "cryptography-46.0.7-cp38-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:1d25aee46d0c6f1a501adcddb2d2fee4b979381346a78558ed13e50aa8a59067"},
-    {file = "cryptography-46.0.7-cp38-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:cdfbe22376065ffcf8be74dc9a909f032df19bc58a699456a21712d6e5eabfd0"},
-    {file = "cryptography-46.0.7-cp38-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:abad9dac36cbf55de6eb49badd4016806b3165d396f64925bf2999bcb67837ba"},
-    {file = "cryptography-46.0.7-cp38-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:935ce7e3cfdb53e3536119a542b839bb94ec1ad081013e9ab9b7cfd478b05006"},
-    {file = "cryptography-46.0.7-cp38-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:35719dc79d4730d30f1c2b6474bd6acda36ae2dfae1e3c16f2051f215df33ce0"},
-    {file = "cryptography-46.0.7-cp38-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:7bbc6ccf49d05ac8f7d7b5e2e2c33830d4fe2061def88210a126d130d7f71a85"},
-    {file = "cryptography-46.0.7-cp38-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:a1529d614f44b863a7b480c6d000fe93b59acee9c82ffa027cfadc77521a9f5e"},
-    {file = "cryptography-46.0.7-cp38-abi3-win32.whl", hash = "sha256:f247c8c1a1fb45e12586afbb436ef21ff1e80670b2861a90353d9b025583d246"},
-    {file = "cryptography-46.0.7-cp38-abi3-win_amd64.whl", hash = "sha256:506c4ff91eff4f82bdac7633318a526b1d1309fc07ca76a3ad182cb5b686d6d3"},
-    {file = "cryptography-46.0.7-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:fc9ab8856ae6cf7c9358430e49b368f3108f050031442eaeb6b9d87e4dcf4e4f"},
-    {file = "cryptography-46.0.7-pp311-pypy311_pp73-manylinux_2_28_aarch64.whl", hash = "sha256:d3b99c535a9de0adced13d159c5a9cf65c325601aa30f4be08afd680643e9c15"},
-    {file = "cryptography-46.0.7-pp311-pypy311_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:d02c738dacda7dc2a74d1b2b3177042009d5cab7c7079db74afc19e56ca1b455"},
-    {file = "cryptography-46.0.7-pp311-pypy311_pp73-manylinux_2_34_aarch64.whl", hash = "sha256:04959522f938493042d595a736e7dbdff6eb6cc2339c11465b3ff89343b65f65"},
-    {file = "cryptography-46.0.7-pp311-pypy311_pp73-manylinux_2_34_x86_64.whl", hash = "sha256:3986ac1dee6def53797289999eabe84798ad7817f3e97779b5061a95b0ee4968"},
-    {file = "cryptography-46.0.7-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:258514877e15963bd43b558917bc9f54cf7cf866c38aa576ebf47a77ddbc43a4"},
-    {file = "cryptography-46.0.7.tar.gz", hash = "sha256:e4cfd68c5f3e0bfdad0d38e023239b96a2fe84146481852dffbcca442c245aa5"},
+    {file = "cryptography-47.0.0-cp311-abi3-macosx_10_9_universal2.whl", hash = "sha256:160ad728f128972d362e714054f6ba0067cab7fb350c5202a9ae8ae4ce3ef1a0"},
+    {file = "cryptography-47.0.0-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:b9a8943e359b7615db1a3ba587994618e094ff3d6fa5a390c73d079ce18b3973"},
+    {file = "cryptography-47.0.0-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:f5c15764f261394b22aef6b00252f5195f46f2ca300bec57149474e2538b31f8"},
+    {file = "cryptography-47.0.0-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:9c59ab0e0fa3a180a5a9c59f3a5abe3ef90d474bc56d7fadfbe80359491b615b"},
+    {file = "cryptography-47.0.0-cp311-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:34b4358b925a5ea3e14384ca781a2c0ef7ac219b57bb9eacc4457078e2b19f92"},
+    {file = "cryptography-47.0.0-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:0024b87d47ae2399165a6bfb20d24888881eeab83ae2566d62467c5ff0030ce7"},
+    {file = "cryptography-47.0.0-cp311-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:1e47422b5557bb82d3fff997e8d92cff4e28b9789576984f08c248d2b3535d93"},
+    {file = "cryptography-47.0.0-cp311-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:6f29f36582e6151d9686235e586dd35bb67491f024767d10b842e520dc6a07ac"},
+    {file = "cryptography-47.0.0-cp311-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:a9b761f012a943b7de0e828843c5688d0de94a0578d44d6c85a1bae32f87791f"},
+    {file = "cryptography-47.0.0-cp311-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:4e1de79e047e25d6e9f8cea71c86b4a53aced64134f0f003bbcbf3655fd172c8"},
+    {file = "cryptography-47.0.0-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:ef6b3634087f18d2155b1e8ce264e5345a753da2c5fa9815e7d41315c90f8318"},
+    {file = "cryptography-47.0.0-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:11dbb9f50a0f1bb9757b3d8c27c1101780efb8f0bdecfb12439c22a74d64c001"},
+    {file = "cryptography-47.0.0-cp311-abi3-win32.whl", hash = "sha256:7fda2f02c9015db3f42bb8a22324a454516ed10a8c29ca6ece6cdbb5efe2a203"},
+    {file = "cryptography-47.0.0-cp311-abi3-win_amd64.whl", hash = "sha256:f5c3296dab66202f1b18a91fa266be93d6aa0c2806ea3d67762c69f60adc71aa"},
+    {file = "cryptography-47.0.0-cp314-cp314t-macosx_10_9_universal2.whl", hash = "sha256:be12cb6a204f77ed968bcefe68086eb061695b540a3dd05edac507a3111b25f0"},
+    {file = "cryptography-47.0.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:2ebd84adf0728c039a3be2700289378e1c164afc6748df1a5ed456767bef9ba7"},
+    {file = "cryptography-47.0.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7f68d6fbc7fbbcfb0939fea72c3b96a9f9a6edfc0e1b1d29778a2066030418b1"},
+    {file = "cryptography-47.0.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:6651d32eff255423503aa276739da98c30f26c40cbeffcc6048e0d54ef704c0c"},
+    {file = "cryptography-47.0.0-cp314-cp314t-manylinux_2_28_ppc64le.whl", hash = "sha256:3fb8fa48075fad7193f2e5496135c6a76ac4b2aa5a38433df0a539296b377829"},
+    {file = "cryptography-47.0.0-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:11438c7518132d95f354fa01a4aa2f806d172a061a7bed18cf18cbdacdb204d7"},
+    {file = "cryptography-47.0.0-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:8c1a736bbb3288005796c3f7ccb9453360d7fed483b13b9f468aea5171432923"},
+    {file = "cryptography-47.0.0-cp314-cp314t-manylinux_2_34_aarch64.whl", hash = "sha256:f1557695e5c2b86e204f6ce9470497848634100787935ab7adc5397c54abd7ab"},
+    {file = "cryptography-47.0.0-cp314-cp314t-manylinux_2_34_ppc64le.whl", hash = "sha256:f9a034b642b960767fb343766ae5ba6ad653f2e890ddd82955aef288ffea8736"},
+    {file = "cryptography-47.0.0-cp314-cp314t-manylinux_2_34_x86_64.whl", hash = "sha256:b1c76fca783aa7698eb21eb14f9c4aa09452248ee54a627d125025a43f83e7a7"},
+    {file = "cryptography-47.0.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:4f7722c97826770bab8ae92959a2e7b20a5e9e9bf4deae68fd86c3ca457bab52"},
+    {file = "cryptography-47.0.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:09f6d7bf6724f8db8b32f11eccf23efc8e759924bc5603800335cf8859a3ddbd"},
+    {file = "cryptography-47.0.0-cp314-cp314t-win32.whl", hash = "sha256:6eebcaf0df1d21ce1f90605c9b432dd2c4f4ab665ac29a40d5e3fc68f51b5e63"},
+    {file = "cryptography-47.0.0-cp314-cp314t-win_amd64.whl", hash = "sha256:51c9313e90bd1690ec5a75ed047c27c0b8e6c570029712943d6116ef9a90620b"},
+    {file = "cryptography-47.0.0-cp38-abi3-macosx_10_9_universal2.whl", hash = "sha256:14432c8a9bcb37009784f9594a62fae211a2ae9543e96c92b2a8e4c3cd5cd0c4"},
+    {file = "cryptography-47.0.0-cp38-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:07efe86201817e7d3c18781ca9770bc0db04e1e48c994be384e4602bc38f8f27"},
+    {file = "cryptography-47.0.0-cp38-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:2b45761c6ec22b7c726d6a829558777e32d0f1c8be7c3f3480f9c912d5ee8a10"},
+    {file = "cryptography-47.0.0-cp38-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:edd4da498015da5b9f26d38d3bfc2e90257bfa9cbed1f6767c282a0025ae649b"},
+    {file = "cryptography-47.0.0-cp38-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:9af828c0d5a65c70ec729cd7495a4bf1a67ecb66417b8f02ff125ab8a6326a74"},
+    {file = "cryptography-47.0.0-cp38-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:256d07c78a04d6b276f5df935a9923275f53bd1522f214447fdf365494e2d515"},
+    {file = "cryptography-47.0.0-cp38-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:5d0e362ff51041b0c0d219cc7d6924d7b8996f57ce5712bdcef71eb3c65a59cc"},
+    {file = "cryptography-47.0.0-cp38-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:1581aef4219f7ca2849d0250edaa3866212fb74bf5667284f46aa92f9e65c1ca"},
+    {file = "cryptography-47.0.0-cp38-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:a49a3eb5341b9503fa3000a9a0db033161db90d47285291f53c2a9d2cd1b7f76"},
+    {file = "cryptography-47.0.0-cp38-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:2207a498b03275d0051589e326b79d4cf59985c99031b05bb292ac52631c37fe"},
+    {file = "cryptography-47.0.0-cp38-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:7a02675e2fabd0c0fc04c868b8781863cbf1967691543c22f5470500ff840b31"},
+    {file = "cryptography-47.0.0-cp38-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:80887c5cbd1774683cb126f0ab4184567f080071d5acf62205acb354b4b753b7"},
+    {file = "cryptography-47.0.0-cp38-abi3-win32.whl", hash = "sha256:ed67ea4e0cfb5faa5bc7ecb6e2b8838f3807a03758eec239d6c21c8769355310"},
+    {file = "cryptography-47.0.0-cp38-abi3-win_amd64.whl", hash = "sha256:835d2d7f47cdc53b3224e90810fb1d36ca94ea29cc1801fb4c1bc43876735769"},
+    {file = "cryptography-47.0.0-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:7f1207974a904e005f762869996cf620e9bf79ecb4622f148550bb48e0eb35a7"},
+    {file = "cryptography-47.0.0-pp311-pypy311_pp73-manylinux_2_28_aarch64.whl", hash = "sha256:1a405c08857258c11016777e11c02bacbe7ef596faf259305d282272a3a05cbe"},
+    {file = "cryptography-47.0.0-pp311-pypy311_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:20fdbe3e38fb67c385d233c89371fa27f9909f6ebca1cecc20c13518dae65475"},
+    {file = "cryptography-47.0.0-pp311-pypy311_pp73-manylinux_2_34_aarch64.whl", hash = "sha256:f7db373287273d8af1414cf95dc4118b13ffdc62be521997b0f2b270771fef50"},
+    {file = "cryptography-47.0.0-pp311-pypy311_pp73-manylinux_2_34_x86_64.whl", hash = "sha256:9fe6b7c64926c765f9dff301f9c1b867febcda5768868ca084e18589113732ab"},
+    {file = "cryptography-47.0.0-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:cffbba3392df0fa8629bb7f43454ee2925059ee158e23c54620b9063912b86c8"},
+    {file = "cryptography-47.0.0.tar.gz", hash = "sha256:9f8e55fe4e63613a5e1cc5819030f27b97742d720203a087802ce4ce9ceb52bb"},
 ]
 
 [package.dependencies]
 cffi = {version = ">=2.0.0", markers = "python_full_version >= \"3.9.0\" and platform_python_implementation != \"PyPy\""}
 
 [package.extras]
-docs = ["sphinx (>=5.3.0)", "sphinx-inline-tabs", "sphinx-rtd-theme (>=3.0.0)"]
-docstest = ["pyenchant (>=3)", "readme-renderer (>=30.0)", "sphinxcontrib-spelling (>=7.3.1)"]
-nox = ["nox[uv] (>=2024.4.15)"]
-pep8test = ["check-sdist", "click (>=8.0.1)", "mypy (>=1.14)", "ruff (>=0.11.11)"]
-sdist = ["build (>=1.0.0)"]
 ssh = ["bcrypt (>=3.1.5)"]
-test = ["certifi (>=2024)", "cryptography-vectors (==46.0.7)", "pretend (>=0.7)", "pytest (>=7.4.0)", "pytest-benchmark (>=4.0)", "pytest-cov (>=2.10.1)", "pytest-xdist (>=3.5.0)"]
-test-randomorder = ["pytest-randomly"]
 
 [[package]]
 name = "dbus-fast"
@@ -1180,14 +1172,14 @@ smmap = ">=3.0.1,<6"
 
 [[package]]
 name = "gitpython"
-version = "3.1.47"
+version = "3.1.49"
 description = "GitPython is a Python library used to interact with Git repositories"
 optional = false
 python-versions = ">=3.7"
 groups = ["dev"]
 files = [
-    {file = "gitpython-3.1.47-py3-none-any.whl", hash = "sha256:489f590edfd6d20571b2c0e72c6a6ac6915ee8b8cd04572330e3842207a78905"},
-    {file = "gitpython-3.1.47.tar.gz", hash = "sha256:dba27f922bd2b42cb54c87a8ab3cb6beb6bf07f3d564e21ac848913a05a8a3cd"},
+    {file = "gitpython-3.1.49-py3-none-any.whl", hash = "sha256:024b0422d7f84d15cd794844e029ffebd4c5d42a7eb9b936b458697ef550a02c"},
+    {file = "gitpython-3.1.49.tar.gz", hash = "sha256:42f9399c9eb33fc581014bedd76049dfbaf6375aa2a5754575966387280315e1"},
 ]
 
 [package.dependencies]
@@ -2116,14 +2108,14 @@ files = [
 
 [[package]]
 name = "packaging"
-version = "26.1"
+version = "26.2"
 description = "Core utilities for Python packages"
 optional = false
 python-versions = ">=3.8"
 groups = ["main", "docs", "test"]
 files = [
-    {file = "packaging-26.1-py3-none-any.whl", hash = "sha256:5d9c0669c6285e491e0ced2eee587eaf67b670d94a19e94e3984a481aba6802f"},
-    {file = "packaging-26.1.tar.gz", hash = "sha256:f042152b681c4bfac5cae2742a55e103d27ab2ec0f3d88037136b6bfe7c9c5de"},
+    {file = "packaging-26.2-py3-none-any.whl", hash = "sha256:5fc45236b9446107ff2415ce77c807cee2862cb6fac22b8a73826d0693b0980e"},
+    {file = "packaging-26.2.tar.gz", hash = "sha256:ff452ff5a3e828ce110190feff1178bb1f2ea2281fa2075aadb987c2fb221661"},
 ]
 
 [[package]]
@@ -2144,14 +2136,14 @@ lint = ["black"]
 
 [[package]]
 name = "pathspec"
-version = "1.1.0"
+version = "1.1.1"
 description = "Utility library for gitignore style pattern matching of file paths."
 optional = false
 python-versions = ">=3.9"
 groups = ["docs"]
 files = [
-    {file = "pathspec-1.1.0-py3-none-any.whl", hash = "sha256:574b128f7456bd899045ccd142dd446af7e6cfd0072d63ad73fbc55fbb4aaa42"},
-    {file = "pathspec-1.1.0.tar.gz", hash = "sha256:f5d7c555da02fd8dde3e4a2354b6aba817a89112fa8f333f7917a2a4834dd080"},
+    {file = "pathspec-1.1.1-py3-none-any.whl", hash = "sha256:a00ce642f577bf7f473932318056212bc4f8bfdf53128c78bbd5af0b9b20b189"},
+    {file = "pathspec-1.1.1.tar.gz", hash = "sha256:17db5ecd524104a120e173814c90367a96a98d07c45b2e10c2f3919fff91bf5a"},
 ]
 
 [package.extras]
@@ -3094,21 +3086,22 @@ description = "Single-agent task runner for hardened Podman containers"
 optional = false
 python-versions = ">=3.12,<4.0"
 groups = ["main"]
-files = [
-    {file = "terok_executor-0.0.126-py3-none-any.whl", hash = "sha256:abab8bc1a7ae6d80ef686f78eef05d9b31a6640f0e6764c29b73a39f80dd33a5"},
-]
+files = []
+develop = false
 
 [package.dependencies]
 Jinja2 = ">=3.1"
 pwinput = ">=1.0.3"
 pydantic = ">=2.9"
 "ruamel.yaml" = ">=0.18"
-terok_sandbox = {url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.0.105/terok_sandbox-0.0.105-py3-none-any.whl"}
+terok-sandbox = {git = "https://github.com/sliwowitz/terok-sandbox.git", branch = "feat/codex-shared-oauth-vault"}
 tomli-w = ">=1.0"
 
 [package.source]
-type = "url"
-url = "https://github.com/terok-ai/terok-executor/releases/download/v0.0.126/terok_executor-0.0.126-py3-none-any.whl"
+type = "git"
+url = "https://github.com/sliwowitz/terok-executor.git"
+reference = "feat/codex-oauth-expose-dispatch"
+resolved_reference = "a34316cb046d97518866eda358ff5441ceeaa427"
 
 [[package]]
 name = "terok-sandbox"
@@ -3117,9 +3110,8 @@ description = "Hardened Podman container runner with gate server and shield inte
 optional = false
 python-versions = ">=3.12,<4.0"
 groups = ["main"]
-files = [
-    {file = "terok_sandbox-0.0.105-py3-none-any.whl", hash = "sha256:ae5e855d7f6a55d2d51090ef86d64858f79c26a4132b0768402166ed96c5b447"},
-]
+files = []
+develop = false
 
 [package.dependencies]
 aiohttp = ">=3.9"
@@ -3127,12 +3119,14 @@ cryptography = ">=46.0.7"
 packaging = ">=24"
 platformdirs = ">=4.9.6"
 pydantic = ">=2.9"
-terok_clearance = {url = "https://github.com/terok-ai/terok-clearance/releases/download/v0.6.7/terok_clearance-0.6.7-py3-none-any.whl"}
-terok_shield = {url = "https://github.com/terok-ai/terok-shield/releases/download/v0.6.35/terok_shield-0.6.35-py3-none-any.whl"}
+terok-clearance = {url = "https://github.com/terok-ai/terok-clearance/releases/download/v0.6.7/terok_clearance-0.6.7-py3-none-any.whl"}
+terok-shield = {url = "https://github.com/terok-ai/terok-shield/releases/download/v0.6.35/terok_shield-0.6.35-py3-none-any.whl"}
 
 [package.source]
-type = "url"
-url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.0.105/terok_sandbox-0.0.105-py3-none-any.whl"
+type = "git"
+url = "https://github.com/sliwowitz/terok-sandbox.git"
+reference = "feat/codex-shared-oauth-vault"
+resolved_reference = "949d50e504e5cb1083b035ad50f28b56ea321bae"
 
 [[package]]
 name = "terok-shield"
@@ -3711,20 +3705,20 @@ core = ["tree-sitter (>=0.24,<1.0)"]
 
 [[package]]
 name = "typer"
-version = "0.24.2"
+version = "0.25.1"
 description = "Typer, build great CLIs. Easy to code. Based on Python type hints."
 optional = false
 python-versions = ">=3.10"
 groups = ["dev"]
 files = [
-    {file = "typer-0.24.2-py3-none-any.whl", hash = "sha256:b618bc3d721f9a8d30f3e05565be26416d06e9bcc29d49bc491dc26aba674fa8"},
-    {file = "typer-0.24.2.tar.gz", hash = "sha256:ec070dcfca1408e85ee203c6365001e818c3b7fffe686fd07ff2d68095ca0480"},
+    {file = "typer-0.25.1-py3-none-any.whl", hash = "sha256:75caa44ed46a03fb2dab8808753ffacdbfea88495e74c85a28c5eefcf5f39c89"},
+    {file = "typer-0.25.1.tar.gz", hash = "sha256:9616eb8853a09ffeabab1698952f33c6f29ffdbceb4eaeecf571880e8d7664cc"},
 ]
 
 [package.dependencies]
 annotated-doc = ">=0.0.2"
 click = ">=8.2.1"
-rich = ">=12.3.0"
+rich = ">=13.8.0"
 shellingham = ">=1.3.0"
 
 [[package]]
@@ -3802,14 +3796,14 @@ zstd = ["backports-zstd (>=1.0.0) ; python_version < \"3.14\""]
 
 [[package]]
 name = "virtualenv"
-version = "21.2.4"
+version = "21.3.0"
 description = "Virtual Python Environment builder"
 optional = false
 python-versions = ">=3.8"
 groups = ["dev"]
 files = [
-    {file = "virtualenv-21.2.4-py3-none-any.whl", hash = "sha256:29d21e941795206138d0f22f4e45ff7050e5da6c6472299fb7103318763861ac"},
-    {file = "virtualenv-21.2.4.tar.gz", hash = "sha256:b294ef68192638004d72524ce7ef303e9d0cf5a44c95ce2e54a7500a6381cada"},
+    {file = "virtualenv-21.3.0-py3-none-any.whl", hash = "sha256:4d28ee41f6d9ec8f1f00cd472b9ffbcedda1b3d3b9a575b5c94a2d004fd51bd7"},
+    {file = "virtualenv-21.3.0.tar.gz", hash = "sha256:733750db978ec95c2d8eb4feadaa57091002bce404cb39ba69899cf7bd28944e"},
 ]
 
 [package.dependencies]
@@ -3875,14 +3869,14 @@ watchmedo = ["PyYAML (>=3.10)"]
 
 [[package]]
 name = "wcwidth"
-version = "0.6.0"
+version = "0.7.0"
 description = "Measures the displayed width of unicode strings in a terminal"
 optional = false
 python-versions = ">=3.8"
 groups = ["dev"]
 files = [
-    {file = "wcwidth-0.6.0-py3-none-any.whl", hash = "sha256:1a3a1e510b553315f8e146c54764f4fb6264ffad731b3d78088cdb1478ffbdad"},
-    {file = "wcwidth-0.6.0.tar.gz", hash = "sha256:cdc4e4262d6ef9a1a57e018384cbeb1208d8abbc64176027e2c2455c81313159"},
+    {file = "wcwidth-0.7.0-py3-none-any.whl", hash = "sha256:5d69154c429a82910e241c738cd0e2976fac8a2dd47a1a805f4afed1c0f136f2"},
+    {file = "wcwidth-0.7.0.tar.gz", hash = "sha256:90e3a7ea092341c44b99562e75d09e4d5160fe7a3974c6fb842a101a95e7eed0"},
 ]
 
 [[package]]
@@ -4031,4 +4025,4 @@ propcache = ">=0.2.1"
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.12,<4.0"
-content-hash = "bbcf0c8c2474c53671c289021da43cb66278a09ab10a570cbe0e9c43bfaaba83"
+content-hash = "1e0c7bfab04ae41851962c30aec96742ef78edb321bd7f6184391bb251bb1759"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,10 +50,10 @@ unique-namer = ">=1.3"
 textual-serve = ">=1.1.0"
 # DEV-TIME BRANCH PINS — track the Codex vaulted-OAuth PR chain until the
 # sibling wheels ship.  The release chain flips these back to wheel URLs.
-terok-executor = {git = "https://github.com/sliwowitz/terok-executor.git", branch = "feat/codex-oauth-expose-dispatch"}
-terok-sandbox = {git = "https://github.com/sliwowitz/terok-sandbox.git", branch = "feat/codex-shared-oauth-vault"}
-terok-shield = {url = "https://github.com/terok-ai/terok-shield/releases/download/v0.6.35/terok_shield-0.6.35-py3-none-any.whl"}
-terok-clearance = {url = "https://github.com/terok-ai/terok-clearance/releases/download/v0.6.7/terok_clearance-0.6.7-py3-none-any.whl"}
+terok-executor = {url = "https://github.com/terok-ai/terok-executor/releases/download/v0.0.127/terok_executor-0.0.127-py3-none-any.whl"}
+terok-sandbox = {url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.0.106/terok_sandbox-0.0.106-py3-none-any.whl"}
+terok-shield = {url = "https://github.com/terok-ai/terok-shield/releases/download/v0.6.36/terok_shield-0.6.36-py3-none-any.whl"}
+terok-clearance = {url = "https://github.com/terok-ai/terok-clearance/releases/download/v0.6.8/terok_clearance-0.6.8-py3-none-any.whl"}
 
 [tool.poetry.group.dev.dependencies]
 pydevd-pycharm = "261.23567.80"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,10 +48,10 @@ rich = ">=13.0"
 platformdirs = ">=4.5.1"
 unique-namer = ">=1.3"
 textual-serve = ">=1.1.0"
-# DEV-TIME BRANCH PINS — track the dossier-in-events chain end-to-end.
-# Release script flips back to wheel URLs once the four siblings ship.
-terok-executor = {url = "https://github.com/terok-ai/terok-executor/releases/download/v0.0.126/terok_executor-0.0.126-py3-none-any.whl"}
-terok-sandbox = {url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.0.105/terok_sandbox-0.0.105-py3-none-any.whl"}
+# DEV-TIME BRANCH PINS — track the Codex vaulted-OAuth PR chain until the
+# sibling wheels ship.  The release chain flips these back to wheel URLs.
+terok-executor = {git = "https://github.com/sliwowitz/terok-executor.git", branch = "feat/codex-oauth-expose-dispatch"}
+terok-sandbox = {git = "https://github.com/sliwowitz/terok-sandbox.git", branch = "feat/codex-shared-oauth-vault"}
 terok-shield = {url = "https://github.com/terok-ai/terok-shield/releases/download/v0.6.35/terok_shield-0.6.35-py3-none-any.whl"}
 terok-clearance = {url = "https://github.com/terok-ai/terok-clearance/releases/download/v0.6.7/terok_clearance-0.6.7-py3-none-any.whl"}
 

--- a/src/terok/lib/core/config.py
+++ b/src/terok/lib/core/config.py
@@ -691,10 +691,10 @@ def get_codex_allow_oauth() -> bool:
 
     When True (and experimental is enabled), the vault brokers Codex
     OAuth end-to-end: the in-container ``auth.json`` carries a phantom
-    access/refresh token and the real id_token JWT; inference requests
-    ride through ``OPENAI_BASE_URL`` to the vault socket where the
-    phantom is swapped for the live bearer.  Shield denies
-    ``api.openai.com`` to prevent accidental direct hits.
+    access/refresh token plus a synthetic ``id_token``; shared
+    ``~/.codex/config.toml`` is patched so both OpenAI API traffic and
+    ChatGPT ``/backend-api`` traffic ride through the vault.  Shield
+    denies ``api.openai.com`` to prevent accidental direct hits.
 
     Global config (config.yml)::
 
@@ -725,12 +725,12 @@ def get_codex_expose_oauth_token() -> bool:
 def is_codex_oauth_proxied() -> bool:
     """Return True when Codex OAuth traffic is routed through the proxy.
 
-    Kept in lockstep with [`is_claude_oauth_proxied`][terok.lib.core.config.is_claude_oauth_proxied] so shield
-    rules and env overrides stay symmetrical.  The proxied path relies
-    on the ``oauth_refresh`` block in ``codex.yaml`` for background
-    token rotation and on the phantom ``auth.json`` written by
-    `_codex_oauth_mount_writer`
-    for in-container auth brokering.
+    Kept in lockstep with [`is_claude_oauth_proxied`][terok.lib.core.config.is_claude_oauth_proxied]
+    so shield rules and env overrides stay symmetrical.  The proxied path
+    relies on the ``oauth_refresh`` block in ``codex.yaml`` for background
+    token rotation, the phantom ``auth.json`` written by
+    `_codex_oauth_mount_writer` for in-container auth brokering, and the
+    shared Codex config patch selected by terok's environment builder.
     """
     return is_experimental() and get_codex_allow_oauth() and not get_codex_expose_oauth_token()
 
@@ -738,9 +738,9 @@ def is_codex_oauth_proxied() -> bool:
 def is_codex_oauth_exposed() -> bool:
     """Return True when the real Codex OAuth token is intentionally exposed.
 
-    Exposed mode trades token security for working Codex OAuth — the real
-    ``auth.json`` is mounted into every task container instead of being
-    wiped post-capture.  This is Phase 1's only path to a usable Codex.
+    Exposed mode trades token security for direct Codex control of the
+    session — the real ``auth.json`` is mounted into every task
+    container instead of being replaced with the synthetic shared store.
     """
     return is_experimental() and get_codex_expose_oauth_token()
 

--- a/src/terok/lib/core/config.py
+++ b/src/terok/lib/core/config.py
@@ -679,6 +679,15 @@ def is_claude_oauth_exposed() -> bool:
 
 # ---------- Codex OAuth config (agent.codex.*) ----------
 
+CODEX_VAULTED_OAUTH_REQUIRES_EXPERIMENTAL = True
+"""SSOT for whether secure vaulted Codex OAuth still requires ``experimental``.
+
+The insecure exposed-token path intentionally remains experimental
+forever.  This switch only controls the secure path where real OAuth
+tokens stay in the host-side vault and task containers see synthetic
+Codex auth state.
+"""
+
 
 def _codex_agent_config() -> dict:
     """Return the ``agent.codex`` sub-dict, guarding against non-dict values."""
@@ -725,14 +734,18 @@ def get_codex_expose_oauth_token() -> bool:
 def is_codex_oauth_proxied() -> bool:
     """Return True when Codex OAuth traffic is routed through the proxy.
 
-    Kept in lockstep with [`is_claude_oauth_proxied`][terok.lib.core.config.is_claude_oauth_proxied]
-    so shield rules and env overrides stay symmetrical.  The proxied path
-    relies on the ``oauth_refresh`` block in ``codex.yaml`` for background
-    token rotation, the phantom ``auth.json`` written by
-    `_codex_oauth_mount_writer` for in-container auth brokering, and the
-    shared Codex config patch selected by terok's environment builder.
+    The proxied/vaulted path relies on the ``oauth_refresh`` block in
+    ``codex.yaml`` for background token rotation, the phantom ``auth.json``
+    written by `_codex_oauth_mount_writer` for in-container auth brokering,
+    and the shared Codex config patch selected by terok's environment
+    builder.
+
+    Flip [`CODEX_VAULTED_OAUTH_REQUIRES_EXPERIMENTAL`][terok.lib.core.config.CODEX_VAULTED_OAUTH_REQUIRES_EXPERIMENTAL]
+    to lift this secure path out of experimental without touching the
+    insecure exposed mode, which remains permanently experimental.
     """
-    return is_experimental() and get_codex_allow_oauth() and not get_codex_expose_oauth_token()
+    gate_open = not CODEX_VAULTED_OAUTH_REQUIRES_EXPERIMENTAL or is_experimental()
+    return gate_open and get_codex_allow_oauth() and not get_codex_expose_oauth_token()
 
 
 def is_codex_oauth_exposed() -> bool:

--- a/src/terok/lib/orchestration/environment.py
+++ b/src/terok/lib/orchestration/environment.py
@@ -263,40 +263,23 @@ def _apply_claude_oauth_overrides(env: dict[str, str]) -> None:
             env.pop(key, None)
 
 
-def _apply_codex_oauth_overrides(env: dict[str, str]) -> None:
-    """Adjust Codex OAuth env vars based on the experimental proxy config.
-
-    Codex reuses the generic ``OPENAI_API_KEY`` as its phantom env var, so
-    presence alone is ambiguous — the user may have set a real key.  We
-    gate on the phantom marker value to only strip executor-injected
-    vault plumbing:
-
-    - **Proxied** (``is_codex_oauth_proxied``): keep ``OPENAI_BASE_URL``
-      for vault routing; remove the phantom token env so the CLI falls
-      back to its phantom ``auth.json`` bearer (which the vault then
-      swaps for the real one at inference time).
-    - **Skipped / Exposed**: clear both env vars so the in-container
-      Codex CLI reaches ``api.openai.com`` directly via ``auth.json``.
-    """
-    from terok_sandbox import PHANTOM_CREDENTIALS_MARKER
-
+def _enabled_vault_patch_providers(roster: object) -> frozenset[str]:
+    """Return the shared-config patches that should be active for this task."""
     from ..core.config import is_codex_oauth_proxied
 
-    if env.get("OPENAI_API_KEY") != PHANTOM_CREDENTIALS_MARKER:
-        return  # Real key (user-set) or nothing injected — don't touch.
-
-    if is_codex_oauth_proxied():
-        env.pop("OPENAI_API_KEY", None)
-    else:
-        for key in ("OPENAI_API_KEY", "OPENAI_BASE_URL"):
-            env.pop(key, None)
+    providers = frozenset(
+        name for name, route in roster.vault_routes.items() if route.shared_config_patch
+    )
+    if not is_codex_oauth_proxied():
+        providers -= {"codex"}
+    return providers
 
 
 def _warn_leaked_credentials() -> None:
     """Warn about real credential files in shared mounts.
 
     When an OAuth token is intentionally exposed (for Claude subscription
-    features or for Codex OAuth until a proxy route exists), the
+    features or direct Codex control), the
     provider-specific leak warning is suppressed and replaced by a loud,
     explicit banner so the user can't miss that a real token is mounted.
     """
@@ -431,6 +414,11 @@ def build_task_env_and_volumes(
         ensure_vault()
     vault_transport = get_vault_transport()
 
+    roster = get_roster()
+    enabled_patch_providers = (
+        frozenset() if vault_bypass else _enabled_vault_patch_providers(roster)
+    )
+
     result = assemble_container_env(
         ContainerEnvSpec(
             task_id=task_id,
@@ -453,8 +441,9 @@ def build_task_env_and_volumes(
             shared_dir=None if sealed else project.shared_dir,
             envs_dir=sandbox_live_mounts_dir(),
             timezone=project.timezone,
+            enabled_vault_patch_providers=enabled_patch_providers,
         ),
-        get_roster(),
+        roster,
         # bypass → skip proxy entirely (no tokens, no check)
         caller_manages_vault=vault_bypass,
     )
@@ -476,10 +465,9 @@ def build_task_env_and_volumes(
 
         volumes.append(VolumeSpec(cfg.runtime_dir, _CONTAINER_RUNTIME_DIR, sharing=Sharing.SHARED))
 
-    # Claude/Codex OAuth overrides + leaked-cred scan with exposed-token filtering
+    # Claude OAuth env override + leaked-cred scan with exposed-token filtering
     if not vault_bypass:
         _apply_claude_oauth_overrides(env)
-        _apply_codex_oauth_overrides(env)
         _warn_leaked_credentials()
 
     return env, volumes

--- a/src/terok/lib/orchestration/environment.py
+++ b/src/terok/lib/orchestration/environment.py
@@ -263,16 +263,36 @@ def _apply_claude_oauth_overrides(env: dict[str, str]) -> None:
             env.pop(key, None)
 
 
-def _enabled_vault_patch_providers(roster: object) -> frozenset[str]:
-    """Return the shared-config patches that should be active for this task."""
-    from ..core.config import is_codex_oauth_proxied
-
-    providers = frozenset(
+def _shared_config_patch_providers(roster: object) -> frozenset[str]:
+    """Return providers that declare shared config patches in the roster."""
+    return frozenset(
         name for name, route in roster.vault_routes.items() if route.shared_config_patch
     )
+
+
+def _vault_patch_provider_sets(
+    roster: object, *, vault_bypass: bool = False
+) -> tuple[frozenset[str], frozenset[str]]:
+    """Return ``(enabled, disabled)`` shared-config patch provider sets.
+
+    Enabled providers have their roster-declared patches applied.  Disabled
+    providers have previously managed values reconciled away if terok still
+    owns them.  Codex is special only in its feature gate: the secure
+    vaulted OAuth mode enables the shared ``~/.codex/config.toml`` rewrite;
+    disabled/exposed/bypassed modes remove stale managed Codex URLs.
+    """
+    from ..core.config import is_codex_oauth_proxied
+
+    providers = _shared_config_patch_providers(roster)
+    if vault_bypass:
+        return frozenset(), providers
+
+    enabled = providers
+    disabled = frozenset()
     if not is_codex_oauth_proxied():
-        providers -= {"codex"}
-    return providers
+        enabled -= {"codex"}
+        disabled |= providers & {"codex"}
+    return enabled, disabled
 
 
 def _warn_leaked_credentials() -> None:
@@ -415,8 +435,8 @@ def build_task_env_and_volumes(
     vault_transport = get_vault_transport()
 
     roster = get_roster()
-    enabled_patch_providers = (
-        frozenset() if vault_bypass else _enabled_vault_patch_providers(roster)
+    enabled_patch_providers, disabled_patch_providers = _vault_patch_provider_sets(
+        roster, vault_bypass=vault_bypass
     )
 
     result = assemble_container_env(
@@ -442,6 +462,7 @@ def build_task_env_and_volumes(
             envs_dir=sandbox_live_mounts_dir(),
             timezone=project.timezone,
             enabled_vault_patch_providers=enabled_patch_providers,
+            disabled_vault_patch_providers=disabled_patch_providers,
         ),
         roster,
         # bypass → skip proxy entirely (no tokens, no check)

--- a/src/terok/lib/orchestration/task_runners.py
+++ b/src/terok/lib/orchestration/task_runners.py
@@ -401,9 +401,9 @@ def _maybe_deny_anthropic_api(cname: str, task_dir: Path) -> None:
 def _maybe_deny_openai_api(cname: str, task_dir: Path) -> None:
     """Block ``api.openai.com`` when Codex OAuth is proxied.
 
-    Phase 3 hook — currently a no-op because ``is_codex_oauth_proxied``
-    always returns False until a Codex refresh route is wired.  Ships
-    now so Phase 3 only needs to flip the gate, not add new plumbing.
+    The shared Codex config rewrite points built-in OpenAI traffic at the
+    vault.  When the shield is down, this deny rule prevents accidental
+    fallback to the public OpenAI API host.
     """
     from ..core.config import is_codex_oauth_proxied
 

--- a/tests/unit/lib/test_config.py
+++ b/tests/unit/lib/test_config.py
@@ -833,6 +833,19 @@ def test_is_codex_oauth_proxied_when_allowed(
     assert cfg.is_codex_oauth_proxied() is True
 
 
+def test_is_codex_oauth_proxied_can_be_lifted_from_experimental(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """One SSOT switch controls whether secure Codex vaulting needs experimental."""
+    monkeypatch.setenv(
+        "TEROK_CONFIG_FILE",
+        str(write_config(tmp_path, "agent:\n  codex:\n    allow_oauth: true\n")),
+    )
+    monkeypatch.setattr(cfg, "CODEX_VAULTED_OAUTH_REQUIRES_EXPERIMENTAL", False)
+
+    assert cfg.is_codex_oauth_proxied() is True
+
+
 def test_is_codex_oauth_not_proxied_when_exposed(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
@@ -883,6 +896,25 @@ def test_is_oauth_enabled_for(
     """Cross-provider OAuth gate honours the per-provider experimental config."""
     monkeypatch.setenv("TEROK_CONFIG_FILE", str(write_config(tmp_path, yaml_body)))
     assert cfg.is_oauth_enabled_for(provider) is expected
+
+
+def test_codex_expose_flag_blocks_vaulting_even_when_not_experimental(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """The insecure expose flag wins even if secure vaulting no longer needs experimental."""
+    monkeypatch.setenv(
+        "TEROK_CONFIG_FILE",
+        str(
+            write_config(
+                tmp_path,
+                "agent:\n  codex:\n    allow_oauth: true\n    expose_oauth_token: true\n",
+            )
+        ),
+    )
+    monkeypatch.setattr(cfg, "CODEX_VAULTED_OAUTH_REQUIRES_EXPERIMENTAL", False)
+
+    assert cfg.is_codex_oauth_proxied() is False
+    assert cfg.is_codex_oauth_exposed() is False
 
 
 # ---------- Layered config merging ----------

--- a/tests/unit/lib/test_task_runner_internals.py
+++ b/tests/unit/lib/test_task_runner_internals.py
@@ -331,7 +331,7 @@ class TestMaybeDenyOpenAiApi:
     """Verify shield deny for api.openai.com when Codex OAuth is proxied."""
 
     def test_noop_when_not_proxied(self) -> None:
-        """No-op in Phase 1 — ``is_codex_oauth_proxied`` always False."""
+        """No-op when Codex OAuth proxying is disabled."""
         from terok.lib.orchestration.task_runners import _maybe_deny_openai_api
 
         with patch(

--- a/tests/unit/lib/test_vault_env.py
+++ b/tests/unit/lib/test_vault_env.py
@@ -1,18 +1,19 @@
 # SPDX-FileCopyrightText: 2026 Jiri Vyskocil
 # SPDX-License-Identifier: Apache-2.0
 
-"""Tests for terok-specific vault overrides.
+"""Tests for terok-specific vault env/policy selection.
 
 Generic vault plumbing (phantom tokens, socket transport, SSH signer) is
 tested in terok-executor (test_env_builder.py).  These tests cover the
-terok-only Claude OAuth mode overrides and leaked-credential scan with
-exposed-token filtering.
+terok-only Claude OAuth env override, shared config-patch selection, and
+leaked-credential scan with exposed-token filtering.
 """
 
 from __future__ import annotations
 
 import logging
 from pathlib import Path
+from types import SimpleNamespace
 from unittest.mock import patch
 
 import pytest
@@ -74,63 +75,36 @@ class TestClaudeOAuthOverrides:
         assert env == original
 
 
-class TestCodexOAuthOverrides:
-    """Verify _apply_codex_oauth_overrides mode selection and phantom guard."""
+class TestEnabledVaultPatchProviders:
+    """Verify Codex shared-config patch selection from terok config."""
 
-    def test_skipped_strips_phantom_and_base_url(self) -> None:
-        """Default mode + phantom-valued OPENAI_API_KEY → strip both proxy vars."""
-        from terok_sandbox import PHANTOM_CREDENTIALS_MARKER
+    def _roster(self) -> SimpleNamespace:
+        return SimpleNamespace(
+            vault_routes={
+                "codex": SimpleNamespace(shared_config_patch={"file": "config.toml"}),
+                "vibe": SimpleNamespace(shared_config_patch={"file": "config.toml"}),
+                "gh": SimpleNamespace(shared_config_patch={"file": "config.yml"}),
+                "claude": SimpleNamespace(shared_config_patch=None),
+            }
+        )
 
-        from terok.lib.orchestration.environment import _apply_codex_oauth_overrides
+    def test_proxied_keeps_codex_patch(self) -> None:
+        """Codex shared config patch is enabled only in proxied mode."""
+        from terok.lib.orchestration.environment import _enabled_vault_patch_providers
 
-        env = {
-            "OPENAI_API_KEY": PHANTOM_CREDENTIALS_MARKER,
-            "OPENAI_BASE_URL": "http://host.containers.internal:18731",
-            "TEROK_TOKEN_BROKER_PORT": "18731",
-        }
-        with patch("terok.lib.core.config.is_codex_oauth_proxied", return_value=False):
-            _apply_codex_oauth_overrides(env)
-
-        assert "OPENAI_API_KEY" not in env
-        assert "OPENAI_BASE_URL" not in env
-        assert "TEROK_TOKEN_BROKER_PORT" in env
-
-    def test_proxied_keeps_base_url_drops_phantom(self) -> None:
-        """Phase 3 path: proxied → drop phantom, keep OPENAI_BASE_URL for vault routing."""
-        from terok_sandbox import PHANTOM_CREDENTIALS_MARKER
-
-        from terok.lib.orchestration.environment import _apply_codex_oauth_overrides
-
-        env = {
-            "OPENAI_API_KEY": PHANTOM_CREDENTIALS_MARKER,
-            "OPENAI_BASE_URL": "http://host.containers.internal:18731",
-        }
         with patch("terok.lib.core.config.is_codex_oauth_proxied", return_value=True):
-            _apply_codex_oauth_overrides(env)
+            providers = _enabled_vault_patch_providers(self._roster())
 
-        assert "OPENAI_API_KEY" not in env
-        assert env["OPENAI_BASE_URL"] == "http://host.containers.internal:18731"
+        assert providers == frozenset({"codex", "gh", "vibe"})
 
-    def test_leaves_user_set_real_key_untouched(self) -> None:
-        """User-set ``OPENAI_API_KEY`` (not phantom) must survive the override."""
-        from terok.lib.orchestration.environment import _apply_codex_oauth_overrides
+    def test_skipped_omits_codex_patch(self) -> None:
+        """Default/exposed modes omit Codex's shared config rewrite."""
+        from terok.lib.orchestration.environment import _enabled_vault_patch_providers
 
-        env = {
-            "OPENAI_API_KEY": "sk-real-user-key",
-            "OPENAI_BASE_URL": "https://api.openai.com",
-        }
-        original = dict(env)
-        _apply_codex_oauth_overrides(env)
-        assert env == original
+        with patch("terok.lib.core.config.is_codex_oauth_proxied", return_value=False):
+            providers = _enabled_vault_patch_providers(self._roster())
 
-    def test_noop_without_openai_api_key(self) -> None:
-        """No ``OPENAI_API_KEY`` → nothing to clean up."""
-        from terok.lib.orchestration.environment import _apply_codex_oauth_overrides
-
-        env = {"ANTHROPIC_API_KEY": "sk-ant"}
-        original = dict(env)
-        _apply_codex_oauth_overrides(env)
-        assert env == original
+        assert providers == frozenset({"gh", "vibe"})
 
 
 class TestLeakedCredentialsScan:

--- a/tests/unit/lib/test_vault_env.py
+++ b/tests/unit/lib/test_vault_env.py
@@ -75,7 +75,7 @@ class TestClaudeOAuthOverrides:
         assert env == original
 
 
-class TestEnabledVaultPatchProviders:
+class TestVaultPatchProviderSets:
     """Verify Codex shared-config patch selection from terok config."""
 
     def _roster(self) -> SimpleNamespace:
@@ -90,21 +90,32 @@ class TestEnabledVaultPatchProviders:
 
     def test_proxied_keeps_codex_patch(self) -> None:
         """Codex shared config patch is enabled only in proxied mode."""
-        from terok.lib.orchestration.environment import _enabled_vault_patch_providers
+        from terok.lib.orchestration.environment import _vault_patch_provider_sets
 
         with patch("terok.lib.core.config.is_codex_oauth_proxied", return_value=True):
-            providers = _enabled_vault_patch_providers(self._roster())
+            enabled, disabled = _vault_patch_provider_sets(self._roster())
 
-        assert providers == frozenset({"codex", "gh", "vibe"})
+        assert enabled == frozenset({"codex", "gh", "vibe"})
+        assert disabled == frozenset()
 
     def test_skipped_omits_codex_patch(self) -> None:
-        """Default/exposed modes omit Codex's shared config rewrite."""
-        from terok.lib.orchestration.environment import _enabled_vault_patch_providers
+        """Default/exposed modes disable Codex's shared config rewrite."""
+        from terok.lib.orchestration.environment import _vault_patch_provider_sets
 
         with patch("terok.lib.core.config.is_codex_oauth_proxied", return_value=False):
-            providers = _enabled_vault_patch_providers(self._roster())
+            enabled, disabled = _vault_patch_provider_sets(self._roster())
 
-        assert providers == frozenset({"gh", "vibe"})
+        assert enabled == frozenset({"gh", "vibe"})
+        assert disabled == frozenset({"codex"})
+
+    def test_vault_bypass_disables_all_shared_patches(self) -> None:
+        """Vault bypass removes stale managed config for every patch provider."""
+        from terok.lib.orchestration.environment import _vault_patch_provider_sets
+
+        enabled, disabled = _vault_patch_provider_sets(self._roster(), vault_bypass=True)
+
+        assert enabled == frozenset()
+        assert disabled == frozenset({"codex", "gh", "vibe"})
 
 
 class TestLeakedCredentialsScan:


### PR DESCRIPTION
## Summary
- keep Codex on global shared synthetic auth/config state while real OAuth tokens stay host-side in the vault
- add a single SSOT switch for lifting secure vaulted Codex OAuth out of `experimental`; the insecure exposed-token mode remains separately gated
- pass both enabled and disabled shared-config patch provider sets so stale managed Codex vault URLs are reconciled away when the feature is off, exposed, or bypassed
- pin terok to the executor and sandbox PR branch tips while this stack is under review

## Depends on
- terok-ai/terok-executor#241
- terok-ai/terok-sandbox#221

## Testing
- `make lint`
- `poetry run pytest tests/unit/lib/test_vault_env.py tests/unit/lib/test_config.py tests/unit/lib/test_task_runner_internals.py tests/unit/lib/test_tasks.py -q`

Podman/Docker-dependent tests were intentionally not run in this container.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Config flag to allow secure Codex OAuth proxying without enabling experimental mode.
  * Shared-config patch selection for vault-based OAuth routing, with roster-driven enable/disable and a vault bypass option.

* **Documentation**
  * Example config comments showing vault-based Codex OAuth setup and an optional expose-oauth_token escape hatch.

* **Tests**
  * Unit tests updated/added to cover Codex OAuth gating and vault patch provider selection.

* **Chores**
  * Dependency pins bumped to newer releases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->