### PR TITLE
fix(tui): wrap long task names at dashes with hanging indent

### DIFF
--- a/src/terok/lib/util/text_wrap.py
+++ b/src/terok/lib/util/text_wrap.py
@@ -1,0 +1,98 @@
+# SPDX-FileCopyrightText: 2026 Jiri Vyskocil
+# SPDX-License-Identifier: Apache-2.0
+
+"""Hanging-indent wrapping for prefix-aligned labels.
+
+Used by the TUI to wrap long task names at dash boundaries (and char
+boundaries when a single segment overflows), keeping continuation lines
+indented to where the body started after a fixed-width prefix.
+"""
+
+from __future__ import annotations
+
+from rich.cells import cell_len
+
+
+def _wrap_at_dashes(text: str, width: int) -> list[str]:
+    """Split *text* into lines of at most *width* cells, breaking at dashes.
+
+    Dashes stay attached to the segment on their left so a wrap point looks
+    like "foo-\\nbar" rather than "foo\\n-bar". Segments longer than *width*
+    fall back to character-folding.
+    """
+    if width <= 0 or cell_len(text) <= width:
+        return [text]
+
+    # Pair every segment with its cell width to keep this loop O(n).
+    segments: list[tuple[str, int]] = []
+    buf = ""
+    for ch in text:
+        buf += ch
+        if ch == "-":
+            segments.append((buf, cell_len(buf)))
+            buf = ""
+    if buf:
+        segments.append((buf, cell_len(buf)))
+
+    lines: list[tuple[str, int]] = []
+    line, line_w = "", 0
+    for seg, seg_w in segments:
+        if not line or line_w + seg_w <= width:
+            line += seg
+            line_w += seg_w
+        else:
+            lines.append((line, line_w))
+            line, line_w = seg, seg_w
+    if line:
+        lines.append((line, line_w))
+
+    folded: list[str] = []
+    for ln, ln_w in lines:
+        while ln_w > width:
+            cut, taken = "", 0
+            for ch in ln:
+                w = cell_len(ch)
+                if taken + w > width:
+                    break
+                cut += ch
+                taken += w
+            folded.append(cut)
+            ln = ln[len(cut) :]
+            ln_w -= taken
+        folded.append(ln)
+    return folded
+
+
+def wrap_with_hanging_indent(prefix: str, body: str, suffix: str, width: int) -> str:
+    """Render ``prefix + body + suffix`` with continuation lines hanging-indented.
+
+    *body* wraps at dash boundaries (or anywhere, if a dashless segment is
+    still too wide) so that each output line fits in *width* cells. Wrapped
+    lines are prepended with spaces aligning to the cell width of *prefix*,
+    so continuations sit underneath the start of *body*.
+
+    *suffix* attaches to the last body line if it fits; otherwise it lands
+    on its own continuation line with the leading space stripped.
+
+    *width* ≤ 0, or a *prefix* already wider than *width*, disables wrapping
+    and returns the inputs concatenated verbatim.
+    """
+    full = f"{prefix}{body}{suffix}"
+    if width <= 0 or cell_len(full) <= width:
+        return full
+
+    indent = cell_len(prefix)
+    avail = width - indent
+    if avail <= 0:
+        return full
+
+    body_lines = _wrap_at_dashes(body, avail)
+    if suffix:
+        last = body_lines[-1]
+        if cell_len(last) + cell_len(suffix) <= avail:
+            body_lines[-1] = last + suffix
+        else:
+            body_lines.append(suffix.lstrip())
+
+    pad = " " * indent
+    return prefix + body_lines[0] + "".join(f"\n{pad}{ln}" for ln in body_lines[1:])

--- a/src/terok/lib/util/text_wrap.py
+++ b/src/terok/lib/util/text_wrap.py
@@ -1,75 +1,29 @@
 # SPDX-FileCopyrightText: 2026 Jiri Vyskocil
 # SPDX-License-Identifier: Apache-2.0
 
-"""Hanging-indent wrapping for prefix-aligned labels.
+"""Hanging-indent wrapping for prefix-aligned TUI labels.
 
-Used by the TUI to wrap long task names at dash boundaries (and char
-boundaries when a single segment overflows), keeping continuation lines
-indented to where the body started after a fixed-width prefix.
+Wrapping itself is delegated to :func:`textwrap.wrap` (which already breaks
+on hyphens and folds overlong dashless words). This helper exists only to
+stitch together a cell-aware *prefix* (which may contain wide characters
+like emoji that would throw off ``textwrap``'s char-count accounting), the
+wrapped body, and an optional trailing *suffix*.
 """
 
 from __future__ import annotations
 
+import textwrap
+
 from rich.cells import cell_len
-
-
-def _wrap_at_dashes(text: str, width: int) -> list[str]:
-    """Split *text* into lines of at most *width* cells, breaking at dashes.
-
-    Dashes stay attached to the segment on their left so a wrap point looks
-    like "foo-\\nbar" rather than "foo\\n-bar". Segments longer than *width*
-    fall back to character-folding.
-    """
-    if width <= 0 or cell_len(text) <= width:
-        return [text]
-
-    # Pair every segment with its cell width to keep this loop O(n).
-    segments: list[tuple[str, int]] = []
-    buf = ""
-    for ch in text:
-        buf += ch
-        if ch == "-":
-            segments.append((buf, cell_len(buf)))
-            buf = ""
-    if buf:
-        segments.append((buf, cell_len(buf)))
-
-    lines: list[tuple[str, int]] = []
-    line, line_w = "", 0
-    for seg, seg_w in segments:
-        if not line or line_w + seg_w <= width:
-            line += seg
-            line_w += seg_w
-        else:
-            lines.append((line, line_w))
-            line, line_w = seg, seg_w
-    if line:
-        lines.append((line, line_w))
-
-    folded: list[str] = []
-    for ln, ln_w in lines:
-        while ln_w > width:
-            cut, taken = "", 0
-            for ch in ln:
-                w = cell_len(ch)
-                if taken + w > width:
-                    break
-                cut += ch
-                taken += w
-            folded.append(cut)
-            ln = ln[len(cut) :]
-            ln_w -= taken
-        folded.append(ln)
-    return folded
 
 
 def wrap_with_hanging_indent(prefix: str, body: str, suffix: str, width: int) -> str:
     """Render ``prefix + body + suffix`` with continuation lines hanging-indented.
 
-    *body* wraps at dash boundaries (or anywhere, if a dashless segment is
-    still too wide) so that each output line fits in *width* cells. Wrapped
-    lines are prepended with spaces aligning to the cell width of *prefix*,
-    so continuations sit underneath the start of *body*.
+    *body* wraps with :func:`textwrap.wrap` (so dashes are break points and
+    overlong segments fold by character). Continuation lines are prepended
+    with spaces aligning to the *cell* width of *prefix*, so they sit
+    underneath the start of *body* even when *prefix* contains emoji.
 
     *suffix* attaches to the last body line if it fits; otherwise it lands
     on its own continuation line with the leading space stripped.
@@ -86,13 +40,14 @@ def wrap_with_hanging_indent(prefix: str, body: str, suffix: str, width: int) ->
     if avail <= 0:
         return full
 
-    body_lines = _wrap_at_dashes(body, avail)
+    # textwrap counts in chars; it lines up with cell width as long as *body*
+    # is ASCII (terok task names are).
+    lines = textwrap.wrap(body, width=avail) or [""]
     if suffix:
-        last = body_lines[-1]
-        if cell_len(last) + cell_len(suffix) <= avail:
-            body_lines[-1] = last + suffix
+        if cell_len(lines[-1]) + cell_len(suffix) <= avail:
+            lines[-1] += suffix
         else:
-            body_lines.append(suffix.lstrip())
+            lines.append(suffix.lstrip())
 
     pad = " " * indent
-    return prefix + body_lines[0] + "".join(f"\n{pad}{ln}" for ln in body_lines[1:])
+    return prefix + ("\n" + pad).join(lines)

--- a/src/terok/tui/app.py
+++ b/src/terok/tui/app.py
@@ -74,7 +74,7 @@ if _HAS_TEXTUAL:
     from textual import on, work
     from textual.app import App, ComposeResult
     from textual.containers import Horizontal, Vertical
-    from textual.widgets import Footer, Header, Static
+    from textual.widgets import Footer, Header
     from textual.worker import Worker, WorkerState
 
     from ..lib.core.config import (
@@ -132,7 +132,6 @@ if _HAS_TEXTUAL:
         ProjectState,
         TaskDetails,
         TaskList,
-        TaskListItem,
         TaskMeta,
     )
     from .worker_log_screen import WorkerLogScreen
@@ -769,9 +768,7 @@ if _HAS_TEXTUAL:
             task_list = self.query_one("#task-list", TaskList)
             for tm in task_list.tasks:
                 tm.starting = (pid, tm.task_id) in self._launching_tasks
-            for item in task_list.query(TaskListItem):
-                label = task_list._format_task_label(item.task_meta)
-                item.query_one(Static).update(label)
+            task_list.refresh_labels()
             if self.current_task is not None:
                 self.current_task.starting = (
                     pid,
@@ -1046,9 +1043,7 @@ if _HAS_TEXTUAL:
                         changed = True
                 if changed:
                     # Regenerate labels on visible list items so status badges update
-                    for item in task_list.query(TaskListItem):
-                        label = task_list._format_task_label(item.task_meta)
-                        item.query_one(Static).update(label)
+                    task_list.refresh_labels()
                     if self.current_task:
                         details = self.query_one("#task-details", TaskDetails)
                         details.set_task(self.current_task)

--- a/src/terok/tui/screens.py
+++ b/src/terok/tui/screens.py
@@ -1556,16 +1556,30 @@ class TaskDetailsScreen(screen.Screen[str | None]):
 
     def on_mount(self) -> None:
         """Render task details and focus the action list."""
+        self._last_render_width = -1
+        self._render_details()
+        actions = self.query_one("#actions-list", OptionList)
+        actions.focus()
+
+    def _render_details(self) -> None:
+        """Render the cached task into the detail pane at its current width."""
         detail_widget = self.query_one("#detail-content", Static)
+        width = detail_widget.size.width
+        if width == self._last_render_width:
+            return
+        self._last_render_width = width
         rendered = render_task_details(
             self._task_meta,
             project_id=self._project_id,
             image_old=self._image_old,
             empty_message="No task selected.",
+            width=width,
         )
         detail_widget.update(rendered)
-        actions = self.query_one("#actions-list", OptionList)
-        actions.focus()
+
+    def on_resize(self, event: events.Resize) -> None:
+        """Re-render so the Name line wraps to the new screen width."""
+        self._render_details()
 
     def on_option_list_option_selected(self, event: OptionList.OptionSelected) -> None:
         """Dismiss with the chosen action ID."""

--- a/src/terok/tui/screens.py
+++ b/src/terok/tui/screens.py
@@ -1564,7 +1564,7 @@ class TaskDetailsScreen(screen.Screen[str | None]):
     def _render_details(self) -> None:
         """Render the cached task into the detail pane at its current width."""
         detail_widget = self.query_one("#detail-content", Static)
-        width = detail_widget.size.width
+        width = detail_widget.content_size.width
         if width == self._last_render_width:
             return
         self._last_render_width = width

--- a/src/terok/tui/widgets/task_detail.py
+++ b/src/terok/tui/widgets/task_detail.py
@@ -197,7 +197,7 @@ class TaskDetails(Static):
 
     def on_resize(self, event: events.Resize) -> None:
         """Re-render only when the panel's content width changes."""
-        width = self.query_one("#task-details-content", Static).size.width
+        width = self.query_one("#task-details-content", Static).content_size.width
         if width == self._last_render_width:
             return
         self._render()
@@ -205,7 +205,7 @@ class TaskDetails(Static):
     def _render(self) -> None:
         """Render the cached task into the inner Static at the current width."""
         content = self.query_one("#task-details-content", Static)
-        self._last_render_width = content.size.width
+        self._last_render_width = content.content_size.width
 
         # Determine shield hook health from the cached project-level env check.
         hooks_ok: bool | None = None

--- a/src/terok/tui/widgets/task_detail.py
+++ b/src/terok/tui/widgets/task_detail.py
@@ -7,6 +7,7 @@ from typing import Any
 
 from rich.style import Style
 from rich.text import Text
+from textual import events
 from textual.app import ComposeResult
 from textual.widgets import Static
 
@@ -15,6 +16,7 @@ from ...lib.core.task_display import STATUS_DISPLAY, mode_info
 from ...lib.orchestration.tasks import TaskMeta
 from ...lib.util.emoji import render_emoji
 from ...lib.util.net import url_host
+from ...lib.util.text_wrap import wrap_with_hanging_indent
 
 
 def _get_css_variables(widget: Static) -> dict[str, str]:
@@ -36,6 +38,7 @@ def render_task_details(
     show_workspace: bool = True,
     shield_hooks_ok: bool | None = None,
     is_web: bool = False,
+    width: int = 0,
 ) -> Text:
     """Render task details as a Rich Text object.
 
@@ -65,7 +68,7 @@ def render_task_details(
     lines = [
         Text(f"Task ID:   {task.task_id}"),
     ]
-    lines.append(Text(f"Name:      {task.name}"))
+    lines.append(Text(wrap_with_hanging_indent("Name:      ", task.name, "", width)))
     type_line = f"Type:      {m_emoji} {mode_display}".rstrip()
     lines += [
         Text(f"Status:    {render_emoji(s_info)} {s_info.label}"),
@@ -165,6 +168,10 @@ class TaskDetails(Static):
         """Initialize the task details panel."""
         super().__init__(**kwargs)
         self.current_project_id: str | None = None
+        self._current_task: TaskMeta | None = None
+        self._current_empty_message: str | None = None
+        self._current_image_old: bool | None = None
+        self._last_render_width = -1
 
     def compose(self) -> ComposeResult:
         """Yield the inner Static widget used for rendered task content."""
@@ -177,11 +184,28 @@ class TaskDetails(Static):
         image_old: bool | None = None,
     ) -> None:
         """Render and display details for the given task (or clear if None)."""
-        content = self.query_one("#task-details-content", Static)
         if task is None:
             self.current_project_id = None
         else:
             self.current_project_id = self.app.current_project_id if self.app else None
+
+        self._current_task = task
+        self._current_empty_message = empty_message
+        self._current_image_old = image_old
+        self._last_render_width = -1  # task changed — force re-render
+        self._render()
+
+    def on_resize(self, event: events.Resize) -> None:
+        """Re-render only when the panel's content width changes."""
+        width = self.query_one("#task-details-content", Static).size.width
+        if width == self._last_render_width:
+            return
+        self._render()
+
+    def _render(self) -> None:
+        """Render the cached task into the inner Static at the current width."""
+        content = self.query_one("#task-details-content", Static)
+        self._last_render_width = content.size.width
 
         # Determine shield hook health from the cached project-level env check.
         hooks_ok: bool | None = None
@@ -193,14 +217,15 @@ class TaskDetails(Static):
             pass
 
         rendered = render_task_details(
-            task,
+            self._current_task,
             self.current_project_id,
-            image_old,
-            empty_message,
+            self._current_image_old,
+            self._current_empty_message,
             _get_css_variables(self),
             show_workspace=False,
             shield_hooks_ok=hooks_ok,
             is_web=bool(self.app and self.app.is_web),
+            width=self._last_render_width,
         )
         content.update(rendered)
 

--- a/src/terok/tui/widgets/task_list.py
+++ b/src/terok/tui/widgets/task_list.py
@@ -5,12 +5,14 @@
 
 from typing import Any
 
+from textual import events
 from textual.message import Message
 from textual.widgets import ListItem, ListView, Static
 
 from ...lib.core.task_display import STATUS_DISPLAY, mode_info
 from ...lib.orchestration.tasks import TaskMeta
 from ...lib.util.emoji import render_emoji
+from ...lib.util.text_wrap import wrap_with_hanging_indent
 
 
 class TaskListItem(ListItem):
@@ -69,9 +71,15 @@ class TaskList(ListView):
         self.project_id: str | None = None
         self.tasks: list[TaskMeta] = []
         self._generation = 0
+        self._last_label_width = -1
 
-    def _format_task_label(self, task: TaskMeta) -> str:
-        """Build a human-readable label string for a task list entry."""
+    def _format_task_label(self, task: TaskMeta, width: int = 0) -> str:
+        """Build a human-readable label string for a task list entry.
+
+        When *width* is positive, long names wrap at dashes (or anywhere
+        if a dashless segment overflows), with continuations indented to
+        align with the start of the name.
+        """
         m_emoji = render_emoji(mode_info(task.mode))
         s_info = STATUS_DISPLAY.get(task.status, STATUS_DISPLAY["created"])
         s_emoji = render_emoji(s_info)
@@ -82,10 +90,28 @@ class TaskList(ListView):
         if task.web_port is not None:
             extra_parts.append(f"port={task.web_port}")
 
-        label = f"{task.task_id} {m_emoji} {s_emoji} {task.name}"
-        if extra_parts:
-            label += f" [{'; '.join(extra_parts)}]"
-        return label
+        prefix = f"{task.task_id} {m_emoji} {s_emoji} "
+        suffix = f" [{'; '.join(extra_parts)}]" if extra_parts else ""
+        return wrap_with_hanging_indent(prefix, task.name, suffix, width)
+
+    def _label_width(self) -> int:
+        """Cell width available to a list item's label (excludes border/scrollbar)."""
+        return self.content_size.width
+
+    def refresh_labels(self) -> None:
+        """Re-render every visible task label at the current width."""
+        width = self._label_width()
+        for item in self.query(TaskListItem):
+            label = self._format_task_label(item.task_meta, width)
+            item.query_one(Static).update(label)
+
+    def on_resize(self, event: events.Resize) -> None:
+        """Re-wrap labels only when the panel's content width changes."""
+        width = self._label_width()
+        if width == self._last_label_width:
+            return
+        self._last_label_width = width
+        self.refresh_labels()
 
     def set_tasks(self, project_id: str, tasks_meta: list[TaskMeta]) -> None:
         """Populate the list from ``TaskMeta`` instances, newest first."""
@@ -99,12 +125,13 @@ class TaskList(ListView):
         self._generation += 1
         self.clear()
 
+        width = self._label_width()
         for tm in sorted(tasks_meta, key=lambda t: t.created_at or "", reverse=True):
             if tm.task_id in existing_states:
                 tm.container_state = existing_states[tm.task_id]
             self.tasks.append(tm)
 
-            label = self._format_task_label(tm)
+            label = self._format_task_label(tm, width)
             self.append(TaskListItem(project_id, tm, label, self._generation))
 
     def mark_deleting(self, task_id: str) -> bool:
@@ -117,11 +144,12 @@ class TaskList(ListView):
                 found = True
                 break
 
+        width = self._label_width()
         for item in self.query(TaskListItem):
             if item.task_meta.task_id != task_id:
                 continue
             item.task_meta.deleting = True
-            label = self._format_task_label(item.task_meta)
+            label = self._format_task_label(item.task_meta, width)
             item.query_one(Static).update(label)
             found = True
 

--- a/tach.toml
+++ b/tach.toml
@@ -490,6 +490,13 @@ layer = "core"
 depends_on = []
 utility = true
 
+# Hanging-indent text wrapping (TUI label rendering)
+[[modules]]
+path = "terok.lib.util.text_wrap"
+layer = "core"
+depends_on = []
+utility = true
+
 
 # ── Interfaces ────────────────────────────────────────────────────
 

--- a/tach.toml
+++ b/tach.toml
@@ -843,6 +843,10 @@ expose = ["ensure_dir", "ensure_dir_writable", "archive_timestamp", "unique_arch
 from = ["terok.lib.util.fs"]
 
 [[interfaces]]
+expose = ["wrap_with_hanging_indent"]
+from = ["terok.lib.util.text_wrap"]
+
+[[interfaces]]
 expose = ["assign_web_port", "release_web_port"]
 from = ["terok.lib.orchestration.ports"]
 

--- a/tests/unit/lib/util/test_text_wrap.py
+++ b/tests/unit/lib/util/test_text_wrap.py
@@ -1,0 +1,94 @@
+# SPDX-FileCopyrightText: 2026 Jiri Vyskocil
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for the hanging-indent wrapper.
+
+The interesting cases are the *boundaries* between "fits on one line",
+"wraps body", and "suffix overflows onto its own line" — plus the
+cell-aware accounting that keeps wide-character prefixes from confusing
+``textwrap.wrap``.
+"""
+
+import pytest
+
+from terok.lib.util.text_wrap import wrap_with_hanging_indent
+
+# Width 13 (cells): "tk-001 " (7) + "🤖" (2) + " " (1) + "✅" (2) + " " (1).
+EMOJI_PREFIX = "tk-001 \U0001f916 ✅ "
+EMOJI_PREFIX_CELLS = 13
+
+
+@pytest.mark.parametrize("width", [-1, 0])
+def test_nonpositive_width_disables_wrapping(width: int) -> None:
+    """Width ≤ 0 is a "do not wrap" signal — return the inputs verbatim."""
+    out = wrap_with_hanging_indent("P: ", "a-b-c", " [x]", width)
+    assert out == "P: a-b-c [x]"
+
+
+def test_short_input_returns_one_line() -> None:
+    """A label that already fits in *width* is left untouched."""
+    out = wrap_with_hanging_indent("Name:      ", "short", "", 80)
+    assert out == "Name:      short"
+    assert "\n" not in out
+
+
+def test_prefix_wider_than_width_returns_concatenated() -> None:
+    """When the prefix alone fills the width, there is nothing to wrap into."""
+    out = wrap_with_hanging_indent("very-long-prefix: ", "body", "", 5)
+    assert out == "very-long-prefix: body"
+
+
+def test_dash_break_with_hanging_indent() -> None:
+    """Body breaks at dash boundaries; continuations align with body start."""
+    out = wrap_with_hanging_indent(EMOJI_PREFIX, "my-very-long-task-branch-name", "", 30)
+    pad = " " * EMOJI_PREFIX_CELLS
+    assert out == f"{EMOJI_PREFIX}my-very-long-\n{pad}task-branch-name"
+
+
+def test_dashless_long_word_falls_back_to_char_fold() -> None:
+    """A dashless body wider than *avail* still wraps — char-by-char."""
+    out = wrap_with_hanging_indent("Name:      ", "verylongtasknamewithoutdashes", "", 30)
+    assert out == "Name:      verylongtasknamewit\n           houtdashes"
+
+
+def test_suffix_attaches_when_it_fits_on_last_line() -> None:
+    """The suffix rides along on the last body line if there's room for it."""
+    out = wrap_with_hanging_indent(EMOJI_PREFIX, "my-very-long-task-branch-name", " [w=run]", 40)
+    last_line = out.splitlines()[-1]
+    assert last_line.endswith("[w=run]")
+
+
+def test_suffix_overflows_to_new_line_with_leading_space_stripped() -> None:
+    """When the suffix can't fit, it lands on its own line with no leading gap."""
+    out = wrap_with_hanging_indent(
+        EMOJI_PREFIX, "my-very-long-task-branch-name", " [work=running]", 30
+    )
+    pad = " " * EMOJI_PREFIX_CELLS
+    last_line = out.splitlines()[-1]
+    # Suffix sits at the indent column with the leading space stripped.
+    assert last_line == f"{pad}[work=running]"
+
+
+def test_empty_body_emits_just_prefix_and_suffix() -> None:
+    """Empty bodies are accepted — the helper still returns a single line."""
+    assert wrap_with_hanging_indent("Name:      ", "", "", 30) == "Name:      "
+
+
+def test_emoji_prefix_indent_uses_cells_not_chars() -> None:
+    """Continuation indent matches the *cell* width of the prefix, not its len()."""
+    out = wrap_with_hanging_indent(EMOJI_PREFIX, "a-b-c-d-e-f-g-h", "", 20)
+    # Prefix is 13 cells, body avail is 7 cells. Continuation indent = 13 spaces.
+    second_line = out.splitlines()[1]
+    assert second_line.startswith(" " * EMOJI_PREFIX_CELLS)
+    # And exactly that many leading spaces — no over- or under-pad.
+    assert second_line[EMOJI_PREFIX_CELLS] != " "
+
+
+def test_every_continuation_line_gets_the_indent() -> None:
+    """Three or more wrapped lines all share the same hanging indent."""
+    out = wrap_with_hanging_indent(EMOJI_PREFIX, "a-b-c-d-e-f-g-h-i-j-k", "", 18)
+    pad = " " * EMOJI_PREFIX_CELLS
+    lines = out.splitlines()
+    assert len(lines) >= 3
+    for cont in lines[1:]:
+        assert cont.startswith(pad)

--- a/tests/unit/tui/tui_test_helpers.py
+++ b/tests/unit/tui/tui_test_helpers.py
@@ -54,7 +54,11 @@ def build_textual_stubs() -> dict[str, types.ModuleType]:
     class Key:
         pass
 
+    class Resize:
+        pass
+
     events_mod.Key = Key
+    events_mod.Resize = Resize
 
     screen_mod = types.ModuleType("textual.screen")
 


### PR DESCRIPTION
## Summary

- Long task names (which are dash-separated and contain no spaces) used to jump to a fresh line as a single block and run past the panel edge unwrapped. They now break at dash boundaries — falling back to character boundaries for dashless overruns — with continuation lines aligned under the start of the name.
- Applied in both the task list (middle pane) and the task details panel (right pane / full-screen).
- New helper ``terok.lib.util.text_wrap.wrap_with_hanging_indent`` (cell-aware via ``rich.cells.cell_len``, so emoji widths are counted correctly).
- Resize handlers cache the last content width and short-circuit when unchanged, so height-only resize events don't re-wrap every visible label.

### Before / after (width 30, prefix 13 cells)

```
tk-001 🤖 ✅ my-very-long-task-branch-name [work=running]   ← overruns
```

```
tk-001 🤖 ✅ my-very-long-                                   ← wrapped
             task-branch-name
             [work=running]
```

## Test plan

- [x] ``make lint`` clean
- [x] ``make tach`` clean
- [x] ``make test`` (2174 unit tests pass, +helper coverage via existing label tests)
- [x] Smoke-tested ``wrap_with_hanging_indent`` at widths 14/20/30/40/60 with mixed emoji + dashes
- [ ] Visual check in TUI on a narrow terminal (resize-while-running)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a hanging-indent text-wrap utility for labels and detail lines.

* **Improvements**
  * Task names and detail content now wrap based on available panel width, preserving prefix alignment.
  * Detail panes and task labels refresh automatically on resize and when selections change for consistent layout.

* **Tests**
  * Added tests for wrapping behavior and a resize event stub to support responsive rendering tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->