### PR TITLE
fix(tui): rename TaskDetails._render to avoid shadowing Widget._render

### DIFF
--- a/src/terok/tui/widgets/task_detail.py
+++ b/src/terok/tui/widgets/task_detail.py
@@ -193,17 +193,24 @@ class TaskDetails(Static):
         self._current_empty_message = empty_message
         self._current_image_old = image_old
         self._last_render_width = -1  # task changed — force re-render
-        self._render()
+        self._redraw_content()
 
     def on_resize(self, event: events.Resize) -> None:
         """Re-render only when the panel's content width changes."""
         width = self.query_one("#task-details-content", Static).content_size.width
         if width == self._last_render_width:
             return
-        self._render()
+        self._redraw_content()
 
-    def _render(self) -> None:
-        """Render the cached task into the inner Static at the current width."""
+    def _redraw_content(self) -> None:
+        """Render the cached task into the inner Static at the current width.
+
+        Named ``_redraw_content`` (not ``_render``) because Textual's
+        :class:`~textual.widget.Widget` already defines ``_render(self) ->
+        Visual`` as part of its rendering pipeline; shadowing that method
+        crashes the renderer with ``'NoneType' has no attribute
+        'render_strips'`` when this Widget gets repainted.
+        """
         content = self.query_one("#task-details-content", Static)
         self._last_render_width = content.content_size.width
 

--- a/tests/unit/tui/test_detail_screens.py
+++ b/tests/unit/tui/test_detail_screens.py
@@ -427,6 +427,28 @@ class TestRenderHelpers:
         assert task.exit_code == expected
 
 
+class TestTextualMethodNameCollisions:
+    """Guard against shadowing Textual Widget rendering hooks.
+
+    Defining ``_render`` (or ``_render_content``) on a Widget subclass
+    breaks the renderer with ``'NoneType' has no attribute
+    'render_strips'`` because Textual calls ``self._render()`` to obtain
+    a Visual during repaint.  Custom redraw helpers must use a different
+    name (we use ``_redraw_content``).
+    """
+
+    RESERVED_BY_TEXTUAL = ("_render", "_render_content", "_render_widget")
+
+    def test_task_details_does_not_shadow_textual_render(self) -> None:
+        widgets = import_widgets()
+        defined = vars(widgets.TaskDetails)
+        for name in self.RESERVED_BY_TEXTUAL:
+            assert name not in defined, (
+                f"TaskDetails.{name} would shadow Textual's Widget.{name} "
+                "and crash the renderer; rename to e.g. _redraw_content."
+            )
+
+
 class TestScreenConstruction:
     """Tests that screen classes can be instantiated with correct arguments."""
 


### PR DESCRIPTION
## Summary

PR #863 broke startup. ``TaskDetails`` defined a private helper named ``_render`` to mean "redraw the inner Static from cached task state" — but Textual's [Widget._render](https://github.com/Textualize/textual/blob/main/src/textual/widget.py) already exists, returns a ``Visual``, and is called by the rendering pipeline on every repaint. Our override returned ``None``, so the very first paint of the right pane crashed:

```
File ".../textual/widget.py", line 4246, in _render_content
    strips = Visual.to_strips(self, visual, width, height, self.visual_style)
AttributeError: 'NoneType' object has no attribute 'render_strips'
```

(``visual = self._render()`` got ``None`` from our shadow.)

## Fix

- Rename ``TaskDetails._render`` → ``_redraw_content``. ``TaskDetails`` now inherits ``Widget._render`` cleanly.
- Add a regression test that fails if any of Textual's reserved render hooks (``_render``, ``_render_content``, ``_render_widget``) is ever defined on ``TaskDetails`` again.

## Test plan

- [x] ``make lint`` / ``make tach`` clean
- [x] ``make test`` (2186 unit tests pass; +1 regression guard)
- [x] Verified ``TaskDetails._render is Widget._render`` against real (non-stubbed) Textual — pipeline intact
- [ ] Smoke-test ``terok`` TUI on a real terminal (the failing path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved task details widget rendering performance through streamlined content refresh logic and optimized caching behavior to enhance responsiveness

* **Tests**
  * Added validation tests to verify task details widget remains fully compatible with framework rendering standards, preventing potential conflicts and ensuring consistent, reliable behavior across the application

<!-- end of auto-generated comment: release notes by coderabbit.ai -->