### PR TITLE
fix(auth): hide OAuth mode in interactive menu when not in experimental mode

### DIFF
--- a/src/terok/cli/commands/auth.py
+++ b/src/terok/cli/commands/auth.py
@@ -21,6 +21,7 @@ import sys
 
 from terok_executor import AUTH_PROVIDERS
 
+from ...lib.core.config import is_oauth_enabled_for
 from ...lib.core.images import require_agent_installed
 from ...lib.core.projects import load_project
 from ...lib.domain.facade import authenticate
@@ -104,7 +105,7 @@ def _run_interactive(project_id: str | None) -> None:
     for i, name in enumerate(provider_names, 1):
         info = AUTH_PROVIDERS[name]
         modes = []
-        if info.supports_oauth:
+        if info.supports_oauth and is_oauth_enabled_for(name):
             modes.append("oauth")
         if info.supports_api_key:
             modes.append("api-key")

--- a/src/terok/lib/core/config.py
+++ b/src/terok/lib/core/config.py
@@ -743,3 +743,22 @@ def is_codex_oauth_exposed() -> bool:
     wiped post-capture.  This is Phase 1's only path to a usable Codex.
     """
     return is_experimental() and get_codex_expose_oauth_token()
+
+
+# ---------- Cross-provider OAuth gate ----------
+
+
+def is_oauth_enabled_for(provider: str) -> bool:
+    """Return True when OAuth is operationally enabled for *provider*.
+
+    Gated providers (currently claude and codex) require the experimental
+    flag plus a per-provider ``allow_oauth`` or ``expose_oauth_token``
+    config key.  Ungated providers fall through to True so user-facing
+    menus continue to surface OAuth where the underlying flow does not
+    depend on terok's experimental gate.
+    """
+    if provider == "claude":
+        return is_claude_oauth_proxied() or is_claude_oauth_exposed()
+    if provider == "codex":
+        return is_codex_oauth_proxied() or is_codex_oauth_exposed()
+    return True

--- a/tach.toml
+++ b/tach.toml
@@ -685,6 +685,7 @@ expose = [
     "get_codex_expose_oauth_token",
     "is_codex_oauth_proxied",
     "is_codex_oauth_exposed",
+    "is_oauth_enabled_for",
     "get_vault_bypass",
     "get_services_mode",
     "get_vault_transport",

--- a/tests/unit/cli/test_cli_auth.py
+++ b/tests/unit/cli/test_cli_auth.py
@@ -189,6 +189,31 @@ def test_run_interactive_runs_each_selected_provider() -> None:
     ]
 
 
+def test_run_interactive_hides_oauth_when_disabled(capsys: pytest.CaptureFixture[str]) -> None:
+    """Without experimental + allow_oauth, the menu only advertises api-key."""
+    with (
+        patch("sys.stdin", new=StringIO("\n")),
+        patch("terok.cli.commands.auth.is_oauth_enabled_for", return_value=False),
+        patch("terok.cli.commands.auth._run_one"),
+    ):
+        _run_interactive(project_id=None)
+    out = capsys.readouterr().out
+    assert "oauth" not in out
+    assert "api-key" in out
+
+
+def test_run_interactive_shows_oauth_when_enabled(capsys: pytest.CaptureFixture[str]) -> None:
+    """With the gate open, OAuth is surfaced alongside any API-key support."""
+    with (
+        patch("sys.stdin", new=StringIO("\n")),
+        patch("terok.cli.commands.auth.is_oauth_enabled_for", return_value=True),
+        patch("terok.cli.commands.auth._run_one"),
+    ):
+        _run_interactive(project_id=None)
+    out = capsys.readouterr().out
+    assert "oauth" in out
+
+
 # ── single-provider runner ─────────────────────────────────────────────
 
 

--- a/tests/unit/lib/test_config.py
+++ b/tests/unit/lib/test_config.py
@@ -1,5 +1,4 @@
 # SPDX-FileCopyrightText: 2025 Jiri Vyskocil
-# SPDX-FileCopyrightText: 2026 Jiri Vyskocil
 # SPDX-License-Identifier: Apache-2.0
 
 """Tests for core config helpers."""

--- a/tests/unit/lib/test_config.py
+++ b/tests/unit/lib/test_config.py
@@ -852,6 +852,40 @@ def test_is_codex_oauth_not_proxied_when_exposed(
     assert cfg.is_codex_oauth_exposed() is True
 
 
+# ---------- Cross-provider OAuth gate ----------
+
+
+@pytest.mark.parametrize(
+    ("yaml_body", "provider", "expected"),
+    [
+        ("", "claude", False),
+        ("agent:\n  claude:\n    allow_oauth: true\n", "claude", False),
+        ("experimental: true\nagent:\n  claude:\n    allow_oauth: true\n", "claude", True),
+        ("experimental: true\nagent:\n  claude:\n    expose_oauth_token: true\n", "claude", True),
+        ("experimental: true\nagent:\n  codex:\n    allow_oauth: true\n", "codex", True),
+        ("", "gh", True),
+    ],
+    ids=[
+        "claude-default-off",
+        "claude-no-experimental",
+        "claude-proxied",
+        "claude-exposed",
+        "codex-proxied",
+        "unknown-provider-open",
+    ],
+)
+def test_is_oauth_enabled_for(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    yaml_body: str,
+    provider: str,
+    expected: bool,
+) -> None:
+    """Cross-provider OAuth gate honours the per-provider experimental config."""
+    monkeypatch.setenv("TEROK_CONFIG_FILE", str(write_config(tmp_path, yaml_body)))
+    assert cfg.is_oauth_enabled_for(provider) is expected
+
+
 # ---------- Layered config merging ----------
 
 


### PR DESCRIPTION
## Summary

- The `terok auth` interactive menu showed `[oauth, api-key]` for Claude and Codex regardless of `experimental` + `allow_oauth`/`expose_oauth_token`, advertising a path the runtime refuses to take.
- Add `is_oauth_enabled_for(provider)` to `terok.lib.core.config` that delegates to the existing `is_*_oauth_proxied` / `is_*_oauth_exposed` predicates for gated providers (claude, codex) and falls through to `True` for ungated ones (e.g. `gh`).
- Gate the `modes.append("oauth")` line in `_run_interactive` on the new helper. Sibling code paths (`facade._resolve_host_auth_image`'s `needs_container = info.supports_oauth`) have the same shape but are out of scope for this menu fix — flagged for follow-up.

## Test plan

- [x] `ruff check` and `ruff format --check` clean on touched files
- [x] New parametrized test in `tests/unit/lib/test_config.py` covers default-off, no-experimental, proxied, exposed, codex parity, and the ungated-provider fallthrough
- [x] New tests in `tests/unit/cli/test_cli_auth.py` verify the menu hides `oauth` when the gate is closed and shows it when open
- [ ] Full `make test` / `make tach` / `make check` once CI runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * OAuth option in the interactive auth menu is now shown only when both the provider supports it and OAuth is enabled by configuration.
  * Introduced a centralized configuration gate controlling OAuth enablement across providers.

* **Tests**
  * Added unit tests verifying the OAuth option appears or is hidden based on configuration for multiple providers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->