### PR TITLE
feat(tui): spawn login tabs in Ptyxis

### DIFF
--- a/docs/login-design.md
+++ b/docs/login-design.md
@@ -51,12 +51,12 @@ creates, subsequent logins reattach.
 The login command is the same; what varies is how the user gets a terminal to run it.
 A dispatch chain selects the best available method:
 
-    ┌──────────────────────────────────────────────────┐
-    │ 1. Inside tmux?  → tmux new-window              │
-    │ 2. Desktop DE?   → gnome-terminal / konsole      │
-    │ 3. Web mode?     → ttyd + open new browser tab   │
-    │ 4. Fallback      → suspend TUI, run directly     │
-    └──────────────────────────────────────────────────┘
+    ┌─────────────────────────────────────────────────────────┐
+    │ 1. Inside tmux?  → tmux new-window                      │
+    │ 2. Desktop DE?   → gnome-terminal / konsole / ptyxis    │
+    │ 3. Web mode?     → ttyd + open new browser tab          │
+    │ 4. Fallback      → suspend TUI, run directly            │
+    └─────────────────────────────────────────────────────────┘
 
 Methods 1-3 keep the TUI visible. Method 4 (suspend) blocks the TUI but works everywhere.
 

--- a/src/terok/tui/shell_launch.py
+++ b/src/terok/tui/shell_launch.py
@@ -50,8 +50,24 @@ def is_inside_konsole() -> bool:
     return _parent_process_has_name("konsole")
 
 
-def _parent_process_has_name(name: str) -> bool:
-    """Check if any parent process has the given name."""
+def is_inside_ptyxis() -> bool:
+    """Return True if the current process is running inside Ptyxis.
+
+    Checks multiple methods for detection:
+    1. TERM_PROGRAM environment variable
+    2. Parent process name (fallback only if TERM_PROGRAM is not set);
+       both ``ptyxis`` and the per-tab ``ptyxis-agent`` qualify
+    """
+    if os.environ.get("TERM_PROGRAM") == "ptyxis":
+        return True
+    if os.environ.get("TERM_PROGRAM"):
+        return False
+    return _parent_process_has_name("ptyxis", "ptyxis-agent")
+
+
+def _parent_process_has_name(*names: str) -> bool:
+    """Check if any parent process matches one of the given names."""
+    candidates = set(names)
     try:
         pid = os.getppid()
         result = subprocess.run(
@@ -62,7 +78,7 @@ def _parent_process_has_name(name: str) -> bool:
         )
         if result.returncode == 0:
             proc_name = result.stdout.strip()
-            if proc_name == name:
+            if proc_name in candidates:
                 return True
         for _ in range(3):
             result = subprocess.run(
@@ -91,7 +107,7 @@ def _parent_process_has_name(name: str) -> bool:
             if result.returncode != 0:
                 return False
             proc_name = result.stdout.strip()
-            if proc_name == name:
+            if proc_name in candidates:
                 return True
     except (subprocess.TimeoutExpired, FileNotFoundError, ValueError):
         pass
@@ -145,6 +161,16 @@ def spawn_terminal_with_command(command: list[str], title: str | None = None) ->
             args.extend(["-e", "bash", "-c", shell_cmd])
             subprocess.Popen(
                 ["konsole"] + args,
+                start_new_session=True,
+            )
+            return True
+        if is_inside_ptyxis():
+            args = ["--tab"]
+            if title:
+                args.extend(["--title", title])
+            args.extend(["--", "bash", "-c", shell_cmd])
+            subprocess.Popen(
+                ["ptyxis"] + args,
                 start_new_session=True,
             )
             return True

--- a/tests/unit/lib/test_shell_launch.py
+++ b/tests/unit/lib/test_shell_launch.py
@@ -15,6 +15,7 @@ import pytest
 from terok.tui.shell_launch import (
     is_inside_gnome_terminal,
     is_inside_konsole,
+    is_inside_ptyxis,
     is_inside_tmux,
     launch_login,
     spawn_terminal_with_command,
@@ -68,6 +69,10 @@ class TestTerminalDetection:
             (is_inside_konsole, terminal_env("gnome-terminal"), False, False),
             (is_inside_konsole, {}, False, False),
             (is_inside_konsole, {}, True, True),
+            (is_inside_ptyxis, terminal_env("ptyxis"), False, True),
+            (is_inside_ptyxis, terminal_env("gnome-terminal"), False, False),
+            (is_inside_ptyxis, {}, False, False),
+            (is_inside_ptyxis, {}, True, True),
         ],
         ids=[
             "gnome-by-env",
@@ -79,6 +84,10 @@ class TestTerminalDetection:
             "konsole-other-terminal",
             "konsole-missing-env",
             "konsole-parent-fallback",
+            "ptyxis-by-env",
+            "ptyxis-other-terminal",
+            "ptyxis-missing-env",
+            "ptyxis-parent-fallback",
         ],
     )
     def test_terminal_detection(
@@ -170,8 +179,36 @@ class TestSpawnTerminal:
                     _shell_payload(SHELL_COMMAND),
                 ],
             ),
+            (
+                terminal_env("ptyxis"),
+                False,
+                None,
+                ["ptyxis", "--tab", "--", "bash", "-c", _shell_payload(SHELL_COMMAND)],
+            ),
+            (
+                terminal_env("ptyxis"),
+                False,
+                "login:c1",
+                [
+                    "ptyxis",
+                    "--tab",
+                    "--title",
+                    "login:c1",
+                    "--",
+                    "bash",
+                    "-c",
+                    _shell_payload(SHELL_COMMAND),
+                ],
+            ),
         ],
-        ids=["gnome", "gnome-with-title", "konsole", "konsole-with-title"],
+        ids=[
+            "gnome",
+            "gnome-with-title",
+            "konsole",
+            "konsole-with-title",
+            "ptyxis",
+            "ptyxis-with-title",
+        ],
     )
     def test_spawn_terminal_with_supported_terminal(
         self,


### PR DESCRIPTION
## Summary

- Add Ptyxis alongside gnome-terminal and konsole as a recognised desktop terminal in `shell_launch.py`. The TUI's "open container login" flow now spawns a new Ptyxis tab when the user is already running inside Ptyxis.
- Detection mirrors the existing pattern: `TERM_PROGRAM=ptyxis` first, then a parent-process fallback that matches both `ptyxis` and the per-tab `ptyxis-agent`. To support multiple candidate names, `_parent_process_has_name` was generalised to accept varargs.
- Updated `docs/login-design.md` to mention ptyxis in the dispatch chain.

## Test plan

- [x] `poetry run pytest tests/unit/lib/test_shell_launch.py` — 34 passed (4 new detection cases + 2 new spawn cases)
- [x] `poetry run ruff check .` — clean
- [x] `poetry run ruff format --check .` — clean
- [x] `poetry run docstr-coverage src/terok/tui/shell_launch.py` — 100%
- [x] `poetry run tach check` — clean
- [ ] Manual smoke test: launch the TUI inside Ptyxis and verify the login action opens a new tab in the active window

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Ptyxis as a supported terminal option alongside existing alternatives
  * Enhanced terminal environment detection to automatically recognize and work with Ptyxis

<!-- end of auto-generated comment: release notes by coderabbit.ai -->