### PR TITLE
feat: dossier-on-the-wire — JSON task meta + dossier.* annotations

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -3069,58 +3069,57 @@ tomli-w = ">=1.0,<2.0"
 
 [[package]]
 name = "terok-clearance"
-version = "0.6.6"
+version = "0.6.7"
 description = "Shield clearance and desktop notifications for terok"
 optional = false
 python-versions = ">=3.12,<4.0"
 groups = ["main"]
-files = []
-develop = false
+files = [
+    {file = "terok_clearance-0.6.7-py3-none-any.whl", hash = "sha256:463dfaebfbb8408f4f9b1cb327edba0f5c75f16a0dfce8750ffe2c174724ee7f"},
+]
 
 [package.dependencies]
-asyncvarlink = "^0.3.1"
+asyncvarlink = ">=0.3.1,<0.4.0"
 dbus-fast = ">=2.0,<5.0"
-pyyaml = "^6.0"
+pyyaml = ">=6.0,<7.0"
 
 [package.source]
-type = "git"
-url = "https://github.com/sliwowitz/terok-clearance.git"
-reference = "feat/dossier-in-events"
-resolved_reference = "dbc9362e9fae562c01814d935897400e5d0651ae"
+type = "url"
+url = "https://github.com/terok-ai/terok-clearance/releases/download/v0.6.7/terok_clearance-0.6.7-py3-none-any.whl"
 
 [[package]]
 name = "terok-executor"
-version = "0.0.125"
+version = "0.0.126"
 description = "Single-agent task runner for hardened Podman containers"
 optional = false
 python-versions = ">=3.12,<4.0"
 groups = ["main"]
-files = []
-develop = false
+files = [
+    {file = "terok_executor-0.0.126-py3-none-any.whl", hash = "sha256:abab8bc1a7ae6d80ef686f78eef05d9b31a6640f0e6764c29b73a39f80dd33a5"},
+]
 
 [package.dependencies]
 Jinja2 = ">=3.1"
 pwinput = ">=1.0.3"
 pydantic = ">=2.9"
 "ruamel.yaml" = ">=0.18"
-terok-sandbox = {git = "https://github.com/sliwowitz/terok-sandbox.git", branch = "feat/drop-bridge-phase"}
+terok_sandbox = {url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.0.105/terok_sandbox-0.0.105-py3-none-any.whl"}
 tomli-w = ">=1.0"
 
 [package.source]
-type = "git"
-url = "https://github.com/sliwowitz/terok-executor.git"
-reference = "feat/dossier-chain"
-resolved_reference = "13f297b726e6b44f639c5384f77e3452f7c29f0a"
+type = "url"
+url = "https://github.com/terok-ai/terok-executor/releases/download/v0.0.126/terok_executor-0.0.126-py3-none-any.whl"
 
 [[package]]
 name = "terok-sandbox"
-version = "0.0.104"
+version = "0.0.105"
 description = "Hardened Podman container runner with gate server and shield integration"
 optional = false
 python-versions = ">=3.12,<4.0"
 groups = ["main"]
-files = []
-develop = false
+files = [
+    {file = "terok_sandbox-0.0.105-py3-none-any.whl", hash = "sha256:ae5e855d7f6a55d2d51090ef86d64858f79c26a4132b0768402166ed96c5b447"},
+]
 
 [package.dependencies]
 aiohttp = ">=3.9"
@@ -3128,34 +3127,31 @@ cryptography = ">=46.0.7"
 packaging = ">=24"
 platformdirs = ">=4.9.6"
 pydantic = ">=2.9"
-terok-clearance = {git = "https://github.com/sliwowitz/terok-clearance.git", branch = "feat/dossier-in-events"}
-terok-shield = {git = "https://github.com/sliwowitz/terok-shield.git", branch = "feat/dossier-in-events"}
+terok_clearance = {url = "https://github.com/terok-ai/terok-clearance/releases/download/v0.6.7/terok_clearance-0.6.7-py3-none-any.whl"}
+terok_shield = {url = "https://github.com/terok-ai/terok-shield/releases/download/v0.6.35/terok_shield-0.6.35-py3-none-any.whl"}
 
 [package.source]
-type = "git"
-url = "https://github.com/sliwowitz/terok-sandbox.git"
-reference = "feat/drop-bridge-phase"
-resolved_reference = "35a463b93418852120722d50709485b734e98196"
+type = "url"
+url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.0.105/terok_sandbox-0.0.105-py3-none-any.whl"
 
 [[package]]
 name = "terok-shield"
-version = "0.6.34"
+version = "0.6.35"
 description = "nftables-based egress firewalling for Podman containers"
 optional = false
 python-versions = ">=3.12,<4.0"
 groups = ["main"]
-files = []
-develop = false
+files = [
+    {file = "terok_shield-0.6.35-py3-none-any.whl", hash = "sha256:611c7756a54658131c172d115de9bc7f315320c7ee0dd223af1219acc27c4933"},
+]
 
 [package.dependencies]
 pydantic = ">=2.0"
 PyYAML = ">=6.0"
 
 [package.source]
-type = "git"
-url = "https://github.com/sliwowitz/terok-shield.git"
-reference = "feat/dossier-in-events"
-resolved_reference = "eb00289f737f2b3a220e4824563f9c7556eef01e"
+type = "url"
+url = "https://github.com/terok-ai/terok-shield/releases/download/v0.6.35/terok_shield-0.6.35-py3-none-any.whl"
 
 [[package]]
 name = "textual"
@@ -4035,4 +4031,4 @@ propcache = ">=0.2.1"
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.12,<4.0"
-content-hash = "5d1e6fce8afa1b196061d86a6d292e1687a39de50632d80daf997edadb74c3f9"
+content-hash = "bbcf0c8c2474c53671c289021da43cb66278a09ab10a570cbe0e9c43bfaaba83"

--- a/poetry.lock
+++ b/poetry.lock
@@ -3155,7 +3155,7 @@ PyYAML = ">=6.0"
 type = "git"
 url = "https://github.com/sliwowitz/terok-shield.git"
 reference = "feat/dossier-in-events"
-resolved_reference = "f347121965aaf8b07ce491772279528cf88eaf34"
+resolved_reference = "eb00289f737f2b3a220e4824563f9c7556eef01e"
 
 [[package]]
 name = "textual"

--- a/poetry.lock
+++ b/poetry.lock
@@ -269,18 +269,19 @@ dev = ["backports.zoneinfo ; python_version < \"3.9\"", "freezegun (>=1.0,<2.0)"
 
 [[package]]
 name = "backrefs"
-version = "7.0"
+version = "6.2"
 description = "A wrapper around re and regex that adds additional back references."
 optional = false
-python-versions = ">=3.10"
+python-versions = ">=3.9"
 groups = ["docs"]
 files = [
-    {file = "backrefs-7.0-py310-none-any.whl", hash = "sha256:b57cd227ea556b0aed3dc9b8da4628db4eabc0402c6d7fcfc69283a93955f7e9"},
-    {file = "backrefs-7.0-py311-none-any.whl", hash = "sha256:a0fa7360c63509e9e077e174ef4e6d3c21c8db94189b9d957289ae6d794b9475"},
-    {file = "backrefs-7.0-py312-none-any.whl", hash = "sha256:ca42ce6a49ace3d75684dfa9937f3373902a63284ecb385ce36d15e5dcb41c12"},
-    {file = "backrefs-7.0-py313-none-any.whl", hash = "sha256:f2c52955d631b9e1ac4cd56209f0a3a946d592b98e7790e77699339ae01c102a"},
-    {file = "backrefs-7.0-py314-none-any.whl", hash = "sha256:a6448b28180e3ca01134c9cf09dcebafad8531072e09903c5451748a05f24bc9"},
-    {file = "backrefs-7.0.tar.gz", hash = "sha256:4989bb9e1e99eb23647c7160ed51fb21d0b41b5d200f2d3017da41e023097e82"},
+    {file = "backrefs-6.2-py310-none-any.whl", hash = "sha256:0fdc7b012420b6b144410342caeb8adc54c6866cf12064abc9bb211302e496f8"},
+    {file = "backrefs-6.2-py311-none-any.whl", hash = "sha256:08aa7fae530c6b2361d7bdcbda1a7c454e330cc9dbcd03f5c23205e430e5c3be"},
+    {file = "backrefs-6.2-py312-none-any.whl", hash = "sha256:c3f4b9cb2af8cda0d87ab4f57800b57b95428488477be164dd2b47be54db0c90"},
+    {file = "backrefs-6.2-py313-none-any.whl", hash = "sha256:12df81596ab511f783b7d87c043ce26bc5b0288cf3bb03610fe76b8189282b2b"},
+    {file = "backrefs-6.2-py314-none-any.whl", hash = "sha256:e5f805ae09819caa1aa0623b4a83790e7028604aa2b8c73ba602c4454e665de7"},
+    {file = "backrefs-6.2-py39-none-any.whl", hash = "sha256:664e33cd88c6840b7625b826ecf2555f32d491800900f5a541f772c485f7cda7"},
+    {file = "backrefs-6.2.tar.gz", hash = "sha256:f44ff4d48808b243b6c0cdc6231e22195c32f77046018141556c66f8bab72a49"},
 ]
 
 [package.extras]
@@ -842,68 +843,75 @@ toml = ["tomli ; python_full_version <= \"3.11.0a6\""]
 
 [[package]]
 name = "cryptography"
-version = "47.0.0"
+version = "46.0.7"
 description = "cryptography is a package which provides cryptographic recipes and primitives to Python developers."
 optional = false
 python-versions = "!=3.9.0,!=3.9.1,>=3.8"
 groups = ["main"]
 files = [
-    {file = "cryptography-47.0.0-cp311-abi3-macosx_10_9_universal2.whl", hash = "sha256:160ad728f128972d362e714054f6ba0067cab7fb350c5202a9ae8ae4ce3ef1a0"},
-    {file = "cryptography-47.0.0-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:b9a8943e359b7615db1a3ba587994618e094ff3d6fa5a390c73d079ce18b3973"},
-    {file = "cryptography-47.0.0-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:f5c15764f261394b22aef6b00252f5195f46f2ca300bec57149474e2538b31f8"},
-    {file = "cryptography-47.0.0-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:9c59ab0e0fa3a180a5a9c59f3a5abe3ef90d474bc56d7fadfbe80359491b615b"},
-    {file = "cryptography-47.0.0-cp311-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:34b4358b925a5ea3e14384ca781a2c0ef7ac219b57bb9eacc4457078e2b19f92"},
-    {file = "cryptography-47.0.0-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:0024b87d47ae2399165a6bfb20d24888881eeab83ae2566d62467c5ff0030ce7"},
-    {file = "cryptography-47.0.0-cp311-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:1e47422b5557bb82d3fff997e8d92cff4e28b9789576984f08c248d2b3535d93"},
-    {file = "cryptography-47.0.0-cp311-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:6f29f36582e6151d9686235e586dd35bb67491f024767d10b842e520dc6a07ac"},
-    {file = "cryptography-47.0.0-cp311-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:a9b761f012a943b7de0e828843c5688d0de94a0578d44d6c85a1bae32f87791f"},
-    {file = "cryptography-47.0.0-cp311-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:4e1de79e047e25d6e9f8cea71c86b4a53aced64134f0f003bbcbf3655fd172c8"},
-    {file = "cryptography-47.0.0-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:ef6b3634087f18d2155b1e8ce264e5345a753da2c5fa9815e7d41315c90f8318"},
-    {file = "cryptography-47.0.0-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:11dbb9f50a0f1bb9757b3d8c27c1101780efb8f0bdecfb12439c22a74d64c001"},
-    {file = "cryptography-47.0.0-cp311-abi3-win32.whl", hash = "sha256:7fda2f02c9015db3f42bb8a22324a454516ed10a8c29ca6ece6cdbb5efe2a203"},
-    {file = "cryptography-47.0.0-cp311-abi3-win_amd64.whl", hash = "sha256:f5c3296dab66202f1b18a91fa266be93d6aa0c2806ea3d67762c69f60adc71aa"},
-    {file = "cryptography-47.0.0-cp314-cp314t-macosx_10_9_universal2.whl", hash = "sha256:be12cb6a204f77ed968bcefe68086eb061695b540a3dd05edac507a3111b25f0"},
-    {file = "cryptography-47.0.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:2ebd84adf0728c039a3be2700289378e1c164afc6748df1a5ed456767bef9ba7"},
-    {file = "cryptography-47.0.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7f68d6fbc7fbbcfb0939fea72c3b96a9f9a6edfc0e1b1d29778a2066030418b1"},
-    {file = "cryptography-47.0.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:6651d32eff255423503aa276739da98c30f26c40cbeffcc6048e0d54ef704c0c"},
-    {file = "cryptography-47.0.0-cp314-cp314t-manylinux_2_28_ppc64le.whl", hash = "sha256:3fb8fa48075fad7193f2e5496135c6a76ac4b2aa5a38433df0a539296b377829"},
-    {file = "cryptography-47.0.0-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:11438c7518132d95f354fa01a4aa2f806d172a061a7bed18cf18cbdacdb204d7"},
-    {file = "cryptography-47.0.0-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:8c1a736bbb3288005796c3f7ccb9453360d7fed483b13b9f468aea5171432923"},
-    {file = "cryptography-47.0.0-cp314-cp314t-manylinux_2_34_aarch64.whl", hash = "sha256:f1557695e5c2b86e204f6ce9470497848634100787935ab7adc5397c54abd7ab"},
-    {file = "cryptography-47.0.0-cp314-cp314t-manylinux_2_34_ppc64le.whl", hash = "sha256:f9a034b642b960767fb343766ae5ba6ad653f2e890ddd82955aef288ffea8736"},
-    {file = "cryptography-47.0.0-cp314-cp314t-manylinux_2_34_x86_64.whl", hash = "sha256:b1c76fca783aa7698eb21eb14f9c4aa09452248ee54a627d125025a43f83e7a7"},
-    {file = "cryptography-47.0.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:4f7722c97826770bab8ae92959a2e7b20a5e9e9bf4deae68fd86c3ca457bab52"},
-    {file = "cryptography-47.0.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:09f6d7bf6724f8db8b32f11eccf23efc8e759924bc5603800335cf8859a3ddbd"},
-    {file = "cryptography-47.0.0-cp314-cp314t-win32.whl", hash = "sha256:6eebcaf0df1d21ce1f90605c9b432dd2c4f4ab665ac29a40d5e3fc68f51b5e63"},
-    {file = "cryptography-47.0.0-cp314-cp314t-win_amd64.whl", hash = "sha256:51c9313e90bd1690ec5a75ed047c27c0b8e6c570029712943d6116ef9a90620b"},
-    {file = "cryptography-47.0.0-cp38-abi3-macosx_10_9_universal2.whl", hash = "sha256:14432c8a9bcb37009784f9594a62fae211a2ae9543e96c92b2a8e4c3cd5cd0c4"},
-    {file = "cryptography-47.0.0-cp38-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:07efe86201817e7d3c18781ca9770bc0db04e1e48c994be384e4602bc38f8f27"},
-    {file = "cryptography-47.0.0-cp38-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:2b45761c6ec22b7c726d6a829558777e32d0f1c8be7c3f3480f9c912d5ee8a10"},
-    {file = "cryptography-47.0.0-cp38-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:edd4da498015da5b9f26d38d3bfc2e90257bfa9cbed1f6767c282a0025ae649b"},
-    {file = "cryptography-47.0.0-cp38-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:9af828c0d5a65c70ec729cd7495a4bf1a67ecb66417b8f02ff125ab8a6326a74"},
-    {file = "cryptography-47.0.0-cp38-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:256d07c78a04d6b276f5df935a9923275f53bd1522f214447fdf365494e2d515"},
-    {file = "cryptography-47.0.0-cp38-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:5d0e362ff51041b0c0d219cc7d6924d7b8996f57ce5712bdcef71eb3c65a59cc"},
-    {file = "cryptography-47.0.0-cp38-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:1581aef4219f7ca2849d0250edaa3866212fb74bf5667284f46aa92f9e65c1ca"},
-    {file = "cryptography-47.0.0-cp38-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:a49a3eb5341b9503fa3000a9a0db033161db90d47285291f53c2a9d2cd1b7f76"},
-    {file = "cryptography-47.0.0-cp38-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:2207a498b03275d0051589e326b79d4cf59985c99031b05bb292ac52631c37fe"},
-    {file = "cryptography-47.0.0-cp38-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:7a02675e2fabd0c0fc04c868b8781863cbf1967691543c22f5470500ff840b31"},
-    {file = "cryptography-47.0.0-cp38-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:80887c5cbd1774683cb126f0ab4184567f080071d5acf62205acb354b4b753b7"},
-    {file = "cryptography-47.0.0-cp38-abi3-win32.whl", hash = "sha256:ed67ea4e0cfb5faa5bc7ecb6e2b8838f3807a03758eec239d6c21c8769355310"},
-    {file = "cryptography-47.0.0-cp38-abi3-win_amd64.whl", hash = "sha256:835d2d7f47cdc53b3224e90810fb1d36ca94ea29cc1801fb4c1bc43876735769"},
-    {file = "cryptography-47.0.0-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:7f1207974a904e005f762869996cf620e9bf79ecb4622f148550bb48e0eb35a7"},
-    {file = "cryptography-47.0.0-pp311-pypy311_pp73-manylinux_2_28_aarch64.whl", hash = "sha256:1a405c08857258c11016777e11c02bacbe7ef596faf259305d282272a3a05cbe"},
-    {file = "cryptography-47.0.0-pp311-pypy311_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:20fdbe3e38fb67c385d233c89371fa27f9909f6ebca1cecc20c13518dae65475"},
-    {file = "cryptography-47.0.0-pp311-pypy311_pp73-manylinux_2_34_aarch64.whl", hash = "sha256:f7db373287273d8af1414cf95dc4118b13ffdc62be521997b0f2b270771fef50"},
-    {file = "cryptography-47.0.0-pp311-pypy311_pp73-manylinux_2_34_x86_64.whl", hash = "sha256:9fe6b7c64926c765f9dff301f9c1b867febcda5768868ca084e18589113732ab"},
-    {file = "cryptography-47.0.0-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:cffbba3392df0fa8629bb7f43454ee2925059ee158e23c54620b9063912b86c8"},
-    {file = "cryptography-47.0.0.tar.gz", hash = "sha256:9f8e55fe4e63613a5e1cc5819030f27b97742d720203a087802ce4ce9ceb52bb"},
+    {file = "cryptography-46.0.7-cp311-abi3-macosx_10_9_universal2.whl", hash = "sha256:ea42cbe97209df307fdc3b155f1b6fa2577c0defa8f1f7d3be7d31d189108ad4"},
+    {file = "cryptography-46.0.7-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:b36a4695e29fe69215d75960b22577197aca3f7a25b9cf9d165dcfe9d80bc325"},
+    {file = "cryptography-46.0.7-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:5ad9ef796328c5e3c4ceed237a183f5d41d21150f972455a9d926593a1dcb308"},
+    {file = "cryptography-46.0.7-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:73510b83623e080a2c35c62c15298096e2a5dc8d51c3b4e1740211839d0dea77"},
+    {file = "cryptography-46.0.7-cp311-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:cbd5fb06b62bd0721e1170273d3f4d5a277044c47ca27ee257025146c34cbdd1"},
+    {file = "cryptography-46.0.7-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:420b1e4109cc95f0e5700eed79908cef9268265c773d3a66f7af1eef53d409ef"},
+    {file = "cryptography-46.0.7-cp311-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:24402210aa54baae71d99441d15bb5a1919c195398a87b563df84468160a65de"},
+    {file = "cryptography-46.0.7-cp311-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:8a469028a86f12eb7d2fe97162d0634026d92a21f3ae0ac87ed1c4a447886c83"},
+    {file = "cryptography-46.0.7-cp311-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:9694078c5d44c157ef3162e3bf3946510b857df5a3955458381d1c7cfc143ddb"},
+    {file = "cryptography-46.0.7-cp311-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:42a1e5f98abb6391717978baf9f90dc28a743b7d9be7f0751a6f56a75d14065b"},
+    {file = "cryptography-46.0.7-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:91bbcb08347344f810cbe49065914fe048949648f6bd5c2519f34619142bbe85"},
+    {file = "cryptography-46.0.7-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:5d1c02a14ceb9148cc7816249f64f623fbfee39e8c03b3650d842ad3f34d637e"},
+    {file = "cryptography-46.0.7-cp311-abi3-win32.whl", hash = "sha256:d23c8ca48e44ee015cd0a54aeccdf9f09004eba9fc96f38c911011d9ff1bd457"},
+    {file = "cryptography-46.0.7-cp311-abi3-win_amd64.whl", hash = "sha256:397655da831414d165029da9bc483bed2fe0e75dde6a1523ec2fe63f3c46046b"},
+    {file = "cryptography-46.0.7-cp314-cp314t-macosx_10_9_universal2.whl", hash = "sha256:d151173275e1728cf7839aaa80c34fe550c04ddb27b34f48c232193df8db5842"},
+    {file = "cryptography-46.0.7-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:db0f493b9181c7820c8134437eb8b0b4792085d37dbb24da050476ccb664e59c"},
+    {file = "cryptography-46.0.7-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:ebd6daf519b9f189f85c479427bbd6e9c9037862cf8fe89ee35503bd209ed902"},
+    {file = "cryptography-46.0.7-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:b7b412817be92117ec5ed95f880defe9cf18a832e8cafacf0a22337dc1981b4d"},
+    {file = "cryptography-46.0.7-cp314-cp314t-manylinux_2_28_ppc64le.whl", hash = "sha256:fbfd0e5f273877695cb93baf14b185f4878128b250cc9f8e617ea0c025dfb022"},
+    {file = "cryptography-46.0.7-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:ffca7aa1d00cf7d6469b988c581598f2259e46215e0140af408966a24cf086ce"},
+    {file = "cryptography-46.0.7-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:60627cf07e0d9274338521205899337c5d18249db56865f943cbe753aa96f40f"},
+    {file = "cryptography-46.0.7-cp314-cp314t-manylinux_2_34_aarch64.whl", hash = "sha256:80406c3065e2c55d7f49a9550fe0c49b3f12e5bfff5dedb727e319e1afb9bf99"},
+    {file = "cryptography-46.0.7-cp314-cp314t-manylinux_2_34_ppc64le.whl", hash = "sha256:c5b1ccd1239f48b7151a65bc6dd54bcfcc15e028c8ac126d3fada09db0e07ef1"},
+    {file = "cryptography-46.0.7-cp314-cp314t-manylinux_2_34_x86_64.whl", hash = "sha256:d5f7520159cd9c2154eb61eb67548ca05c5774d39e9c2c4339fd793fe7d097b2"},
+    {file = "cryptography-46.0.7-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:fcd8eac50d9138c1d7fc53a653ba60a2bee81a505f9f8850b6b2888555a45d0e"},
+    {file = "cryptography-46.0.7-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:65814c60f8cc400c63131584e3e1fad01235edba2614b61fbfbfa954082db0ee"},
+    {file = "cryptography-46.0.7-cp314-cp314t-win32.whl", hash = "sha256:fdd1736fed309b4300346f88f74cd120c27c56852c3838cab416e7a166f67298"},
+    {file = "cryptography-46.0.7-cp314-cp314t-win_amd64.whl", hash = "sha256:e06acf3c99be55aa3b516397fe42f5855597f430add9c17fa46bf2e0fb34c9bb"},
+    {file = "cryptography-46.0.7-cp38-abi3-macosx_10_9_universal2.whl", hash = "sha256:462ad5cb1c148a22b2e3bcc5ad52504dff325d17daf5df8d88c17dda1f75f2a4"},
+    {file = "cryptography-46.0.7-cp38-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:84d4cced91f0f159a7ddacad249cc077e63195c36aac40b4150e7a57e84fffe7"},
+    {file = "cryptography-46.0.7-cp38-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:128c5edfe5e5938b86b03941e94fac9ee793a94452ad1365c9fc3f4f62216832"},
+    {file = "cryptography-46.0.7-cp38-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:5e51be372b26ef4ba3de3c167cd3d1022934bc838ae9eaad7e644986d2a3d163"},
+    {file = "cryptography-46.0.7-cp38-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:cdf1a610ef82abb396451862739e3fc93b071c844399e15b90726ef7470eeaf2"},
+    {file = "cryptography-46.0.7-cp38-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:1d25aee46d0c6f1a501adcddb2d2fee4b979381346a78558ed13e50aa8a59067"},
+    {file = "cryptography-46.0.7-cp38-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:cdfbe22376065ffcf8be74dc9a909f032df19bc58a699456a21712d6e5eabfd0"},
+    {file = "cryptography-46.0.7-cp38-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:abad9dac36cbf55de6eb49badd4016806b3165d396f64925bf2999bcb67837ba"},
+    {file = "cryptography-46.0.7-cp38-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:935ce7e3cfdb53e3536119a542b839bb94ec1ad081013e9ab9b7cfd478b05006"},
+    {file = "cryptography-46.0.7-cp38-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:35719dc79d4730d30f1c2b6474bd6acda36ae2dfae1e3c16f2051f215df33ce0"},
+    {file = "cryptography-46.0.7-cp38-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:7bbc6ccf49d05ac8f7d7b5e2e2c33830d4fe2061def88210a126d130d7f71a85"},
+    {file = "cryptography-46.0.7-cp38-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:a1529d614f44b863a7b480c6d000fe93b59acee9c82ffa027cfadc77521a9f5e"},
+    {file = "cryptography-46.0.7-cp38-abi3-win32.whl", hash = "sha256:f247c8c1a1fb45e12586afbb436ef21ff1e80670b2861a90353d9b025583d246"},
+    {file = "cryptography-46.0.7-cp38-abi3-win_amd64.whl", hash = "sha256:506c4ff91eff4f82bdac7633318a526b1d1309fc07ca76a3ad182cb5b686d6d3"},
+    {file = "cryptography-46.0.7-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:fc9ab8856ae6cf7c9358430e49b368f3108f050031442eaeb6b9d87e4dcf4e4f"},
+    {file = "cryptography-46.0.7-pp311-pypy311_pp73-manylinux_2_28_aarch64.whl", hash = "sha256:d3b99c535a9de0adced13d159c5a9cf65c325601aa30f4be08afd680643e9c15"},
+    {file = "cryptography-46.0.7-pp311-pypy311_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:d02c738dacda7dc2a74d1b2b3177042009d5cab7c7079db74afc19e56ca1b455"},
+    {file = "cryptography-46.0.7-pp311-pypy311_pp73-manylinux_2_34_aarch64.whl", hash = "sha256:04959522f938493042d595a736e7dbdff6eb6cc2339c11465b3ff89343b65f65"},
+    {file = "cryptography-46.0.7-pp311-pypy311_pp73-manylinux_2_34_x86_64.whl", hash = "sha256:3986ac1dee6def53797289999eabe84798ad7817f3e97779b5061a95b0ee4968"},
+    {file = "cryptography-46.0.7-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:258514877e15963bd43b558917bc9f54cf7cf866c38aa576ebf47a77ddbc43a4"},
+    {file = "cryptography-46.0.7.tar.gz", hash = "sha256:e4cfd68c5f3e0bfdad0d38e023239b96a2fe84146481852dffbcca442c245aa5"},
 ]
 
 [package.dependencies]
 cffi = {version = ">=2.0.0", markers = "python_full_version >= \"3.9.0\" and platform_python_implementation != \"PyPy\""}
 
 [package.extras]
+docs = ["sphinx (>=5.3.0)", "sphinx-inline-tabs", "sphinx-rtd-theme (>=3.0.0)"]
+docstest = ["pyenchant (>=3)", "readme-renderer (>=30.0)", "sphinxcontrib-spelling (>=7.3.1)"]
+nox = ["nox[uv] (>=2024.4.15)"]
+pep8test = ["check-sdist", "click (>=8.0.1)", "mypy (>=1.14)", "ruff (>=0.11.11)"]
+sdist = ["build (>=1.0.0)"]
 ssh = ["bcrypt (>=3.1.5)"]
+test = ["certifi (>=2024)", "cryptography-vectors (==46.0.7)", "pretend (>=0.7)", "pytest (>=7.4.0)", "pytest-benchmark (>=4.0)", "pytest-cov (>=2.10.1)", "pytest-xdist (>=3.5.0)"]
+test-randomorder = ["pytest-randomly"]
 
 [[package]]
 name = "dbus-fast"
@@ -1172,14 +1180,14 @@ smmap = ">=3.0.1,<6"
 
 [[package]]
 name = "gitpython"
-version = "3.1.49"
+version = "3.1.47"
 description = "GitPython is a Python library used to interact with Git repositories"
 optional = false
 python-versions = ">=3.7"
 groups = ["dev"]
 files = [
-    {file = "gitpython-3.1.49-py3-none-any.whl", hash = "sha256:024b0422d7f84d15cd794844e029ffebd4c5d42a7eb9b936b458697ef550a02c"},
-    {file = "gitpython-3.1.49.tar.gz", hash = "sha256:42f9399c9eb33fc581014bedd76049dfbaf6375aa2a5754575966387280315e1"},
+    {file = "gitpython-3.1.47-py3-none-any.whl", hash = "sha256:489f590edfd6d20571b2c0e72c6a6ac6915ee8b8cd04572330e3842207a78905"},
+    {file = "gitpython-3.1.47.tar.gz", hash = "sha256:dba27f922bd2b42cb54c87a8ab3cb6beb6bf07f3d564e21ac848913a05a8a3cd"},
 ]
 
 [package.dependencies]
@@ -2108,14 +2116,14 @@ files = [
 
 [[package]]
 name = "packaging"
-version = "26.2"
+version = "26.1"
 description = "Core utilities for Python packages"
 optional = false
 python-versions = ">=3.8"
 groups = ["main", "docs", "test"]
 files = [
-    {file = "packaging-26.2-py3-none-any.whl", hash = "sha256:5fc45236b9446107ff2415ce77c807cee2862cb6fac22b8a73826d0693b0980e"},
-    {file = "packaging-26.2.tar.gz", hash = "sha256:ff452ff5a3e828ce110190feff1178bb1f2ea2281fa2075aadb987c2fb221661"},
+    {file = "packaging-26.1-py3-none-any.whl", hash = "sha256:5d9c0669c6285e491e0ced2eee587eaf67b670d94a19e94e3984a481aba6802f"},
+    {file = "packaging-26.1.tar.gz", hash = "sha256:f042152b681c4bfac5cae2742a55e103d27ab2ec0f3d88037136b6bfe7c9c5de"},
 ]
 
 [[package]]
@@ -2136,14 +2144,14 @@ lint = ["black"]
 
 [[package]]
 name = "pathspec"
-version = "1.1.1"
+version = "1.1.0"
 description = "Utility library for gitignore style pattern matching of file paths."
 optional = false
 python-versions = ">=3.9"
 groups = ["docs"]
 files = [
-    {file = "pathspec-1.1.1-py3-none-any.whl", hash = "sha256:a00ce642f577bf7f473932318056212bc4f8bfdf53128c78bbd5af0b9b20b189"},
-    {file = "pathspec-1.1.1.tar.gz", hash = "sha256:17db5ecd524104a120e173814c90367a96a98d07c45b2e10c2f3919fff91bf5a"},
+    {file = "pathspec-1.1.0-py3-none-any.whl", hash = "sha256:574b128f7456bd899045ccd142dd446af7e6cfd0072d63ad73fbc55fbb4aaa42"},
+    {file = "pathspec-1.1.0.tar.gz", hash = "sha256:f5d7c555da02fd8dde3e4a2354b6aba817a89112fa8f333f7917a2a4834dd080"},
 ]
 
 [package.extras]
@@ -3066,41 +3074,43 @@ description = "Shield clearance and desktop notifications for terok"
 optional = false
 python-versions = ">=3.12,<4.0"
 groups = ["main"]
-files = [
-    {file = "terok_clearance-0.6.6-py3-none-any.whl", hash = "sha256:8452c25a84587893b2ad902a0b4357167f85dc26d056b3d032529779ccafe241"},
-]
+files = []
+develop = false
 
 [package.dependencies]
-asyncvarlink = ">=0.3.1,<0.4.0"
+asyncvarlink = "^0.3.1"
 dbus-fast = ">=2.0,<5.0"
-pyyaml = ">=6.0,<7.0"
+pyyaml = "^6.0"
 
 [package.source]
-type = "url"
-url = "https://github.com/terok-ai/terok-clearance/releases/download/v0.6.6/terok_clearance-0.6.6-py3-none-any.whl"
+type = "git"
+url = "https://github.com/sliwowitz/terok-clearance.git"
+reference = "feat/dossier-in-events"
+resolved_reference = "32f8942302d79bb43ea805facdab7a62566ea2f6"
 
 [[package]]
 name = "terok-executor"
-version = "0.0.125"
+version = "0.0.124"
 description = "Single-agent task runner for hardened Podman containers"
 optional = false
 python-versions = ">=3.12,<4.0"
 groups = ["main"]
-files = [
-    {file = "terok_executor-0.0.125-py3-none-any.whl", hash = "sha256:33895083a2c548892639e4f00282608b9d6e5367d5034cb8b3857a1fac0f4545"},
-]
+files = []
+develop = false
 
 [package.dependencies]
 Jinja2 = ">=3.1"
 pwinput = ">=1.0.3"
 pydantic = ">=2.9"
 "ruamel.yaml" = ">=0.18"
-terok_sandbox = {url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.0.104/terok_sandbox-0.0.104-py3-none-any.whl"}
+terok-sandbox = {git = "https://github.com/sliwowitz/terok-sandbox.git", branch = "feat/drop-bridge-phase"}
 tomli-w = ">=1.0"
 
 [package.source]
-type = "url"
-url = "https://github.com/terok-ai/terok-executor/releases/download/v0.0.125/terok_executor-0.0.125-py3-none-any.whl"
+type = "git"
+url = "https://github.com/sliwowitz/terok-executor.git"
+reference = "feat/dossier-chain"
+resolved_reference = "96a827ff7982674ab198be6ae361760ac12888b8"
 
 [[package]]
 name = "terok-sandbox"
@@ -3109,9 +3119,8 @@ description = "Hardened Podman container runner with gate server and shield inte
 optional = false
 python-versions = ">=3.12,<4.0"
 groups = ["main"]
-files = [
-    {file = "terok_sandbox-0.0.104-py3-none-any.whl", hash = "sha256:a85dd2cb3c7375e07a15ecd4127bf6fa3c8b23c85463d4452a95f81a268a7a85"},
-]
+files = []
+develop = false
 
 [package.dependencies]
 aiohttp = ">=3.9"
@@ -3119,12 +3128,14 @@ cryptography = ">=46.0.7"
 packaging = ">=24"
 platformdirs = ">=4.9.6"
 pydantic = ">=2.9"
-terok_clearance = {url = "https://github.com/terok-ai/terok-clearance/releases/download/v0.6.6/terok_clearance-0.6.6-py3-none-any.whl"}
-terok_shield = {url = "https://github.com/terok-ai/terok-shield/releases/download/v0.6.34/terok_shield-0.6.34-py3-none-any.whl"}
+terok-clearance = {git = "https://github.com/sliwowitz/terok-clearance.git", branch = "feat/dossier-in-events"}
+terok-shield = {git = "https://github.com/sliwowitz/terok-shield.git", branch = "feat/dossier-in-events"}
 
 [package.source]
-type = "url"
-url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.0.104/terok_sandbox-0.0.104-py3-none-any.whl"
+type = "git"
+url = "https://github.com/sliwowitz/terok-sandbox.git"
+reference = "feat/drop-bridge-phase"
+resolved_reference = "35a463b93418852120722d50709485b734e98196"
 
 [[package]]
 name = "terok-shield"
@@ -3133,17 +3144,18 @@ description = "nftables-based egress firewalling for Podman containers"
 optional = false
 python-versions = ">=3.12,<4.0"
 groups = ["main"]
-files = [
-    {file = "terok_shield-0.6.34-py3-none-any.whl", hash = "sha256:a0545059d973f1f134241ef9f00f76e48625ca817d2f964fb5bfee42f26ca169"},
-]
+files = []
+develop = false
 
 [package.dependencies]
 pydantic = ">=2.0"
 PyYAML = ">=6.0"
 
 [package.source]
-type = "url"
-url = "https://github.com/terok-ai/terok-shield/releases/download/v0.6.34/terok_shield-0.6.34-py3-none-any.whl"
+type = "git"
+url = "https://github.com/sliwowitz/terok-shield.git"
+reference = "feat/dossier-in-events"
+resolved_reference = "0334200c5c4b9aef893dc7ed028026351781aae8"
 
 [[package]]
 name = "textual"
@@ -3703,20 +3715,20 @@ core = ["tree-sitter (>=0.24,<1.0)"]
 
 [[package]]
 name = "typer"
-version = "0.25.1"
+version = "0.24.2"
 description = "Typer, build great CLIs. Easy to code. Based on Python type hints."
 optional = false
 python-versions = ">=3.10"
 groups = ["dev"]
 files = [
-    {file = "typer-0.25.1-py3-none-any.whl", hash = "sha256:75caa44ed46a03fb2dab8808753ffacdbfea88495e74c85a28c5eefcf5f39c89"},
-    {file = "typer-0.25.1.tar.gz", hash = "sha256:9616eb8853a09ffeabab1698952f33c6f29ffdbceb4eaeecf571880e8d7664cc"},
+    {file = "typer-0.24.2-py3-none-any.whl", hash = "sha256:b618bc3d721f9a8d30f3e05565be26416d06e9bcc29d49bc491dc26aba674fa8"},
+    {file = "typer-0.24.2.tar.gz", hash = "sha256:ec070dcfca1408e85ee203c6365001e818c3b7fffe686fd07ff2d68095ca0480"},
 ]
 
 [package.dependencies]
 annotated-doc = ">=0.0.2"
 click = ">=8.2.1"
-rich = ">=13.8.0"
+rich = ">=12.3.0"
 shellingham = ">=1.3.0"
 
 [[package]]
@@ -3794,14 +3806,14 @@ zstd = ["backports-zstd (>=1.0.0) ; python_version < \"3.14\""]
 
 [[package]]
 name = "virtualenv"
-version = "21.3.0"
+version = "21.2.4"
 description = "Virtual Python Environment builder"
 optional = false
 python-versions = ">=3.8"
 groups = ["dev"]
 files = [
-    {file = "virtualenv-21.3.0-py3-none-any.whl", hash = "sha256:4d28ee41f6d9ec8f1f00cd472b9ffbcedda1b3d3b9a575b5c94a2d004fd51bd7"},
-    {file = "virtualenv-21.3.0.tar.gz", hash = "sha256:733750db978ec95c2d8eb4feadaa57091002bce404cb39ba69899cf7bd28944e"},
+    {file = "virtualenv-21.2.4-py3-none-any.whl", hash = "sha256:29d21e941795206138d0f22f4e45ff7050e5da6c6472299fb7103318763861ac"},
+    {file = "virtualenv-21.2.4.tar.gz", hash = "sha256:b294ef68192638004d72524ce7ef303e9d0cf5a44c95ce2e54a7500a6381cada"},
 ]
 
 [package.dependencies]
@@ -4023,4 +4035,4 @@ propcache = ">=0.2.1"
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.12,<4.0"
-content-hash = "6fb4bb1d7a08c97ecebbec022f7b154a0645e5ac5e6f81a612df20c00ae60aeb"
+content-hash = "5d1e6fce8afa1b196061d86a6d292e1687a39de50632d80daf997edadb74c3f9"

--- a/poetry.lock
+++ b/poetry.lock
@@ -3155,7 +3155,7 @@ PyYAML = ">=6.0"
 type = "git"
 url = "https://github.com/sliwowitz/terok-shield.git"
 reference = "feat/dossier-in-events"
-resolved_reference = "0334200c5c4b9aef893dc7ed028026351781aae8"
+resolved_reference = "4ad2cdcfa6ef86dba64301e345d5bf7166e6d0b3"
 
 [[package]]
 name = "textual"

--- a/poetry.lock
+++ b/poetry.lock
@@ -3155,7 +3155,7 @@ PyYAML = ">=6.0"
 type = "git"
 url = "https://github.com/sliwowitz/terok-shield.git"
 reference = "feat/dossier-in-events"
-resolved_reference = "af3e68c4c16c43b42283bd498c97753b5d701008"
+resolved_reference = "f347121965aaf8b07ce491772279528cf88eaf34"
 
 [[package]]
 name = "textual"

--- a/poetry.lock
+++ b/poetry.lock
@@ -3086,11 +3086,11 @@ pyyaml = "^6.0"
 type = "git"
 url = "https://github.com/sliwowitz/terok-clearance.git"
 reference = "feat/dossier-in-events"
-resolved_reference = "32f8942302d79bb43ea805facdab7a62566ea2f6"
+resolved_reference = "dbc9362e9fae562c01814d935897400e5d0651ae"
 
 [[package]]
 name = "terok-executor"
-version = "0.0.124"
+version = "0.0.125"
 description = "Single-agent task runner for hardened Podman containers"
 optional = false
 python-versions = ">=3.12,<4.0"
@@ -3110,7 +3110,7 @@ tomli-w = ">=1.0"
 type = "git"
 url = "https://github.com/sliwowitz/terok-executor.git"
 reference = "feat/dossier-chain"
-resolved_reference = "96a827ff7982674ab198be6ae361760ac12888b8"
+resolved_reference = "13f297b726e6b44f639c5384f77e3452f7c29f0a"
 
 [[package]]
 name = "terok-sandbox"
@@ -3155,7 +3155,7 @@ PyYAML = ">=6.0"
 type = "git"
 url = "https://github.com/sliwowitz/terok-shield.git"
 reference = "feat/dossier-in-events"
-resolved_reference = "4ad2cdcfa6ef86dba64301e345d5bf7166e6d0b3"
+resolved_reference = "af3e68c4c16c43b42283bd498c97753b5d701008"
 
 [[package]]
 name = "textual"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,10 +50,10 @@ unique-namer = ">=1.3"
 textual-serve = ">=1.1.0"
 # DEV-TIME BRANCH PINS — track the dossier-in-events chain end-to-end.
 # Release script flips back to wheel URLs once the four siblings ship.
-terok-executor = {git = "https://github.com/sliwowitz/terok-executor.git", branch = "feat/dossier-chain"}
-terok-sandbox = {git = "https://github.com/sliwowitz/terok-sandbox.git", branch = "feat/drop-bridge-phase"}
-terok-shield = {git = "https://github.com/sliwowitz/terok-shield.git", branch = "feat/dossier-in-events"}
-terok-clearance = {git = "https://github.com/sliwowitz/terok-clearance.git", branch = "feat/dossier-in-events"}
+terok-executor = {url = "https://github.com/terok-ai/terok-executor/releases/download/v0.0.126/terok_executor-0.0.126-py3-none-any.whl"}
+terok-sandbox = {url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.0.105/terok_sandbox-0.0.105-py3-none-any.whl"}
+terok-shield = {url = "https://github.com/terok-ai/terok-shield/releases/download/v0.6.35/terok_shield-0.6.35-py3-none-any.whl"}
+terok-clearance = {url = "https://github.com/terok-ai/terok-clearance/releases/download/v0.6.7/terok_clearance-0.6.7-py3-none-any.whl"}
 
 [tool.poetry.group.dev.dependencies]
 pydevd-pycharm = "261.23567.80"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,10 +48,12 @@ rich = ">=13.0"
 platformdirs = ">=4.5.1"
 unique-namer = ">=1.3"
 textual-serve = ">=1.1.0"
-terok-executor = {url = "https://github.com/terok-ai/terok-executor/releases/download/v0.0.125/terok_executor-0.0.125-py3-none-any.whl"}
-terok-sandbox = {url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.0.104/terok_sandbox-0.0.104-py3-none-any.whl"}
-terok-shield = {url = "https://github.com/terok-ai/terok-shield/releases/download/v0.6.34/terok_shield-0.6.34-py3-none-any.whl"}
-terok-clearance = {url = "https://github.com/terok-ai/terok-clearance/releases/download/v0.6.6/terok_clearance-0.6.6-py3-none-any.whl"}
+# DEV-TIME BRANCH PINS — track the dossier-in-events chain end-to-end.
+# Release script flips back to wheel URLs once the four siblings ship.
+terok-executor = {git = "https://github.com/sliwowitz/terok-executor.git", branch = "feat/dossier-chain"}
+terok-sandbox = {git = "https://github.com/sliwowitz/terok-sandbox.git", branch = "feat/drop-bridge-phase"}
+terok-shield = {git = "https://github.com/sliwowitz/terok-shield.git", branch = "feat/dossier-in-events"}
+terok-clearance = {git = "https://github.com/sliwowitz/terok-clearance.git", branch = "feat/dossier-in-events"}
 
 [tool.poetry.group.dev.dependencies]
 pydevd-pycharm = "261.23567.80"

--- a/src/terok/cli/commands/sickbay.py
+++ b/src/terok/cli/commands/sickbay.py
@@ -27,10 +27,12 @@ from pathlib import Path
 
 from terok_clearance import (
     check_units_outdated as _clearance_check_units_outdated,
+    read_installed_notifier_unit_version as _clearance_notifier_unit_version,
     read_installed_unit_version as _clearance_hub_unit_version,
 )
 from terok_clearance.runtime.installer import (
     HUB_UNIT_NAME as _CLEARANCE_HUB_UNIT_NAME,
+    NOTIFIER_UNIT_NAME as _CLEARANCE_NOTIFIER_UNIT_NAME,
 )
 from terok_sandbox import (
     SERVICES_TCP_OPTOUT_YAML,
@@ -147,16 +149,25 @@ def _check_clearance_stack() -> _CheckResult:
 
     Delegates drift detection to the clearance package so sickbay
     tracks whatever new units terok-clearance ships next without
-    knowing the triple's shape itself.
+    knowing the triple's shape itself.  Hub and notifier versions
+    surface side-by-side so an operator who edits the notifier-only
+    profile (e.g. hardening tweaks) doesn't have to read the unit
+    file to see whether their drift was picked up.
     """
     label = "Clearance stack"
     outdated = _clearance_check_units_outdated()
     if outdated:
         return ("warn", label, outdated)
-    installed = _clearance_hub_unit_version()
-    if installed is None:
+    hub = _clearance_hub_unit_version()
+    notifier = _clearance_notifier_unit_version()
+    if hub is None and notifier is None:
         return ("ok", label, f"{_CLEARANCE_HUB_UNIT_NAME} not installed")
-    return ("ok", label, f"{_CLEARANCE_HUB_UNIT_NAME} v{installed}")
+    parts: list[str] = []
+    if hub is not None:
+        parts.append(f"{_CLEARANCE_HUB_UNIT_NAME} v{hub}")
+    if notifier is not None:
+        parts.append(f"{_CLEARANCE_NOTIFIER_UNIT_NAME} v{notifier}")
+    return ("ok", label, ", ".join(parts))
 
 
 def _check_vault() -> _CheckResult:

--- a/src/terok/cli/commands/sickbay.py
+++ b/src/terok/cli/commands/sickbay.py
@@ -51,22 +51,18 @@ from ...lib.core.projects import list_projects, load_project
 from ...lib.orchestration.container_doctor import run_container_doctor
 from ...lib.orchestration.hooks import run_hook
 from ...lib.orchestration.tasks import (
+    _iter_task_ids,
+    _meta_path,
+    _read_task_meta,
     container_name,
     is_task_id,
     resolve_task_id,
     tasks_meta_dir,
 )
 from ...lib.util.check_reporter import CheckReporter
-from ...lib.util.yaml import load as _yaml_load
 
 # Type alias for check results: (severity, label, detail)
 _CheckResult = tuple[str, str, str]
-
-#: Glob pattern for per-task metadata files under ``tasks_meta_dir(project_id)``.
-#: Used across multiple sickbay checks that enumerate tasks by walking the
-#: metadata directory.  Kept as a named constant so changing the convention
-#: later is a one-line edit.
-_TASK_META_GLOB = "*.yml"
 
 
 def register(subparsers: argparse._SubParsersAction[argparse.ArgumentParser]) -> None:
@@ -195,30 +191,36 @@ def _check_vault() -> _CheckResult:
 
 
 def _task_meta_path(pid: str, tid: str) -> Path | None:
-    """Resolve a task's metadata YAML path, refusing traversal in *pid* / *tid*.
+    """Resolve a task's canonical metadata path, refusing traversal in *pid* / *tid*.
 
     Both IDs arrive from CLI positional args (``terok sickbay <project>
     <task>``).  A hostile value like ``../../etc/passwd`` would otherwise
     escape ``tasks_meta_dir`` via ``Path`` join; reject anything that
     doesn't match the established project/task-ID grammars.
+
+    The returned path always points at the JSON canonical name; YAML
+    files from earlier installs are migrated by ``_read_task_meta`` on
+    the read path.
     """
     if not is_valid_project_id(pid) or not is_task_id(tid):
         return None
-    return tasks_meta_dir(pid) / f"{tid}.yml"
+    return _meta_path(tasks_meta_dir(pid), tid)
 
 
 def _check_task_hook(
     pid: str, tid: str, project: ProjectConfig, *, fix: bool
 ) -> _CheckResult | None:
     """Check a single task for unfired post_stop hook.  Returns None if ok."""
-    meta_path = _task_meta_path(pid, tid)
-    if meta_path is None or not meta_path.is_file():
+    if not is_valid_project_id(pid) or not is_task_id(tid):
         return None
-
+    meta_dir = tasks_meta_dir(pid)
     try:
-        meta = _yaml_load(meta_path.read_text()) or {}
+        meta = _read_task_meta(meta_dir, tid)
     except Exception:
-        return ("warn", f"Task {pid}/{tid}", f"bad metadata: {meta_path}")
+        return ("warn", f"Task {pid}/{tid}", f"bad metadata: {_meta_path(meta_dir, tid)}")
+    if meta is None:
+        return None
+    meta_path = _meta_path(meta_dir, tid)
 
     mode = meta.get("mode")
     if not mode:
@@ -274,12 +276,14 @@ def _check_task_shield_annotation(
     TUI (which only know the container name) to the wrong state dir, or to
     nothing at all.  Non-shielded containers and stopped ones are skipped.
     """
-    meta_path = _task_meta_path(pid, tid)
-    if meta_path is None or not meta_path.is_file():
+    if not is_valid_project_id(pid) or not is_task_id(tid):
         return None
+    meta_dir = tasks_meta_dir(pid)
     try:
-        meta = _yaml_load(meta_path.read_text()) or {}
+        meta = _read_task_meta(meta_dir, tid)
     except Exception:  # noqa: BLE001
+        return None
+    if meta is None:
         return None
     mode = meta.get("mode")
     if not mode:
@@ -329,9 +333,7 @@ def _check_unfired_hooks(
         if not meta_dir.is_dir():
             continue
 
-        task_ids = (
-            [f.stem for f in meta_dir.glob(_TASK_META_GLOB)] if task_id is None else [task_id]
-        )
+        task_ids = list(_iter_task_ids(meta_dir)) if task_id is None else [task_id]
         for tid in task_ids:
             result = _check_task_hook(pid, tid, project, fix=fix)
             if result:
@@ -353,9 +355,7 @@ def _check_shield_annotations(project_id: str | None, task_id: str | None) -> li
         meta_dir = tasks_meta_dir(pid)
         if not meta_dir.is_dir():
             continue
-        task_ids = (
-            [f.stem for f in meta_dir.glob(_TASK_META_GLOB)] if task_id is None else [task_id]
-        )
+        task_ids = list(_iter_task_ids(meta_dir)) if task_id is None else [task_id]
         for tid in task_ids:
             result = _check_task_shield_annotation(pid, tid, project)
             if result:
@@ -490,8 +490,7 @@ def _stream_containers(
         meta_dir = tasks_meta_dir(pid)
         if not meta_dir.is_dir():
             continue
-        for meta_file in meta_dir.glob(_TASK_META_GLOB):
-            tid = meta_file.stem
+        for tid in _iter_task_ids(meta_dir):
             run_container_doctor(
                 pid,
                 tid,

--- a/src/terok/cli/commands/uninstall.py
+++ b/src/terok/cli/commands/uninstall.py
@@ -4,17 +4,18 @@
 """Mirror of ``terok setup``: tears down everything the bootstrap installs.
 
 Reverse install order: desktop entry first (most user-visible), then
-the sandbox aggregator's symmetric uninstall.  The aggregator now
-owns every piece of the service stack, including the shield→clearance
-event bridge — its ``run_bridge_uninstall_phase`` runs first in the
-teardown sequence so the wire goes down before its endpoints
-(clearance hub/verdict/notifier → gate → vault → shield hooks).
-Terok's wrapper is a thin delegating call into the aggregator; this
-module no longer performs any direct reader/bridge cleanup of its
-own.
+the sandbox aggregator's symmetric uninstall.  The aggregator owns
+every piece of the service stack — clearance hub/verdict/notifier,
+gate, vault, and the shield hook pair (which now installs both nft
+and bridge hooks together, so a single shield-uninstall covers the
+event wire too).  Terok's wrapper is a thin delegating call.
 
-The vault credential DB is left on disk so a re-install picks up the
-operator's tokens and SSH keys without a fresh auth cycle;
+The standalone NFLOG reader script under XDG_DATA_HOME survives an
+uninstall on purpose: it's harmless without the hooks that feed it,
+and the next ``terok setup`` overwrites it.
+
+The vault credential DB is also left on disk so a re-install picks up
+the operator's tokens and SSH keys without a fresh auth cycle;
 ``--purge-credentials`` deletes it.
 """
 
@@ -35,8 +36,11 @@ def register(subparsers: argparse._SubParsersAction[argparse.ArgumentParser]) ->
         description=(
             "Symmetric teardown of `terok setup` — removes desktop entry "
             "plus the full sandbox stack (clearance, gate, vault, shield "
-            "hooks, NFLOG reader) via the sandbox aggregator.  The vault "
-            "credential DB is preserved unless --purge-credentials is passed."
+            "hooks) via the sandbox aggregator.  The standalone NFLOG "
+            "reader script under XDG_DATA_HOME is preserved (harmless "
+            "without the hooks that feed it; the next setup overwrites "
+            "it).  The vault credential DB is also preserved unless "
+            "--purge-credentials is passed."
         ),
     )
     p.add_argument(

--- a/src/terok/cli/commands/uninstall.py
+++ b/src/terok/cli/commands/uninstall.py
@@ -131,13 +131,12 @@ def _uninstall_desktop_entry() -> bool:
 def _uninstall_sandbox_stack(*, root: bool) -> bool:
     """Delegate the full teardown to the sandbox aggregator.
 
-    The aggregator now owns the bridge teardown phase as a first-class
-    integration step (``run_bridge_uninstall_phase`` in
-    ``terok_sandbox._setup``) — runs first in the uninstall sequence
-    so the wire goes down before its endpoints.  The earlier
-    workaround that called ``uninstall_shield_bridge`` here directly
-    is no longer needed; the explicit call has been removed and the
-    aggregator's own stage line covers the same teardown.
+    The sandbox aggregator now teardowns both hook pairs (nft + bridge)
+    in one shot — shield's ``setup_global_hooks`` installs them
+    together since the dossier-in-events refactor — so terok's wrapper
+    is a thin delegating call.  The standalone NFLOG reader script
+    survives an uninstall on purpose: it's harmless without the hooks
+    that feed it, and the reinstall path overwrites it.
     """
     from terok_sandbox import sandbox_uninstall
 
@@ -147,7 +146,7 @@ def _uninstall_sandbox_stack(*, root: bool) -> bool:
         except (SystemExit, Exception) as exc:  # noqa: BLE001 — aggregator may raise
             s.fail(str(exc))
             return False
-        s.ok("clearance + bridge + gate + vault + shield removed")
+        s.ok("clearance + gate + vault + shield removed")
         return True
 
 

--- a/src/terok/lib/domain/task_logs.py
+++ b/src/terok/lib/domain/task_logs.py
@@ -19,8 +19,7 @@ from terok_executor import AgentRunner
 
 from ..core import runtime as _rt
 from ..core.projects import load_project
-from ..orchestration.tasks import container_name, tasks_meta_dir
-from ..util.yaml import load as _yaml_load
+from ..orchestration.tasks import _read_task_meta, container_name, tasks_meta_dir
 from .log_format import auto_detect_formatter
 
 
@@ -80,10 +79,9 @@ def task_logs(
 
     project = load_project(project_id)
     meta_dir = tasks_meta_dir(project.id)
-    meta_path = meta_dir / f"{task_id}.yml"
-    if not meta_path.is_file():
+    meta = _read_task_meta(meta_dir, task_id)
+    if meta is None:
         raise SystemExit(f"Unknown task {task_id}")
-    meta = _yaml_load(meta_path.read_text(encoding="utf-8")) or {}
 
     mode = meta.get("mode")
     if not mode:

--- a/src/terok/lib/orchestration/container_doctor.py
+++ b/src/terok/lib/orchestration/container_doctor.py
@@ -32,7 +32,7 @@ from ..core.config import make_sandbox_config
 from ..core.projects import load_project
 from ..util.check_reporter import CheckReporter
 from ..util.logging_utils import _log_debug
-from .tasks import container_name, load_task_meta, tasks_meta_dir
+from .tasks import _has_task_meta, container_name, load_task_meta, tasks_meta_dir
 
 # Type alias matching sickbay.py convention
 _CheckResult = tuple[str, str, str]
@@ -329,7 +329,7 @@ def _resolve_running_container(
     """
     label = f"Task {project_id}/{task_id}"
     meta_dir = tasks_meta_dir(project_id)
-    if not (meta_dir / f"{task_id}.yml").is_file():
+    if not _has_task_meta(meta_dir, task_id):
         return ("", Path(), [("warn", label, "metadata not found")])
 
     meta, _ = load_task_meta(project_id, task_id)

--- a/src/terok/lib/orchestration/hooks.py
+++ b/src/terok/lib/orchestration/hooks.py
@@ -11,7 +11,6 @@ reconcile missed hooks (e.g. post_stop after an unclean shutdown).
 
 from __future__ import annotations
 
-import json
 import logging
 import os
 import subprocess  # nosec B404 — hooks execute user-configured commands by design
@@ -52,61 +51,66 @@ def _build_hook_env(
     return env
 
 
-def _record_hook(meta_path: Path, hook_name: str) -> None:
-    """Append *hook_name* to the ``hooks_fired`` list in task metadata.
+def _record_hook(dossier_path: Path, hook_name: str) -> None:
+    """Append *hook_name* to the ``hooks_fired`` list in task bookkeeping.
 
-    The path the caller hands in may be either the canonical JSON file
-    or a leftover YAML one from an older install.  We resolve to the
-    canonical ``.json`` path first — once the migration has happened
-    (any earlier hook in this run could have done it) the on-disk YAML
-    is gone, so a stale ``Path("…task.yml")`` would otherwise fail the
-    existence check and silently drop subsequent hook records.
-
-    The write goes through the same ``.tmp`` + ``os.replace`` pattern
-    the rest of the metadata layer uses, so an interrupted record can
-    never leave a truncated ``.json`` behind.
+    *dossier_path* is the dossier-file handle the caller already has
+    (returned by ``load_task_meta`` / ``_dossier_path``).  ``hooks_fired``
+    is bookkeeping (not wire dossier), so the actual write targets the
+    sibling ``_meta.yml`` file.  Atomic-rename keeps an interrupted
+    record from leaving a torn YAML behind.
     """
-    json_path = meta_path.with_suffix(".json")
-    if json_path.is_file():
-        source_path = json_path
-    elif meta_path.is_file():
-        source_path = meta_path
-    else:
+    yml_path = _bookkeeping_yml_for(dossier_path)
+    if not yml_path.is_file():
+        # No bookkeeping file yet (task hasn't been written by terok)
+        # — nothing to update.  The hook still ran; we just don't have
+        # a place to record the marker.
         return
     try:
-        text = source_path.read_text(encoding="utf-8")
-        meta = _decode_meta(text, source_path.suffix)
+        from ..util.yaml import dump as _yaml_dump, load as _yaml_load
+
+        meta = _plain(_yaml_load(yml_path.read_text(encoding="utf-8")) or {})
         fired = meta.get("hooks_fired") or []
         if hook_name not in fired:
             fired.append(hook_name)
         meta["hooks_fired"] = fired
-        tmp = json_path.with_suffix(json_path.suffix + ".tmp")
-        tmp.write_text(
-            json.dumps(meta, indent=2, ensure_ascii=False, default=str) + "\n",
-            encoding="utf-8",
-        )
-        os.replace(tmp, json_path)
-        if source_path.suffix == ".yml":
-            source_path.unlink(missing_ok=True)
+        tmp = yml_path.with_suffix(yml_path.suffix + ".tmp")
+        tmp.write_text(_yaml_dump(meta), encoding="utf-8")
+        os.replace(tmp, yml_path)
     except Exception:
-        logger.warning("failed to record hook %s in %s", hook_name, meta_path, exc_info=True)
+        logger.warning("failed to record hook %s in %s", hook_name, yml_path, exc_info=True)
 
 
-def _decode_meta(text: str, suffix: str) -> dict:
-    """Parse task meta text — JSON for ``.json``, ruamel for legacy ``.yml``.
+#: Suffixes the hook recorder recognises on a dossier-file handle —
+#: kept inline rather than imported from ``tasks.py`` because that
+#: module imports ``run_hook`` from here and the reverse would build
+#: a cycle.  The canonical (``_dossier.json``) and pre-self-describing
+#: (``.json``) layouts both map to the bookkeeping YAML alongside.
+_DOSSIER_SUFFIXES = ("_dossier.json", ".json")
+_BOOKKEEPING_SUFFIXES = ("_meta.yml", ".yml")
 
-    Kept inline (rather than importing the canonical reader from
-    ``tasks.py``) so this module stays at its tach layer; ``tasks.py``
-    imports ``run_hook`` from here, so the reverse import would build a
-    cycle and tach correctly rejects it.
+
+def _bookkeeping_yml_for(dossier_path: Path) -> Path:
+    """Return the ``_meta.yml`` sibling of *dossier_path*.
+
+    Falls back to the legacy ``.yml`` location if it's the one on disk
+    — a hook firing mid-migration shouldn't lose its record just
+    because the rename hasn't happened yet.
     """
-    if suffix == ".yml":
-        from ..util.yaml import load as _yaml_load
-
-        raw = _yaml_load(text) or {}
-        # Ruamel hands back ``CommentedMap``; convert to a plain dict.
-        return _plain(raw)
-    return json.loads(text) if text.strip() else {}
+    name = dossier_path.name
+    for src in _DOSSIER_SUFFIXES:
+        if name.endswith(src):
+            stem = name[: -len(src)]
+            new = dossier_path.parent / f"{stem}{_BOOKKEEPING_SUFFIXES[0]}"
+            if new.is_file():
+                return new
+            legacy = dossier_path.parent / f"{stem}{_BOOKKEEPING_SUFFIXES[1]}"
+            return legacy if legacy.is_file() else new
+    # Unknown dossier suffix — best-effort sibling under the dossier
+    # path's stem with the canonical bookkeeping suffix.  Used when a
+    # caller hands us a path that doesn't match either layout (tests
+    # constructing toy paths, defensive code paths in callers).
+    return dossier_path.parent / f"{dossier_path.stem}{_BOOKKEEPING_SUFFIXES[0]}"
 
 
 def _plain(obj: object) -> object:

--- a/src/terok/lib/orchestration/hooks.py
+++ b/src/terok/lib/orchestration/hooks.py
@@ -55,28 +55,39 @@ def _build_hook_env(
 def _record_hook(meta_path: Path, hook_name: str) -> None:
     """Append *hook_name* to the ``hooks_fired`` list in task metadata.
 
-    The path may be the canonical JSON file (post-migration) or a
-    leftover YAML file from an older install that no read has touched
-    yet — both shapes are tolerated so the post-stop hook can record
-    itself even when the task was created before the JSON migration
-    landed.  After a YAML record, the file rotates to JSON.
+    The path the caller hands in may be either the canonical JSON file
+    or a leftover YAML one from an older install.  We resolve to the
+    canonical ``.json`` path first — once the migration has happened
+    (any earlier hook in this run could have done it) the on-disk YAML
+    is gone, so a stale ``Path("…task.yml")`` would otherwise fail the
+    existence check and silently drop subsequent hook records.
+
+    The write goes through the same ``.tmp`` + ``os.replace`` pattern
+    the rest of the metadata layer uses, so an interrupted record can
+    never leave a truncated ``.json`` behind.
     """
-    if not meta_path.is_file():
+    json_path = meta_path.with_suffix(".json")
+    if json_path.is_file():
+        source_path = json_path
+    elif meta_path.is_file():
+        source_path = meta_path
+    else:
         return
     try:
-        text = meta_path.read_text(encoding="utf-8")
-        meta = _decode_meta(text, meta_path.suffix)
+        text = source_path.read_text(encoding="utf-8")
+        meta = _decode_meta(text, source_path.suffix)
         fired = meta.get("hooks_fired") or []
         if hook_name not in fired:
             fired.append(hook_name)
         meta["hooks_fired"] = fired
-        json_path = meta_path.with_suffix(".json")
-        json_path.write_text(
+        tmp = json_path.with_suffix(json_path.suffix + ".tmp")
+        tmp.write_text(
             json.dumps(meta, indent=2, ensure_ascii=False, default=str) + "\n",
             encoding="utf-8",
         )
-        if meta_path.suffix == ".yml":
-            meta_path.unlink(missing_ok=True)
+        os.replace(tmp, json_path)
+        if source_path.suffix == ".yml":
+            source_path.unlink(missing_ok=True)
     except Exception:
         logger.warning("failed to record hook %s in %s", hook_name, meta_path, exc_info=True)
 

--- a/src/terok/lib/orchestration/hooks.py
+++ b/src/terok/lib/orchestration/hooks.py
@@ -11,12 +11,11 @@ reconcile missed hooks (e.g. post_stop after an unclean shutdown).
 
 from __future__ import annotations
 
+import json
 import logging
 import os
 import subprocess  # nosec B404 — hooks execute user-configured commands by design
 from pathlib import Path
-
-from ..util.yaml import dump as _yaml_dump, load as _yaml_load
 
 logger = logging.getLogger(__name__)
 
@@ -54,18 +53,58 @@ def _build_hook_env(
 
 
 def _record_hook(meta_path: Path, hook_name: str) -> None:
-    """Append *hook_name* to the ``hooks_fired`` list in task metadata."""
+    """Append *hook_name* to the ``hooks_fired`` list in task metadata.
+
+    The path may be the canonical JSON file (post-migration) or a
+    leftover YAML file from an older install that no read has touched
+    yet — both shapes are tolerated so the post-stop hook can record
+    itself even when the task was created before the JSON migration
+    landed.  After a YAML record, the file rotates to JSON.
+    """
     if not meta_path.is_file():
         return
     try:
-        meta = _yaml_load(meta_path.read_text()) or {}
+        text = meta_path.read_text(encoding="utf-8")
+        meta = _decode_meta(text, meta_path.suffix)
         fired = meta.get("hooks_fired") or []
         if hook_name not in fired:
             fired.append(hook_name)
         meta["hooks_fired"] = fired
-        meta_path.write_text(_yaml_dump(meta))
+        json_path = meta_path.with_suffix(".json")
+        json_path.write_text(
+            json.dumps(meta, indent=2, ensure_ascii=False, default=str) + "\n",
+            encoding="utf-8",
+        )
+        if meta_path.suffix == ".yml":
+            meta_path.unlink(missing_ok=True)
     except Exception:
         logger.warning("failed to record hook %s in %s", hook_name, meta_path, exc_info=True)
+
+
+def _decode_meta(text: str, suffix: str) -> dict:
+    """Parse task meta text — JSON for ``.json``, ruamel for legacy ``.yml``.
+
+    Kept inline (rather than importing the canonical reader from
+    ``tasks.py``) so this module stays at its tach layer; ``tasks.py``
+    imports ``run_hook`` from here, so the reverse import would build a
+    cycle and tach correctly rejects it.
+    """
+    if suffix == ".yml":
+        from ..util.yaml import load as _yaml_load
+
+        raw = _yaml_load(text) or {}
+        # Ruamel hands back ``CommentedMap``; convert to a plain dict.
+        return _plain(raw)
+    return json.loads(text) if text.strip() else {}
+
+
+def _plain(obj: object) -> object:
+    """Recursively unwrap commented containers to plain dict/list."""
+    if isinstance(obj, dict):
+        return {str(k): _plain(v) for k, v in obj.items()}
+    if isinstance(obj, list):
+        return [_plain(v) for v in obj]
+    return obj
 
 
 def run_hook(

--- a/src/terok/lib/orchestration/task_runners.py
+++ b/src/terok/lib/orchestration/task_runners.py
@@ -58,7 +58,7 @@ from .hooks import run_hook
 from .ports import assign_web_port, release_web_port
 from .tasks import (
     CONTAINER_TEROK_CONFIG,
-    _meta_path,
+    _dossier_path,
     _write_task_meta,
     container_name,
     load_task_meta,
@@ -498,10 +498,10 @@ def _run_container(
     # the pointed-at JSON file as ``ClearanceEvent.dossier`` on every
     # event.  The JSON file IS the wire dossier — wire-shape keys, no
     # projection, no snapshot — so one annotation is enough.
-    task_meta_path = _meta_path(tasks_meta_dir(project.id), task_id)
+    task_dossier_path = _dossier_path(tasks_meta_dir(project.id), task_id)
     annotations = [
         "--annotation",
-        f"dossier.meta_path={task_meta_path}",
+        f"dossier.meta_path={task_dossier_path}",
     ]
     merged_args = annotations + list(extra_args or ()) + _project_runtime_flags(project)
     try:

--- a/src/terok/lib/orchestration/task_runners.py
+++ b/src/terok/lib/orchestration/task_runners.py
@@ -1,5 +1,4 @@
 # SPDX-FileCopyrightText: 2025 Jiri Vyskocil
-# SPDX-FileCopyrightText: 2026 Jiri Vyskocil
 # SPDX-License-Identifier: Apache-2.0
 
 """Task container runners: CLI, headless, toad, and restart."""

--- a/src/terok/lib/orchestration/task_runners.py
+++ b/src/terok/lib/orchestration/task_runners.py
@@ -1,4 +1,5 @@
 # SPDX-FileCopyrightText: 2025 Jiri Vyskocil
+# SPDX-FileCopyrightText: 2026 Jiri Vyskocil
 # SPDX-License-Identifier: Apache-2.0
 
 """Task container runners: CLI, headless, toad, and restart."""
@@ -465,13 +466,13 @@ def _run_container(
 ) -> None:
     """Launch a detached task container, annotated for clearance enrichment.
 
-    Three ``dossier.*`` OCI annotations bind the container to its task
-    identity so clearance popups can render "Task: project/task_id ·
-    name" instead of raw short IDs: ``dossier.project``,
-    ``dossier.task``, and ``dossier.meta_path``.  The meta-path
-    annotation carries the JSON path (not a snapshot of the name) so a
-    rename mid-run surfaces the fresh label in the next popup — the
-    shield reader rereads the file on every emit.
+    A single ``dossier.meta_path`` OCI annotation binds the container
+    to its task identity: it points at the wire-dossier JSON file
+    terok writes per task (``{project, task, name}`` in wire shape).
+    Shield rereads that file on every event emit, so a task rename
+    mid-run surfaces the fresh label in the next popup without touching
+    the annotation.  Project/task IDs lived as separate annotations in
+    earlier iterations; the JSON file made them redundant.
 
     Podman command assembly (userns, shield/bypass, GPU, env redaction,
     CDI detection) is delegated to `AgentRunner.launch_prepared`.
@@ -492,20 +493,13 @@ def _run_container(
         command: Optional command + args appended after the image name.
         hooks: Optional lifecycle callbacks fired around the launch.
     """
-    # OCI annotations under the ``dossier.*`` namespace flow through to the
-    # shield reader, which picks them up at hook spawn time and ships them
-    # on every clearance event as ``ClearanceEvent.dossier``.  Shield treats
-    # the namespace as opaque, so any orchestrator key is welcome here; the
-    # subset clearance renders today is ``project``, ``task``, ``name``,
-    # and ``meta_path`` (a JSON sidecar reread on every emit so a
-    # ``task_rename`` mid-run surfaces the fresh name without touching the
-    # annotation).
+    # OCI annotation under the ``dossier.*`` namespace flows through to
+    # the shield reader, which picks it up at hook spawn time and uses
+    # the pointed-at JSON file as ``ClearanceEvent.dossier`` on every
+    # event.  The JSON file IS the wire dossier — wire-shape keys, no
+    # projection, no snapshot — so one annotation is enough.
     task_meta_path = _meta_path(tasks_meta_dir(project.id), task_id)
     annotations = [
-        "--annotation",
-        f"dossier.project={project.id}",
-        "--annotation",
-        f"dossier.task={task_id}",
         "--annotation",
         f"dossier.meta_path={task_meta_path}",
     ]

--- a/src/terok/lib/orchestration/task_runners.py
+++ b/src/terok/lib/orchestration/task_runners.py
@@ -1,4 +1,5 @@
 # SPDX-FileCopyrightText: 2025 Jiri Vyskocil
+# SPDX-FileCopyrightText: 2026 Jiri Vyskocil
 # SPDX-License-Identifier: Apache-2.0
 
 """Task container runners: CLI, headless, toad, and restart."""
@@ -49,7 +50,7 @@ from ..util.ansi import (
     yellow as _yellow,
 )
 from ..util.net import url_host
-from ..util.yaml import dump as _yaml_dump, load as _yaml_load
+from ..util.yaml import load as _yaml_load
 from .agent_config import resolve_agent_config
 from .container_exec import container_git_diff
 from .environment import build_task_env_and_volumes, ensure_vault
@@ -57,6 +58,8 @@ from .hooks import run_hook
 from .ports import assign_web_port, release_web_port
 from .tasks import (
     CONTAINER_TEROK_CONFIG,
+    _meta_path,
+    _write_task_meta,
     container_name,
     load_task_meta,
     task_new,
@@ -463,12 +466,13 @@ def _run_container(
 ) -> None:
     """Launch a detached task container, annotated for clearance enrichment.
 
-    Three ``ai.terok.*`` OCI annotations bind the container to its task
+    Three ``dossier.*`` OCI annotations bind the container to its task
     identity so clearance popups can render "Task: project/task_id ·
-    name" instead of raw short IDs: project, task_id, and
-    task_meta_path.  The meta-path annotation carries the YAML path
-    (not a snapshot of the name) so a rename mid-run surfaces the
-    fresh label in the next popup.
+    name" instead of raw short IDs: ``dossier.project``,
+    ``dossier.task``, and ``dossier.meta_path``.  The meta-path
+    annotation carries the JSON path (not a snapshot of the name) so a
+    rename mid-run surfaces the fresh label in the next popup — the
+    shield reader rereads the file on every emit.
 
     Podman command assembly (userns, shield/bypass, GPU, env redaction,
     CDI detection) is delegated to `AgentRunner.launch_prepared`.
@@ -489,20 +493,22 @@ def _run_container(
         command: Optional command + args appended after the image name.
         hooks: Optional lifecycle callbacks fired around the launch.
     """
-    # OCI annotations picked up by ``terok_clearance.IdentityResolver``
-    # to render task-aware clearance popups.  Shield writes its own set
-    # through the same path; these are additive.  The ``task_meta_path``
-    # annotation is a data contract: clearance reads the YAML at that
-    # path on every dispatch, so a ``task_rename`` mid-run surfaces the
-    # fresh name in the next popup without touching the annotation.
-    task_meta_path = tasks_meta_dir(project.id) / f"{task_id}.yml"
+    # OCI annotations under the ``dossier.*`` namespace flow through to the
+    # shield reader, which picks them up at hook spawn time and ships them
+    # on every clearance event as ``ClearanceEvent.dossier``.  Shield treats
+    # the namespace as opaque, so any orchestrator key is welcome here; the
+    # subset clearance renders today is ``project``, ``task``, ``name``,
+    # and ``meta_path`` (a JSON sidecar reread on every emit so a
+    # ``task_rename`` mid-run surfaces the fresh name without touching the
+    # annotation).
+    task_meta_path = _meta_path(tasks_meta_dir(project.id), task_id)
     annotations = [
         "--annotation",
-        f"ai.terok.project={project.id}",
+        f"dossier.project={project.id}",
         "--annotation",
-        f"ai.terok.task={task_id}",
+        f"dossier.task={task_id}",
         "--annotation",
-        f"ai.terok.task_meta_path={task_meta_path}",
+        f"dossier.meta_path={task_meta_path}",
     ]
     merged_args = annotations + list(extra_args or ()) + _project_runtime_flags(project)
     try:
@@ -595,7 +601,7 @@ def task_run_cli(
         _apply_shield_policy(project, cname, task_dir, is_restart=True)
         meta["mode"] = "cli"
         meta["ready_at"] = datetime.now(UTC).isoformat()
-        meta_path.write_text(_yaml_dump(meta))
+        _write_task_meta(meta_path, meta)
         print("Container started.")
         _print_login_instructions(project.id, task_id, cname, color_enabled)
         return
@@ -683,7 +689,7 @@ def task_run_cli(
     meta["unrestricted"] = unrestricted
     if preset:
         meta["preset"] = preset
-    meta_path.write_text(_yaml_dump(meta))
+    _write_task_meta(meta_path, meta)
 
     color_enabled = _supports_color()
     print(
@@ -762,7 +768,7 @@ def task_run_toad(
     meta["unrestricted"] = unrestricted
     if preset:
         meta["preset"] = preset
-    meta_path.write_text(_yaml_dump(meta))
+    _write_task_meta(meta_path, meta)
 
     # Preserve the address family when the public host is a loopback — binding
     # ::1 to 127.0.0.1 would make the URL we print (``http://[::1]:…``)
@@ -845,7 +851,7 @@ def task_run_toad(
     )
 
     meta["ready_at"] = datetime.now(UTC).isoformat()
-    meta_path.write_text(_yaml_dump(meta))
+    _write_task_meta(meta_path, meta)
 
     color_enabled = _supports_color()
     url = _toad_browser_url(pub_host, port, token)
@@ -1035,7 +1041,7 @@ def task_run_headless(request: HeadlessRunRequest) -> str:
     meta["unrestricted"] = unrestricted
     if request.preset:
         meta["preset"] = request.preset
-    meta_path.write_text(_yaml_dump(meta))
+    _write_task_meta(meta_path, meta)
 
     color_enabled = _supports_color()
 
@@ -1174,7 +1180,7 @@ def task_followup_headless(
 
     # Clear previous exit_code so effective_status shows "running" until new exit
     meta["exit_code"] = None
-    meta_path.write_text(_yaml_dump(meta))
+    _write_task_meta(meta_path, meta)
 
     color_enabled = _supports_color()
 

--- a/src/terok/lib/orchestration/tasks.py
+++ b/src/terok/lib/orchestration/tasks.py
@@ -4,17 +4,28 @@
 
 """Task metadata, lifecycle, and query operations.
 
-Provides module-level functions for CRUD over JSON-backed task metadata.
-The shield reader reads the same files at every event emit (see the
-``dossier.meta_path`` OCI annotation contract), so the on-disk format
-is JSON: stdlib-only on the consumer side, no PyYAML dependency on the
-hot path.  Files written by older terok versions are migrated to JSON
-on first read.
+On disk each task is two sibling files keyed on its ID:
 
-Container runner functions (``task_run_cli``,
-``task_run_headless``, ``task_restart``) live in the companion
-``task_runners`` module.  Display types and status computation live in
-``task_display``.  Log viewing lives in ``task_logs``.
+* ``<task_id>.json`` — the wire-dossier file shield consumers read,
+  in wire shape (``{project, task, name}``).
+* ``<task_id>.yml`` — terok's internal bookkeeping (mode, workspace,
+  web port, hooks_fired, exit_code, lifecycle state).
+
+Format-as-contract: when a file's name says JSON, its audience is
+"anyone consuming shield events", so its shape *is* the wire dossier
+— no projection, no key translation.  YAML is for terok's eyes only;
+ruamel keeps comments and round-trip ergonomics cheap.
+
+The split is reconciled at the I/O boundary: ``_read_task_meta``
+returns one merged dict in internal-storage shape (``project_id``,
+``task_id``, …), ``_write_task_meta`` splits a single dict back to
+both files atomically.  Pre-split single-JSON layouts are detected
+and split-on-first-read so an upgrade path never loses data.
+
+Container runner functions (``task_run_cli``, ``task_run_headless``,
+``task_restart``) live in the companion ``task_runners`` module.
+Display types and status computation live in ``task_display``.  Log
+viewing lives in ``task_logs``.
 """
 
 import json
@@ -54,66 +65,157 @@ from ..util.emoji import render_emoji
 from ..util.fs import archive_timestamp, create_archive_dir, ensure_dir
 from ..util.host_cmd import WORKSPACE_DANGEROUS_DIRNAME
 from ..util.logging_utils import _log_debug
-from ..util.yaml import load as _yaml_load
+from ..util.yaml import dump as _yaml_dump, load as _yaml_load
 from .container_exec import container_git_diff
 
 # ---------- Task meta file format ----------
+#
+# Per-task state lives in two sibling files keyed on ``task_id``:
+#
+# * ``<task_id>.json`` — the **wire dossier**.  Exactly the keys the
+#   clearance UI renders (``project`` / ``task`` / ``name``).  This
+#   file's audience is anyone consuming shield events: terok-shield
+#   reads it from inside the container's user namespace via stdlib
+#   ``json`` (no ruamel, no terok package), and forwards its contents
+#   onto every block / shield-up / shield-down event.  Format is part
+#   of the contract: JSON, dict-of-strings, wire shape.
+#
+# * ``<task_id>.yml`` — terok's **internal bookkeeping**.  Mode,
+#   workspace, web port, web token, hooks_fired, exit_code, lifecycle
+#   state — everything the orchestrator cares about and nobody else
+#   does.  YAML to keep human edits and round-trip comments cheap;
+#   single consumer, so ruamel is fine on the hot path.
+#
+# The split is deliberate.  When the file format itself signals the
+# audience, there's no question whether a given field belongs on the
+# wire — its filename answers.
+
+# Subset of meta keys that belong on the wire (and thus in the JSON
+# dossier file).  The orchestrator stores them under their internal
+# names (``project_id`` / ``task_id`` / ``name``); ``_dossier_path``
+# is written with the wire-key shape ``{project, task, name}``.
+_DOSSIER_INTERNAL_KEYS = ("project_id", "task_id", "name")
+_DOSSIER_TO_WIRE = {"project_id": "project", "task_id": "task", "name": "name"}
+_DOSSIER_FROM_WIRE = {v: k for k, v in _DOSSIER_TO_WIRE.items()}
 
 
 def _meta_path(meta_dir: Path, task_id: str) -> Path:
-    """Canonical task-meta file path — JSON since the dossier-on-the-wire refactor.
+    """Path to the wire-dossier JSON file — canonical shield-consumer pointer.
 
-    The shield reader reads this file from inside the container's user
-    namespace using nothing but the stdlib (no PyYAML, no terok package);
-    JSON keeps the consumer side trivial.  YAML files from earlier installs
-    are migrated on first read by ``_read_task_meta``.
+    The OCI ``dossier.meta_path`` annotation points operators at *this*
+    file.  Companion bookkeeping lives at the ``.yml`` sibling.
     """
     return meta_dir / f"{task_id}.json"
 
 
-def _read_task_meta(meta_dir: Path, task_id: str) -> dict | None:
-    """Load task meta as a plain dict — migrating ``.yml`` → ``.json`` on encounter.
+def _state_path(meta_dir: Path, task_id: str) -> Path:
+    """Path to the orchestrator-internal bookkeeping YAML.
 
-    Returns ``None`` when neither shape is on disk.  When only the legacy YAML
-    file exists, this performs a one-shot migration: parses with ruamel, writes
-    the JSON form atomically, deletes the YAML.  Subsequent reads find the
-    JSON directly with zero YAML dependency on the hot path.
+    Holds everything except the wire-dossier triple.  Single consumer
+    (terok itself), so ruamel round-tripping is fine.
+    """
+    return meta_dir / f"{task_id}.yml"
+
+
+def _read_task_meta(meta_dir: Path, task_id: str) -> dict | None:
+    """Compose the orchestrator's logical task-meta dict from the on-disk pair.
+
+    Reads the wire-dossier JSON and the internal YAML, translates the
+    JSON's wire keys back to internal storage names, and returns the
+    union.  Either file may be absent: a fresh task before its first
+    write writes one before the other; an upgrade path that
+    encounters a single-file ``<task_id>.json`` from before this
+    split splits it on the spot.
+
+    Returns ``None`` only when neither file is on disk.
     """
     json_path = _meta_path(meta_dir, task_id)
+    yml_path = _state_path(meta_dir, task_id)
+    legacy_yml = meta_dir / f"{task_id}.yml"  # pre-JSON-migration single YAML
+
+    if not (json_path.is_file() or yml_path.is_file() or legacy_yml.is_file()):
+        return None
+
+    json_data: dict = {}
     if json_path.is_file():
         text = json_path.read_text(encoding="utf-8")
-        return json.loads(text) if text.strip() else {}
-    yml_path = meta_dir / f"{task_id}.yml"
-    if not yml_path.is_file():
-        return None
-    meta = _to_plain(_yaml_load(yml_path.read_text(encoding="utf-8")) or {})
-    _write_task_meta(json_path, meta)
-    yml_path.unlink(missing_ok=True)
-    return meta
+        json_data = json.loads(text) if text.strip() else {}
+
+    # If the JSON file holds non-dossier fields, it predates the
+    # one-file-per-audience split — a single-JSON layout that mixed
+    # wire dossier with terok bookkeeping.  Split it now so the next
+    # read sees the canonical pair.
+    spillover = {k: v for k, v in json_data.items() if k not in _DOSSIER_FROM_WIRE}
+    if spillover:
+        json_data = {k: v for k, v in json_data.items() if k in _DOSSIER_FROM_WIRE}
+
+    yml_data: dict = {}
+    if yml_path.is_file():
+        yml_data = _to_plain(_yaml_load(yml_path.read_text(encoding="utf-8")) or {})
+    elif legacy_yml.is_file() and legacy_yml != yml_path:  # pragma: no cover — same path today
+        # Defensive: ``legacy_yml`` resolves to the same path as ``yml_path``
+        # under the current naming, so this branch is unreachable.  Kept as a
+        # tripwire if either filename ever drifts from the other.
+        yml_data = _to_plain(_yaml_load(legacy_yml.read_text(encoding="utf-8")) or {})
+
+    # Spillover came from a recent caller writing the legacy single-JSON
+    # layout (tests, or a pre-split terok release).  Treat it as more
+    # authoritative than any YAML still on disk — that YAML was written
+    # before the latest mutation and may be stale.
+    if spillover:
+        yml_data = {**yml_data, **spillover}
+
+    merged: dict = dict(yml_data)
+    for wire_key, value in json_data.items():
+        if wire_key in _DOSSIER_FROM_WIRE:
+            merged[_DOSSIER_FROM_WIRE[wire_key]] = value
+
+    if spillover:
+        # Normalise on disk so the next read takes the fast path.
+        _write_task_meta(json_path, merged)
+
+    return merged
 
 
 def _write_task_meta(json_path: Path, meta: dict) -> None:
-    """Atomic JSON write: stage as ``.tmp``, ``os.replace`` over the canonical path.
+    """Atomic split-write: wire-dossier JSON + orchestrator bookkeeping YAML.
 
-    The shield reader and the orchestrator both read this file; a partial
-    write under EINTR / power loss could otherwise feed JSON-decode errors
-    to either side.  ``os.replace`` is the rename(2) primitive POSIX
-    requires to be atomic on the same filesystem.
+    Both files live in the same directory and get atomic-rename writes
+    (``.tmp`` + ``os.replace``).  A partial write under EINTR / power
+    loss can leave one stale and the other fresh, but never a
+    half-written file — readers always get a parseable shape.
+
+    The wire dossier is small and well-known; the internal YAML
+    carries everything else.  The split on disk mirrors the contract:
+    JSON for shield consumers, YAML for terok-internal state.
     """
+    yml_path = _state_path(json_path.parent, json_path.stem)
     json_path.parent.mkdir(parents=True, exist_ok=True)
-    tmp = json_path.with_suffix(json_path.suffix + ".tmp")
-    tmp.write_text(
-        json.dumps(meta, indent=2, ensure_ascii=False, default=str) + "\n", encoding="utf-8"
-    )
-    os.replace(tmp, json_path)
+
+    dossier = {
+        wire_key: str(meta[internal_key])
+        for internal_key, wire_key in _DOSSIER_TO_WIRE.items()
+        if meta.get(internal_key)
+    }
+    state = {k: v for k, v in meta.items() if k not in _DOSSIER_INTERNAL_KEYS}
+
+    _atomic_write(json_path, json.dumps(dossier, indent=2, ensure_ascii=False, default=str) + "\n")
+    _atomic_write(yml_path, _yaml_dump(state))
+
+
+def _atomic_write(path: Path, text: str) -> None:
+    """Stage to ``<path>.tmp`` and rename — POSIX-atomic on the same filesystem."""
+    tmp = path.with_suffix(path.suffix + ".tmp")
+    tmp.write_text(text, encoding="utf-8")
+    os.replace(tmp, path)
 
 
 def _to_plain(obj: object) -> object:
     """Recursively unwrap ruamel ``CommentedMap`` / ``CommentedSeq`` to plain types.
 
     Round-trip-mode YAML hands back commented containers that are dict/list
-    subclasses.  ``json.dumps`` accepts them but the migration result should
-    be fully plain so downstream readers don't accidentally inherit metadata
+    subclasses.  ``json.dumps`` accepts them but the merged dict should be
+    fully plain so downstream readers don't inadvertently inherit metadata
     that no longer applies.
     """
     if isinstance(obj, dict):
@@ -124,24 +226,28 @@ def _to_plain(obj: object) -> object:
 
 
 def _iter_task_ids(meta_dir: Path) -> Iterator[str]:
-    """Yield every task ID with a meta file in *meta_dir* — JSON first, YAML fallback.
+    """Yield every task ID with at least one meta file in *meta_dir*.
 
-    Mid-migration the directory may contain both shapes; the iterator
-    deduplicates so a freshly migrated entry isn't double-counted.
+    A task is identified by either of its two sibling files (``<id>.json``
+    or ``<id>.yml``); the iterator deduplicates so a normal pair isn't
+    double-counted.  ``.tmp`` scratch files from a mid-flight atomic write
+    are filtered out.
     """
     if not meta_dir.is_dir():
         return
     seen: set[str] = set()
     for ext in ("json", "yml"):
         for path in meta_dir.glob(f"*.{ext}"):
-            if path.stem not in seen:
-                seen.add(path.stem)
-                yield path.stem
+            tid = path.stem
+            if tid in seen or path.name.endswith(".tmp"):
+                continue
+            seen.add(tid)
+            yield tid
 
 
 def _has_task_meta(meta_dir: Path, prefix: str) -> bool:
-    """``True`` if a meta file exists for *prefix* — either JSON or legacy YAML."""
-    return (meta_dir / f"{prefix}.json").is_file() or (meta_dir / f"{prefix}.yml").is_file()
+    """``True`` if either meta file exists for *prefix* (JSON dossier or YAML state)."""
+    return _meta_path(meta_dir, prefix).is_file() or _state_path(meta_dir, prefix).is_file()
 
 
 # ---------- Task IDs ----------
@@ -919,9 +1025,15 @@ def _archive_task(project: ProjectConfig, task_id: str, meta: dict) -> Path | No
         archive_root = tasks_archive_dir(project.id)
         archive_dir = create_archive_dir(archive_root, dir_name)
 
-        # Save metadata snapshot — JSON matches the live-task format so
-        # archived entries remain readable with the same loader.
-        _write_task_meta(archive_dir / "task.json", _to_plain(meta))
+        # Save the *merged* meta as a single self-contained JSON snapshot.
+        # The live-task layout splits dossier (JSON) from state (YAML)
+        # because each file has a different audience; an archive entry
+        # has only one audience (the operator looking at history) and is
+        # never re-read by shield, so the split brings no value here.
+        _atomic_write(
+            archive_dir / "task.json",
+            json.dumps(_to_plain(meta), indent=2, ensure_ascii=False, default=str) + "\n",
+        )
 
         # Copy logs if they exist
         task_dir = project.tasks_root / str(task_id)

--- a/src/terok/lib/orchestration/tasks.py
+++ b/src/terok/lib/orchestration/tasks.py
@@ -1,5 +1,4 @@
 # SPDX-FileCopyrightText: 2025 Jiri Vyskocil
-# SPDX-FileCopyrightText: 2026 Jiri Vyskocil
 # SPDX-License-Identifier: Apache-2.0
 
 """Task metadata, lifecycle, and query operations.
@@ -190,7 +189,16 @@ def _read_task_meta(meta_dir: Path, task_id: str) -> dict | None:
         if wire_key in _DOSSIER_FROM_WIRE:
             merged[_DOSSIER_FROM_WIRE[wire_key]] = value
 
-    if spillover:
+    # Backfill ``project_id`` from the meta-dir path for legacy records
+    # that predate the field landing in TaskMeta.  Without this, a
+    # task-rename on a legacy task lands a half-populated dossier (no
+    # ``project``) on the wire until some other code path happens to
+    # set it.  Path layout is ``<state>/projects/<project_id>/tasks``.
+    backfill_needed = not merged.get("project_id")
+    if backfill_needed and meta_dir.parent.parent.name == "projects":
+        merged["project_id"] = meta_dir.parent.name
+
+    if spillover or backfill_needed:
         # Normalise on disk so the next read takes the fast path.
         _write_task_meta(_dossier_path(meta_dir, task_id), merged)
 
@@ -629,7 +637,9 @@ def get_task_meta(project_id: str, task_id: str) -> TaskMeta:
             pass
     return TaskMeta(
         task_id=tid,
-        project_id=raw.get("project_id", project_id),
+        # ``or`` (not the dict default) so a migrated record carrying an
+        # empty string still falls back to the path-derived project_id.
+        project_id=raw.get("project_id") or project_id,
         mode=mode,
         workspace=raw.get("workspace", ""),
         web_port=raw.get("web_port"),

--- a/src/terok/lib/orchestration/tasks.py
+++ b/src/terok/lib/orchestration/tasks.py
@@ -6,21 +6,22 @@
 
 On disk each task is two sibling files keyed on its ID:
 
-* ``<task_id>.json`` — the wire-dossier file shield consumers read,
-  in wire shape (``{project, task, name}``).
-* ``<task_id>.yml`` — terok's internal bookkeeping (mode, workspace,
-  web port, hooks_fired, exit_code, lifecycle state).
+* ``<task_id>_dossier.json`` — the wire-dossier file shield consumers
+  read, in wire shape (``{project, task, name}``).
+* ``<task_id>_meta.yml`` — terok's internal bookkeeping (mode,
+  workspace, web port, hooks_fired, exit_code, lifecycle state).
 
-Format-as-contract: when a file's name says JSON, its audience is
-"anyone consuming shield events", so its shape *is* the wire dossier
-— no projection, no key translation.  YAML is for terok's eyes only;
-ruamel keeps comments and round-trip ergonomics cheap.
+Format-as-contract: the JSON file's filename says "dossier" and its
+audience is "anyone consuming shield events", so its shape *is* the
+wire dossier — no projection, no key translation.  The YAML file's
+filename says "meta" and its audience is terok-internal; ruamel keeps
+comments and round-trip ergonomics cheap.
 
 The split is reconciled at the I/O boundary: ``_read_task_meta``
 returns one merged dict in internal-storage shape (``project_id``,
 ``task_id``, …), ``_write_task_meta`` splits a single dict back to
-both files atomically.  Pre-split single-JSON layouts are detected
-and split-on-first-read so an upgrade path never loses data.
+both files atomically.  Pre-self-describing names (``<id>.json`` /
+``<id>.yml``) are migrated to the new layout in place on first read.
 
 Container runner functions (``task_run_cli``, ``task_run_headless``,
 ``task_restart``) live in the companion ``task_runners`` module.
@@ -70,51 +71,76 @@ from .container_exec import container_git_diff
 
 # ---------- Task meta file format ----------
 #
-# Per-task state lives in two sibling files keyed on ``task_id``:
+# Per-task state lives in two sibling files in ``tasks_meta_dir``,
+# named with a self-describing suffix that signals their audience:
 #
-# * ``<task_id>.json`` — the **wire dossier**.  Exactly the keys the
+# * ``<task_id>_dossier.json`` — *the dossier*.  Exactly the keys the
 #   clearance UI renders (``project`` / ``task`` / ``name``).  This
-#   file's audience is anyone consuming shield events: terok-shield
-#   reads it from inside the container's user namespace via stdlib
-#   ``json`` (no ruamel, no terok package), and forwards its contents
-#   onto every block / shield-up / shield-down event.  Format is part
-#   of the contract: JSON, dict-of-strings, wire shape.
+#   file is the contract terok-shield reads on every event from
+#   inside the container's user namespace using nothing but the
+#   stdlib (no ruamel, no terok package), forwarding its contents
+#   verbatim onto every block / shield-up / shield-down.  JSON,
+#   dict-of-strings, wire shape — the format is part of the
+#   contract.
 #
-# * ``<task_id>.yml`` — terok's **internal bookkeeping**.  Mode,
-#   workspace, web port, web token, hooks_fired, exit_code, lifecycle
-#   state — everything the orchestrator cares about and nobody else
-#   does.  YAML to keep human edits and round-trip comments cheap;
-#   single consumer, so ruamel is fine on the hot path.
+# * ``<task_id>_meta.yml`` — terok's internal bookkeeping.  Mode,
+#   workspace, web port, web token, hooks_fired, exit_code,
+#   lifecycle state — everything the orchestrator cares about and
+#   nobody else does.  YAML to keep round-trip comments and human
+#   edits cheap; single consumer, so ruamel on the hot path is fine.
 #
-# The split is deliberate.  When the file format itself signals the
-# audience, there's no question whether a given field belongs on the
-# wire — its filename answers.
+# Format-as-contract: when a file's name says JSON, its audience is
+# "anyone consuming shield events"; when it says YAML, the audience
+# is terok-internal.  No question which field belongs where — the
+# filename answers.
 
-# Subset of meta keys that belong on the wire (and thus in the JSON
-# dossier file).  The orchestrator stores them under their internal
-# names (``project_id`` / ``task_id`` / ``name``); ``_dossier_path``
-# is written with the wire-key shape ``{project, task, name}``.
+#: Suffix of the wire-dossier JSON file (full name: ``<task_id>_dossier.json``).
+_DOSSIER_SUFFIX = "_dossier.json"
+
+#: Suffix of the orchestrator-bookkeeping YAML file (full name: ``<task_id>_meta.yml``).
+_META_SUFFIX = "_meta.yml"
+
+# Subset of in-memory meta keys that belong on the wire (and thus in
+# the JSON dossier file).  Stored under internal names — translated
+# at the I/O boundary by ``_DOSSIER_TO_WIRE`` / ``_DOSSIER_FROM_WIRE``.
 _DOSSIER_INTERNAL_KEYS = ("project_id", "task_id", "name")
 _DOSSIER_TO_WIRE = {"project_id": "project", "task_id": "task", "name": "name"}
 _DOSSIER_FROM_WIRE = {v: k for k, v in _DOSSIER_TO_WIRE.items()}
 
 
-def _meta_path(meta_dir: Path, task_id: str) -> Path:
-    """Path to the wire-dossier JSON file — canonical shield-consumer pointer.
+def _dossier_path(meta_dir: Path, task_id: str) -> Path:
+    """Path to the wire-dossier JSON file — what shield consumers read.
 
     The OCI ``dossier.meta_path`` annotation points operators at *this*
-    file.  Companion bookkeeping lives at the ``.yml`` sibling.
+    file.  Companion bookkeeping lives at the ``_meta.yml`` sibling.
     """
-    return meta_dir / f"{task_id}.json"
+    return meta_dir / f"{task_id}{_DOSSIER_SUFFIX}"
 
 
-def _state_path(meta_dir: Path, task_id: str) -> Path:
-    """Path to the orchestrator-internal bookkeeping YAML.
+def _meta_path(meta_dir: Path, task_id: str) -> Path:
+    """Path to the orchestrator-bookkeeping YAML — terok-internal state.
 
     Holds everything except the wire-dossier triple.  Single consumer
     (terok itself), so ruamel round-tripping is fine.
     """
-    return meta_dir / f"{task_id}.yml"
+    return meta_dir / f"{task_id}{_META_SUFFIX}"
+
+
+def _migrate_legacy_filenames(meta_dir: Path, task_id: str) -> None:
+    """Rename pre-self-describing meta files in place — one-shot, idempotent.
+
+    Earlier iterations stored the dossier and meta as ``<task_id>.json``
+    and ``<task_id>.yml``; the new names spell out their audience.
+    Rename eagerly so every other read/write/iter helper deals with the
+    canonical layout exclusively.  Idempotent: a second call is a no-op.
+    """
+    pairs = (
+        (meta_dir / f"{task_id}.json", _dossier_path(meta_dir, task_id)),
+        (meta_dir / f"{task_id}.yml", _meta_path(meta_dir, task_id)),
+    )
+    for old, new in pairs:
+        if old.is_file() and not new.is_file():
+            old.rename(new)
 
 
 def _read_task_meta(meta_dir: Path, task_id: str) -> dict | None:
@@ -122,18 +148,20 @@ def _read_task_meta(meta_dir: Path, task_id: str) -> dict | None:
 
     Reads the wire-dossier JSON and the internal YAML, translates the
     JSON's wire keys back to internal storage names, and returns the
-    union.  Either file may be absent: a fresh task before its first
-    write writes one before the other; an upgrade path that
-    encounters a single-file ``<task_id>.json`` from before this
-    split splits it on the spot.
+    union.  Either file may be absent.  Returns ``None`` only when
+    neither file is on disk.
 
-    Returns ``None`` only when neither file is on disk.
+    A pre-self-describing layout (``<task_id>.json`` / ``<task_id>.yml``)
+    is migrated to the new names in place before the read so callers
+    never see the legacy paths.  Likewise a single-JSON layout that
+    mixed wire dossier with bookkeeping (the brief intermediate state
+    on this branch before the split) is detected and re-split here.
     """
-    json_path = _meta_path(meta_dir, task_id)
-    yml_path = _state_path(meta_dir, task_id)
-    legacy_yml = meta_dir / f"{task_id}.yml"  # pre-JSON-migration single YAML
+    _migrate_legacy_filenames(meta_dir, task_id)
+    json_path = _dossier_path(meta_dir, task_id)
+    yml_path = _meta_path(meta_dir, task_id)
 
-    if not (json_path.is_file() or yml_path.is_file() or legacy_yml.is_file()):
+    if not (json_path.is_file() or yml_path.is_file()):
         return None
 
     json_data: dict = {}
@@ -141,10 +169,8 @@ def _read_task_meta(meta_dir: Path, task_id: str) -> dict | None:
         text = json_path.read_text(encoding="utf-8")
         json_data = json.loads(text) if text.strip() else {}
 
-    # If the JSON file holds non-dossier fields, it predates the
-    # one-file-per-audience split — a single-JSON layout that mixed
-    # wire dossier with terok bookkeeping.  Split it now so the next
-    # read sees the canonical pair.
+    # Pre-split single-JSON layout (this branch's earlier iteration)
+    # mixed wire dossier with bookkeeping.  Detect, split, normalise.
     spillover = {k: v for k, v in json_data.items() if k not in _DOSSIER_FROM_WIRE}
     if spillover:
         json_data = {k: v for k, v in json_data.items() if k in _DOSSIER_FROM_WIRE}
@@ -152,16 +178,10 @@ def _read_task_meta(meta_dir: Path, task_id: str) -> dict | None:
     yml_data: dict = {}
     if yml_path.is_file():
         yml_data = _to_plain(_yaml_load(yml_path.read_text(encoding="utf-8")) or {})
-    elif legacy_yml.is_file() and legacy_yml != yml_path:  # pragma: no cover — same path today
-        # Defensive: ``legacy_yml`` resolves to the same path as ``yml_path``
-        # under the current naming, so this branch is unreachable.  Kept as a
-        # tripwire if either filename ever drifts from the other.
-        yml_data = _to_plain(_yaml_load(legacy_yml.read_text(encoding="utf-8")) or {})
 
-    # Spillover came from a recent caller writing the legacy single-JSON
-    # layout (tests, or a pre-split terok release).  Treat it as more
-    # authoritative than any YAML still on disk — that YAML was written
-    # before the latest mutation and may be stale.
+    # Spillover came from a caller writing the pre-split layout — treat
+    # it as more authoritative than any YAML on disk, since that YAML
+    # was written before the latest mutation and may be stale.
     if spillover:
         yml_data = {**yml_data, **spillover}
 
@@ -172,25 +192,24 @@ def _read_task_meta(meta_dir: Path, task_id: str) -> dict | None:
 
     if spillover:
         # Normalise on disk so the next read takes the fast path.
-        _write_task_meta(json_path, merged)
+        _write_task_meta(_dossier_path(meta_dir, task_id), merged)
 
     return merged
 
 
-def _write_task_meta(json_path: Path, meta: dict) -> None:
-    """Atomic split-write: wire-dossier JSON + orchestrator bookkeeping YAML.
+def _write_task_meta(dossier_path: Path, meta: dict) -> None:
+    """Atomic split-write: ``_dossier.json`` + ``_meta.yml`` in one atomic step each.
 
-    Both files live in the same directory and get atomic-rename writes
-    (``.tmp`` + ``os.replace``).  A partial write under EINTR / power
-    loss can leave one stale and the other fresh, but never a
-    half-written file — readers always get a parseable shape.
-
-    The wire dossier is small and well-known; the internal YAML
-    carries everything else.  The split on disk mirrors the contract:
-    JSON for shield consumers, YAML for terok-internal state.
+    *dossier_path* is the canonical dossier-file handle — what
+    ``_dossier_path()`` returns and what ``load_task_meta`` hands back.
+    The companion bookkeeping path is derived by swapping the suffix.
+    Atomic-rename writes (``.tmp`` + ``os.replace``) on each file mean
+    a partial write under EINTR / power loss can leave one stale and
+    the other fresh, but never a half-written file — readers always
+    get a parseable shape.
     """
-    yml_path = _state_path(json_path.parent, json_path.stem)
-    json_path.parent.mkdir(parents=True, exist_ok=True)
+    meta_dir, task_id = _dossier_handle_to_dir_and_id(dossier_path)
+    meta_dir.mkdir(parents=True, exist_ok=True)
 
     dossier = {
         wire_key: str(meta[internal_key])
@@ -199,8 +218,28 @@ def _write_task_meta(json_path: Path, meta: dict) -> None:
     }
     state = {k: v for k, v in meta.items() if k not in _DOSSIER_INTERNAL_KEYS}
 
-    _atomic_write(json_path, json.dumps(dossier, indent=2, ensure_ascii=False, default=str) + "\n")
-    _atomic_write(yml_path, _yaml_dump(state))
+    _atomic_write(
+        _dossier_path(meta_dir, task_id),
+        json.dumps(dossier, indent=2, ensure_ascii=False, default=str) + "\n",
+    )
+    _atomic_write(_meta_path(meta_dir, task_id), _yaml_dump(state))
+
+
+def _dossier_handle_to_dir_and_id(path: Path) -> tuple[Path, str]:
+    """Decompose a dossier-file handle into ``(meta_dir, task_id)``.
+
+    Accepts both the canonical ``<task_id>_dossier.json`` and the
+    pre-self-describing ``<task_id>.json`` so callers caching a handle
+    across the migration boundary keep working.  Raises on anything
+    else — silently inferring a task_id from a foreign filename would
+    let bugs pass undetected.
+    """
+    name = path.name
+    if name.endswith(_DOSSIER_SUFFIX):
+        return path.parent, name[: -len(_DOSSIER_SUFFIX)]
+    if name.endswith(".json"):
+        return path.parent, name[: -len(".json")]
+    raise ValueError(f"not a dossier-file handle: {path}")
 
 
 def _atomic_write(path: Path, text: str) -> None:
@@ -228,26 +267,40 @@ def _to_plain(obj: object) -> object:
 def _iter_task_ids(meta_dir: Path) -> Iterator[str]:
     """Yield every task ID with at least one meta file in *meta_dir*.
 
-    A task is identified by either of its two sibling files (``<id>.json``
-    or ``<id>.yml``); the iterator deduplicates so a normal pair isn't
-    double-counted.  ``.tmp`` scratch files from a mid-flight atomic write
-    are filtered out.
+    Recognises both the canonical layout (``<id>_dossier.json`` /
+    ``<id>_meta.yml``) and the pre-self-describing layout
+    (``<id>.json`` / ``<id>.yml``) — the latter is migrated lazily on
+    the next ``_read_task_meta`` call, so transient mixed states are
+    yielded under their canonical task ID without double-counting.
     """
     if not meta_dir.is_dir():
         return
     seen: set[str] = set()
-    for ext in ("json", "yml"):
-        for path in meta_dir.glob(f"*.{ext}"):
-            tid = path.stem
-            if tid in seen or path.name.endswith(".tmp"):
-                continue
+    for path in meta_dir.iterdir():
+        if not path.is_file() or path.name.endswith(".tmp"):
+            continue
+        tid = _task_id_from_filename(path.name)
+        if tid and tid not in seen:
             seen.add(tid)
             yield tid
 
 
+def _task_id_from_filename(name: str) -> str:
+    """Strip the meta-file suffix to recover the task ID, ``""`` if unrecognised."""
+    for suffix in (_DOSSIER_SUFFIX, _META_SUFFIX, ".json", ".yml"):
+        if name.endswith(suffix):
+            return name[: -len(suffix)]
+    return ""
+
+
 def _has_task_meta(meta_dir: Path, prefix: str) -> bool:
-    """``True`` if either meta file exists for *prefix* (JSON dossier or YAML state)."""
-    return _meta_path(meta_dir, prefix).is_file() or _state_path(meta_dir, prefix).is_file()
+    """``True`` if either meta file exists for *prefix* (canonical or legacy layout)."""
+    return (
+        _dossier_path(meta_dir, prefix).is_file()
+        or _meta_path(meta_dir, prefix).is_file()
+        or (meta_dir / f"{prefix}.json").is_file()
+        or (meta_dir / f"{prefix}.yml").is_file()
+    )
 
 
 # ---------- Task IDs ----------
@@ -669,7 +722,7 @@ def update_task_exit_code(project_id: str, task_id: str, exit_code: int | None) 
     if meta is None:
         return
     meta["exit_code"] = exit_code
-    _write_task_meta(_meta_path(meta_dir, task_id), meta)
+    _write_task_meta(_dossier_path(meta_dir, task_id), meta)
 
 
 def _write_task_readme(task_dir: Path) -> None:
@@ -741,7 +794,7 @@ def _task_new(project: ProjectConfig, *, name: str | None = None) -> str:
         "web_port": None,
         "created_at": datetime.now(tz=UTC).isoformat(),
     }
-    _write_task_meta(_meta_path(meta_dir, next_id), meta)
+    _write_task_meta(_dossier_path(meta_dir, next_id), meta)
     print(f"Created task {next_id} ({task_name}) in {ws}")
     return next_id
 
@@ -794,7 +847,7 @@ def _task_rename(project: ProjectConfig, task_id: str, new_name: str) -> None:
     if err:
         raise SystemExit(f"Invalid task name: {err}")
     meta["name"] = sanitized
-    _write_task_meta(_meta_path(meta_dir, task_id), meta)
+    _write_task_meta(_dossier_path(meta_dir, task_id), meta)
     print(f"Renamed task {task_id} to {sanitized}")
 
 
@@ -954,9 +1007,15 @@ def load_task_meta(
 ) -> tuple[dict, Path]:
     """Load task metadata and optionally validate mode.
 
-    Returns (meta, meta_path). Raises SystemExit if task is unknown or mode
-    conflicts with *expected_mode*.  ``meta_path`` is always the canonical
-    JSON path even when the on-disk file was migrated from YAML on this read.
+    Returns the merged in-memory dict (dossier + bookkeeping in their
+    internal storage shape).  Raises SystemExit if the task is unknown
+    or its mode conflicts with *expected_mode*.
+
+    Returns ``(meta, dossier_path)``: the merged in-memory dict (in
+    its internal storage shape — ``project_id`` / ``task_id`` / …)
+    plus the canonical dossier-file handle for write-back via
+    ``_write_task_meta(dossier_path, meta)``.  Raises SystemExit if
+    the task is unknown or its mode conflicts with *expected_mode*.
     """
     meta_dir = tasks_meta_dir(project_id)
     meta = _read_task_meta(meta_dir, task_id)
@@ -964,7 +1023,7 @@ def load_task_meta(
         raise SystemExit(f"Unknown task {task_id}")
     if expected_mode is not None:
         _check_mode(meta, expected_mode)
-    return meta, _meta_path(meta_dir, task_id)
+    return meta, _dossier_path(meta_dir, task_id)
 
 
 def mark_task_deleting(project_id: str, task_id: str) -> None:
@@ -975,7 +1034,7 @@ def mark_task_deleting(project_id: str, task_id: str) -> None:
         if meta is None:
             return
         meta["deleting"] = True
-        _write_task_meta(_meta_path(meta_dir, task_id), meta)
+        _write_task_meta(_dossier_path(meta_dir, task_id), meta)
     except Exception as e:
         _log_debug(f"mark_task_deleting: failed project_id={project_id} task_id={task_id}: {e}")
 
@@ -1070,9 +1129,16 @@ def _task_delete(project: ProjectConfig, task_id: str) -> TaskDeleteResult:
 
     workspace = project.tasks_root / str(task_id)
     meta_dir = tasks_meta_dir(project.id)
+    dossier_path = _dossier_path(meta_dir, task_id)
     meta_path = _meta_path(meta_dir, task_id)
+    # Pre-self-describing layout (`<id>.json` / `<id>.yml`) — clean too,
+    # in case the task was created before the rename and never since
+    # touched (no read = no migration).
+    legacy_json = meta_dir / f"{task_id}.json"
     legacy_yml = meta_dir / f"{task_id}.yml"
-    _log_debug(f"task_delete: workspace={workspace} meta_path={meta_path}")
+    _log_debug(
+        f"task_delete: workspace={workspace} dossier_path={dossier_path} meta_path={meta_path}"
+    )
 
     meta = _read_task_meta(meta_dir, task_id) or {}
 
@@ -1134,14 +1200,16 @@ def _task_delete(project: ProjectConfig, task_id: str) -> TaskDeleteResult:
             _log_debug(f"task_delete: workspace removal failed: {exc}")
             warnings.append(f"Workspace removal failed: {exc}")
 
-    # Both shapes might be present mid-migration (the read above migrates
-    # YAML→JSON, but a sibling reader could lose the race); clean both.
-    if meta_path.is_file() or legacy_yml.is_file():
-        _log_debug("task_delete: removing metadata file")
+    # Drop both halves of the on-disk pair plus any legacy single-file
+    # remnants.  Each ``unlink(missing_ok=True)`` is independent so a
+    # half-installed bundle still cleans up everything that was there.
+    paths_to_remove = (dossier_path, meta_path, legacy_json, legacy_yml)
+    if any(p.is_file() for p in paths_to_remove):
+        _log_debug("task_delete: removing metadata files")
         try:
-            meta_path.unlink(missing_ok=True)
-            legacy_yml.unlink(missing_ok=True)
-            _log_debug("task_delete: metadata file removed")
+            for p in paths_to_remove:
+                p.unlink(missing_ok=True)
+            _log_debug("task_delete: metadata files removed")
         except Exception as exc:
             _log_debug(f"task_delete: metadata removal failed: {exc}")
             warnings.append(f"Metadata removal failed: {exc}")

--- a/src/terok/lib/orchestration/tasks.py
+++ b/src/terok/lib/orchestration/tasks.py
@@ -1,5 +1,4 @@
 # SPDX-FileCopyrightText: 2025 Jiri Vyskocil
-# SPDX-FileCopyrightText: 2026 Jiri Vyskocil
 # SPDX-License-Identifier: Apache-2.0
 
 """Task metadata, lifecycle, and query operations.

--- a/src/terok/lib/orchestration/tasks.py
+++ b/src/terok/lib/orchestration/tasks.py
@@ -4,7 +4,12 @@
 
 """Task metadata, lifecycle, and query operations.
 
-Provides module-level functions for CRUD over YAML-backed task metadata.
+Provides module-level functions for CRUD over JSON-backed task metadata.
+The shield reader reads the same files at every event emit (see the
+``dossier.meta_path`` OCI annotation contract), so the on-disk format
+is JSON: stdlib-only on the consumer side, no PyYAML dependency on the
+hot path.  Files written by older terok versions are migrated to JSON
+on first read.
 
 Container runner functions (``task_run_cli``,
 ``task_run_headless``, ``task_restart``) live in the companion
@@ -12,12 +17,14 @@ Container runner functions (``task_run_cli``,
 ``task_display``.  Log viewing lives in ``task_logs``.
 """
 
+import json
 import os
 import re
 import secrets
 import shutil
 import string
 import warnings
+from collections.abc import Iterator
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from pathlib import Path
@@ -47,14 +54,97 @@ from ..util.emoji import render_emoji
 from ..util.fs import archive_timestamp, create_archive_dir, ensure_dir
 from ..util.host_cmd import WORKSPACE_DANGEROUS_DIRNAME
 from ..util.logging_utils import _log_debug
-from ..util.yaml import dump as _yaml_dump, load as _yaml_load
+from ..util.yaml import load as _yaml_load
 from .container_exec import container_git_diff
 
+# ---------- Task meta file format ----------
+
+
+def _meta_path(meta_dir: Path, task_id: str) -> Path:
+    """Canonical task-meta file path — JSON since the dossier-on-the-wire refactor.
+
+    The shield reader reads this file from inside the container's user
+    namespace using nothing but the stdlib (no PyYAML, no terok package);
+    JSON keeps the consumer side trivial.  YAML files from earlier installs
+    are migrated on first read by ``_read_task_meta``.
+    """
+    return meta_dir / f"{task_id}.json"
+
+
+def _read_task_meta(meta_dir: Path, task_id: str) -> dict | None:
+    """Load task meta as a plain dict — migrating ``.yml`` → ``.json`` on encounter.
+
+    Returns ``None`` when neither shape is on disk.  When only the legacy YAML
+    file exists, this performs a one-shot migration: parses with ruamel, writes
+    the JSON form atomically, deletes the YAML.  Subsequent reads find the
+    JSON directly with zero YAML dependency on the hot path.
+    """
+    json_path = _meta_path(meta_dir, task_id)
+    if json_path.is_file():
+        text = json_path.read_text(encoding="utf-8")
+        return json.loads(text) if text.strip() else {}
+    yml_path = meta_dir / f"{task_id}.yml"
+    if not yml_path.is_file():
+        return None
+    meta = _to_plain(_yaml_load(yml_path.read_text(encoding="utf-8")) or {})
+    _write_task_meta(json_path, meta)
+    yml_path.unlink(missing_ok=True)
+    return meta
+
+
+def _write_task_meta(json_path: Path, meta: dict) -> None:
+    """Atomic JSON write: stage as ``.tmp``, ``os.replace`` over the canonical path.
+
+    The shield reader and the orchestrator both read this file; a partial
+    write under EINTR / power loss could otherwise feed JSON-decode errors
+    to either side.  ``os.replace`` is the rename(2) primitive POSIX
+    requires to be atomic on the same filesystem.
+    """
+    json_path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = json_path.with_suffix(json_path.suffix + ".tmp")
+    tmp.write_text(
+        json.dumps(meta, indent=2, ensure_ascii=False, default=str) + "\n", encoding="utf-8"
+    )
+    os.replace(tmp, json_path)
+
+
+def _to_plain(obj: object) -> object:
+    """Recursively unwrap ruamel ``CommentedMap`` / ``CommentedSeq`` to plain types.
+
+    Round-trip-mode YAML hands back commented containers that are dict/list
+    subclasses.  ``json.dumps`` accepts them but the migration result should
+    be fully plain so downstream readers don't accidentally inherit metadata
+    that no longer applies.
+    """
+    if isinstance(obj, dict):
+        return {str(k): _to_plain(v) for k, v in obj.items()}
+    if isinstance(obj, list):
+        return [_to_plain(v) for v in obj]
+    return obj
+
+
+def _iter_task_ids(meta_dir: Path) -> Iterator[str]:
+    """Yield every task ID with a meta file in *meta_dir* — JSON first, YAML fallback.
+
+    Mid-migration the directory may contain both shapes; the iterator
+    deduplicates so a freshly migrated entry isn't double-counted.
+    """
+    if not meta_dir.is_dir():
+        return
+    seen: set[str] = set()
+    for ext in ("json", "yml"):
+        for path in meta_dir.glob(f"*.{ext}"):
+            if path.stem not in seen:
+                seen.add(path.stem)
+                yield path.stem
+
+
+def _has_task_meta(meta_dir: Path, prefix: str) -> bool:
+    """``True`` if a meta file exists for *prefix* — either JSON or legacy YAML."""
+    return (meta_dir / f"{prefix}.json").is_file() or (meta_dir / f"{prefix}.yml").is_file()
+
+
 # ---------- Task IDs ----------
-
-
-_META_GLOB = "*.yml"
-"""Glob pattern for task metadata YAML files."""
 
 _TASK_ID_HEAD_CHARS = "ghjkmnpqrstvwxyz"
 """Crockford-legal lowercase letters outside hex (``g-z`` minus ``i l o u``, 16 chars).
@@ -201,12 +291,10 @@ def resolve_task_id(project_id: str, prefix: str) -> str:
     meta_dir = tasks_meta_dir(project_id)
     if not meta_dir.is_dir():
         raise SystemExit(f"No tasks found for project {project_id}")
-    if (meta_dir / f"{prefix}.yml").is_file():
+    if _has_task_meta(meta_dir, prefix):
         return prefix
     matches = [
-        p.stem
-        for p in meta_dir.glob(_META_GLOB)
-        if is_task_id(p.stem) and p.stem.startswith(prefix)
+        tid for tid in _iter_task_ids(meta_dir) if is_task_id(tid) and tid.startswith(prefix)
     ]
     if len(matches) == 1:
         return matches[0]
@@ -345,10 +433,9 @@ def get_task_meta(project_id: str, task_id: str) -> TaskMeta:
     Raises ``SystemExit`` if the task metadata file is not found.
     """
     meta_dir = tasks_meta_dir(project_id)
-    meta_path = meta_dir / f"{task_id}.yml"
-    if not meta_path.is_file():
+    raw = _read_task_meta(meta_dir, task_id)
+    if raw is None:
         raise SystemExit(f"Unknown task {task_id}")
-    raw = _yaml_load(meta_path.read_text()) or {}
     mode = raw.get("mode")
     tid = str(raw.get("task_id", ""))
     # Hydrate live container state only for tasks that have actually been started
@@ -409,10 +496,9 @@ def get_workspace_git_diff(project_id: str, task_id: str, against: str = "HEAD")
     try:
         load_project(project_id)  # validate project exists
         meta_dir = tasks_meta_dir(project_id)
-        meta_path = meta_dir / f"{task_id}.yml"
-        if not meta_path.is_file():
+        meta = _read_task_meta(meta_dir, task_id)
+        if meta is None:
             return None
-        meta = _yaml_load(meta_path.read_text()) or {}
         mode = meta.get("mode")
         if not mode:
             return None
@@ -429,7 +515,7 @@ def get_workspace_git_diff(project_id: str, task_id: str, against: str = "HEAD")
 
 
 def tasks_meta_dir(project_id: str) -> Path:
-    """Return the directory containing task metadata YAML files for *project_id*."""
+    """Return the directory containing task metadata files for *project_id*."""
     return core_state_dir() / "projects" / project_id / "tasks"
 
 
@@ -462,12 +548,11 @@ def update_task_exit_code(project_id: str, task_id: str, exit_code: int | None) 
         exit_code: The exit code from the task, or None if unknown/failed
     """
     meta_dir = tasks_meta_dir(project_id)
-    meta_path = meta_dir / f"{task_id}.yml"
-    if not meta_path.is_file():
+    meta = _read_task_meta(meta_dir, task_id)
+    if meta is None:
         return
-    meta = _yaml_load(meta_path.read_text()) or {}
     meta["exit_code"] = exit_code
-    meta_path.write_text(_yaml_dump(meta))
+    _write_task_meta(_meta_path(meta_dir, task_id), meta)
 
 
 def _write_task_readme(task_dir: Path) -> None:
@@ -510,7 +595,7 @@ def _task_new(project: ProjectConfig, *, name: str | None = None) -> str:
     meta_dir = tasks_meta_dir(project.id)
     ensure_dir(meta_dir)
 
-    existing = {p.stem for p in meta_dir.glob(_META_GLOB)}
+    existing = set(_iter_task_ids(meta_dir))
     next_id = _generate_unique_id(existing)
 
     ws = tasks_root / next_id
@@ -538,7 +623,7 @@ def _task_new(project: ProjectConfig, *, name: str | None = None) -> str:
         "web_port": None,
         "created_at": datetime.now(tz=UTC).isoformat(),
     }
-    (meta_dir / f"{next_id}.yml").write_text(_yaml_dump(meta))
+    _write_task_meta(_meta_path(meta_dir, next_id), meta)
     print(f"Created task {next_id} ({task_name}) in {ws}")
     return next_id
 
@@ -579,12 +664,11 @@ def task_new(project_id: str, *, name: str | None = None) -> str:
 
 
 def _task_rename(project: ProjectConfig, task_id: str, new_name: str) -> None:
-    """Rename a task by updating its metadata YAML."""
+    """Rename a task by updating its metadata file."""
     meta_dir = tasks_meta_dir(project.id)
-    meta_path = meta_dir / f"{task_id}.yml"
-    if not meta_path.is_file():
+    meta = _read_task_meta(meta_dir, task_id)
+    if meta is None:
         raise SystemExit(f"Unknown task {task_id}")
-    meta = _yaml_load(meta_path.read_text()) or {}
     sanitized = sanitize_task_name(new_name)
     if sanitized is None:
         raise SystemExit(f"Invalid task name: {new_name!r}")
@@ -592,12 +676,12 @@ def _task_rename(project: ProjectConfig, task_id: str, new_name: str) -> None:
     if err:
         raise SystemExit(f"Invalid task name: {err}")
     meta["name"] = sanitized
-    meta_path.write_text(_yaml_dump(meta))
+    _write_task_meta(_meta_path(meta_dir, task_id), meta)
     print(f"Renamed task {task_id} to {sanitized}")
 
 
 def task_rename(project_id: str, task_id: str, new_name: str) -> None:
-    """Rename a task by updating its metadata YAML.
+    """Rename a task by updating its metadata file.
 
     Sanitizes *new_name* and writes the result to the task's metadata file.
     Raises ``SystemExit`` if the task is unknown or the sanitized name is invalid.
@@ -616,11 +700,13 @@ def _get_tasks(project_id: str, reverse: bool = False) -> list[TaskMeta]:
         tasks_root = project.tasks_root
     except SystemExit:
         tasks_root = None
-    for f in meta_dir.glob(_META_GLOB):
-        if not is_task_id(f.stem):
+    for tid_stem in _iter_task_ids(meta_dir):
+        if not is_task_id(tid_stem):
             continue
         try:
-            meta = _yaml_load(f.read_text()) or {}
+            meta = _read_task_meta(meta_dir, tid_stem)
+            if meta is None:
+                continue
             tid = str(meta.get("task_id", ""))
             ws_status = None
             ws_message = None
@@ -653,7 +739,7 @@ def _get_tasks(project_id: str, reverse: bool = False) -> list[TaskMeta]:
         except Exception as exc:
             from ..util.logging_utils import log_warning
 
-            log_warning(f"Skipping malformed task metadata file: {f}: {exc}")
+            log_warning(f"Skipping malformed task metadata file for {tid_stem}: {exc}")
             continue
 
     tasks.sort(key=lambda t: t.task_id or "", reverse=reverse)
@@ -751,28 +837,27 @@ def load_task_meta(
     """Load task metadata and optionally validate mode.
 
     Returns (meta, meta_path). Raises SystemExit if task is unknown or mode
-    conflicts with *expected_mode*.
+    conflicts with *expected_mode*.  ``meta_path`` is always the canonical
+    JSON path even when the on-disk file was migrated from YAML on this read.
     """
     meta_dir = tasks_meta_dir(project_id)
-    meta_path = meta_dir / f"{task_id}.yml"
-    if not meta_path.is_file():
+    meta = _read_task_meta(meta_dir, task_id)
+    if meta is None:
         raise SystemExit(f"Unknown task {task_id}")
-    meta = _yaml_load(meta_path.read_text()) or {}
     if expected_mode is not None:
         _check_mode(meta, expected_mode)
-    return meta, meta_path
+    return meta, _meta_path(meta_dir, task_id)
 
 
 def mark_task_deleting(project_id: str, task_id: str) -> None:
-    """Persist ``deleting: true`` to the task's YAML metadata file."""
+    """Persist ``deleting: true`` to the task's metadata file."""
     try:
         meta_dir = tasks_meta_dir(project_id)
-        meta_path = meta_dir / f"{task_id}.yml"
-        if not meta_path.is_file():
+        meta = _read_task_meta(meta_dir, task_id)
+        if meta is None:
             return
-        meta = _yaml_load(meta_path.read_text()) or {}
         meta["deleting"] = True
-        meta_path.write_text(_yaml_dump(meta))
+        _write_task_meta(_meta_path(meta_dir, task_id), meta)
     except Exception as e:
         _log_debug(f"mark_task_deleting: failed project_id={project_id} task_id={task_id}: {e}")
 
@@ -822,8 +907,9 @@ def _archive_task(project: ProjectConfig, task_id: str, meta: dict) -> Path | No
         archive_root = tasks_archive_dir(project.id)
         archive_dir = create_archive_dir(archive_root, dir_name)
 
-        # Save metadata snapshot
-        (archive_dir / "task.yml").write_text(_yaml_dump(meta))
+        # Save metadata snapshot — JSON matches the live-task format so
+        # archived entries remain readable with the same loader.
+        _write_task_meta(archive_dir / "task.json", _to_plain(meta))
 
         # Copy logs if they exist
         task_dir = project.tasks_root / str(task_id)
@@ -860,12 +946,11 @@ def _task_delete(project: ProjectConfig, task_id: str) -> TaskDeleteResult:
 
     workspace = project.tasks_root / str(task_id)
     meta_dir = tasks_meta_dir(project.id)
-    meta_path = meta_dir / f"{task_id}.yml"
+    meta_path = _meta_path(meta_dir, task_id)
+    legacy_yml = meta_dir / f"{task_id}.yml"
     _log_debug(f"task_delete: workspace={workspace} meta_path={meta_path}")
 
-    meta = {}
-    if meta_path.is_file():
-        meta = _yaml_load(meta_path.read_text()) or {}
+    meta = _read_task_meta(meta_dir, task_id) or {}
 
     mode = meta.get("mode")
     if mode:
@@ -925,10 +1010,13 @@ def _task_delete(project: ProjectConfig, task_id: str) -> TaskDeleteResult:
             _log_debug(f"task_delete: workspace removal failed: {exc}")
             warnings.append(f"Workspace removal failed: {exc}")
 
-    if meta_path.is_file():
+    # Both shapes might be present mid-migration (the read above migrates
+    # YAML→JSON, but a sibling reader could lose the race); clean both.
+    if meta_path.is_file() or legacy_yml.is_file():
         _log_debug("task_delete: removing metadata file")
         try:
-            meta_path.unlink()
+            meta_path.unlink(missing_ok=True)
+            legacy_yml.unlink(missing_ok=True)
             _log_debug("task_delete: metadata file removed")
         except Exception as exc:
             _log_debug(f"task_delete: metadata removal failed: {exc}")
@@ -968,10 +1056,9 @@ def _validate_login(project: ProjectConfig, task_id: str) -> tuple[str, str]:
     Raises ``SystemExit`` with actionable messages on failure.
     """
     meta_dir = tasks_meta_dir(project.id)
-    meta_path = meta_dir / f"{task_id}.yml"
-    if not meta_path.is_file():
+    meta = _read_task_meta(meta_dir, task_id)
+    if meta is None:
         raise SystemExit(f"Unknown task {task_id}")
-    meta = _yaml_load(meta_path.read_text()) or {}
 
     mode = meta.get("mode")
     if not mode:
@@ -1017,10 +1104,10 @@ def _task_stop(project: ProjectConfig, task_id: str, *, timeout: int | None = No
     """Gracefully stop a running task container."""
     effective_timeout = timeout if timeout is not None else project.shutdown_timeout
     meta_dir = tasks_meta_dir(project.id)
-    meta_path = meta_dir / f"{task_id}.yml"
-    if not meta_path.is_file():
+    meta = _read_task_meta(meta_dir, task_id)
+    if meta is None:
         raise SystemExit(f"Unknown task {task_id}")
-    meta = _yaml_load(meta_path.read_text()) or {}
+    meta_path = _meta_path(meta_dir, task_id)
 
     mode = meta.get("mode")
     if not mode:
@@ -1090,10 +1177,9 @@ def task_status(project_id: str, task_id: str) -> None:
     """Show live task status with container state diagnostics."""
     project = load_project(project_id)
     meta_dir = tasks_meta_dir(project.id)
-    meta_path = meta_dir / f"{task_id}.yml"
-    if not meta_path.is_file():
+    meta = _read_task_meta(meta_dir, task_id)
+    if meta is None:
         raise SystemExit(f"Unknown task {task_id}")
-    meta = _yaml_load(meta_path.read_text()) or {}
 
     mode = meta.get("mode")
     web_port = meta.get("web_port")
@@ -1175,6 +1261,30 @@ class ArchivedTask:
     exit_code: int | None
 
 
+def _load_archived_task_meta(entry: Path) -> dict | None:
+    """Load an archived task's snapshot — JSON or legacy YAML — or ``None`` on miss.
+
+    Older archives wrote ``task.yml``; new ones write ``task.json``.  Both
+    are tolerated indefinitely on the read path because archives are
+    immutable once written and there's no operator action that would
+    rewrite them.
+    """
+    json_path = entry / "task.json"
+    if json_path.is_file():
+        try:
+            text = json_path.read_text(encoding="utf-8")
+            return json.loads(text) if text.strip() else {}
+        except (OSError, ValueError):
+            return None
+    yml_path = entry / "task.yml"
+    if not yml_path.is_file():
+        return None
+    try:
+        return _to_plain(_yaml_load(yml_path.read_text(encoding="utf-8")) or {})
+    except Exception:
+        return None
+
+
 def list_archived_tasks(project_id: str) -> list[ArchivedTask]:
     """Return archived tasks for *project_id*, sorted newest-first."""
     archive_root = tasks_archive_dir(project_id)
@@ -1184,12 +1294,8 @@ def list_archived_tasks(project_id: str) -> list[ArchivedTask]:
     for entry in sorted(archive_root.iterdir(), reverse=True):
         if not entry.is_dir():
             continue
-        meta_path = entry / "task.yml"
-        if not meta_path.is_file():
-            continue
-        try:
-            meta = _yaml_load(meta_path.read_text()) or {}
-        except Exception:
+        meta = _load_archived_task_meta(entry)
+        if meta is None:
             continue
         # Parse archive timestamp from directory name: <timestamp>_<task_id>[_<name>]
         parts = entry.name.split("_", 2)

--- a/src/terok/lib/orchestration/tasks.py
+++ b/src/terok/lib/orchestration/tasks.py
@@ -1,4 +1,5 @@
 # SPDX-FileCopyrightText: 2025 Jiri Vyskocil
+# SPDX-FileCopyrightText: 2026 Jiri Vyskocil
 # SPDX-License-Identifier: Apache-2.0
 
 """Task metadata, lifecycle, and query operations.
@@ -319,6 +320,16 @@ class TaskMeta(TaskState):
     """
 
     task_id: str
+    project_id: str = ""
+    """Project the task belongs to.
+
+    Carried in the meta JSON so consumers that don't already know the
+    project (e.g. terok-shield's host-side dossier resolver, which only
+    has the meta-path pointer) can render full ``project/task`` identity
+    without re-deriving it from the on-disk path.  Empty string for
+    pre-this-release meta files; the lifecycle backfills it on the
+    next mutation.
+    """
     mode: str | None
     workspace: str
     web_port: int | None
@@ -459,6 +470,7 @@ def get_task_meta(project_id: str, task_id: str) -> TaskMeta:
             pass
     return TaskMeta(
         task_id=tid,
+        project_id=raw.get("project_id", project_id),
         mode=mode,
         workspace=raw.get("workspace", ""),
         web_port=raw.get("web_port"),
@@ -615,6 +627,7 @@ def _task_new(project: ProjectConfig, *, name: str | None = None) -> str:
     _write_task_readme(ws)
 
     meta = {
+        "project_id": project.id,
         "task_id": next_id,
         "name": task_name,
         "mode": None,

--- a/src/terok/tui/clearance_screen.py
+++ b/src/terok/tui/clearance_screen.py
@@ -125,17 +125,15 @@ class _LifecyclePosted(Message):
 def _render_notification(message: _NotificationPosted) -> str:
     """Format a notification for the TUI log + pending list.
 
-    When both the container name and ID arrived on the bus, surface them
-    together as ``name (id)`` — the TUI has the space and operators running
-    multiple tasks benefit from the disambiguation.  When only one is
-    available (older hubs, resolver miss), the subscriber-generated body
-    is already correct; pass it through untouched.
+    The subscriber's body already does dossier-aware identity rendering
+    via ``_identity_label`` (``project/task · name`` or fall back to the
+    bare container slug) — the TUI just concatenates the title and body
+    so every consumer of the same event renders identically.  An earlier
+    iteration here recomposed ``Container: {name} ({id})`` from the
+    notifier's typed kwargs and silently diverged from the desktop
+    popup; one renderer, one source of truth, no divergence.
     """
-    if not (message.container_name and message.container_id):
-        return f"{message.summary}  {message.body}"
-    body_lines = message.body.split("\n", 1)
-    tail = f"\n{body_lines[1]}" if len(body_lines) == 2 else ""
-    return f"{message.summary}  Container: {message.container_name} ({message.container_id}){tail}"
+    return f"{message.summary}  {message.body}"
 
 
 # ---------------------------------------------------------------------------

--- a/src/terok/tui/clearance_screen.py
+++ b/src/terok/tui/clearance_screen.py
@@ -227,18 +227,17 @@ class ClearanceScreen(screen.Screen[None]):
         """Connect to the clearance hub and start the event subscriber."""
         log = self.query_one(_ID_EVENT_LOG, RichLog)
         try:
-            from terok_clearance import CallbackNotifier, EventSubscriber, IdentityResolver
-            from terok_sandbox import create_container_inspector
+            from terok_clearance import CallbackNotifier, EventSubscriber
 
             self._notifier = CallbackNotifier(
                 on_notify=self._on_notify,
                 on_container_started=self._on_container_started,
                 on_container_exited=self._on_container_exited,
             )
-            self._subscriber = EventSubscriber(
-                self._notifier,
-                identity_resolver=IdentityResolver(inspector=create_container_inspector()),
-            )
+            # Identity resolution is no longer a TUI concern: the shield
+            # reader resolves the orchestrator dossier at emit time and
+            # ships it on every event, so the subscriber just reads it.
+            self._subscriber = EventSubscriber(self._notifier)
             await self._subscriber.start()
             log.write(Text("Connected to clearance hub...", style=_STYLE_INFO))
         except Exception as exc:

--- a/tach.toml
+++ b/tach.toml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 Jiri Vyskocil
+# SPDX-License-Identifier: Apache-2.0
+
 exclude = [
     "**/__pycache__",
     "**/tests/**",
@@ -605,10 +608,11 @@ expose = [
     "normalize_task_id_input",
     "CONTAINER_TEROK_CONFIG",
     "agent_config_dir",
-    # Migration helpers — exported so the few writers outside tasks.py
-    # (task_runners, sickbay) can land JSON via the same atomic-rename
+    # Meta-layer helpers — exported so the few writers outside tasks.py
+    # (task_runners, sickbay) can land state via the same atomic-rename
     # path tasks.py uses.  Underscore-prefixed because the on-disk
     # shape isn't a public contract.
+    "_dossier_path",
     "_meta_path",
     "_read_task_meta",
     "_write_task_meta",

--- a/tach.toml
+++ b/tach.toml
@@ -605,6 +605,15 @@ expose = [
     "normalize_task_id_input",
     "CONTAINER_TEROK_CONFIG",
     "agent_config_dir",
+    # Migration helpers — exported so the few writers outside tasks.py
+    # (task_runners, sickbay) can land JSON via the same atomic-rename
+    # path tasks.py uses.  Underscore-prefixed because the on-disk
+    # shape isn't a public contract.
+    "_meta_path",
+    "_read_task_meta",
+    "_write_task_meta",
+    "_iter_task_ids",
+    "_has_task_meta",
 ]
 from = ["terok.lib.orchestration.tasks"]
 

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -188,7 +188,7 @@ class TerokIntegrationEnv:
 
     def task_meta_path(self, project_id: str, task_id: str) -> Path:
         """Return the metadata YAML path for *task_id*."""
-        return self.task_meta_dir(project_id) / f"{task_id}.yml"
+        return self.task_meta_dir(project_id) / f"{task_id}_meta.yml"
 
     def task_archive_root(self, project_id: str) -> Path:
         """Return the archive root for deleted tasks."""

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -190,6 +190,34 @@ class TerokIntegrationEnv:
         """Return the metadata YAML path for *task_id*."""
         return self.task_meta_dir(project_id) / f"{task_id}_meta.yml"
 
+    def task_dossier_path(self, project_id: str, task_id: str) -> Path:
+        """Return the wire-dossier JSON path for *task_id*."""
+        return self.task_meta_dir(project_id) / f"{task_id}_dossier.json"
+
+    def task_meta(self, project_id: str, task_id: str) -> dict:
+        """Return the merged on-disk task meta — dossier (JSON) ∪ bookkeeping (YAML).
+
+        Mirrors the in-memory shape ``_read_task_meta`` produces for terok
+        internal callers, so integration assertions can ask for ``name``
+        / ``mode`` / ``web_port`` / etc. without caring which file each
+        field actually lives in.
+        """
+        from ruamel.yaml import YAML
+
+        result: dict = {}
+        yml = self.task_meta_path(project_id, task_id)
+        if yml.is_file():
+            data = YAML(typ="rt").load(yml.read_text(encoding="utf-8")) or {}
+            result.update({str(k): v for k, v in data.items()})
+        dossier = self.task_dossier_path(project_id, task_id)
+        if dossier.is_file():
+            text = dossier.read_text(encoding="utf-8")
+            wire = json.loads(text) if text.strip() else {}
+            for src, dst in (("project", "project_id"), ("task", "task_id"), ("name", "name")):
+                if wire.get(src):
+                    result[dst] = wire[src]
+        return result
+
     def task_archive_root(self, project_id: str) -> Path:
         """Return the archive root for deleted tasks."""
         return self.base_dir / "archive" / project_id / "tasks"

--- a/tests/integration/launch/test_task_start.py
+++ b/tests/integration/launch/test_task_start.py
@@ -13,7 +13,6 @@ from typing import Any
 
 import pytest
 
-from terok.lib.util.yaml import load as yaml_load
 from tests.test_utils import assert_task_id
 from tests.testnet import EXAMPLE_UPSTREAM_URL, LOCALHOST, localhost_url
 
@@ -109,7 +108,7 @@ class TestLaunchWorkflows:
         tid = _extract_task_id(result.stdout)
         assert_task_id(tid)
         cli_container = f"{PROJECT_ID}-cli-{tid}"
-        meta = yaml_load(terok_env.task_meta_path(PROJECT_ID, tid).read_text(encoding="utf-8"))
+        meta = terok_env.task_meta(PROJECT_ID, tid)
         state = _load_fake_podman_state(state_path)
         args = _container_args(state, cli_container)
 
@@ -144,7 +143,7 @@ class TestLaunchWorkflows:
         tid = _extract_task_id(result.stdout)
         web_port = _extract_web_port(result.stdout)
         toad_container = f"{PROJECT_ID}-toad-{tid}"
-        meta = yaml_load(terok_env.task_meta_path(PROJECT_ID, tid).read_text(encoding="utf-8"))
+        meta = terok_env.task_meta(PROJECT_ID, tid)
         state = _load_fake_podman_state(state_path)
         args = _container_args(state, toad_container)
 

--- a/tests/integration/tasks/test_lifecycle.py
+++ b/tests/integration/tasks/test_lifecycle.py
@@ -83,7 +83,10 @@ class TestTaskLifecycle:
         archive_root = terok_env.task_archive_root("demo")
         archived_entries = [entry for entry in archive_root.iterdir() if entry.is_dir()]
         assert archived_entries, "Expected task delete to create an archive entry"
-        assert any((entry / "task.yml").is_file() for entry in archived_entries)
+        # Archive snapshots are single-file JSON — one audience (operator
+        # browsing history), never reread by shield, so the live-task
+        # dossier/meta split brings no value here.
+        assert any((entry / "task.json").is_file() for entry in archived_entries)
 
         archived = terok_env.run_cli("task", "archive", "list", "demo")
         assert f"#{tid}: ship-it" in archived.stdout

--- a/tests/unit/cli/test_cli_uninstall.py
+++ b/tests/unit/cli/test_cli_uninstall.py
@@ -49,14 +49,7 @@ class TestUninstallDesktopEntry:
 
 
 class TestUninstallSandboxStack:
-    """Sandbox aggregator owns the full teardown — bridge + clearance + gate + vault + shield.
-
-    The earlier reader-cleanup workaround (``uninstall_shield_bridge``
-    called from terok directly) was removed once sandbox grew the
-    bridge teardown phase as a first-class integration step
-    (``run_bridge_uninstall_phase``).  Tests here cover the thin
-    delegating wrapper that's left.
-    """
+    """Sandbox aggregator owns the full teardown — bridge + clearance + gate + vault + shield."""
 
     def test_happy_path_delegates_to_aggregator(self, capsys: pytest.CaptureFixture[str]) -> None:
         with patch("terok_sandbox.sandbox_uninstall") as aggregator:
@@ -64,13 +57,6 @@ class TestUninstallSandboxStack:
         aggregator.assert_called_once_with(root=False)
         out = capsys.readouterr().out
         assert "Sandbox stack" in out
-        # The success-line wording is a deliberate operator-visible
-        # contract: the word "bridge" appearing here documents that
-        # the integration wire is part of what got torn down (sandbox
-        # owns the bridge phase as of v0.7.7).  Asserting "removed"
-        # alone wouldn't catch a regression that drops "bridge" from
-        # the success phrase.
-        assert "bridge" in out
         assert "removed" in out
 
     def test_aggregator_failure_reports_fail(self, capsys: pytest.CaptureFixture[str]) -> None:

--- a/tests/unit/cli/test_sickbay.py
+++ b/tests/unit/cli/test_sickbay.py
@@ -35,7 +35,7 @@ def task_meta_dir(tmp_path: Path) -> Path:
 
 def _write_meta(meta_dir: Path, tid: str, meta: dict) -> Path:
     """Write task metadata to a YAML file and return the path."""
-    p = meta_dir / f"{tid}.yml"
+    p = meta_dir / f"{tid}_meta.yml"
     p.write_text(yaml_dump(meta))
     return p
 

--- a/tests/unit/cli/test_sickbay.py
+++ b/tests/unit/cli/test_sickbay.py
@@ -722,6 +722,7 @@ class TestCheckClearanceStack:
     """
 
     def test_current_version_is_ok(self) -> None:
+        """Both install targets surface in the detail line, side-by-side."""
         from terok.cli.commands.sickbay import _check_clearance_stack
 
         with (
@@ -731,11 +732,15 @@ class TestCheckClearanceStack:
             unittest.mock.patch(
                 "terok.cli.commands.sickbay._clearance_hub_unit_version", return_value=1
             ),
+            unittest.mock.patch(
+                "terok.cli.commands.sickbay._clearance_notifier_unit_version", return_value=3
+            ),
         ):
             sev, label, detail = _check_clearance_stack()
         assert sev == "ok"
         assert label == "Clearance stack"
         assert "terok-clearance-hub.service v1" in detail
+        assert "terok-clearance-notifier.service v3" in detail
 
     def test_outdated_is_warn(self) -> None:
         from terok.cli.commands.sickbay import _check_clearance_stack
@@ -759,7 +764,37 @@ class TestCheckClearanceStack:
             unittest.mock.patch(
                 "terok.cli.commands.sickbay._clearance_hub_unit_version", return_value=None
             ),
+            unittest.mock.patch(
+                "terok.cli.commands.sickbay._clearance_notifier_unit_version", return_value=None
+            ),
         ):
             sev, _, detail = _check_clearance_stack()
         assert sev == "ok"
         assert "not installed" in detail
+
+    def test_notifier_only_install_renders_just_the_notifier_line(self) -> None:
+        """Headless hosts that ship only the notifier (or vice versa) render one stamp.
+
+        Sickbay must not assume both stamps are always present — a
+        partial-install host (e.g. someone disabled the hub) should
+        still produce a sensible detail string rather than hiding the
+        one install target that does exist behind a misleading "not
+        installed" branch.
+        """
+        from terok.cli.commands.sickbay import _check_clearance_stack
+
+        with (
+            unittest.mock.patch(
+                "terok.cli.commands.sickbay._clearance_check_units_outdated", return_value=None
+            ),
+            unittest.mock.patch(
+                "terok.cli.commands.sickbay._clearance_hub_unit_version", return_value=None
+            ),
+            unittest.mock.patch(
+                "terok.cli.commands.sickbay._clearance_notifier_unit_version", return_value=3
+            ),
+        ):
+            sev, _, detail = _check_clearance_stack()
+        assert sev == "ok"
+        assert "terok-clearance-hub" not in detail
+        assert "terok-clearance-notifier.service v3" in detail

--- a/tests/unit/lib/test_autopilot.py
+++ b/tests/unit/lib/test_autopilot.py
@@ -139,8 +139,16 @@ def read_task_agents(base: Path, project_id: str, task_id: str = "1") -> dict[st
 
 
 def read_task_meta(base: Path, project_id: str, task_id: str = "1") -> dict[str, object]:
-    """Load task metadata JSON for a task."""
-    return json.loads(task_paths(base, project_id, task_id)[1].read_text() or "{}")
+    """Load merged task metadata for a task — wire-dossier + bookkeeping.
+
+    Live tasks store the wire-dossier triple in JSON (the file shield
+    consumers parse) and everything else in YAML; ``_read_task_meta``
+    composes them back into the orchestrator's logical dict shape.
+    """
+    from terok.lib.orchestration.tasks import _read_task_meta
+
+    meta_dir = task_paths(base, project_id, task_id)[1].parent
+    return _read_task_meta(meta_dir, task_id) or {}
 
 
 def prepare_agent_config(

--- a/tests/unit/lib/test_autopilot.py
+++ b/tests/unit/lib/test_autopilot.py
@@ -101,7 +101,7 @@ def task_paths(base: Path, project_id: str, task_id: str = "1") -> tuple[Path, P
     state = base / "state"
     return (
         sandbox_live / "tasks" / project_id / task_id / "agent-config",
-        state / "projects" / project_id / "tasks" / f"{task_id}.json",
+        state / "projects" / project_id / "tasks" / f"{task_id}_dossier.json",
     )
 
 

--- a/tests/unit/lib/test_autopilot.py
+++ b/tests/unit/lib/test_autopilot.py
@@ -18,8 +18,6 @@ from typing import TYPE_CHECKING
 
 import pytest
 
-from terok.lib.util.yaml import dump as yaml_dump, load as yaml_load
-
 if TYPE_CHECKING:
     from terok_sandbox import RunSpec
 
@@ -103,7 +101,7 @@ def task_paths(base: Path, project_id: str, task_id: str = "1") -> tuple[Path, P
     state = base / "state"
     return (
         sandbox_live / "tasks" / project_id / task_id / "agent-config",
-        state / "projects" / project_id / "tasks" / f"{task_id}.yml",
+        state / "projects" / project_id / "tasks" / f"{task_id}.json",
     )
 
 
@@ -141,8 +139,8 @@ def read_task_agents(base: Path, project_id: str, task_id: str = "1") -> dict[st
 
 
 def read_task_meta(base: Path, project_id: str, task_id: str = "1") -> dict[str, object]:
-    """Load task metadata YAML for a task."""
-    return yaml_load(task_paths(base, project_id, task_id)[1].read_text())
+    """Load task metadata JSON for a task."""
+    return json.loads(task_paths(base, project_id, task_id)[1].read_text() or "{}")
 
 
 def prepare_agent_config(
@@ -594,9 +592,9 @@ class TestTaskFollowupHeadless:
                 with mock_git_config():
                     task_id = task_new("proj_mode")
                     _agent_cfg, meta_path = task_paths(base, "proj_mode", task_id)
-                    meta = yaml_load(meta_path.read_text())
+                    meta = json.loads(meta_path.read_text() or "{}")
                     meta["mode"] = "cli"
-                    meta_path.write_text(yaml_dump(meta))
+                    meta_path.write_text(json.dumps(meta, indent=2))
 
                     with pytest.raises(SystemExit) as ctx:
                         task_followup_headless("proj_mode", task_id, "test")
@@ -617,9 +615,9 @@ class TestTaskFollowupHeadless:
                 with mock_git_config():
                     task_id = task_new("proj_run")
                     _agent_cfg, meta_path = task_paths(base, "proj_run", task_id)
-                    meta = yaml_load(meta_path.read_text())
+                    meta = json.loads(meta_path.read_text() or "{}")
                     meta["mode"] = "run"
-                    meta_path.write_text(yaml_dump(meta))
+                    meta_path.write_text(json.dumps(meta, indent=2))
 
                     mock_runtime.container.return_value.state = "running"
                     with pytest.raises(SystemExit) as ctx:

--- a/tests/unit/lib/test_container_lifecycle.py
+++ b/tests/unit/lib/test_container_lifecycle.py
@@ -32,7 +32,7 @@ def project_config(project_id: str, *, shutdown_timeout: int | None = None) -> s
 
 def task_meta_path(ctx: SimpleNamespace, project_id: str, task_id: str) -> Path:
     """Return the metadata path for *task_id* inside the temporary project env."""
-    return ctx.state_dir / "projects" / project_id / "tasks" / f"{task_id}.json"
+    return ctx.state_dir / "projects" / project_id / "tasks" / f"{task_id}_dossier.json"
 
 
 def update_task_meta(

--- a/tests/unit/lib/test_container_lifecycle.py
+++ b/tests/unit/lib/test_container_lifecycle.py
@@ -5,6 +5,7 @@
 
 from __future__ import annotations
 
+import json
 import subprocess
 from collections.abc import Callable
 from contextlib import redirect_stdout
@@ -18,7 +19,6 @@ from terok_sandbox import PodmanRuntime
 
 from terok.lib.orchestration.task_runners import task_restart
 from terok.lib.orchestration.tasks import get_task_container_state, task_new, task_status, task_stop
-from terok.lib.util.yaml import dump as yaml_dump, load as yaml_load
 from tests.test_utils import mock_git_config, project_env
 
 
@@ -32,7 +32,7 @@ def project_config(project_id: str, *, shutdown_timeout: int | None = None) -> s
 
 def task_meta_path(ctx: SimpleNamespace, project_id: str, task_id: str) -> Path:
     """Return the metadata path for *task_id* inside the temporary project env."""
-    return ctx.state_dir / "projects" / project_id / "tasks" / f"{task_id}.yml"
+    return ctx.state_dir / "projects" / project_id / "tasks" / f"{task_id}.json"
 
 
 def update_task_meta(
@@ -40,9 +40,9 @@ def update_task_meta(
 ) -> None:
     """Patch selected metadata keys for a generated task."""
     meta_path = task_meta_path(ctx, project_id, task_id)
-    meta = yaml_load(meta_path.read_text()) or {}
+    meta = json.loads(meta_path.read_text() or "{}") or {}
     meta.update(changes)
-    meta_path.write_text(yaml_dump(meta), encoding="utf-8")
+    meta_path.write_text(json.dumps(meta, indent=2), encoding="utf-8")
 
 
 def create_task_with_mode(ctx: SimpleNamespace, project_id: str, *, mode: str = "cli") -> str:

--- a/tests/unit/lib/test_hooks.py
+++ b/tests/unit/lib/test_hooks.py
@@ -5,6 +5,7 @@
 
 from __future__ import annotations
 
+import json
 import subprocess
 import unittest.mock
 from pathlib import Path
@@ -45,82 +46,89 @@ class TestBuildHookEnv:
 
 
 class TestRecordHook:
-    """Tests for _record_hook metadata tracking."""
+    """Tests for _record_hook bookkeeping — writes to the ``_meta.yml`` sibling."""
 
-    def test_record_hook_writes_to_metadata(self, tmp_path: Path) -> None:
-        """Verify _record_hook appends hook_name to hooks_fired list."""
-        import json
-
-        meta_path = tmp_path / "1.json"
-        meta_path.write_text(json.dumps({"task_id": "1", "mode": "cli"}, indent=2))
-
-        _record_hook(meta_path, "post_start")
-
-        meta = json.loads(meta_path.read_text() or "{}")
-        assert meta["hooks_fired"] == ["post_start"]
-
-    def test_record_hook_appends_without_duplicates(self, tmp_path: Path) -> None:
-        """Verify _record_hook doesn't duplicate existing entries."""
-        import json
-
-        meta_path = tmp_path / "1.json"
-        meta_path.write_text(json.dumps({"task_id": "1", "hooks_fired": ["post_start"]}, indent=2))
-
-        _record_hook(meta_path, "post_start")
-        _record_hook(meta_path, "post_ready")
-
-        meta = json.loads(meta_path.read_text() or "{}")
-        assert meta["hooks_fired"] == ["post_start", "post_ready"]
-
-    def test_record_hook_skips_missing_file(self, tmp_path: Path) -> None:
-        """Verify _record_hook is a no-op when the metadata file doesn't exist."""
-        meta_path = tmp_path / "nonexistent.json"
-        _record_hook(meta_path, "post_start")  # should not raise
-
-    def test_record_hook_migrates_yaml_then_keeps_recording(self, tmp_path: Path) -> None:
-        """A caller pinning the legacy ``.yml`` Path keeps recording after migration.
-
-        Regression: the first call rotates ``.yml`` → ``.json`` and unlinks
-        the YAML.  Without resolving to the canonical ``.json`` first, every
-        later call (``post_start`` → ``post_ready`` → ``post_stop``) would hit
-        the existence check on the now-gone YAML and silently drop the hook
-        from ``hooks_fired``.
-        """
-        import json
-
+    @staticmethod
+    def _seed_pair(tmp_path: Path, task_id: str, state: dict | None = None) -> Path:
+        """Create the ``<id>_dossier.json`` + ``<id>_meta.yml`` pair, return dossier handle."""
         from terok.lib.util.yaml import dump as yaml_dump
 
-        # Caller hands in a stale YAML path — the typical pre_start/post_start
-        # call site captures meta_path before any migration has happened.
-        yaml_path = tmp_path / "1.yml"
-        yaml_path.write_text(yaml_dump({"task_id": "1", "mode": "cli"}))
+        dossier_path = tmp_path / f"{task_id}_dossier.json"
+        meta_path = tmp_path / f"{task_id}_meta.yml"
+        dossier_path.write_text(json.dumps({"task": task_id}))
+        meta_path.write_text(yaml_dump(state or {}))
+        return dossier_path
 
-        _record_hook(yaml_path, "pre_start")  # migrates to JSON, unlinks YAML
-        _record_hook(yaml_path, "post_start")  # would no-op without the fix
-        _record_hook(yaml_path, "post_ready")
-        _record_hook(yaml_path, "post_stop")
+    def test_record_hook_writes_to_bookkeeping_yml(self, tmp_path: Path) -> None:
+        """``hooks_fired`` lands in ``_meta.yml`` (bookkeeping), not in the dossier JSON."""
+        from terok.lib.util.yaml import load as yaml_load
 
-        # YAML is gone, JSON is canonical.
-        assert not yaml_path.exists()
-        json_path = tmp_path / "1.json"
-        assert json_path.is_file()
-        meta = json.loads(json_path.read_text())
-        assert meta["hooks_fired"] == ["pre_start", "post_start", "post_ready", "post_stop"]
+        dossier_path = self._seed_pair(tmp_path, "1", {"mode": "cli"})
+
+        _record_hook(dossier_path, "post_start")
+
+        meta = yaml_load((tmp_path / "1_meta.yml").read_text())
+        assert list(meta["hooks_fired"]) == ["post_start"]
+        # Dossier untouched — ``hooks_fired`` is not on the wire.
+        assert "hooks_fired" not in json.loads(dossier_path.read_text())
+
+    def test_record_hook_appends_without_duplicates(self, tmp_path: Path) -> None:
+        """Re-recording the same hook is a no-op; new hooks append in order."""
+        from terok.lib.util.yaml import load as yaml_load
+
+        dossier_path = self._seed_pair(tmp_path, "1", {"hooks_fired": ["post_start"]})
+
+        _record_hook(dossier_path, "post_start")
+        _record_hook(dossier_path, "post_ready")
+
+        meta = yaml_load((tmp_path / "1_meta.yml").read_text())
+        assert list(meta["hooks_fired"]) == ["post_start", "post_ready"]
+
+    def test_record_hook_skips_when_bookkeeping_absent(self, tmp_path: Path) -> None:
+        """No ``_meta.yml`` → no place to record; soft-fail rather than crash."""
+        dossier_path = tmp_path / "1_dossier.json"
+        dossier_path.write_text("{}")
+        _record_hook(dossier_path, "post_start")  # must not raise
+
+    def test_record_hook_skips_missing_file(self, tmp_path: Path) -> None:
+        """Verify _record_hook is a no-op when neither file is on disk."""
+        _record_hook(tmp_path / "nonexistent_dossier.json", "post_start")  # should not raise
+
+    def test_record_hook_handles_legacy_yml_layout(self, tmp_path: Path) -> None:
+        """A pre-self-describing ``<id>.yml`` is updated in place when present.
+
+        Tasks created before the rename to ``<id>_meta.yml`` keep
+        receiving hook records until they're migrated by the next
+        ``_read_task_meta`` call.
+        """
+        from terok.lib.util.yaml import dump as yaml_dump, load as yaml_load
+
+        legacy = tmp_path / "1.yml"
+        legacy.write_text(yaml_dump({"mode": "cli"}))
+        # The dossier handle the caller has — pre-migration single-file path.
+        dossier_handle = tmp_path / "1.json"
+        dossier_handle.write_text("{}")
+
+        _record_hook(dossier_handle, "post_start")
+
+        meta = yaml_load(legacy.read_text())
+        assert list(meta["hooks_fired"]) == ["post_start"]
 
     def test_record_hook_writes_atomically(self, tmp_path: Path) -> None:
-        """``_record_hook`` stages to ``*.tmp`` and ``os.replace`` — no truncated JSON.
+        """``_record_hook`` stages to ``*.tmp`` and ``os.replace`` — no truncated YAML.
 
         An interrupted record must never leave a partial file behind.  Force
-        a failure during the temp-file write and assert the canonical JSON
-        is unchanged (would otherwise be truncated under the old in-place
-        ``write_text`` pattern).
+        a failure during the temp-file write and assert the canonical YAML
+        is unchanged.
         """
-        import json
         from unittest import mock
 
-        meta_path = tmp_path / "1.json"
-        original = {"task_id": "1", "hooks_fired": ["pre_start"]}
-        meta_path.write_text(json.dumps(original, indent=2))
+        from terok.lib.util.yaml import dump as yaml_dump, load as yaml_load
+
+        original = {"hooks_fired": ["pre_start"]}
+        dossier_path = self._seed_pair(tmp_path, "1", original)
+        meta_yml = tmp_path / "1_meta.yml"
+        original_text = meta_yml.read_text()
 
         original_write_text = Path.write_text
 
@@ -130,10 +138,13 @@ class TestRecordHook:
             return original_write_text(self, *args, **kwargs)
 
         with mock.patch.object(Path, "write_text", _fail_on_tmp):
-            _record_hook(meta_path, "post_start")  # logs + swallows OSError
+            _record_hook(dossier_path, "post_start")  # logs + swallows OSError
 
         # Original content intact — no torn write.
-        assert json.loads(meta_path.read_text()) == original
+        assert meta_yml.read_text() == original_text
+        # Sanity: the original list is still parseable.
+        assert list(yaml_load(meta_yml.read_text())["hooks_fired"]) == ["pre_start"]
+        del yaml_dump  # keep ruff happy when only the loader is used
 
 
 class TestRunHook:
@@ -265,11 +276,13 @@ class TestRunHook:
             )
 
     def test_run_hook_with_meta_path_records(self, tmp_path: Path) -> None:
-        """Verify run_hook records the hook name in metadata when meta_path is given."""
-        import json
+        """Verify run_hook records the hook name in bookkeeping when meta_path is given."""
+        from terok.lib.util.yaml import dump as yaml_dump, load as yaml_load
 
-        meta_path = tmp_path / "1.json"
-        meta_path.write_text(json.dumps({"task_id": "1", "mode": "cli"}, indent=2))
+        dossier_path = tmp_path / "1_dossier.json"
+        meta_yml = tmp_path / "1_meta.yml"
+        dossier_path.write_text(json.dumps({"task": "1"}))
+        meta_yml.write_text(yaml_dump({"mode": "cli"}))
 
         with unittest.mock.patch("terok.lib.orchestration.hooks.subprocess.run"):
             run_hook(
@@ -279,18 +292,19 @@ class TestRunHook:
                 task_id="1",
                 mode="cli",
                 cname="c",
-                meta_path=meta_path,
+                meta_path=dossier_path,
             )
 
-        meta = json.loads(meta_path.read_text() or "{}")
-        assert "post_start" in meta["hooks_fired"]
+        assert "post_start" in yaml_load(meta_yml.read_text())["hooks_fired"]
 
     def test_run_hook_records_even_without_command(self, tmp_path: Path) -> None:
         """Verify run_hook records even when command is None (hook point reached)."""
-        import json
+        from terok.lib.util.yaml import dump as yaml_dump, load as yaml_load
 
-        meta_path = tmp_path / "1.json"
-        meta_path.write_text(json.dumps({"task_id": "1", "mode": "cli"}, indent=2))
+        dossier_path = tmp_path / "1_dossier.json"
+        meta_yml = tmp_path / "1_meta.yml"
+        dossier_path.write_text(json.dumps({"task": "1"}))
+        meta_yml.write_text(yaml_dump({"mode": "cli"}))
 
         run_hook(
             "post_ready",
@@ -299,8 +313,7 @@ class TestRunHook:
             task_id="1",
             mode="cli",
             cname="c",
-            meta_path=meta_path,
+            meta_path=dossier_path,
         )
 
-        meta = json.loads(meta_path.read_text() or "{}")
-        assert "post_ready" in meta["hooks_fired"]
+        assert "post_ready" in yaml_load(meta_yml.read_text())["hooks_fired"]

--- a/tests/unit/lib/test_hooks.py
+++ b/tests/unit/lib/test_hooks.py
@@ -49,32 +49,32 @@ class TestRecordHook:
 
     def test_record_hook_writes_to_metadata(self, tmp_path: Path) -> None:
         """Verify _record_hook appends hook_name to hooks_fired list."""
-        from terok.lib.util.yaml import dump as _yaml_dump, load as _yaml_load
+        import json
 
-        meta_path = tmp_path / "1.yml"
-        meta_path.write_text(_yaml_dump({"task_id": "1", "mode": "cli"}))
+        meta_path = tmp_path / "1.json"
+        meta_path.write_text(json.dumps({"task_id": "1", "mode": "cli"}, indent=2))
 
         _record_hook(meta_path, "post_start")
 
-        meta = _yaml_load(meta_path.read_text())
+        meta = json.loads(meta_path.read_text() or "{}")
         assert meta["hooks_fired"] == ["post_start"]
 
     def test_record_hook_appends_without_duplicates(self, tmp_path: Path) -> None:
         """Verify _record_hook doesn't duplicate existing entries."""
-        from terok.lib.util.yaml import dump as _yaml_dump, load as _yaml_load
+        import json
 
-        meta_path = tmp_path / "1.yml"
-        meta_path.write_text(_yaml_dump({"task_id": "1", "hooks_fired": ["post_start"]}))
+        meta_path = tmp_path / "1.json"
+        meta_path.write_text(json.dumps({"task_id": "1", "hooks_fired": ["post_start"]}, indent=2))
 
         _record_hook(meta_path, "post_start")
         _record_hook(meta_path, "post_ready")
 
-        meta = _yaml_load(meta_path.read_text())
+        meta = json.loads(meta_path.read_text() or "{}")
         assert meta["hooks_fired"] == ["post_start", "post_ready"]
 
     def test_record_hook_skips_missing_file(self, tmp_path: Path) -> None:
         """Verify _record_hook is a no-op when the metadata file doesn't exist."""
-        meta_path = tmp_path / "nonexistent.yml"
+        meta_path = tmp_path / "nonexistent.json"
         _record_hook(meta_path, "post_start")  # should not raise
 
 
@@ -208,10 +208,10 @@ class TestRunHook:
 
     def test_run_hook_with_meta_path_records(self, tmp_path: Path) -> None:
         """Verify run_hook records the hook name in metadata when meta_path is given."""
-        from terok.lib.util.yaml import dump as _yaml_dump, load as _yaml_load
+        import json
 
-        meta_path = tmp_path / "1.yml"
-        meta_path.write_text(_yaml_dump({"task_id": "1", "mode": "cli"}))
+        meta_path = tmp_path / "1.json"
+        meta_path.write_text(json.dumps({"task_id": "1", "mode": "cli"}, indent=2))
 
         with unittest.mock.patch("terok.lib.orchestration.hooks.subprocess.run"):
             run_hook(
@@ -224,15 +224,15 @@ class TestRunHook:
                 meta_path=meta_path,
             )
 
-        meta = _yaml_load(meta_path.read_text())
+        meta = json.loads(meta_path.read_text() or "{}")
         assert "post_start" in meta["hooks_fired"]
 
     def test_run_hook_records_even_without_command(self, tmp_path: Path) -> None:
         """Verify run_hook records even when command is None (hook point reached)."""
-        from terok.lib.util.yaml import dump as _yaml_dump, load as _yaml_load
+        import json
 
-        meta_path = tmp_path / "1.yml"
-        meta_path.write_text(_yaml_dump({"task_id": "1", "mode": "cli"}))
+        meta_path = tmp_path / "1.json"
+        meta_path.write_text(json.dumps({"task_id": "1", "mode": "cli"}, indent=2))
 
         run_hook(
             "post_ready",
@@ -244,5 +244,5 @@ class TestRunHook:
             meta_path=meta_path,
         )
 
-        meta = _yaml_load(meta_path.read_text())
+        meta = json.loads(meta_path.read_text() or "{}")
         assert "post_ready" in meta["hooks_fired"]

--- a/tests/unit/lib/test_hooks.py
+++ b/tests/unit/lib/test_hooks.py
@@ -77,6 +77,64 @@ class TestRecordHook:
         meta_path = tmp_path / "nonexistent.json"
         _record_hook(meta_path, "post_start")  # should not raise
 
+    def test_record_hook_migrates_yaml_then_keeps_recording(self, tmp_path: Path) -> None:
+        """A caller pinning the legacy ``.yml`` Path keeps recording after migration.
+
+        Regression: the first call rotates ``.yml`` → ``.json`` and unlinks
+        the YAML.  Without resolving to the canonical ``.json`` first, every
+        later call (``post_start`` → ``post_ready`` → ``post_stop``) would hit
+        the existence check on the now-gone YAML and silently drop the hook
+        from ``hooks_fired``.
+        """
+        import json
+
+        from terok.lib.util.yaml import dump as yaml_dump
+
+        # Caller hands in a stale YAML path — the typical pre_start/post_start
+        # call site captures meta_path before any migration has happened.
+        yaml_path = tmp_path / "1.yml"
+        yaml_path.write_text(yaml_dump({"task_id": "1", "mode": "cli"}))
+
+        _record_hook(yaml_path, "pre_start")  # migrates to JSON, unlinks YAML
+        _record_hook(yaml_path, "post_start")  # would no-op without the fix
+        _record_hook(yaml_path, "post_ready")
+        _record_hook(yaml_path, "post_stop")
+
+        # YAML is gone, JSON is canonical.
+        assert not yaml_path.exists()
+        json_path = tmp_path / "1.json"
+        assert json_path.is_file()
+        meta = json.loads(json_path.read_text())
+        assert meta["hooks_fired"] == ["pre_start", "post_start", "post_ready", "post_stop"]
+
+    def test_record_hook_writes_atomically(self, tmp_path: Path) -> None:
+        """``_record_hook`` stages to ``*.tmp`` and ``os.replace`` — no truncated JSON.
+
+        An interrupted record must never leave a partial file behind.  Force
+        a failure during the temp-file write and assert the canonical JSON
+        is unchanged (would otherwise be truncated under the old in-place
+        ``write_text`` pattern).
+        """
+        import json
+        from unittest import mock
+
+        meta_path = tmp_path / "1.json"
+        original = {"task_id": "1", "hooks_fired": ["pre_start"]}
+        meta_path.write_text(json.dumps(original, indent=2))
+
+        original_write_text = Path.write_text
+
+        def _fail_on_tmp(self: Path, *args, **kwargs):  # noqa: ANN001, ANN202
+            if self.suffix == ".tmp":
+                raise OSError("disk full")
+            return original_write_text(self, *args, **kwargs)
+
+        with mock.patch.object(Path, "write_text", _fail_on_tmp):
+            _record_hook(meta_path, "post_start")  # logs + swallows OSError
+
+        # Original content intact — no torn write.
+        assert json.loads(meta_path.read_text()) == original
+
 
 class TestRunHook:
     """Tests for run_hook execution."""

--- a/tests/unit/lib/test_login.py
+++ b/tests/unit/lib/test_login.py
@@ -32,7 +32,7 @@ def setup_task_with_mode(
     """
     task_id = task_new(project_id)
     if mode:
-        meta_path = ctx.state_dir / "projects" / project_id / "tasks" / f"{task_id}.json"
+        meta_path = ctx.state_dir / "projects" / project_id / "tasks" / f"{task_id}_dossier.json"
         meta = json.loads(meta_path.read_text() or "{}")
         meta["mode"] = mode
         meta_path.write_text(json.dumps(meta, indent=2), encoding="utf-8")

--- a/tests/unit/lib/test_login.py
+++ b/tests/unit/lib/test_login.py
@@ -5,13 +5,13 @@
 
 from __future__ import annotations
 
+import json
 import types
 import unittest.mock
 
 import pytest
 
 from terok.lib.orchestration.tasks import get_login_command, task_login, task_new
-from terok.lib.util.yaml import dump as yaml_dump, load as yaml_load
 from tests.test_utils import mock_git_config, project_env
 
 
@@ -32,10 +32,10 @@ def setup_task_with_mode(
     """
     task_id = task_new(project_id)
     if mode:
-        meta_path = ctx.state_dir / "projects" / project_id / "tasks" / f"{task_id}.yml"
-        meta = yaml_load(meta_path.read_text())
+        meta_path = ctx.state_dir / "projects" / project_id / "tasks" / f"{task_id}.json"
+        meta = json.loads(meta_path.read_text() or "{}")
         meta["mode"] = mode
-        meta_path.write_text(yaml_dump(meta), encoding="utf-8")
+        meta_path.write_text(json.dumps(meta, indent=2), encoding="utf-8")
     return task_id
 
 

--- a/tests/unit/lib/test_task_ids.py
+++ b/tests/unit/lib/test_task_ids.py
@@ -112,7 +112,7 @@ class TestResolveTaskId:
         meta_dir = tasks_meta_dir(project_id)
         meta_dir.mkdir(parents=True, exist_ok=True)
         meta = {"task_id": task_id, "name": "test-task", "mode": None, "workspace": "/tmp/ws"}
-        (meta_dir / f"{task_id}.json").write_text(json.dumps(meta, indent=2))
+        (meta_dir / f"{task_id}_dossier.json").write_text(json.dumps(meta, indent=2))
 
     def test_exact_match(self) -> None:
         """Full task ID should resolve immediately."""
@@ -212,7 +212,7 @@ class TestLegacyHexCompat:
         meta_dir = tasks_meta_dir(project_id)
         meta_dir.mkdir(parents=True, exist_ok=True)
         meta = {"task_id": task_id, "name": "legacy", "mode": None, "workspace": "/tmp/ws"}
-        (meta_dir / f"{task_id}.json").write_text(json.dumps(meta, indent=2))
+        (meta_dir / f"{task_id}_dossier.json").write_text(json.dumps(meta, indent=2))
 
     def test_legacy_hex_resolves_with_deprecation(self) -> None:
         """A legacy 8-char hex task on disk should still resolve, with a DeprecationWarning."""

--- a/tests/unit/lib/test_task_ids.py
+++ b/tests/unit/lib/test_task_ids.py
@@ -5,6 +5,7 @@
 
 from __future__ import annotations
 
+import json
 import unittest.mock
 
 import pytest
@@ -19,7 +20,6 @@ from terok.lib.orchestration.tasks import (
     resolve_task_id,
     tasks_meta_dir,
 )
-from terok.lib.util.yaml import dump as yaml_dump
 from tests.test_utils import assert_task_id, project_env
 
 MINIMAL_PROJECT = """
@@ -112,7 +112,7 @@ class TestResolveTaskId:
         meta_dir = tasks_meta_dir(project_id)
         meta_dir.mkdir(parents=True, exist_ok=True)
         meta = {"task_id": task_id, "name": "test-task", "mode": None, "workspace": "/tmp/ws"}
-        (meta_dir / f"{task_id}.yml").write_text(yaml_dump(meta))
+        (meta_dir / f"{task_id}.json").write_text(json.dumps(meta, indent=2))
 
     def test_exact_match(self) -> None:
         """Full task ID should resolve immediately."""
@@ -212,7 +212,7 @@ class TestLegacyHexCompat:
         meta_dir = tasks_meta_dir(project_id)
         meta_dir.mkdir(parents=True, exist_ok=True)
         meta = {"task_id": task_id, "name": "legacy", "mode": None, "workspace": "/tmp/ws"}
-        (meta_dir / f"{task_id}.yml").write_text(yaml_dump(meta))
+        (meta_dir / f"{task_id}.json").write_text(json.dumps(meta, indent=2))
 
     def test_legacy_hex_resolves_with_deprecation(self) -> None:
         """A legacy 8-char hex task on disk should still resolve, with a DeprecationWarning."""
@@ -235,8 +235,10 @@ class TestLegacyHexCompat:
         with project_env(MINIMAL_PROJECT) as _ctx:
             meta_dir = tasks_meta_dir("test-proj")
             meta_dir.mkdir(parents=True, exist_ok=True)
-            (meta_dir / f"{ID_A}.yml").write_text(
-                yaml_dump({"task_id": ID_A, "name": "n", "mode": None, "workspace": "/tmp/ws"})
+            (meta_dir / f"{ID_A}.json").write_text(
+                json.dumps(
+                    {"task_id": ID_A, "name": "n", "mode": None, "workspace": "/tmp/ws"}, indent=2
+                )
             )
             with warnings.catch_warnings():
                 warnings.simplefilter("error", DeprecationWarning)

--- a/tests/unit/lib/test_task_names.py
+++ b/tests/unit/lib/test_task_names.py
@@ -41,7 +41,7 @@ def project_yaml(project_id: str, *, name_categories: list[str] | None = None) -
 
 def task_meta_name(ctx, project_id: str, task_id: str) -> str:
     """Return the persisted task name from task metadata."""
-    meta_path = ctx.state_dir / "projects" / project_id / "tasks" / f"{task_id}.json"
+    meta_path = ctx.state_dir / "projects" / project_id / "tasks" / f"{task_id}_dossier.json"
     return json.loads(meta_path.read_text() or "{}")["name"]
 
 

--- a/tests/unit/lib/test_task_names.py
+++ b/tests/unit/lib/test_task_names.py
@@ -5,6 +5,7 @@
 
 from __future__ import annotations
 
+import json
 import re
 from contextlib import redirect_stdout
 from io import StringIO
@@ -15,6 +16,7 @@ import pytest
 from terok.lib.orchestration.tasks import (
     TASK_NAME_MAX_LEN,
     _default_categories_for_project,
+    _iter_task_ids,  # noqa: F401 — used in renamed assert
     _resolve_name_categories,
     generate_task_name,
     get_tasks,
@@ -23,7 +25,6 @@ from terok.lib.orchestration.tasks import (
     task_rename,
     validate_task_name,
 )
-from terok.lib.util.yaml import load as yaml_load
 from tests.test_utils import project_env
 
 SLUG_PATTERN = r"^[a-z]+-[a-z0-9]+$"
@@ -40,8 +41,8 @@ def project_yaml(project_id: str, *, name_categories: list[str] | None = None) -
 
 def task_meta_name(ctx, project_id: str, task_id: str) -> str:
     """Return the persisted task name from task metadata."""
-    meta_path = ctx.state_dir / "projects" / project_id / "tasks" / f"{task_id}.yml"
-    return yaml_load(meta_path.read_text())["name"]
+    meta_path = ctx.state_dir / "projects" / project_id / "tasks" / f"{task_id}.json"
+    return json.loads(meta_path.read_text() or "{}")["name"]
 
 
 def create_task_and_get_name(project_id: str, *, explicit_name: str | None = None) -> str:
@@ -136,7 +137,7 @@ def test_task_new_rejects_invalid_names(bad_name: str) -> None:
         with pytest.raises(SystemExit):
             task_new(project_id, name=bad_name)
         tasks_dir = ctx.state_dir / "projects" / project_id / "tasks"
-        assert not tasks_dir.exists() or not list(tasks_dir.glob("*.yml"))
+        assert not tasks_dir.exists() or not list(_iter_task_ids(tasks_dir))
 
 
 def test_task_new_prints_name() -> None:

--- a/tests/unit/lib/test_task_runner_internals.py
+++ b/tests/unit/lib/test_task_runner_internals.py
@@ -472,12 +472,12 @@ class TestRunContainer:
         # ``{project, task, name}``).  The shield reader rereads it on
         # every emit so renames surface live.  Caller-supplied extras come
         # after.
-        from terok.lib.orchestration.tasks import tasks_meta_dir
+        from terok.lib.orchestration.tasks import _dossier_path, tasks_meta_dir
 
-        expected_meta_path = tasks_meta_dir("p1") / "t1.json"
+        expected_dossier_path = _dossier_path(tasks_meta_dir("p1"), "t1")
         assert spec.extra_args == (
             "--annotation",
-            f"dossier.meta_path={expected_meta_path}",
+            f"dossier.meta_path={expected_dossier_path}",
             "-p",
             "8080:80",
         )

--- a/tests/unit/lib/test_task_runner_internals.py
+++ b/tests/unit/lib/test_task_runner_internals.py
@@ -467,18 +467,15 @@ class TestRunContainer:
             )
 
         spec = captured_runspec(sandbox_factory)
-        # _run_container prepends three annotations under the
-        # ``dossier.*`` namespace so the shield reader can resolve a
-        # task-aware identity at emit time; the caller-supplied extras
-        # come after.
+        # _run_container prepends a single ``dossier.meta_path`` annotation
+        # — the file at that path *is* the wire dossier (wire-shape JSON,
+        # ``{project, task, name}``).  The shield reader rereads it on
+        # every emit so renames surface live.  Caller-supplied extras come
+        # after.
         from terok.lib.orchestration.tasks import tasks_meta_dir
 
         expected_meta_path = tasks_meta_dir("p1") / "t1.json"
         assert spec.extra_args == (
-            "--annotation",
-            "dossier.project=p1",
-            "--annotation",
-            "dossier.task=t1",
             "--annotation",
             f"dossier.meta_path={expected_meta_path}",
             "-p",

--- a/tests/unit/lib/test_task_runner_internals.py
+++ b/tests/unit/lib/test_task_runner_internals.py
@@ -467,20 +467,20 @@ class TestRunContainer:
             )
 
         spec = captured_runspec(sandbox_factory)
-        # _run_container prepends three annotations
-        # (``ai.terok.{project,task,task_meta_path}``) so the clearance
-        # IdentityResolver can map container → task metadata; the
-        # caller-supplied extras come after.
+        # _run_container prepends three annotations under the
+        # ``dossier.*`` namespace so the shield reader can resolve a
+        # task-aware identity at emit time; the caller-supplied extras
+        # come after.
         from terok.lib.orchestration.tasks import tasks_meta_dir
 
-        expected_meta_path = tasks_meta_dir("p1") / "t1.yml"
+        expected_meta_path = tasks_meta_dir("p1") / "t1.json"
         assert spec.extra_args == (
             "--annotation",
-            "ai.terok.project=p1",
+            "dossier.project=p1",
             "--annotation",
-            "ai.terok.task=t1",
+            "dossier.task=t1",
             "--annotation",
-            f"ai.terok.task_meta_path={expected_meta_path}",
+            f"dossier.meta_path={expected_meta_path}",
             "-p",
             "8080:80",
         )

--- a/tests/unit/lib/test_tasks.py
+++ b/tests/unit/lib/test_tasks.py
@@ -139,6 +139,46 @@ class TestTask:
             assert not meta_path.exists()
             assert not workspace.exists()
 
+    def test_read_task_meta_backfills_legacy_project_id(self) -> None:
+        """A pre-``project_id``-field record gets the field populated from the meta-dir path.
+
+        Tasks created before ``project_id`` joined ``TaskMeta`` had only
+        ``task_id`` on disk; without backfill, the next ``_write_task_meta``
+        would land an empty wire dossier (no ``project`` key) and the
+        clearance UI would render a half-identity until some unrelated
+        write happened to repopulate the field.  The backfill leans on
+        the meta-dir path layout (``…/projects/<project_id>/tasks/``)
+        rather than threading ``project_id`` through every reader.
+        """
+        from terok.lib.util.yaml import dump as yaml_dump
+
+        project_id = "proj_backfill"
+        with project_env(
+            f"project:\n  id: {project_id}\n",
+            project_id=project_id,
+        ) as ctx:
+            meta_dir = ctx.state_dir / "projects" / project_id / "tasks"
+            meta_dir.mkdir(parents=True, exist_ok=True)
+            tid = "x9y1z"
+            # Seed a legacy single-YAML record (pre-self-describing,
+            # pre-project_id-field).  Mimics what an upgrading operator
+            # has on disk.
+            (meta_dir / f"{tid}.yml").write_text(
+                yaml_dump({"task_id": tid, "name": "diligent-octopus", "mode": "cli"})
+            )
+
+            meta = _read_task_meta(meta_dir, tid)
+
+            assert meta is not None
+            assert meta["project_id"] == project_id
+            # The on-disk dossier now carries the wire shape.
+            dossier = json.loads((meta_dir / f"{tid}_dossier.json").read_text(encoding="utf-8"))
+            assert dossier == {
+                "project": project_id,
+                "task": tid,
+                "name": "diligent-octopus",
+            }
+
     def test_task_new_records_created_at(self) -> None:
         """task_new writes an ISO 8601 created_at timestamp that round-trips via get_tasks.
 

--- a/tests/unit/lib/test_tasks.py
+++ b/tests/unit/lib/test_tasks.py
@@ -1,4 +1,5 @@
 # SPDX-FileCopyrightText: 2025 Jiri Vyskocil
+# SPDX-FileCopyrightText: 2026 Jiri Vyskocil
 # SPDX-License-Identifier: Apache-2.0
 
 import contextlib
@@ -26,6 +27,7 @@ from terok.lib.orchestration.task_runners import (
 )
 from terok.lib.orchestration.tasks import (
     TaskDeleteResult,
+    _read_task_meta,
     get_tasks,
     get_workspace_git_diff,
     task_delete,
@@ -115,7 +117,7 @@ class TestTask:
             meta_path = meta_dir / f"{returned_id}.json"
             assert meta_path.is_file()
 
-            meta = json.loads(meta_path.read_text(encoding="utf-8"))
+            meta = _read_task_meta(meta_dir, returned_id) or {}
             assert meta["task_id"] == returned_id
             workspace_value = meta.get("workspace")
             assert workspace_value
@@ -149,8 +151,8 @@ class TestTask:
             project_id=project_id,
         ) as ctx:
             tid = task_new(project_id)
-            meta_path = ctx.state_dir / "projects" / project_id / "tasks" / f"{tid}.json"
-            meta = json.loads(meta_path.read_text() or "{}")
+            meta_dir = ctx.state_dir / "projects" / project_id / "tasks"
+            meta = _read_task_meta(meta_dir, tid) or {}
 
             assert "created_at" in meta
             parsed = datetime.fromisoformat(meta["created_at"])
@@ -633,7 +635,7 @@ class TestTask:
                 mock_runtime.container.return_value.start.assert_called_once_with()
 
                 # Verify metadata mode is preserved
-                meta = json.loads(meta_path.read_text() or "{}")
+                meta = _read_task_meta(meta_dir, tid) or {}
                 assert meta["mode"] == "cli"
 
     def test_get_workspace_git_diff_no_task(self) -> None:

--- a/tests/unit/lib/test_tasks.py
+++ b/tests/unit/lib/test_tasks.py
@@ -114,7 +114,7 @@ class TestTask:
             returned_id = task_new(project_id)
             assert_task_id(returned_id)
             meta_dir = ctx.state_dir / "projects" / project_id / "tasks"
-            meta_path = meta_dir / f"{returned_id}.json"
+            meta_path = meta_dir / f"{returned_id}_dossier.json"
             assert meta_path.is_file()
 
             meta = _read_task_meta(meta_dir, returned_id) or {}
@@ -190,7 +190,7 @@ class TestTask:
     def _patch_task_meta(ctx, project_id: str, tid: str, **updates) -> None:
         """Load a task's YAML metadata, apply updates, and write it back."""
         meta_dir = ctx.state_dir / "projects" / project_id / "tasks"
-        meta_path = meta_dir / f"{tid}.json"
+        meta_path = meta_dir / f"{tid}_dossier.json"
         meta = json.loads(meta_path.read_text() or "{}")
         meta.update(updates)
         # Setting mode implies the task reached readiness (ready_at marker).
@@ -614,7 +614,7 @@ class TestTask:
         ) as ctx:
             tid = task_new(project_id)
             meta_dir = ctx.state_dir / "projects" / project_id / "tasks"
-            meta_path = meta_dir / f"{tid}.json"
+            meta_path = meta_dir / f"{tid}_dossier.json"
 
             # Simulate task was previously run
             meta = json.loads(meta_path.read_text() or "{}")
@@ -670,7 +670,7 @@ class TestTask:
             tid = task_new(project_id)
             from terok.lib.orchestration.tasks import tasks_meta_dir
 
-            meta_path = tasks_meta_dir(project_id) / f"{tid}.json"
+            meta_path = tasks_meta_dir(project_id) / f"{tid}_dossier.json"
             meta = json.loads(meta_path.read_text() or "{}")
             meta["mode"] = "cli"
             meta_path.write_text(json.dumps(meta, indent=2))
@@ -694,7 +694,7 @@ class TestTask:
             tid = task_new(project_id)
             from terok.lib.orchestration.tasks import tasks_meta_dir
 
-            meta_path = tasks_meta_dir(project_id) / f"{tid}.json"
+            meta_path = tasks_meta_dir(project_id) / f"{tid}_dossier.json"
             meta = json.loads(meta_path.read_text() or "{}")
             meta["mode"] = "run"
             meta_path.write_text(json.dumps(meta, indent=2))
@@ -718,7 +718,7 @@ class TestTask:
             tid = task_new(project_id)
             from terok.lib.orchestration.tasks import tasks_meta_dir
 
-            meta_path = tasks_meta_dir(project_id) / f"{tid}.json"
+            meta_path = tasks_meta_dir(project_id) / f"{tid}_dossier.json"
             meta = json.loads(meta_path.read_text() or "{}")
             meta["mode"] = "cli"
             meta_path.write_text(json.dumps(meta, indent=2))
@@ -1189,7 +1189,7 @@ class TestTaskLogs:
         from terok.lib.core.paths import core_state_dir
 
         meta_dir = core_state_dir() / "projects" / project_id / "tasks"
-        meta_path = meta_dir / f"{task_id}.json"
+        meta_path = meta_dir / f"{task_id}_dossier.json"
         meta = json.loads(meta_path.read_text() or "{}") or {}
         meta["mode"] = mode
         meta_path.write_text(json.dumps(meta, indent=2))
@@ -1461,7 +1461,7 @@ class TestTaskArchive:
             with mock_git_config():
                 task_id = task_new(project_id)
                 meta_dir = ctx.state_dir / "projects" / project_id / "tasks"
-                meta_path = meta_dir / f"{task_id}.json"
+                meta_path = meta_dir / f"{task_id}_dossier.json"
 
                 # Set mode in metadata (simulating a task that ran)
                 meta = json.loads(meta_path.read_text() or "{}") or {}

--- a/tests/unit/lib/test_tasks.py
+++ b/tests/unit/lib/test_tasks.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import contextlib
+import json
 import os
 import re
 import subprocess
@@ -32,7 +33,6 @@ from terok.lib.orchestration.tasks import (
     task_new,
 )
 from terok.lib.util.net import url_host
-from terok.lib.util.yaml import dump as yaml_dump, load as yaml_load
 from terok.tui.clipboard import (
     copy_to_clipboard_detailed,
     get_clipboard_helper_status,
@@ -41,7 +41,6 @@ from tests.test_utils import (
     assert_task_id,
     captured_runspec,
     mock_git_config,
-    parse_meta_value,
     project_env,
     write_project,
 )
@@ -113,14 +112,13 @@ class TestTask:
             returned_id = task_new(project_id)
             assert_task_id(returned_id)
             meta_dir = ctx.state_dir / "projects" / project_id / "tasks"
-            meta_path = meta_dir / f"{returned_id}.yml"
+            meta_path = meta_dir / f"{returned_id}.json"
             assert meta_path.is_file()
 
-            meta_text = meta_path.read_text(encoding="utf-8")
-            assert parse_meta_value(meta_text, "task_id") == returned_id
-            workspace_value = parse_meta_value(meta_text, "workspace")
-            assert workspace_value is not None
-            assert workspace_value != ""
+            meta = json.loads(meta_path.read_text(encoding="utf-8"))
+            assert meta["task_id"] == returned_id
+            workspace_value = meta.get("workspace")
+            assert workspace_value
             workspace = Path(workspace_value)  # type: ignore[arg-type]
             assert workspace.is_dir()
 
@@ -151,8 +149,8 @@ class TestTask:
             project_id=project_id,
         ) as ctx:
             tid = task_new(project_id)
-            meta_path = ctx.state_dir / "projects" / project_id / "tasks" / f"{tid}.yml"
-            meta = yaml_load(meta_path.read_text())
+            meta_path = ctx.state_dir / "projects" / project_id / "tasks" / f"{tid}.json"
+            meta = json.loads(meta_path.read_text() or "{}")
 
             assert "created_at" in meta
             parsed = datetime.fromisoformat(meta["created_at"])
@@ -190,13 +188,13 @@ class TestTask:
     def _patch_task_meta(ctx, project_id: str, tid: str, **updates) -> None:
         """Load a task's YAML metadata, apply updates, and write it back."""
         meta_dir = ctx.state_dir / "projects" / project_id / "tasks"
-        meta_path = meta_dir / f"{tid}.yml"
-        meta = yaml_load(meta_path.read_text())
+        meta_path = meta_dir / f"{tid}.json"
+        meta = json.loads(meta_path.read_text() or "{}")
         meta.update(updates)
         # Setting mode implies the task reached readiness (ready_at marker).
         if "mode" in updates and updates["mode"] is not None and "ready_at" not in updates:
             meta.setdefault("ready_at", "2025-01-01T00:00:00+00:00")
-        meta_path.write_text(yaml_dump(meta))
+        meta_path.write_text(json.dumps(meta, indent=2))
 
     @staticmethod
     def _task_list_output(project_id: str, states: dict[str, str | None], **filters: str) -> str:
@@ -614,12 +612,12 @@ class TestTask:
         ) as ctx:
             tid = task_new(project_id)
             meta_dir = ctx.state_dir / "projects" / project_id / "tasks"
-            meta_path = meta_dir / f"{tid}.yml"
+            meta_path = meta_dir / f"{tid}.json"
 
             # Simulate task was previously run
-            meta = yaml_load(meta_path.read_text())
+            meta = json.loads(meta_path.read_text() or "{}")
             meta["mode"] = "cli"
-            meta_path.write_text(yaml_dump(meta))
+            meta_path.write_text(json.dumps(meta, indent=2))
 
             cname = f"{project_id}-cli-{tid}"
             with (
@@ -635,7 +633,7 @@ class TestTask:
                 mock_runtime.container.return_value.start.assert_called_once_with()
 
                 # Verify metadata mode is preserved
-                meta = yaml_load(meta_path.read_text())
+                meta = json.loads(meta_path.read_text() or "{}")
                 assert meta["mode"] == "cli"
 
     def test_get_workspace_git_diff_no_task(self) -> None:
@@ -670,10 +668,10 @@ class TestTask:
             tid = task_new(project_id)
             from terok.lib.orchestration.tasks import tasks_meta_dir
 
-            meta_path = tasks_meta_dir(project_id) / f"{tid}.yml"
-            meta = yaml_load(meta_path.read_text())
+            meta_path = tasks_meta_dir(project_id) / f"{tid}.json"
+            meta = json.loads(meta_path.read_text() or "{}")
             meta["mode"] = "cli"
-            meta_path.write_text(yaml_dump(meta))
+            meta_path.write_text(json.dumps(meta, indent=2))
 
             expected = "diff --git a/f.txt b/f.txt\n+line\n"
             with unittest.mock.patch(
@@ -694,10 +692,10 @@ class TestTask:
             tid = task_new(project_id)
             from terok.lib.orchestration.tasks import tasks_meta_dir
 
-            meta_path = tasks_meta_dir(project_id) / f"{tid}.yml"
-            meta = yaml_load(meta_path.read_text())
+            meta_path = tasks_meta_dir(project_id) / f"{tid}.json"
+            meta = json.loads(meta_path.read_text() or "{}")
             meta["mode"] = "run"
-            meta_path.write_text(yaml_dump(meta))
+            meta_path.write_text(json.dumps(meta, indent=2))
 
             expected = "diff --git a/f.txt b/f.txt\n+prev\n"
             with unittest.mock.patch(
@@ -718,10 +716,10 @@ class TestTask:
             tid = task_new(project_id)
             from terok.lib.orchestration.tasks import tasks_meta_dir
 
-            meta_path = tasks_meta_dir(project_id) / f"{tid}.yml"
-            meta = yaml_load(meta_path.read_text())
+            meta_path = tasks_meta_dir(project_id) / f"{tid}.json"
+            meta = json.loads(meta_path.read_text() or "{}")
             meta["mode"] = "cli"
-            meta_path.write_text(yaml_dump(meta))
+            meta_path.write_text(json.dumps(meta, indent=2))
 
             with unittest.mock.patch(
                 "terok.lib.orchestration.tasks.container_git_diff",
@@ -1079,9 +1077,9 @@ class TestResumeToadContainer:
         from terok.lib.orchestration.tasks import load_task_meta
 
         _, meta_path = load_task_meta(project.id, task_id, "toad")
-        meta = yaml_load(meta_path.read_text(encoding="utf-8"))
+        meta = json.loads(meta_path.read_text(encoding="utf-8") or "{}")
         meta.update({"mode": "toad", "web_port": port, "web_token": token})
-        meta_path.write_text(yaml_dump(meta))
+        meta_path.write_text(json.dumps(meta, indent=2))
         (project.tasks_root / str(task_id) / "agent-config").mkdir(parents=True, exist_ok=True)
 
     def test_resume_running_container_prints_tokenized_url(self, mock_runtime) -> None:
@@ -1189,10 +1187,10 @@ class TestTaskLogs:
         from terok.lib.core.paths import core_state_dir
 
         meta_dir = core_state_dir() / "projects" / project_id / "tasks"
-        meta_path = meta_dir / f"{task_id}.yml"
-        meta = yaml_load(meta_path.read_text()) or {}
+        meta_path = meta_dir / f"{task_id}.json"
+        meta = json.loads(meta_path.read_text() or "{}") or {}
         meta["mode"] = mode
-        meta_path.write_text(yaml_dump(meta))
+        meta_path.write_text(json.dumps(meta, indent=2))
         return task_id
 
     def test_unknown_task_raises(self) -> None:
@@ -1461,14 +1459,14 @@ class TestTaskArchive:
             with mock_git_config():
                 task_id = task_new(project_id)
                 meta_dir = ctx.state_dir / "projects" / project_id / "tasks"
-                meta_path = meta_dir / f"{task_id}.yml"
+                meta_path = meta_dir / f"{task_id}.json"
 
                 # Set mode in metadata (simulating a task that ran)
-                meta = yaml_load(meta_path.read_text()) or {}
+                meta = json.loads(meta_path.read_text() or "{}") or {}
                 meta["mode"] = "run"
                 meta["name"] = "test-task"
                 meta["exit_code"] = 0
-                meta_path.write_text(yaml_dump(meta))
+                meta_path.write_text(json.dumps(meta, indent=2))
 
                 # Create logs dir to simulate persisted logs
                 task_dir = ctx.state_dir / "tasks" / project_id / task_id
@@ -1504,10 +1502,10 @@ class TestTaskArchive:
                 assert task_id in archive_entry.name
                 assert "test-task" in archive_entry.name
 
-                # Archive should contain task.yml
-                archived_meta = archive_entry / "task.yml"
+                # Archive should contain task.json
+                archived_meta = archive_entry / "task.json"
                 assert archived_meta.is_file()
-                archived_data = yaml_load(archived_meta.read_text())
+                archived_data = json.loads(archived_meta.read_text() or "{}")
                 assert archived_data["task_id"] == task_id
                 assert archived_data["name"] == "test-task"
 
@@ -1545,9 +1543,9 @@ class TestTaskArchive:
                 archives = list(archive_root.iterdir())
                 assert len(archives) == 1
 
-                # Should have task.yml but no logs subdir
+                # Should have task.json but no logs subdir
                 archive_entry = archives[0]
-                assert (archive_entry / "task.yml").is_file()
+                assert (archive_entry / "task.json").is_file()
                 assert not (archive_entry / "logs").exists()
 
     def test_list_archived_tasks(self) -> None:
@@ -1566,14 +1564,15 @@ class TestTaskArchive:
             for i, ts in enumerate(["20260301T100000Z", "20260302T100000Z", "20260303T100000Z"]):
                 entry_dir = archive_root / f"{ts}_{i + 1}_task-{i + 1}"
                 entry_dir.mkdir()
-                (entry_dir / "task.yml").write_text(
-                    yaml_dump(
+                (entry_dir / "task.json").write_text(
+                    json.dumps(
                         {
                             "task_id": str(i + 1),
                             "name": f"task-{i + 1}",
                             "mode": "run",
                             "exit_code": 0,
-                        }
+                        },
+                        indent=2,
                     )
                 )
 
@@ -1743,7 +1742,7 @@ class TestTaskDeleteWarnings:
                         orig_unlink = Path.unlink
 
                         def _guarded_unlink(self, *a, **kw):
-                            if "tasks" in str(self) and self.suffix == ".yml":
+                            if "tasks" in str(self) and self.suffix == ".json":
                                 raise unlink_side_effect
                             return orig_unlink(self, *a, **kw)
 

--- a/tests/unit/tui/test_clearance_screen.py
+++ b/tests/unit/tui/test_clearance_screen.py
@@ -136,27 +136,39 @@ class TestLifecycleBridge:
 
 
 class TestRenderNotification:
-    """``_render_notification`` builds the log line from structured fields."""
+    """``_render_notification`` is a one-liner that joins ``summary`` + subscriber body.
 
-    def test_name_and_id_render_as_name_paren_id(self) -> None:
-        """When both name and id are present, show ``name (id)`` with protocol."""
+    The subscriber's body already does dossier-aware identity rendering —
+    ``Task: project/task · name`` for orchestrator-managed containers,
+    ``Container: <slug>`` otherwise — so the TUI must not recompose its
+    own identity string.  An earlier iteration here built ``Container:
+    {name} ({id})`` from the typed kwargs and silently diverged from the
+    desktop popup.  These tests pin the no-divergence contract: whatever
+    the subscriber wrote in ``body`` is what the operator sees.
+    """
+
+    def test_passes_subscriber_body_through_verbatim(self) -> None:
+        """The dossier-aware body the subscriber composed lands in the log unchanged."""
         mod = _import_clearance()
         msg = mod._NotificationPosted(
             nid=1,
             summary="Blocked: seznam.cz:80",
-            body="Container: my-task\nProtocol: TCP",
+            body="Task: terok/abc · diligent-octopus\nProtocol: TCP",
             actions=[("allow", "Allow"), ("deny", "Deny")],
             replaces_id=0,
             container_id="fa0905d97a1c",
-            container_name="my-task",
+            container_name="terok-cli-abc",
+            project="terok",
+            task_id="abc",
+            task_name="diligent-octopus",
         )
         assert (
             mod._render_notification(msg)
-            == "Blocked: seznam.cz:80  Container: my-task (fa0905d97a1c)\nProtocol: TCP"
+            == "Blocked: seznam.cz:80  Task: terok/abc · diligent-octopus\nProtocol: TCP"
         )
 
-    def test_id_only_passes_body_through(self) -> None:
-        """Without a resolved name, the subscriber-built body reaches the log as-is."""
+    def test_bare_container_body_passes_through_too(self) -> None:
+        """Standalone container path: the subscriber's bare-name body reaches the log as-is."""
         mod = _import_clearance()
         msg = mod._NotificationPosted(
             nid=1,


### PR DESCRIPTION
## Summary

Final PR of the four-PR dossier-in-events chain (terok-shield#275, terok-clearance#79, terok-sandbox#231, this PR).  Wires the orchestrator side of the refactor: terok now writes task metadata as JSON and tags new containers with ``dossier.*`` OCI annotations the shield reader resolves at every event emit.

## What changes

* **Annotations rename**: ``ai.terok.{project,task,task_meta_path}`` → ``dossier.{project,task,meta_path}``.  No back-compat shim — in-flight containers degrade cosmetically (``Container: <short-id>`` popups) for their remaining lifetime; new containers get the full ``Task: project/task · name`` body line.
* **Task meta YAML → JSON**: stdlib-only on the consumer side keeps the shield reader free of PyYAML inside ``NS_ROOTLESS``.  Files written by older terok versions migrate on first read (one-shot, in-place rotation: write JSON, ``unlink`` YAML).  Atomic ``write_text(.tmp) + os.replace`` everywhere.  Older archives' ``task.yml`` are tolerated indefinitely on the read path.
* **TUI**: ``terok.tui.clearance_screen`` drops ``create_container_inspector`` + ``IdentityResolver``; the embedded clearance subscriber consumes ``event.dossier`` directly, same as the desktop notifier.
* **Uninstall**: ``_uninstall_sandbox_stack`` shrinks to a thin delegating call into ``terok_sandbox.sandbox_uninstall`` — sandbox's aggregator owns the bridge teardown now (terok-sandbox#231).

## Pin updates

Tracks the chain end-to-end: terok-shield, terok-clearance, terok-sandbox, terok-executor all pin to their feature-branch tips.  Release script flips back to wheel URLs once the four siblings ship.

## Test plan

- [x] ``make test-unit`` — 2157 tests pass
- [x] ``make tach``, ``make lint``, ``make security``, ``make docstrings``, ``make reuse``, ``make lint-imports``
- [ ] End-to-end on a Fedora-Atomic test host:
  - ``terok setup`` — confirm one shield stage line (no separate "Shield bridge")
  - ``terok task run …`` — confirm desktop popup body shows ``Task: <project>/<task> · <name>``
  - ``systemd-analyze security --user terok-clearance-notifier`` — expect ~2.7 OK after the chain merges
  - In-flight ``.yml`` task meta migrates to ``.json`` on first interaction
  - Audit log (``audit.jsonl``) carries ``dossier`` field on block lines

## Deferred / out of scope

* PyYAML stays in deps for one release cycle as the migration path; removable in the next minor.
* D-Bus broker / xdg-dbus-proxy filter for the notifier — orthogonal hardening tracked separately.
* Multi-orchestrator docs for the ``dossier.*`` namespace — worth a docs follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Infrastructure**
  * Migrated task metadata to canonical per-task JSON with atomic writes and shared helpers; standardized metadata handling across orchestration, runners, and tools.
  * Switched runtime clearance annotations to the dossier.* namespace.
  * CLI now reports both hub and notifier clearance stamps when present.

* **UI**
  * Simplified clearance notification rendering to show summary and body verbatim.

* **Documentation**
  * Clarified uninstall messaging about preserved NFLOG reader and credential DB.

* **Chores**
  * Dependencies updated to track specific feature branches (git-based references).

* **Tests**
  * Updated unit tests for JSON metadata and new annotation/notification behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->