### PR TITLE
fix(yaml): make ruamel.yaml helper thread-safe

### DIFF
--- a/src/terok/lib/util/yaml.py
+++ b/src/terok/lib/util/yaml.py
@@ -26,13 +26,20 @@ from ruamel.yaml import YAML, YAMLError  # noqa: F401 — re-exported
 
 __all__ = ["load", "dump", "YAMLError"]
 
-_yaml = YAML(typ="rt")
-_yaml.preserve_quotes = True
+
+def _rt() -> YAML:
+    # A fresh instance per call: ``YAML`` carries composer/parser/scanner state
+    # on the object, so a shared module-level instance races under concurrent
+    # ``load`` / ``dump`` from Textual worker threads — symptom is
+    # ``'MappingEndEvent' object has no attribute 'anchor'``.
+    yaml = YAML(typ="rt")
+    yaml.preserve_quotes = True
+    return yaml
 
 
 def load(text: str) -> Any:
     """Round-trip load from a YAML string, preserving comments and order."""
-    return _yaml.load(text)
+    return _rt().load(text)
 
 
 def dump(data: Any, *, default_flow_style: bool = False) -> str:
@@ -42,10 +49,8 @@ def dump(data: Any, *, default_flow_style: bool = False) -> str:
     round-tripped data).  ``sort_keys`` is always ``False`` — the caller never
     needs to pass it.
     """
-    emitter = _yaml
+    emitter = _rt()
     if default_flow_style:
-        emitter = YAML(typ="rt")
-        emitter.preserve_quotes = True
         emitter.default_flow_style = True
     buf = StringIO()
     emitter.dump(data, buf)

--- a/tests/unit/lib/test_yaml_util.py
+++ b/tests/unit/lib/test_yaml_util.py
@@ -186,6 +186,65 @@ class TestRoundTrip:
         assert "name: test" in text
 
 
+class TestThreadSafety:
+    """Concurrent ``load`` / ``dump`` from worker threads must not race.
+
+    Regression: a shared module-level ``YAML()`` instance carries
+    composer/parser/scanner state, so concurrent calls scrambled its event
+    stream and surfaced as ``'MappingEndEvent' object has no attribute
+    'anchor'`` deep inside the Textual TUI's shield-state worker.
+    """
+
+    SAMPLE = (
+        "# top comment\n"
+        "name: terok\n"
+        "git:\n"
+        "  remote: origin\n"
+        "  branch: master  # default\n"
+        "tasks:\n"
+        "  - id: 1\n"
+        "    title: 'first'\n"
+        "  - id: 2\n"
+        '    title: "second"\n'
+        "nested:\n"
+        "  a:\n"
+        "    b:\n"
+        "      c: 42\n"
+    )
+
+    def test_concurrent_load(self) -> None:
+        from concurrent.futures import ThreadPoolExecutor
+
+        def work() -> int:
+            for _ in range(50):
+                data = load(self.SAMPLE)
+                assert data["name"] == "terok"
+                assert data["nested"]["a"]["b"]["c"] == 42
+            return 0
+
+        with ThreadPoolExecutor(max_workers=8) as pool:
+            futures = [pool.submit(work) for _ in range(8)]
+            for f in futures:
+                f.result()  # re-raises any exception from a worker
+
+    def test_concurrent_load_and_dump(self) -> None:
+        from concurrent.futures import ThreadPoolExecutor
+
+        def loader() -> None:
+            for _ in range(50):
+                load(self.SAMPLE)
+
+        def dumper() -> None:
+            data = load(self.SAMPLE)
+            for _ in range(50):
+                dump(data)
+
+        with ThreadPoolExecutor(max_workers=8) as pool:
+            futures = [pool.submit(loader if i % 2 else dumper) for i in range(8)]
+            for f in futures:
+                f.result()
+
+
 class TestYAMLError:
     """Tests for ``YAMLError`` re-export."""
 


### PR DESCRIPTION
## Summary

- Replaces the shared module-level `YAML(typ=\"rt\")` instance in `src/terok/lib/util/yaml.py` with per-call instantiation. ruamel.yaml's `YAML` class carries composer/parser/scanner state on the instance, so concurrent `load`/`dump` from different threads scrambled its event stream.
- Adds a regression test (`TestThreadSafety`) that runs 8 worker threads doing concurrent load and load+dump on a non-trivial document. The test reproduces the race against the old shared-instance implementation (`IndexError`/`AttributeError` from corrupted scanner state) and passes against the fix.

## Symptom

Reported in the TUI as a hard crash from a Textual worker thread:

```
Failed to read .../project.yml: AttributeError:
  'MappingEndEvent' object has no attribute 'anchor'
```

The trace originates inside `_load_shield_state` (`src/terok/tui/app.py:898`), which is dispatched via `run_worker(..., thread=True)`. While that worker calls `load_project()` → `_yaml_load()`, the main thread (or other shield-state workers in different `group=...` slots) can call `_yaml_load()` / `_yaml_dump()` on the same module-level `_yaml` and corrupt its state. The crash is non-deterministic; the offending YAML file itself is fine.

## Pre-existing on master

- The shared `_yaml` instance was introduced in #463 (PyYAML → ruamel.yaml refactor, `692944b0`).
- The threaded shield-state worker that triggers the race was introduced in #405 (`02d69741`).

So this is a latent race on master — any concurrent caller can hit it.

## Why per-call instantiation

`YAML(typ=\"rt\")` is cheap to construct (lazy composer/parser), and per-call instantiation makes thread safety obvious without locks. A short docstring on the helper documents the trap so nobody re-introduces the shared instance later.

## Test plan

- [x] `poetry run pytest tests/unit/` — 2189 passed
- [x] `poetry run ruff check .` and `ruff format --check .` — clean
- [x] `poetry run tach check` — clean
- [x] `poetry run lint-imports` — 4 contracts kept, 0 broken
- [x] `poetry run docstr-coverage src/terok/ --fail-under=95` — 98.4%
- [x] `poetry run reuse lint` — compliant
- [x] `poetry run bandit -r src/terok/ -ll` — 0 medium, 0 high
- [x] Verified the new `TestThreadSafety` tests fail against the pre-fix shared-instance implementation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of YAML parsing and serialization under concurrent operations.

* **Tests**
  * Added comprehensive test coverage for YAML utilities under concurrent execution scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->