### PR TITLE
feat(tui): add ⏳ starting status for in-flight task launches

### DIFF
--- a/src/terok/lib/core/task_display.py
+++ b/src/terok/lib/core/task_display.py
@@ -33,6 +33,11 @@ class TaskState:
     exit_code: int | None = None
     deleting: bool = False
     initialized: bool = False
+    # UI-only flag the TUI flips while a launch worker is in flight but
+    # podman has not yet created the container.  Bridges the gap between
+    # "task created" and "container running (init)" so users see ⏳
+    # instead of an ambiguous 🆕.
+    starting: bool = False
 
 
 @dataclass(frozen=True)
@@ -66,6 +71,7 @@ class ProjectBadge:
 STATUS_DISPLAY: dict[str, StatusInfo] = {
     "running": StatusInfo(label="running", emoji="\U0001f7e2", color="green"),
     "init": StatusInfo(label="init", emoji="\U0001f7e1", color="yellow"),
+    "starting": StatusInfo(label="starting", emoji="\u23f3", color="yellow"),
     "stopped": StatusInfo(label="stopped", emoji="\U0001f534", color="red"),
     "completed": StatusInfo(label="completed", emoji="\u2705", color="green"),
     "failed": StatusInfo(label="failed", emoji="\u274c", color="red"),
@@ -111,8 +117,8 @@ def effective_status(task: TaskState) -> str:
     - ``initialized`` (bool): True once ``ready_at`` is persisted to YAML
 
     Returns one of: ``"deleting"``, ``"running"``, ``"init"``,
-    ``"stopped"``, ``"completed"``, ``"failed"``, ``"created"``,
-    ``"not found"``.
+    ``"starting"``, ``"stopped"``, ``"completed"``, ``"failed"``,
+    ``"created"``, ``"not found"``.
     """
     if task.deleting:
         return "deleting"
@@ -125,6 +131,11 @@ def effective_status(task: TaskState) -> str:
     if cs is not None:
         return _exit_code_status(task.exit_code) or "stopped"
 
+    # No container yet — ``starting`` fills the launch-worker gap
+    # before podman has created the container.  Once it's up, the
+    # ``cs == "running"`` branch above takes over with ``init``.
+    if task.starting:
+        return "starting"
     if not task.initialized:
         return "created"
     return _exit_code_status(task.exit_code) or "not found"

--- a/src/terok/tui/app.py
+++ b/src/terok/tui/app.py
@@ -319,6 +319,9 @@ if _HAS_TEXTUAL:
             # project actually spawns a subprocess.  Users who don't opt in
             # never bind the socket.
             self._askpass_service: AskpassService | None = None
+            # Tasks whose CLI/Toad launch worker is in flight; drives the
+            # ⏳ badge via ``TaskMeta.starting``.
+            self._launching_tasks: set[tuple[str, str]] = set()
 
         def _update_title(self):
             """Update the TUI title with version and branch information."""
@@ -702,9 +705,15 @@ if _HAS_TEXTUAL:
             """Reload tasks for the current project and update the task list."""
             if not self.current_project_id:
                 return
-            tasks_meta = get_tasks(self.current_project_id, reverse=True)
+            pid = self.current_project_id
+            tasks_meta = get_tasks(pid, reverse=True)
+            # Set the launching flag before ``set_tasks`` so the first
+            # label render is already correct — avoids reformatting every
+            # row a second time.
+            for tm in tasks_meta:
+                tm.starting = (pid, tm.task_id) in self._launching_tasks
             task_list = self.query_one("#task-list", TaskList)
-            task_list.set_tasks(self.current_project_id, tasks_meta)
+            task_list.set_tasks(pid, tasks_meta)
 
             if task_list.tasks:
                 # Try to restore last selected task for this project
@@ -749,6 +758,44 @@ if _HAS_TEXTUAL:
             details.set_task(self.current_task)
             if not self.current_task.deleting:
                 self._queue_task_image_status(self.current_project_id, self.current_task)
+
+        # ---------- Launch tracking ----------
+
+        def _apply_launching_to_tasks(self) -> None:
+            """Mirror ``_launching_tasks`` onto current ``TaskMeta`` instances and repaint."""
+            pid = self.current_project_id
+            if pid is None:
+                return
+            task_list = self.query_one("#task-list", TaskList)
+            for tm in task_list.tasks:
+                tm.starting = (pid, tm.task_id) in self._launching_tasks
+            for item in task_list.query(TaskListItem):
+                label = task_list._format_task_label(item.task_meta)
+                item.query_one(Static).update(label)
+            if self.current_task is not None:
+                self.current_task.starting = (
+                    pid,
+                    self.current_task.task_id,
+                ) in self._launching_tasks
+                self.query_one("#task-details", TaskDetails).set_task(self.current_task)
+
+        def _mark_launching(self, project_id: str, task_id: str) -> None:
+            """Flag a task as currently being launched.  Triggers a repaint."""
+            key = (project_id, task_id)
+            if key in self._launching_tasks:
+                return
+            self._launching_tasks.add(key)
+            if project_id == self.current_project_id:
+                self._apply_launching_to_tasks()
+
+        def _unmark_launching(self, project_id: str, task_id: str) -> None:
+            """Clear the launching flag once the worker has reached a terminal state."""
+            key = (project_id, task_id)
+            if key not in self._launching_tasks:
+                return
+            self._launching_tasks.discard(key)
+            if project_id == self.current_project_id:
+                self._apply_launching_to_tasks()
 
         # ---------- Status / notifications ----------
 
@@ -923,6 +970,16 @@ if _HAS_TEXTUAL:
         async def handle_worker_state_changed(self, event: Worker.StateChanged) -> None:
             """Dispatch completed worker results to the appropriate UI panel."""
             worker = event.worker
+            # ERROR/CANCELLED need ⏳ cleanup too or the badge gets stuck.
+            if event.state in (
+                WorkerState.SUCCESS,
+                WorkerState.ERROR,
+                WorkerState.CANCELLED,
+            ) and worker.group in ("cli-launch", "toad-launch"):
+                name = worker.name if isinstance(worker.name, str) else ""
+                parts = name.split(":")
+                if len(parts) == 3:
+                    self._unmark_launching(parts[1], parts[2])
             if event.state != WorkerState.SUCCESS:
                 if worker.group == "project-state" and event.state == WorkerState.ERROR:
                     state_widget = self.query_one("#project-state", ProjectState)

--- a/src/terok/tui/task_actions.py
+++ b/src/terok/tui/task_actions.py
@@ -202,6 +202,7 @@ class TaskActionsMixin:
         self._focus_task_after_creation(pid, task_id)
         cname = container_name(pid, "cli", task_id)
 
+        self._mark_launching(pid, task_id)
         self.run_worker(
             lambda: self._start_cli_container_quiet(pid, task_id),
             name=f"cli-launch:{pid}:{task_id}",
@@ -307,6 +308,7 @@ class TaskActionsMixin:
             return
         self._focus_task_after_creation(pid, task_id)
 
+        self._mark_launching(pid, task_id)
         self.run_worker(
             lambda: self._start_toad_container_quiet(pid, task_id),
             name=f"toad-launch:{pid}:{task_id}",

--- a/src/terok/tui/widgets/task_detail.py
+++ b/src/terok/tui/widgets/task_detail.py
@@ -55,7 +55,10 @@ def render_task_details(
 
     m_info = mode_info(task.mode)
     m_emoji = render_emoji(m_info)
-    mode_display = m_info.label or "Not assigned (choose CLI or Web mode)"
+    # Empty label for an unset mode lets the cricket emoji speak for
+    # itself — modes are picked via the Start CLI/Toad/Autopilot menu,
+    # not from this panel.
+    mode_display = m_info.label
 
     s_info = STATUS_DISPLAY.get(task.status, STATUS_DISPLAY["created"])
 
@@ -63,9 +66,10 @@ def render_task_details(
         Text(f"Task ID:   {task.task_id}"),
     ]
     lines.append(Text(f"Name:      {task.name}"))
+    type_line = f"Type:      {m_emoji} {mode_display}".rstrip()
     lines += [
         Text(f"Status:    {render_emoji(s_info)} {s_info.label}"),
-        Text(f"Type:      {m_emoji} {mode_display}"),
+        Text(type_line),
     ]
     if task.work_status:
         work_text = task.work_status

--- a/tests/unit/lib/test_effective_status.py
+++ b/tests/unit/lib/test_effective_status.py
@@ -45,6 +45,9 @@ EFFECTIVE_STATUS_CASES = [
     ({"container_state": None, "mode": "run", "exit_code": 2}, "failed"),
     ({"container_state": "running", "mode": "cli", "deleting": True}, "deleting"),
     ({"container_state": "running", "mode": "cli", "deleting": False}, "running"),
+    ({"container_state": None, "mode": None, "starting": True}, "starting"),
+    ({"container_state": "running", "mode": None, "starting": True}, "init"),
+    ({"container_state": None, "mode": None, "starting": True, "deleting": True}, "deleting"),
     ({}, "created"),
 ]
 
@@ -70,6 +73,9 @@ MODE_INFO_CASES = [
         "no-container-failure",
         "deleting-overrides-all",
         "deleting-false-ignored",
+        "starting-fills-pre-container-gap",
+        "starting-yields-to-init-once-container-running",
+        "deleting-overrides-starting",
         "minimal-defaults",
     ],
 )

--- a/tests/unit/tui/test_detail_screens.py
+++ b/tests/unit/tui/test_detail_screens.py
@@ -110,6 +110,7 @@ def make_creation_app(app_class: type) -> object:
     instance._save_selection_state = mock.Mock()
     instance.refresh_tasks = mock.AsyncMock()
     instance.push_screen = fake_push_screen
+    instance._mark_launching = mock.Mock()
     return instance
 
 

--- a/tests/unit/tui/test_new_task_flow.py
+++ b/tests/unit/tui/test_new_task_flow.py
@@ -681,6 +681,7 @@ class TestStartCliTaskBackgroundPassesName:
         instance.run_worker = mock.Mock()
         instance.push_screen = mock.AsyncMock()
         instance.refresh_tasks = mock.AsyncMock()
+        instance._mark_launching = mock.Mock()
 
         fake_project = mock.Mock()
         fake_project.default_login = "claude"

--- a/tests/unit/tui/tui_test_helpers.py
+++ b/tests/unit/tui/tui_test_helpers.py
@@ -271,6 +271,7 @@ def build_textual_stubs() -> dict[str, types.ModuleType]:
     class WorkerState:
         SUCCESS = "success"
         ERROR = "error"
+        CANCELLED = "cancelled"
 
     worker_mod.Worker = Worker
     worker_mod.WorkerState = WorkerState


### PR DESCRIPTION
## Summary

A freshly-created task (e.g. via `terok task new` outside the TUI) and a task whose CLI/Toad launch worker is currently in flight rendered identically (🆕 + 🦗), and the detail pane prompted users to *"choose CLI or Web mode"* — outdated wording from before the Start CLI/Toad/Autopilot menu (Web isn't a mode anymore).

This PR makes those two states distinct and drops the outdated wording.

## Changes

- **`task_display.py`** — new `starting: bool` field on `TaskState`, new `"starting"` entry (⏳, yellow) in `STATUS_DISPLAY`. `effective_status` returns it only when no container exists yet, so the existing `init` → `running` progression continues to take over once podman has the container up.
- **`app.py`** — `_launching_tasks: set[tuple[str, str]]` tracks in-flight launches. `_mark_launching` is called before `run_worker` for cli/toad starts; the worker-state handler clears the flag on terminal states (SUCCESS/ERROR/CANCELLED) so the badge doesn't get stuck on failures. `refresh_tasks` pre-applies the flag onto `tasks_meta` before `set_tasks` so labels render correctly on the first paint.
- **`task_detail.py`** — drops `"Not assigned (choose CLI or Web mode)"` fallback. The cricket emoji on the `Type:` line now stands on its own for unset modes.
- **Tests** — adds `starting` cases to `test_effective_status.py`, mocks `_mark_launching` in two existing action-handler tests, adds `CANCELLED` to the stub `WorkerState`.

## Status table after this PR

| state | rendering |
|---|---|
| Idle (`terok task new` outside TUI) | 🆕 + 🦗 |
| Pressed Start CLI/Toad, container not up yet | ⏳ + 🦗 |
| Container booting (init script running) | 🟡 + 💻/🐸 |
| Ready | 🟢 + mode |

## Scope notes

- Autopilot launches are not covered: the task_id is created *inside* the worker (via `task_run_headless`), not before it, so it isn't known at `_mark_launching` time. In practice the user isn't focused on the new task during autopilot launch — `_focus_task_after_creation` runs in the SUCCESS handler by which point `mode == "run"` is already written — so the cricket-confusion doesn't manifest. Separable follow-up if it ever does.
- Pre-existing tech debt left untouched: no constants for the `"cli-launch"`/`"toad-launch"` worker-group strings (six+ sites today), no shared parser for `f"{group}:{pid}:{tid}"` worker names (two ad-hoc consumers).

## Test plan

- [x] `pytest tests/unit/` — 1665 pass
- [x] `ruff check`, `ruff format --check`, `tach check` — clean
- [ ] Manual: in TUI, press `c` (CLI) on a project — task appears with ⏳ + 🦗 immediately, transitions to 🟡 once the container is running, then 🟢 + 💻 when ready.
- [ ] Manual: detail pane on an idle (mode-unset) task shows `Type:      🦗` with no extra text.
- [ ] Manual: kill a CLI launch worker mid-flight — ⏳ clears (doesn't get stuck).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added "starting" status indicator during task launch phase, displayed with an hourglass emoji.

* **Bug Fixes**
  * Fixed status badges remaining in launching state after task startup completes.
  * Improved task mode label rendering in task details panel.

* **Tests**
  * Extended test coverage for new task launching states and state transitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->