### PR TITLE
fix(tui): subtract scrollbar gutter from wrap width

### DIFF
--- a/src/terok/tui/screens.py
+++ b/src/terok/tui/screens.py
@@ -1564,7 +1564,10 @@ class TaskDetailsScreen(screen.Screen[str | None]):
     def _render_details(self) -> None:
         """Render the cached task into the detail pane at its current width."""
         detail_widget = self.query_one("#detail-content", Static)
-        width = detail_widget.content_size.width
+        # ``scrollable_content_region`` subtracts the vertical scrollbar's
+        # gutter (the pane has ``overflow-y: auto``) so the wrap doesn't
+        # overshoot once the content scrolls.
+        width = detail_widget.scrollable_content_region.size.width
         if width == self._last_render_width:
             return
         self._last_render_width = width

--- a/src/terok/tui/widgets/task_detail.py
+++ b/src/terok/tui/widgets/task_detail.py
@@ -197,7 +197,7 @@ class TaskDetails(Static):
 
     def on_resize(self, event: events.Resize) -> None:
         """Re-render only when the panel's content width changes."""
-        width = self.query_one("#task-details-content", Static).content_size.width
+        width = self.query_one("#task-details-content", Static).scrollable_content_region.size.width
         if width == self._last_render_width:
             return
         self._redraw_content()
@@ -212,7 +212,7 @@ class TaskDetails(Static):
         'render_strips'`` when this Widget gets repainted.
         """
         content = self.query_one("#task-details-content", Static)
-        self._last_render_width = content.content_size.width
+        self._last_render_width = content.scrollable_content_region.size.width
 
         # Determine shield hook health from the cached project-level env check.
         hooks_ok: bool | None = None

--- a/src/terok/tui/widgets/task_list.py
+++ b/src/terok/tui/widgets/task_list.py
@@ -95,8 +95,14 @@ class TaskList(ListView):
         return wrap_with_hanging_indent(prefix, task.name, suffix, width)
 
     def _label_width(self) -> int:
-        """Cell width available to a list item's label (excludes border/scrollbar)."""
-        return self.content_size.width
+        """Cell width available to a list item's label.
+
+        ``scrollable_content_region`` (rather than ``content_size``)
+        subtracts the vertical scrollbar's gutter when one appears —
+        otherwise the wrap overshoots by 2 cells the moment enough
+        tasks pile up to make the list scroll.
+        """
+        return self.scrollable_content_region.size.width
 
     def refresh_labels(self) -> None:
         """Re-render every visible task label at the current width."""


### PR DESCRIPTION
## Summary

When the Tasks list grew enough to scroll, long task names wrapped slightly off — the second wrapped line was 2 cells too wide, so Rich folded a tail fragment (e.g. ``n-``) onto its own line flush at column 0, breaking the hanging indent. Reproduces visibly with several long task names in the list (see PR description for screenshots from the original report).

## Root cause

Textual's ``Widget.content_size.width`` shrinks the region by padding and border but **not** by the scrollbar gutter. The vertical scrollbar Textual reserves when content overflows takes 2 cells, and our wrap was overshooting by exactly that amount.

## Fix

Read ``scrollable_content_region.size.width`` instead — same property family, same semantics, plus subtracts ``scrollbar_gutter``. When no scrollbar is visible the gutter is empty and the value matches the old reading, so this is a strict refinement.

Three call sites updated:
- ``TaskList._label_width``
- ``TaskDetails._redraw_content`` / ``on_resize``
- ``TaskDetailsScreen._render_details``

## Test plan

- [x] ``make lint`` / ``make tach`` clean
- [x] ``make test`` (2186 unit tests, no regressions)
- [ ] Smoke-test on a real terminal at narrow widths with enough tasks to scroll the list

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed text wrapping behavior in task details and task lists by correctly accounting for scrollbar width in scrollable areas. When scrollbars were present, text would wrap incorrectly and extend beyond visible boundaries. The fix ensures text displays properly within the visible area, improving overall readability and user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->