### PR TITLE
feat(tui): streamline new-task launch — bash launch notes, prominent Dismiss

### DIFF
--- a/src/terok/lib/orchestration/task_runners.py
+++ b/src/terok/lib/orchestration/task_runners.py
@@ -56,6 +56,7 @@ from .environment import build_task_env_and_volumes, ensure_vault
 from .hooks import run_hook
 from .ports import assign_web_port, release_web_port
 from .tasks import (
+    CONTAINER_TEROK_CONFIG,
     container_name,
     load_task_meta,
     task_new,
@@ -77,7 +78,6 @@ _TOAD_TOKEN_FILE_NAME = "toad.token"  # nosec B105 — filename, not a credentia
 _ANTHROPIC_API_HOST = "api.anthropic.com"
 _OPENAI_API_HOST = "api.openai.com"
 _FALSE_STRINGS = frozenset({"false", "0", "no", "off"})
-_CONTAINER_TEROK_CONFIG = "/home/dev/.terok"
 
 
 def _str_to_bool(value: object) -> bool:
@@ -604,7 +604,7 @@ def task_run_cli(
 
     # Resolve layered agent config (global → project → preset → CLI overrides)
     agent_config_dir = _prepare_agent_config(project, project_id, task_id, agents, preset)
-    volumes.append(VolumeSpec(agent_config_dir, _CONTAINER_TEROK_CONFIG, sharing=Sharing.PRIVATE))
+    volumes.append(VolumeSpec(agent_config_dir, CONTAINER_TEROK_CONFIG, sharing=Sharing.PRIVATE))
 
     # Resolve unrestricted mode: CLI flag → config → default (True)
     if unrestricted is None:
@@ -735,7 +735,7 @@ def task_run_toad(
     env, volumes = build_task_env_and_volumes(project, task_id)
 
     agent_config_dir = _prepare_agent_config(project, project_id, task_id, agents, preset)
-    volumes.append(VolumeSpec(agent_config_dir, _CONTAINER_TEROK_CONFIG, sharing=Sharing.PRIVATE))
+    volumes.append(VolumeSpec(agent_config_dir, CONTAINER_TEROK_CONFIG, sharing=Sharing.PRIVATE))
 
     token = _ensure_toad_token(agent_config_dir)
     meta["web_token"] = token
@@ -982,7 +982,7 @@ def task_run_headless(request: HeadlessRunRequest) -> str:
         _apply_unrestricted_env(env)
 
     # Mount agent-config dir to /home/dev/.terok
-    volumes.append(VolumeSpec(agent_config_dir, _CONTAINER_TEROK_CONFIG, sharing=Sharing.PRIVATE))
+    volumes.append(VolumeSpec(agent_config_dir, CONTAINER_TEROK_CONFIG, sharing=Sharing.PRIVATE))
 
     # Build headless command via provider registry
     headless_cmd = build_headless_command(

--- a/src/terok/lib/orchestration/tasks.py
+++ b/src/terok/lib/orchestration/tasks.py
@@ -433,6 +433,15 @@ def tasks_meta_dir(project_id: str) -> Path:
     return core_state_dir() / "projects" / project_id / "tasks"
 
 
+CONTAINER_TEROK_CONFIG = "/home/dev/.terok"
+"""In-container mount point for the per-task agent-config dir."""
+
+
+def agent_config_dir(project_id: str, task_id: str) -> Path:
+    """Host path of the agent-config dir bind-mounted at `CONTAINER_TEROK_CONFIG`."""
+    return load_project(project_id).tasks_root / str(task_id) / "agent-config"
+
+
 def tasks_archive_dir(project_id: str) -> Path:
     """Return the directory containing archived task data for *project_id*.
 

--- a/src/terok/tui/screens.py
+++ b/src/terok/tui/screens.py
@@ -1272,14 +1272,16 @@ class TaskLaunchScreen(screen.ModalScreen["tuple[str, str, str, str, str, str | 
             yield Select(choices, value=login_value, id="login-agent")
             yield Input(placeholder="Initial prompt (optional)", id="launch-prompt")
             with Horizontal(id="launch-buttons"):
-                yield Button("Dismiss", id="btn-dismiss", variant="default")
-                yield Button("Login", id="btn-login", variant="primary", disabled=True)
+                # While the container is starting, Dismiss is the only enabled
+                # action — promote it to primary so it's not visually muted.
+                # Roles swap in _poll_status() once Login becomes available.
+                yield Button("Dismiss", id="btn-dismiss", variant="primary")
+                yield Button("Login", id="btn-login", variant="default", disabled=True)
         dialog.border_title = f"CLI Task {self._task_id} ({self._task_name})"
         dialog.border_subtitle = "Esc to dismiss"
 
     def on_mount(self) -> None:
         """Start polling for container readiness and focus the prompt input."""
-        self._update_prompt_state()
         prompt = self.query_one("#launch-prompt", Input)
         prompt.focus()
         self._poll_timer = self.set_interval(1.5, self._poll_status)
@@ -1317,7 +1319,10 @@ class TaskLaunchScreen(screen.ModalScreen["tuple[str, str, str, str, str, str | 
             if has_mode:
                 status_widget.update("Status: Container ready")
                 self._container_ready = True
-                self.query_one("#btn-login", Button).disabled = False
+                login_btn = self.query_one("#btn-login", Button)
+                login_btn.disabled = False
+                login_btn.variant = "primary"
+                self.query_one("#btn-dismiss", Button).variant = "default"
                 if self._poll_timer:
                     self._poll_timer.stop()
                     self._poll_timer = None
@@ -1327,20 +1332,6 @@ class TaskLaunchScreen(screen.ModalScreen["tuple[str, str, str, str, str, str | 
             status_widget.update(f"Status: {state}")
         elif self._poll_count >= self._POLL_STALL_THRESHOLD:
             status_widget.update("Status: Launch may have failed \u2014 check notifications")
-
-    def _update_prompt_state(self) -> None:
-        """Enable/disable prompt input based on selected agent."""
-        agent_select = self.query_one("#login-agent", Select)
-        prompt_input = self.query_one("#launch-prompt", Input)
-        if agent_select.value == "bash":
-            prompt_input.value = ""
-            prompt_input.disabled = True
-        else:
-            prompt_input.disabled = False
-
-    def on_select_changed(self, event: "Select.Changed") -> None:  # type: ignore[name-defined]
-        """Update prompt visibility when agent selection changes."""
-        self._update_prompt_state()
 
     def on_input_submitted(self, event: "Input.Submitted") -> None:  # type: ignore[name-defined]
         """Treat Enter in the prompt input as Login if container is ready."""
@@ -1360,8 +1351,6 @@ class TaskLaunchScreen(screen.ModalScreen["tuple[str, str, str, str, str, str | 
         agent = agent_select.value
         prompt_input = self.query_one("#launch-prompt", Input)
         prompt = prompt_input.value.strip() or None
-        if agent == "bash":
-            prompt = None
         self.dismiss(
             (
                 self._project_id,

--- a/src/terok/tui/task_actions.py
+++ b/src/terok/tui/task_actions.py
@@ -34,6 +34,8 @@ from ..lib.domain.facade import (
 )
 from ..lib.orchestration.autopilot import wait_for_container_exit
 from ..lib.orchestration.tasks import (
+    CONTAINER_TEROK_CONFIG,
+    agent_config_dir,
     container_name,
     generate_task_name,
     get_login_command,
@@ -62,6 +64,39 @@ def _build_interactive_agent_command(provider: object, prompt: str | None) -> st
     if not prompt:
         return provider.binary
     return f"{provider.binary} {shlex.quote(prompt)}"
+
+
+_LAUNCH_NOTE_FILENAME = "launch-note.txt"
+_LAUNCH_NOTE_PATH = f"{CONTAINER_TEROK_CONFIG}/{_LAUNCH_NOTE_FILENAME}"
+
+# Shell wrapper for bash-agent launches with a note. Reads the note via cat
+# (no shell expansion of user data), prints it after the login profile has
+# run, removes it, and execs an interactive shell.  Wrapper string contains
+# zero user-data interpolation — the note travels via the file mount.
+_BASH_NOTE_WRAPPER = (
+    f"n={shlex.quote(_LAUNCH_NOTE_PATH)}; "
+    '[ -s "$n" ] && { '
+    'printf "\\n\\033[1;33m\U0001f4dd Launch note:\\033[0m\\n"; '
+    'cat "$n"; printf "\\n\\n"; rm -f "$n"; '
+    "}; exec bash -i"
+)
+
+
+def _build_bash_login_cmd(
+    base_cmd: list[str], project_id: str, task_id: str, prompt: str | None
+) -> list[str]:
+    """Login command for the bash agent, optionally surfacing a launch note.
+
+    With no prompt the base login command (login shell inside tmux) is used
+    unchanged.  With a prompt, the note is written to the task's mounted
+    agent-config dir and a small wrapper prints it after the login banner
+    before dropping into an interactive shell.
+    """
+    if not prompt:
+        return base_cmd
+    note_path = agent_config_dir(project_id, task_id) / _LAUNCH_NOTE_FILENAME
+    note_path.write_text(prompt + "\n", encoding="utf-8")
+    return [*base_cmd, "bash", "-lc", _BASH_NOTE_WRAPPER]
 
 
 def _login_title(project_id: str, task_id: str, task_name: str) -> str:
@@ -263,7 +298,7 @@ class TaskActionsMixin:
             return
 
         if agent == "bash":
-            cmd = base_cmd
+            cmd = _build_bash_login_cmd(base_cmd, pid, tid, prompt)
         else:
             from terok_executor import AGENT_PROVIDERS
 

--- a/src/terok/tui/task_actions.py
+++ b/src/terok/tui/task_actions.py
@@ -66,36 +66,34 @@ def _build_interactive_agent_command(provider: object, prompt: str | None) -> st
     return f"{provider.binary} {shlex.quote(prompt)}"
 
 
-_LAUNCH_NOTE_FILENAME = "launch-note.txt"
-_LAUNCH_NOTE_PATH = f"{CONTAINER_TEROK_CONFIG}/{_LAUNCH_NOTE_FILENAME}"
+_INITIAL_PROMPT_FILENAME = "initial-prompt.txt"
+_INITIAL_PROMPT_PATH = f"{CONTAINER_TEROK_CONFIG}/{_INITIAL_PROMPT_FILENAME}"
 
-# Shell wrapper for bash-agent launches with a note. The note travels via
-# the file mount, never as a shell argument — wrapper string contains zero
-# user-data interpolation.
-_BASH_NOTE_WRAPPER = (
-    f"n={shlex.quote(_LAUNCH_NOTE_PATH)}; "
-    '[ -s "$n" ] && { '
-    'printf "\\n\\033[1;33m\U0001f4dd Launch note:\\033[0m\\n"; '
-    'cat "$n"; printf "\\n\\n"; '
+# Shell wrapper for bash-agent launches with an initial prompt. The prompt
+# travels via the file mount, never as a shell argument — wrapper string
+# contains zero user-data interpolation.
+_BASH_INITIAL_PROMPT_WRAPPER = (
+    f"p={shlex.quote(_INITIAL_PROMPT_PATH)}; "
+    '[ -s "$p" ] && { '
+    'printf "\\n\\033[1;33m\U0001f4dd Initial prompt:\\033[0m\\n"; '
+    'cat "$p"; printf "\\n\\n"; '
     "}; exec bash -i"
 )
 
 
-def _build_bash_login_cmd(
-    base_cmd: list[str], project_id: str, task_id: str, prompt: str | None
-) -> list[str]:
-    """Login command for the bash agent, optionally surfacing a launch note.
+def _save_initial_prompt(project_id: str, task_id: str, prompt: str | None) -> None:
+    """Persist the user's initial prompt to the task's mounted agent-config dir."""
+    if not prompt:
+        return
+    path = agent_config_dir(project_id, task_id) / _INITIAL_PROMPT_FILENAME
+    path.write_text(prompt + "\n", encoding="utf-8")
 
-    With no prompt the base login command (login shell inside tmux) is used
-    unchanged.  With a prompt, the note is dropped into the task's mounted
-    agent-config dir and a small wrapper prints it after the login banner
-    before dropping into an interactive shell.
-    """
+
+def _build_bash_login_cmd(base_cmd: list[str], prompt: str | None) -> list[str]:
+    """Login command for the bash agent, surfacing the saved initial prompt if any."""
     if not prompt:
         return base_cmd
-    note_path = agent_config_dir(project_id, task_id) / _LAUNCH_NOTE_FILENAME
-    note_path.write_text(prompt + "\n", encoding="utf-8")
-    return [*base_cmd, "bash", "-lc", _BASH_NOTE_WRAPPER]
+    return [*base_cmd, "bash", "-lc", _BASH_INITIAL_PROMPT_WRAPPER]
 
 
 def _login_title(project_id: str, task_id: str, task_name: str) -> str:
@@ -296,8 +294,10 @@ class TaskActionsMixin:
             self.notify(str(e))
             return
 
+        _save_initial_prompt(pid, tid, prompt)
+
         if agent == "bash":
-            cmd = _build_bash_login_cmd(base_cmd, pid, tid, prompt)
+            cmd = _build_bash_login_cmd(base_cmd, prompt)
         else:
             from terok_executor import AGENT_PROVIDERS
 

--- a/src/terok/tui/task_actions.py
+++ b/src/terok/tui/task_actions.py
@@ -71,13 +71,17 @@ _LAUNCH_NOTE_PATH = f"{CONTAINER_TEROK_CONFIG}/{_LAUNCH_NOTE_FILENAME}"
 
 # Shell wrapper for bash-agent launches with a note. Reads the note via cat
 # (no shell expansion of user data), prints it after the login profile has
-# run, removes it, and execs an interactive shell.  Wrapper string contains
-# zero user-data interpolation — the note travels via the file mount.
+# run, then execs an interactive shell.  The note file is left in place so
+# the user can pipe it into whichever agent they invoke from the shell
+# (``claude < $note``, ``codex < $note``, etc.) — overwritten on the next
+# bash launch with a fresh prompt, removed when the task is deleted.
+# Wrapper string contains zero user-data interpolation — the note travels
+# via the file mount.
 _BASH_NOTE_WRAPPER = (
     f"n={shlex.quote(_LAUNCH_NOTE_PATH)}; "
     '[ -s "$n" ] && { '
     'printf "\\n\\033[1;33m\U0001f4dd Launch note:\\033[0m\\n"; '
-    'cat "$n"; printf "\\n\\n"; rm -f "$n"; '
+    'cat "$n"; printf "\\n\\n"; '
     "}; exec bash -i"
 )
 
@@ -90,7 +94,9 @@ def _build_bash_login_cmd(
     With no prompt the base login command (login shell inside tmux) is used
     unchanged.  With a prompt, the note is written to the task's mounted
     agent-config dir and a small wrapper prints it after the login banner
-    before dropping into an interactive shell.
+    before dropping into an interactive shell.  The note persists at
+    ``$CONTAINER_TEROK_CONFIG/launch-note.txt`` so the user can feed it
+    into any agent they invoke later.
     """
     if not prompt:
         return base_cmd

--- a/src/terok/tui/task_actions.py
+++ b/src/terok/tui/task_actions.py
@@ -69,14 +69,9 @@ def _build_interactive_agent_command(provider: object, prompt: str | None) -> st
 _LAUNCH_NOTE_FILENAME = "launch-note.txt"
 _LAUNCH_NOTE_PATH = f"{CONTAINER_TEROK_CONFIG}/{_LAUNCH_NOTE_FILENAME}"
 
-# Shell wrapper for bash-agent launches with a note. Reads the note via cat
-# (no shell expansion of user data), prints it after the login profile has
-# run, then execs an interactive shell.  The note file is left in place so
-# the user can pipe it into whichever agent they invoke from the shell
-# (``claude < $note``, ``codex < $note``, etc.) — overwritten on the next
-# bash launch with a fresh prompt, removed when the task is deleted.
-# Wrapper string contains zero user-data interpolation — the note travels
-# via the file mount.
+# Shell wrapper for bash-agent launches with a note. The note travels via
+# the file mount, never as a shell argument — wrapper string contains zero
+# user-data interpolation.
 _BASH_NOTE_WRAPPER = (
     f"n={shlex.quote(_LAUNCH_NOTE_PATH)}; "
     '[ -s "$n" ] && { '
@@ -92,11 +87,9 @@ def _build_bash_login_cmd(
     """Login command for the bash agent, optionally surfacing a launch note.
 
     With no prompt the base login command (login shell inside tmux) is used
-    unchanged.  With a prompt, the note is written to the task's mounted
+    unchanged.  With a prompt, the note is dropped into the task's mounted
     agent-config dir and a small wrapper prints it after the login banner
-    before dropping into an interactive shell.  The note persists at
-    ``$CONTAINER_TEROK_CONFIG/launch-note.txt`` so the user can feed it
-    into any agent they invoke later.
+    before dropping into an interactive shell.
     """
     if not prompt:
         return base_cmd

--- a/tach.toml
+++ b/tach.toml
@@ -603,6 +603,8 @@ expose = [
     "resolve_task_id",
     "is_task_id",
     "normalize_task_id_input",
+    "CONTAINER_TEROK_CONFIG",
+    "agent_config_dir",
 ]
 from = ["terok.lib.orchestration.tasks"]
 

--- a/tests/unit/tui/test_new_task_flow.py
+++ b/tests/unit/tui/test_new_task_flow.py
@@ -183,7 +183,7 @@ class TestTaskLaunchScreen:
         screen._do_login()
         screen.dismiss.assert_called_once_with(("p", "1", "fix-bug", "c", "claude", "fix the bug"))
 
-    def test_do_login_bash_keeps_prompt_as_note(self) -> None:
+    def test_do_login_bash_keeps_prompt(self) -> None:
         screens, _ = import_screens()
         screen = screens.TaskLaunchScreen(
             container_name="c", project_id="p", task_id="1", task_name="my-task"
@@ -774,7 +774,10 @@ class TestOnLaunchScreenResultTitle:
         with (
             mock.patch.dict(
                 action_globals,
-                {"get_login_command": mock.Mock(return_value=["podman", "exec", "-it", "c"])},
+                {
+                    "get_login_command": mock.Mock(return_value=["podman", "exec", "-it", "c"]),
+                    "_save_initial_prompt": mock.Mock(),
+                },
             ),
             mock.patch.dict(
                 "terok_executor.provider.providers.AGENT_PROVIDERS",
@@ -812,7 +815,10 @@ class TestOnLaunchScreenResultTitle:
         with (
             mock.patch.dict(
                 action_globals,
-                {"get_login_command": mock.Mock(return_value=["podman", "exec", "-it", "c"])},
+                {
+                    "get_login_command": mock.Mock(return_value=["podman", "exec", "-it", "c"]),
+                    "_save_initial_prompt": mock.Mock(),
+                },
             ),
             mock.patch.dict(
                 "terok_executor.provider.providers.AGENT_PROVIDERS",

--- a/tests/unit/tui/test_new_task_flow.py
+++ b/tests/unit/tui/test_new_task_flow.py
@@ -183,7 +183,7 @@ class TestTaskLaunchScreen:
         screen._do_login()
         screen.dismiss.assert_called_once_with(("p", "1", "fix-bug", "c", "claude", "fix the bug"))
 
-    def test_do_login_bash_clears_prompt(self) -> None:
+    def test_do_login_bash_keeps_prompt_as_note(self) -> None:
         screens, _ = import_screens()
         screen = screens.TaskLaunchScreen(
             container_name="c", project_id="p", task_id="1", task_name="my-task"
@@ -193,7 +193,31 @@ class TestTaskLaunchScreen:
         mock_select = mock.Mock()
         mock_select.value = "bash"
         mock_input = mock.Mock()
-        mock_input.value = "should be ignored"
+        mock_input.value = "scribble for the agent"
+
+        def query_one(selector, cls=None):
+            if "login-agent" in selector:
+                return mock_select
+            return mock_input
+
+        screen.query_one = query_one
+
+        screen._do_login()
+        screen.dismiss.assert_called_once_with(
+            ("p", "1", "my-task", "c", "bash", "scribble for the agent")
+        )
+
+    def test_do_login_bash_empty_prompt_is_none(self) -> None:
+        screens, _ = import_screens()
+        screen = screens.TaskLaunchScreen(
+            container_name="c", project_id="p", task_id="1", task_name="my-task"
+        )
+        screen.dismiss = mock.Mock()
+
+        mock_select = mock.Mock()
+        mock_select.value = "bash"
+        mock_input = mock.Mock()
+        mock_input.value = "   "
 
         def query_one(selector, cls=None):
             if "login-agent" in selector:


### PR DESCRIPTION
## Summary

Two UX fixes for the post-creation **TaskLaunchScreen** (the modal that pops up after \`task new\` while the container is booting):

- **Bash launches now carry a launch note.** Previously the prompt textbox was wiped and disabled the moment the user picked the \`bash\` agent — defeating the whole point of having a textbox right there. It now stays usable, and when bash is launched with a non-empty prompt, the note is written to the task's mounted \`agent-config\` dir and a fixed shell wrapper prints it after the login profile, removes it, and execs an interactive shell. The wrapper string contains zero user-data interpolation — the note travels via the file mount, so we sidestep shell-quoting fragility entirely.
- **Dismiss is no longer visually muted while the container is starting.** During the startup phase \`Login\` is disabled, so \`Dismiss\` is the only enabled action — promoted to \`primary\` while we wait, swapped back to \`default\` once Login becomes available.

While in there, \`CONTAINER_TEROK_CONFIG\` and a new public \`agent_config_dir(project_id, task_id)\` helper were lifted into \`orchestration.tasks\` so the TUI no longer reaches into \`project.tasks_root\` to derive the agent-config bind-mount path. \`task_runners.py\` now sources the constant from there too — single source of truth.

## Test plan

- [x] \`make lint\` / \`ruff format --check\` clean
- [x] \`make tach\` clean (added \`CONTAINER_TEROK_CONFIG\` and \`agent_config_dir\` to the \`orchestration.tasks\` exposed interface)
- [x] \`make test\` — full unit suite passes (2187/2187)
- [x] \`make docstrings\` — 98.5% (no regression)
- [x] \`make reuse\` — compliant
- [x] \`bandit -ll\` — no medium/high
- [ ] Manual TUI smoke test: launch a CLI task, type a note in the prompt box, pick \`bash\`, verify the note appears as a yellow banner in the shell session and that the file at \`/home/dev/.terok/launch-note.txt\` is removed afterwards.
- [ ] Manual TUI smoke test: confirm the \`Dismiss\` button is visually prominent during startup and reverts to muted once \`Login\` becomes available.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Bash agent now saves and displays user-submitted prompts as a per-task launch note before starting interactive sessions.

* **UI/UX Improvements**
  * Task launch screen button behavior: Dismiss is primary initially; Login is disabled until the container is ready, then becomes primary.
  * Prompt input is retained when switching agents (including bash).

* **Tests**
  * Updated tests to reflect preserved/whitespace-handling of bash prompts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->