### PR TITLE
feat(tui): initial-prompt path in banner; pull in Fedora hilfe fix

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -3086,21 +3086,22 @@ description = "Single-agent task runner for hardened Podman containers"
 optional = false
 python-versions = ">=3.12,<4.0"
 groups = ["main"]
-files = [
-    {file = "terok_executor-0.0.124-py3-none-any.whl", hash = "sha256:57858c66189a335ac8affbb42bbb608abb25c5874c56f54cda2aa4fdfc3023b9"},
-]
+files = []
+develop = false
 
 [package.dependencies]
 Jinja2 = ">=3.1"
 pwinput = ">=1.0.3"
 pydantic = ">=2.9"
 "ruamel.yaml" = ">=0.18"
-terok_sandbox = {url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.0.104/terok_sandbox-0.0.104-py3-none-any.whl"}
+terok-sandbox = {url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.0.104/terok_sandbox-0.0.104-py3-none-any.whl"}
 tomli-w = ">=1.0"
 
 [package.source]
-type = "url"
-url = "https://github.com/terok-ai/terok-executor/releases/download/v0.0.124/terok_executor-0.0.124-py3-none-any.whl"
+type = "git"
+url = "https://github.com/sliwowitz/terok-executor.git"
+reference = "fix/fedora-banner-bashrc"
+resolved_reference = "d2d109cf35fccf4b8c8bd498667244ac707880fe"
 
 [[package]]
 name = "terok-sandbox"
@@ -4023,4 +4024,4 @@ propcache = ">=0.2.1"
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.12,<4.0"
-content-hash = "918b8ecb798eb68b913fc1004c5906b06bf627f9b0af0aafbbb727a465b064d3"
+content-hash = "9a573341b153ce3cc9d1e3547fb374736a6e8c135a6ffe10f28639298abb85c8"

--- a/poetry.lock
+++ b/poetry.lock
@@ -3081,27 +3081,26 @@ url = "https://github.com/terok-ai/terok-clearance/releases/download/v0.6.6/tero
 
 [[package]]
 name = "terok-executor"
-version = "0.0.124"
+version = "0.0.125"
 description = "Single-agent task runner for hardened Podman containers"
 optional = false
 python-versions = ">=3.12,<4.0"
 groups = ["main"]
-files = []
-develop = false
+files = [
+    {file = "terok_executor-0.0.125-py3-none-any.whl", hash = "sha256:33895083a2c548892639e4f00282608b9d6e5367d5034cb8b3857a1fac0f4545"},
+]
 
 [package.dependencies]
 Jinja2 = ">=3.1"
 pwinput = ">=1.0.3"
 pydantic = ">=2.9"
 "ruamel.yaml" = ">=0.18"
-terok-sandbox = {url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.0.104/terok_sandbox-0.0.104-py3-none-any.whl"}
+terok_sandbox = {url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.0.104/terok_sandbox-0.0.104-py3-none-any.whl"}
 tomli-w = ">=1.0"
 
 [package.source]
-type = "git"
-url = "https://github.com/sliwowitz/terok-executor.git"
-reference = "fix/fedora-banner-bashrc"
-resolved_reference = "d2d109cf35fccf4b8c8bd498667244ac707880fe"
+type = "url"
+url = "https://github.com/terok-ai/terok-executor/releases/download/v0.0.125/terok_executor-0.0.125-py3-none-any.whl"
 
 [[package]]
 name = "terok-sandbox"
@@ -4024,4 +4023,4 @@ propcache = ">=0.2.1"
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.12,<4.0"
-content-hash = "9a573341b153ce3cc9d1e3547fb374736a6e8c135a6ffe10f28639298abb85c8"
+content-hash = "6fb4bb1d7a08c97ecebbec022f7b154a0645e5ac5e6f81a612df20c00ae60aeb"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,10 @@ rich = ">=13.0"
 platformdirs = ">=4.5.1"
 unique-namer = ">=1.3"
 textual-serve = ">=1.1.0"
-terok-executor = {url = "https://github.com/terok-ai/terok-executor/releases/download/v0.0.124/terok_executor-0.0.124-py3-none-any.whl"}
+# DEV-TIME BRANCH PIN — tracks terok-executor's fix/fedora-banner-bashrc, which
+# wires the hilfe banner into the right system bashrc per family (Fedora was
+# silently dropping it).  Switch back to a wheel pin once that PR ships a release.
+terok-executor = {git = "https://github.com/sliwowitz/terok-executor.git", branch = "fix/fedora-banner-bashrc"}
 terok-sandbox = {url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.0.104/terok_sandbox-0.0.104-py3-none-any.whl"}
 terok-shield = {url = "https://github.com/terok-ai/terok-shield/releases/download/v0.6.34/terok_shield-0.6.34-py3-none-any.whl"}
 terok-clearance = {url = "https://github.com/terok-ai/terok-clearance/releases/download/v0.6.6/terok_clearance-0.6.6-py3-none-any.whl"}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,10 +48,7 @@ rich = ">=13.0"
 platformdirs = ">=4.5.1"
 unique-namer = ">=1.3"
 textual-serve = ">=1.1.0"
-# DEV-TIME BRANCH PIN — tracks terok-executor's fix/fedora-banner-bashrc, which
-# wires the hilfe banner into the right system bashrc per family (Fedora was
-# silently dropping it).  Switch back to a wheel pin once that PR ships a release.
-terok-executor = {git = "https://github.com/sliwowitz/terok-executor.git", branch = "fix/fedora-banner-bashrc"}
+terok-executor = {url = "https://github.com/terok-ai/terok-executor/releases/download/v0.0.125/terok_executor-0.0.125-py3-none-any.whl"}
 terok-sandbox = {url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.0.104/terok_sandbox-0.0.104-py3-none-any.whl"}
 terok-shield = {url = "https://github.com/terok-ai/terok-shield/releases/download/v0.6.34/terok_shield-0.6.34-py3-none-any.whl"}
 terok-clearance = {url = "https://github.com/terok-ai/terok-clearance/releases/download/v0.6.6/terok_clearance-0.6.6-py3-none-any.whl"}

--- a/src/terok/tui/task_actions.py
+++ b/src/terok/tui/task_actions.py
@@ -75,7 +75,7 @@ _INITIAL_PROMPT_PATH = f"{CONTAINER_TEROK_CONFIG}/{_INITIAL_PROMPT_FILENAME}"
 _BASH_INITIAL_PROMPT_WRAPPER = (
     f"p={shlex.quote(_INITIAL_PROMPT_PATH)}; "
     '[ -s "$p" ] && { '
-    'printf "\\n\\033[1;33m\U0001f4dd Initial prompt:\\033[0m\\n"; '
+    f'printf "\\n\\033[1;33m\U0001f4dd Initial prompt\\033[0m \\033[2m(%s)\\033[0m\\n" {shlex.quote(_INITIAL_PROMPT_PATH)}; '
     'cat "$p"; printf "\\n\\n"; '
     "}; exec bash -i"
 )


### PR DESCRIPTION
## Summary

Two small follow-ups on the initial-prompt feature shipped in #867:

1. **Show the initial-prompt path next to the banner.** The bash launch banner now reads \`📝 Initial prompt (/home/dev/.terok/initial-prompt.txt)\` so the user sees at a glance where to \`cat\` the prompt from later (e.g. \`claude < /home/dev/.terok/initial-prompt.txt\`) when piping it into another agent.

2. **Pull in a Fedora regression fix from terok-executor.** On RPM-family L1 images the \`hilfe --kurz\` help banner was silently dropped at login because the L1 build wires it into \`/etc/bash.bashrc\` — a Debian-only convention. Companion PR: https://github.com/terok-ai/terok-executor/pull/253 wires the banner (and the \`terok-env\` source line) into \`/etc/bashrc\` on RPM family at template time.

## Dependency chain

This PR pins \`terok-executor\` to the tip of \`fix/fedora-banner-bashrc\` so end-to-end testing works on this branch. Once that PR merges and a release wheel ships, the pin should be flipped back to a versioned wheel.

## Test plan

- [x] \`make lint\` / \`ruff format --check\` clean
- [x] \`make tach\` clean
- [x] \`make test\` — full unit suite passes (2187/2187)
- [ ] Manual TUI smoke test (Debian-based image): launch a CLI task with bash + a non-empty prompt; confirm the banner now reads \`📝 Initial prompt (/home/dev/.terok/initial-prompt.txt)\`.
- [ ] Manual TUI smoke test (Fedora-based image): \`terok login\` into a fresh task; confirm \`hilfe --kurz\` banner now appears (regression coverage for #253).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Updates**
  * Bumped terok-executor dependency to v0.0.125.
  * Shell initial prompt message now includes the mounted prompt file path alongside the colored prompt indicator for clearer visibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->