### PR TITLE
docs: audit pass — vocab, defaults, examples, drop sales-y bits

### DIFF
--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -36,7 +36,7 @@ and how much friction you are willing to tolerate.
 
 ```mermaid
 graph LR
-    A["<b>Chat Window</b><br/>Copy-paste snippets<br/>Agent sees nothing"] --- B["<b>Restricted Agent</b><br/>Read-only access<br/>No network, no push"] --- C["<b>Gatekept Agent</b><br/>Full workspace<br/>Pushes to gate only"] --- D["<b>Online Agent</b><br/>Full workspace<br/>Pushes to upstream"] --- E["<b>Unrestricted Local</b><br/>Full machine access<br/>Your SSH keys"]
+    A["<b>Chat Window</b><br/>Copy-paste snippets<br/>Agent sees nothing"] --- B["<b>Restricted Agent</b><br/>Read-only access<br/>No network, no push"] --- C["<b>Gatekeeping mode</b><br/>Full workspace<br/>Pushes to gate only"] --- D["<b>Online mode</b><br/>Full workspace<br/>Pushes to upstream"] --- E["<b>Unrestricted Local</b><br/>Full machine access<br/>Your SSH keys"]
 
 ```
 
@@ -44,11 +44,11 @@ graph LR
 |-------|-----------|-------------|----------|
 | **Chat window** | Read pasted snippets | See files, run tools, push code | Quick questions, small edits |
 | **Restricted** | Read code, run tests | Write to git, access network | Code review, analysis |
-| **Gatekept** (terok default) | Edit code, push to gate | Push to upstream, access arbitrary hosts | Autonomous development with human review |
+| **Gatekeeping** (terok default) | Edit code, push to gate | Push to upstream, access arbitrary hosts | Autonomous development with human review |
 | **Online** | Edit code, push to upstream | Escape the container | Trusted agents, CI-like workflows |
 | **Unrestricted local** | Everything on the machine | Nothing is off-limits | Dangerous — no isolation at all |
 
-terok provides the **gatekept** and **online** levels, with configurable
+terok provides the **gatekeeping** and **online** modes, with configurable
 options to tune the exact trade-off within each.
 
 ---
@@ -556,22 +556,6 @@ sequenceDiagram
 The gate is a standard git repository. Any git client — your IDE,
 `git` CLI, or a GUI tool — can interact with it using normal git
 operations.
-
----
-
-## Comparison: terok vs. Alternatives
-
-| Capability | Chat window | Agent on bare metal | Docker-based tools | **terok** |
-|------------|-------------|--------------------|--------------------|-----------|
-| Agent runs tests | No | Yes | Yes | Yes |
-| Agent installs packages | No | Yes (risky) | Yes | Yes |
-| Agent pushes to GitHub | No | Yes (risky) | Varies | Configurable |
-| Parallel agents | No | Manual | Varies | Built-in |
-| Human review checkpoint | N/A | No | Varies | Gate (gatekeeping) |
-| Egress firewall | N/A | No | Rare | Shield |
-| No root/daemon required | N/A | N/A | Docker needs daemon | Podman rootless |
-| Multi-vendor agents | N/A | One at a time | Usually one | Claude, Codex, Copilot, Vibe, Blablador |
-| Per-task workspace isolation | N/A | Manual | Varies | Automatic |
 
 ---
 

--- a/docs/container-layers.md
+++ b/docs/container-layers.md
@@ -64,8 +64,6 @@ Built `FROM` the L1 image.
 - `terok task run <project>` (default `--mode cli`) creates a fresh task and
   runs a container from `<project>:l2-cli`.  `--mode toad` uses the same
   L2 image with the Toad browser TUI entry point.
-- `terokctl task attach <project> <task> --mode cli` re-runs an existing
-  task in the same L2 image (scripting surface).
 - Mounts a per-task workspace to `/workspace` and shared credential directories.
 - The init script clones or syncs the project repository into `/workspace`.
 

--- a/docs/container-lifecycle.md
+++ b/docs/container-lifecycle.md
@@ -7,22 +7,22 @@ terok manages two types of resources:
 - **Containers** — mutable instances of images, one per task
 
 ```text
-┌─────────────────────────────────────────────────────────────────┐
-│                         IMAGES (immutable)                      │
-│  ┌─────────┐    ┌─────────────┐    ┌─────────────────────────┐  │
-│  │   L0    │───▶│     L1      │───▶│          L2             │  │
-│  │  (dev)  │    │   (cli)     │    │     (project-cli)       │  │
-│  └─────────┘    └─────────────┘    └─────────────────────────┘  │
-└─────────────────────────────────────────────────────────────────┘
-                              │
-                              ▼
-┌─────────────────────────────────────────────────────────────────┐
-│                      CONTAINERS (mutable)                       │
-│  ┌─────────────────┐  ┌─────────────────┐  ┌─────────────────┐  │
-│  │  project-cli-1  │  │  project-cli-2  │  │  project-cli-3  │  │
-│  │    (task 1)     │  │    (task 2)     │  │    (task 3)     │  │
-│  └─────────────────┘  └─────────────────┘  └─────────────────┘  │
-└─────────────────────────────────────────────────────────────────┘
+┌──────────────────────────────────────────────────────────────────────────────┐
+│                              IMAGES (immutable)                              │
+│   ┌─────────┐     ┌─────────────┐     ┌─────────────────────────┐            │
+│   │   L0    │ ──▶ │     L1      │ ──▶ │           L2            │            │
+│   │  (dev)  │     │   (cli)     │     │      (project-cli)      │            │
+│   └─────────┘     └─────────────┘     └─────────────────────────┘            │
+└──────────────────────────────────────────────────────────────────────────────┘
+                                  │
+                                  ▼
+┌──────────────────────────────────────────────────────────────────────────────┐
+│                            CONTAINERS (mutable)                              │
+│  ┌────────────────────┐  ┌────────────────────┐  ┌────────────────────┐      │
+│  │ project-cli-v9krt  │  │ project-cli-h4y12  │  │ project-cli-k3v8h  │      │
+│  │   (task v9krt)     │  │   (task h4y12)     │  │   (task k3v8h)     │      │
+│  └────────────────────┘  └────────────────────┘  └────────────────────┘      │
+└──────────────────────────────────────────────────────────────────────────────┘
 ```
 
 ---
@@ -34,10 +34,10 @@ terok manages two types of resources:
 A task consists of three persistent components:
 
 ```text
-Task #1
-├── Workspace    ~/.local/share/terok/tasks/<project>/1/workspace-dangerous/
-├── Metadata     ~/.local/share/terok/projects/<project>/tasks/1.yml
-└── Container    <project>-cli-1
+Task v9krt
+├── Workspace    ~/.local/share/terok/tasks/<project>/v9krt/workspace-dangerous/
+├── Metadata     ~/.local/share/terok/projects/<project>/tasks/v9krt.yml
+└── Container    <project>-cli-v9krt
 ```
 
 All three persist independently and survive:
@@ -86,7 +86,6 @@ All three persist independently and survive:
 | `task restart` | `podman stop` → `podman start` | `podman start` | Error: suggests `task run` |
 | `task status`  | Shows state            | Shows state     | Shows "not found"      |
 | `task delete` | `podman rm -f` + cleanup | `podman rm -f` + cleanup | Cleanup only |
-| `terokctl task attach` | Shows "already running" | `podman start` | Error: task has no container |
 
 ### Container Naming
 
@@ -94,7 +93,7 @@ All three persist independently and survive:
 <project-id>-<mode>-<task-id>
 
 Examples:
-  myproject-cli-1       # CLI container for task 1
+  myproject-cli-v9krt   # CLI container for task v9krt
   myproject-auth-codex  # Auth container (ephemeral, uses --rm)
 ```
 
@@ -187,42 +186,41 @@ Container image hash ≠ Current project build hash
 ### Starting a Task
 
 ```bash
-# First time (creates container)
-terok task new myproject        # Create task metadata + workspace
-terokctl task attach --mode cli myproject 1  # Create and start container
+# Create a fresh task + container in one step (default on a TTY: also attaches)
+terok task run myproject
 
-# Subsequent times (reuses container)
-terokctl task attach --mode cli myproject 1  # Starts existing container
+# Re-attach a shell into a running task (prefix accepted if unambiguous)
+terok login myproject v9krt
 ```
 
 ### Stopping and Restarting
 
 ```bash
-terok task stop myproject 1     # Graceful stop (container persists)
-terok task restart myproject 1  # Fast restart (podman start)
+terok task stop myproject v9krt     # Graceful stop (container persists)
+terok task restart myproject v9krt  # Fast restart (podman start)
 ```
 
 ### Checking Status
 
 ```bash
-terok task status myproject 1   # Shows metadata vs actual container state
-terok task list myproject       # Lists all tasks with status
+terok task status myproject v9krt   # Shows metadata vs actual container state
+terok task list myproject           # Lists all tasks with status
 ```
 
 ### Cleaning Up
 
 ```bash
-terok task delete myproject 1   # Removes container + workspace + metadata
+terok task delete myproject v9krt   # Removes container + workspace + metadata
 ```
 
 ### Manual Container Management
 
 ```bash
 # These work because containers persist
-podman ps -a --filter name=myproject  # List all project containers
-podman logs myproject-cli-1           # View container logs
-podman exec -it myproject-cli-1 bash  # Enter running container
-podman stop myproject-cli-1           # Stop container
-podman start myproject-cli-1          # Start stopped container
-podman rm myproject-cli-1             # Remove container (keeps workspace)
+podman ps -a --filter name=myproject     # List all project containers
+podman logs myproject-cli-v9krt          # View container logs
+podman exec -it myproject-cli-v9krt bash # Enter running container
+podman stop myproject-cli-v9krt          # Stop container
+podman start myproject-cli-v9krt         # Start stopped container
+podman rm myproject-cli-v9krt            # Remove container (keeps workspace)
 ```

--- a/docs/developer.md
+++ b/docs/developer.md
@@ -496,8 +496,8 @@ panel edges misalign — and **cannot be fixed by padding alone**.
 6. Guard tests in `tests/lib/test_emoji.py` verify all project emojis are
    natively 2 cells wide — adding a VS16 emoji will fail CI.  Tests also
    verify that all emoji dicts have non-empty labels for `--no-emoji` mode.
-7. Emojis are **on by default**.  Pass `--no-emoji` to `terok-tui` (TUI) or
-   `terok` (CLI) to replace all emojis with `[label]` text badges.
+7. Emojis are **on by default**.  Pass `--no-emoji` to `terok` to replace
+   all emojis with `[label]` text badges.
 
 See `src/terok/lib/util/emoji.py` module docstring for full background,
 references, and future terminal developments to watch (Kitty text sizing

--- a/docs/login-design.md
+++ b/docs/login-design.md
@@ -95,13 +95,6 @@ The user gets a real terminal in the new tab while the TUI remains in the origin
 
 ### `--tmux` opt-in wrapper (R3, R5)
 
-`terok-tui --tmux` wraps the TUI in a managed tmux session with the host config
+`terok tui --tmux` wraps the TUI in a managed tmux session with the host config
 (blue status bar, usage hints). Login sessions become additional tmux windows.
 This is opt-in — without the flag, the TUI runs directly in the terminal as before.
-
-## Future Directions
-
-- Embedded terminal widget in the TUI (pyte-based, requires significant effort)
-- Support for additional terminal emulators beyond gnome-terminal and konsole
-- Auto-wrap in tmux by default (pending user feedback on the opt-in flag)
-- Toad/ACP integration as alternative agent frontend

--- a/docs/shield-security.md
+++ b/docs/shield-security.md
@@ -31,27 +31,22 @@ logging continues.**
 **Secrets exfiltration.**
 A compromised or prompt-injected agent can send API keys, tokens, SSH
 private keys, or any other secrets mounted in the container to arbitrary
-external endpoints.  With the shield *up*, outbound connections are limited
-to explicitly allowlisted domains, making bulk exfiltration far harder.
+external endpoints.  With the shield *up*, outbound connections are
+limited to the configured allowlist, narrowing the destinations an
+exfiltration attempt can reach.
 
 **Prompt injection surface.**
-Without egress restrictions, an agent can fetch arbitrary content from the
-internet — including attacker-controlled pages designed to inject malicious
-instructions.  The shield limits which domains can serve content to the
-agent, dramatically reducing this attack vector.
+Without egress restrictions, the agent can fetch content from any host on
+the internet, including attacker-controlled pages.  The shield narrows
+this to the allowlist; it does not stop injection from content served by
+allowlisted hosts.
 
 **Internal network exposure.**
-Containers running without egress filtering can scan and attack hosts on
-private networks (RFC 1918 ranges: `10.0.0.0/8`, `172.16.0.0/12`,
-`192.168.0.0/16`).  If the host is connected to a corporate LAN, VPN, or
-cloud VPC, a compromised agent gains lateral movement capability.  The
-shield blocks RFC 1918 destinations by default.
-
-**Unrestricted downloads.**
-Agents can download and execute arbitrary binaries, install packages from
-untrusted sources, or pull container images — all without audit trail
-filtering.  This enables supply-chain attacks where the agent is tricked
-into installing backdoored dependencies.
+Containers without egress filtering can reach hosts on private networks
+(RFC 1918 ranges: `10.0.0.0/8`, `172.16.0.0/12`, `192.168.0.0/16`).  On a
+host connected to a corporate LAN, VPN, or cloud VPC, that exposes
+internal services to the agent.  The shield blocks RFC 1918 destinations
+by default.
 
 ### What you keep
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -35,11 +35,10 @@ pipx install ./terok-*.whl
 pip install ./terok-*.whl
 ```
 
-After install, you should have console scripts: `terok` (TUI), `terok` (CLI).
+After install, the `terok` command is on `$PATH`.  Run it with no arguments
+on a TTY to launch the TUI; pass a subcommand to drive the CLI.
 
 ### Global Flags
-
-Both `terok` and `terok` support:
 
 | Flag | Description |
 |------|-------------|
@@ -122,7 +121,7 @@ Every project needs these fields in its `project.yml`:
 ```yaml
 project:
   id: myproj
-  security_class: online        # or "gatekeeping"
+  security_class: gatekeeping   # default — or "online" for direct push
 
 image:
   base_image: docker.io/library/ubuntu:24.04
@@ -197,7 +196,7 @@ install.  The steps below show the equivalent CLI workflow.
 
 - Podman installed and working
 - OpenSSH client tools (ssh, ssh-keygen) for private Git over SSH
-- tmux (optional, for `terok-tui --tmux` and persistent container sessions)
+- tmux (optional, for the TUI under tmux and persistent container sessions)
 
 ### Step 1: Create Project Directory
 
@@ -211,7 +210,7 @@ mkdir -p ~/.config/terok/projects/myproj
 # ~/.config/terok/projects/myproj/project.yml
 project:
   id: myproj
-  security_class: online    # or "gatekeeping" for restricted mode
+  security_class: gatekeeping   # default — or "online" for direct push
 
 image:
   base_image: docker.io/library/ubuntu:24.04
@@ -342,30 +341,24 @@ terok task list myproj
 #### Additional Task Operations
 
 ```bash
-# Create a task metadata record without running it (scripting, terokctl only)
-terokctl task new myproj
-
-# Attach to an existing task (terokctl, scripting)
-terokctl task attach --mode cli myproj 1
-
 # Rename a task
-terok task rename myproj 1 fix-auth-bug
+terok task rename myproj v9krt fix-auth-bug
 
 # Follow up on a completed/failed headless task with a new prompt
-terok task followup myproj 1 -p "Now add tests for the fix"
+terok task followup myproj v9krt -p "Now add tests for the fix"
 
 # View formatted container logs
-terok task logs myproj 1              # Latest logs
-terok task logs myproj 1 -f           # Follow live output
-terok task logs myproj 1 --tail 50    # Last 50 lines
-terok task logs myproj 1 --raw        # Raw podman output
+terok task logs myproj v9krt              # Latest logs
+terok task logs myproj v9krt -f           # Follow live output
+terok task logs myproj v9krt --tail 50    # Last 50 lines
+terok task logs myproj v9krt --raw        # Raw podman output
 
 # Stop or restart a task
-terok task stop myproj 1
-terok task restart myproj 1
+terok task stop myproj v9krt
+terok task restart myproj v9krt
 
 # Delete a task
-terok task delete myproj 1
+terok task delete myproj v9krt
 
 # View archived (deleted) tasks and their logs
 terok task archive list myproj
@@ -376,13 +369,21 @@ terok task archive logs myproj 20260305T143000Z
 
 ```bash
 # Open a shell in a running task container (persistent tmux session)
-terok login myproj 1
+terok login myproj v9krt
+
+# Any unambiguous prefix works — terok resolves it against the live task list
+terok login myproj v9k
+terok login myproj v9
 ```
 
 This opens a tmux session inside the container. The session persists across
 disconnects — re-running `terok login` reattaches to the same session.
 Interactive shells show `hilfe --kurz` on entry; run `hilfe` inside the
 container for the fuller in-container help.
+
+`login` and the other per-task verbs (`task stop`, `task restart`,
+`task delete`, `task logs`, `task followup`, `task rename`) all accept an
+unambiguous prefix in place of the full task ID.
 
 #### From the TUI
 
@@ -399,7 +400,7 @@ method automatically:
 #### Running the TUI under tmux (recommended)
 
 ```bash
-terok-tui --tmux
+terok tui --tmux
 ```
 
 This wraps the TUI in a managed tmux session with a blue status bar showing
@@ -617,7 +618,7 @@ unrestricted (`true`).
 #### Checking the current mode
 
 ```bash
-terok task status myproj 1
+terok task status myproj v9krt
 # Output includes: Permissions: unrestricted
 ```
 
@@ -677,7 +678,6 @@ terok task run myproj "Debug and plan a fix" --provider claude --agent debugger 
 The `--agent` flag also works with interactive modes:
 
 ```bash
-terokctl task attach --mode cli myproj 1 --agent debugger
 terok task run myproj --agent debugger
 ```
 
@@ -740,7 +740,7 @@ Every task container receives instructions explaining the workspace layout, avai
 
 - **Claude**: injected via `--append-system-prompt` (system-level context)
 - **Codex**: loaded from `/home/dev/.terok/instructions.md` via `-c model_instructions_file=...`
-  in the wrapper (applies to both `terok task run` and `terokctl task attach --mode cli`)
+  in the wrapper
 - **Other providers**: prepended to the task prompt (headless `terok task run`)
 
 ### Scenarios
@@ -880,7 +880,6 @@ Presets work with all task modes:
 
 ```bash
 terok task run myproj --preset review
-terokctl task attach --mode cli myproj 1 --preset team
 ```
 
 ### See What's Available

--- a/src/terok/lib/core/yaml_schema.py
+++ b/src/terok/lib/core/yaml_schema.py
@@ -85,8 +85,8 @@ class RawProjectSection(BaseModel):
     )
     name: str | None = Field(default=None, description="Human-readable project name (display only)")
     security_class: str = Field(
-        default="online",
-        description="Security mode: ``online`` (direct push) or ``gatekeeping`` (gated mirror)",
+        default="gatekeeping",
+        description="Security mode: ``gatekeeping`` (gated mirror, default) or ``online`` (direct push)",
     )
     isolation: str = Field(
         default="shared", description="shared (bind mounts) or sealed (no mounts)"

--- a/tests/unit/lib/test_autopilot.py
+++ b/tests/unit/lib/test_autopilot.py
@@ -127,7 +127,11 @@ def write_runner_project(base: Path, project_id: str, extra_yml: str = "") -> Pa
     projects_root.mkdir(parents=True, exist_ok=True)
     config_file = base / "config.yml"
     config_file.write_text(f"credentials:\n  dir: {envs_dir}\n", encoding="utf-8")
-    write_project(projects_root, project_id, f"project:\n  id: {project_id}\n{extra_yml}")
+    write_project(
+        projects_root,
+        project_id,
+        f"project:\n  id: {project_id}\n  security_class: online\n{extra_yml}",
+    )
     return config_file
 
 

--- a/tests/unit/lib/test_image.py
+++ b/tests/unit/lib/test_image.py
@@ -20,10 +20,11 @@ DEFAULT_BRANCH = "main"
 @contextmanager
 def image_project(project_id: str, *, security_class: str = "online") -> Iterator[object]:
     """Create a minimal project config suitable for Dockerfile generation tests."""
-    lines = [f"project:\n  id: {project_id}\n"]
-    if security_class != "online":
-        lines.append(f"  security_class: {security_class}\n")
-    lines.append("git:\n")
+    lines = [
+        f"project:\n  id: {project_id}\n",
+        f"  security_class: {security_class}\n",
+        "git:\n",
+    ]
     lines.append(f"  upstream_url: {UPSTREAM_URL}\n")
     lines.append(f"  default_branch: {DEFAULT_BRANCH}\n")
     yaml = "".join(lines)

--- a/tests/unit/lib/test_projects.py
+++ b/tests/unit/lib/test_projects.py
@@ -226,6 +226,7 @@ class TestProject:
         yaml = (
             "project:\n"
             "  id: hostless\n"
+            "  security_class: online\n"
             "git:\n"
             "  upstream_url: git@github.com:user/repo.git\n"
             "gate:\n"

--- a/tests/unit/lib/test_tasks.py
+++ b/tests/unit/lib/test_tasks.py
@@ -445,7 +445,7 @@ class TestTask:
         """Task containers receive the resolved Git authorship mode."""
         project_id = "proj_authorship_env"
         with project_env(
-            f"project:\n  id: {project_id}\ngit:\n  upstream_url: https://example.com/repo.git\n  authorship: human-agent\n",
+            f"project:\n  id: {project_id}\n  security_class: online\ngit:\n  upstream_url: https://example.com/repo.git\n  authorship: human-agent\n",
             project_id=project_id,
         ):
             env, _volumes = build_task_env_and_volumes(load_project(project_id), task_id="1")
@@ -454,7 +454,7 @@ class TestTask:
     def test_task_run_cli_colors_login_lines_when_tty(self, mock_runtime) -> None:
         project_id = "proj_cli_color"
         with project_env(
-            f"project:\n  id: {project_id}\n",
+            f"project:\n  id: {project_id}\n  security_class: online\n",
             project_id=project_id,
             with_config_file=True,
             clear_env=True,
@@ -493,7 +493,7 @@ class TestTask:
         """Interactive CLI startup must not add files to workspace before init clone."""
         project_id = "proj_cli_clean_workspace"
         with project_env(
-            f"project:\n  id: {project_id}\n",
+            f"project:\n  id: {project_id}\n  security_class: online\n",
             project_id=project_id,
             with_config_file=True,
             clear_env=True,
@@ -516,7 +516,7 @@ class TestTask:
         """task_run_toad must pass --public-url with the host port to toad serve."""
         project_id = "proj_toad_url"
         with project_env(
-            f"project:\n  id: {project_id}\n",
+            f"project:\n  id: {project_id}\n  security_class: online\n",
             project_id=project_id,
             with_config_file=True,
             clear_env=True,
@@ -556,7 +556,7 @@ class TestTask:
         project_id = "proj_toad_pub"
         monkeypatch.setenv("TEROK_PUBLIC_HOST", "myserver")
         with project_env(
-            f"project:\n  id: {project_id}\n",
+            f"project:\n  id: {project_id}\n  security_class: online\n",
             project_id=project_id,
             with_config_file=True,
             clear_env=True,

--- a/tests/unit/lib/test_yaml_schema.py
+++ b/tests/unit/lib/test_yaml_schema.py
@@ -26,7 +26,7 @@ class RawProjectYamlTests(unittest.TestCase):
     def test_minimal_valid_input(self) -> None:
         """Empty dict produces all defaults."""
         raw = RawProjectYaml.model_validate({})
-        self.assertEqual(raw.project.security_class, "online")
+        self.assertEqual(raw.project.security_class, "gatekeeping")
         self.assertIsNone(raw.git.upstream_url)
         self.assertEqual(raw.image.base_image, "ubuntu:24.04")
         self.assertEqual(raw.run.shutdown_timeout, 10)
@@ -83,7 +83,7 @@ class RawProjectYamlTests(unittest.TestCase):
     def test_none_section_coerced_to_empty(self) -> None:
         """Top-level ``None`` section values are coerced to ``{}``."""
         raw = RawProjectYaml.model_validate({"project": None, "git": None, "ssh": None})
-        self.assertEqual(raw.project.security_class, "online")
+        self.assertEqual(raw.project.security_class, "gatekeeping")
         self.assertIsNone(raw.git.upstream_url)
         self.assertFalse(raw.ssh.use_personal)
 


### PR DESCRIPTION
## Summary

Audit pass over the user-facing docs.  Changes group into four buckets:

**Vocabulary + default change.**
- Switch the `security_class` default from `online` to `gatekeeping`
  in `yaml_schema.py`.  Gatekeeping is the safer default and matches
  how we want users to reason about the system.
- Across docs: drop the noun `Gatekept`; use `gatekeeping` /
  `gatekeeping mode` consistently.
- Tests updated to set `security_class` explicitly where they
  exercise online-mode paths (no test relied on the implicit default).

**Stop exposing the multi-binary architecture.**
The user-facing docs no longer mention `terokctl` and `terok-tui`.
The install note, global-flags blurb and TUI-under-tmux examples all
just say `terok` now.  Scripting-only `terokctl task new` /
`task attach` examples removed from the user guide.

**Realistic task IDs + prefix resolution.**
Example task IDs in user docs flip from `"1"` to current-format
Crockford-style IDs (`v9krt`, `h4y12`, `k3v8h`).  A short note in
`usage.md` documents that `login` and the other per-task verbs accept
an unambiguous prefix.

**Drop sales-y / aspirational content.**
- `concepts.md`: delete the "Comparison: terok vs. Alternatives"
  table — it framed terok as winning every row against unspecified
  competitors.
- `login-design.md`: delete "Future Directions" — brainstorming
  doesn't belong in shipped docs.
- `shield-security.md`: tone down the "What you lose protection
  against" prose; remove the supply-chain-attack bullet —
  terok-shield doesn't actually defend against supply-chain attacks.

## Test plan

- [x] `make lint` clean
- [x] `pytest tests/unit/` — 2159 pass
- [ ] CI green (lint, unit, integration-host, tach, security, docstrings, reuse)

🤖 Generated with [Claude Code](https://claude.com/claude-code)