### PR TITLE
feat(tui): drop in-process prompt plumbing — wrapper picks it up

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -3086,21 +3086,22 @@ description = "Single-agent task runner for hardened Podman containers"
 optional = false
 python-versions = ">=3.12,<4.0"
 groups = ["main"]
-files = [
-    {file = "terok_executor-0.0.127-py3-none-any.whl", hash = "sha256:7cfdcc6295ed3a7cc368eac1c18e933acf2753d485b4d165c81f26c2e3e49a9b"},
-]
+files = []
+develop = false
 
 [package.dependencies]
 Jinja2 = ">=3.1"
 pwinput = ">=1.0.3"
 pydantic = ">=2.9"
 "ruamel.yaml" = ">=0.18"
-terok_sandbox = {url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.0.106/terok_sandbox-0.0.106-py3-none-any.whl"}
+terok-sandbox = {url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.0.106/terok_sandbox-0.0.106-py3-none-any.whl"}
 tomli-w = ">=1.0"
 
 [package.source]
-type = "url"
-url = "https://github.com/terok-ai/terok-executor/releases/download/v0.0.127/terok_executor-0.0.127-py3-none-any.whl"
+type = "git"
+url = "https://github.com/sliwowitz/terok-executor.git"
+reference = "feat/initial-prompt-wrapper-pickup"
+resolved_reference = "61b79db70dbf9240d469e500617b3e1625cae45d"
 
 [[package]]
 name = "terok-sandbox"
@@ -4023,4 +4024,4 @@ propcache = ">=0.2.1"
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.12,<4.0"
-content-hash = "b2c4292d718116a481410dd843a02e772d2f7b691dd5f4060849dcef1dd141a3"
+content-hash = "d844e75c951997c86c481416429b22e990f14e09be87708ba53321e0f6372500"

--- a/poetry.lock
+++ b/poetry.lock
@@ -3081,27 +3081,26 @@ url = "https://github.com/terok-ai/terok-clearance/releases/download/v0.6.8/tero
 
 [[package]]
 name = "terok-executor"
-version = "0.0.127"
+version = "0.0.128"
 description = "Single-agent task runner for hardened Podman containers"
 optional = false
 python-versions = ">=3.12,<4.0"
 groups = ["main"]
-files = []
-develop = false
+files = [
+    {file = "terok_executor-0.0.128-py3-none-any.whl", hash = "sha256:6c69e85e0b7cf12f918c64073bc7904e80913e63e86d92657357f5a55ab38570"},
+]
 
 [package.dependencies]
 Jinja2 = ">=3.1"
 pwinput = ">=1.0.3"
 pydantic = ">=2.9"
 "ruamel.yaml" = ">=0.18"
-terok-sandbox = {url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.0.106/terok_sandbox-0.0.106-py3-none-any.whl"}
+terok_sandbox = {url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.0.106/terok_sandbox-0.0.106-py3-none-any.whl"}
 tomli-w = ">=1.0"
 
 [package.source]
-type = "git"
-url = "https://github.com/sliwowitz/terok-executor.git"
-reference = "feat/initial-prompt-wrapper-pickup"
-resolved_reference = "61b79db70dbf9240d469e500617b3e1625cae45d"
+type = "url"
+url = "https://github.com/terok-ai/terok-executor/releases/download/v0.0.128/terok_executor-0.0.128-py3-none-any.whl"
 
 [[package]]
 name = "terok-sandbox"
@@ -4024,4 +4023,4 @@ propcache = ">=0.2.1"
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.12,<4.0"
-content-hash = "d844e75c951997c86c481416429b22e990f14e09be87708ba53321e0f6372500"
+content-hash = "a66d07afeacc9cf80333afbea404b30a672f9788d0ebbf30fd0f22f847c39392"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,7 @@ unique-namer = ">=1.3"
 textual-serve = ">=1.1.0"
 # DEV-TIME BRANCH PINS — track the Codex vaulted-OAuth PR chain until the
 # sibling wheels ship.  The release chain flips these back to wheel URLs.
-terok-executor = {url = "https://github.com/terok-ai/terok-executor/releases/download/v0.0.127/terok_executor-0.0.127-py3-none-any.whl"}
+terok-executor = {git = "https://github.com/sliwowitz/terok-executor.git", branch = "feat/initial-prompt-wrapper-pickup"}
 terok-sandbox = {url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.0.106/terok_sandbox-0.0.106-py3-none-any.whl"}
 terok-shield = {url = "https://github.com/terok-ai/terok-shield/releases/download/v0.6.36/terok_shield-0.6.36-py3-none-any.whl"}
 terok-clearance = {url = "https://github.com/terok-ai/terok-clearance/releases/download/v0.6.8/terok_clearance-0.6.8-py3-none-any.whl"}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,7 @@ unique-namer = ">=1.3"
 textual-serve = ">=1.1.0"
 # DEV-TIME BRANCH PINS — track the Codex vaulted-OAuth PR chain until the
 # sibling wheels ship.  The release chain flips these back to wheel URLs.
-terok-executor = {git = "https://github.com/sliwowitz/terok-executor.git", branch = "feat/initial-prompt-wrapper-pickup"}
+terok-executor = {url = "https://github.com/terok-ai/terok-executor/releases/download/v0.0.128/terok_executor-0.0.128-py3-none-any.whl"}
 terok-sandbox = {url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.0.106/terok_sandbox-0.0.106-py3-none-any.whl"}
 terok-shield = {url = "https://github.com/terok-ai/terok-shield/releases/download/v0.6.36/terok_shield-0.6.36-py3-none-any.whl"}
 terok-clearance = {url = "https://github.com/terok-ai/terok-clearance/releases/download/v0.6.8/terok_clearance-0.6.8-py3-none-any.whl"}

--- a/src/terok/tui/task_actions.py
+++ b/src/terok/tui/task_actions.py
@@ -8,7 +8,6 @@ login, restart, follow-up, log viewing, and diff copying.
 """
 
 import io
-import shlex
 from collections.abc import Callable
 from contextlib import redirect_stdout
 from pathlib import Path
@@ -34,7 +33,6 @@ from ..lib.domain.facade import (
 )
 from ..lib.orchestration.autopilot import wait_for_container_exit
 from ..lib.orchestration.tasks import (
-    CONTAINER_TEROK_CONFIG,
     agent_config_dir,
     container_name,
     generate_task_name,
@@ -53,32 +51,10 @@ from .screens import (
 )
 from .widgets import TaskList
 
-
-def _build_interactive_agent_command(provider: object, prompt: str | None) -> str:
-    """Build shell command to launch an agent interactively with optional prompt.
-
-    Uses the binary as a positional command — the prompt is a first-turn
-    argument, NOT the headless ``-p`` flag.  The agent runs interactively
-    inside tmux so the user can re-attach later.
-    """
-    if not prompt:
-        return provider.binary
-    return f"{provider.binary} {shlex.quote(prompt)}"
-
-
+# Per-task file the agent wrappers (terok-executor) consume one-shot, and the
+# bashrc banner (also from terok-executor) displays after the help banner.
+# Filename is the contract; the wrapper hard-codes the same path.
 _INITIAL_PROMPT_FILENAME = "initial-prompt.txt"
-_INITIAL_PROMPT_PATH = f"{CONTAINER_TEROK_CONFIG}/{_INITIAL_PROMPT_FILENAME}"
-
-# Shell wrapper for bash-agent launches with an initial prompt. The prompt
-# travels via the file mount, never as a shell argument — wrapper string
-# contains zero user-data interpolation.
-_BASH_INITIAL_PROMPT_WRAPPER = (
-    f"p={shlex.quote(_INITIAL_PROMPT_PATH)}; "
-    '[ -s "$p" ] && { '
-    f'printf "\\n\\033[1;33m\U0001f4dd Initial prompt\\033[0m \\033[2m(%s)\\033[0m\\n" {shlex.quote(_INITIAL_PROMPT_PATH)}; '
-    'cat "$p"; printf "\\n\\n"; '
-    "}; exec bash -i"
-)
 
 
 def _save_initial_prompt(project_id: str, task_id: str, prompt: str | None) -> None:
@@ -87,13 +63,6 @@ def _save_initial_prompt(project_id: str, task_id: str, prompt: str | None) -> N
         return
     path = agent_config_dir(project_id, task_id) / _INITIAL_PROMPT_FILENAME
     path.write_text(prompt + "\n", encoding="utf-8")
-
-
-def _build_bash_login_cmd(base_cmd: list[str], prompt: str | None) -> list[str]:
-    """Login command for the bash agent, surfacing the saved initial prompt if any."""
-    if not prompt:
-        return base_cmd
-    return [*base_cmd, "bash", "-lc", _BASH_INITIAL_PROMPT_WRAPPER]
 
 
 def _login_title(project_id: str, task_id: str, task_name: str) -> str:
@@ -294,10 +263,15 @@ class TaskActionsMixin:
             self.notify(str(e))
             return
 
+        # Stash the prompt where the agent wrappers (terok-executor) and the
+        # interactive bash banner can pick it up.  Bash displays it after
+        # `hilfe --kurz`; the per-provider wrapper consumes it one-shot on
+        # bare invocation and renames the file so subsequent runs --resume
+        # the saved session instead of replaying the prompt.
         _save_initial_prompt(pid, tid, prompt)
 
         if agent == "bash":
-            cmd = _build_bash_login_cmd(base_cmd, prompt)
+            cmd = base_cmd
         else:
             from terok_executor import AGENT_PROVIDERS
 
@@ -305,8 +279,7 @@ class TaskActionsMixin:
             if not provider:
                 self.notify(f"Unknown agent: {agent}")
                 return
-            agent_cmd = _build_interactive_agent_command(provider, prompt)
-            cmd = [*base_cmd, "bash", "-lc", agent_cmd]
+            cmd = [*base_cmd, "bash", "-lc", provider.binary]
 
         await self._launch_terminal_session(
             cmd, title=_login_title(pid, tid, task_name), cname=cname

--- a/tests/unit/lib/test_image.py
+++ b/tests/unit/lib/test_image.py
@@ -100,7 +100,10 @@ def test_generate_dockerfiles_outputs_expected_files_and_content() -> None:
         )
         l2_content = (out_dir / "L2.Dockerfile").read_text(encoding="utf-8")
         l1_cli_content = (out_dir / "L1.cli.Dockerfile").read_text(encoding="utf-8")
-        assert "hilfe --kurz" in l1_cli_content
+        # Banner snippet is now concatenated from a sidecar (see
+        # terok-executor scripts/terok-bash-banner.sh), so the bashrc setup
+        # references the snippet path rather than the literal hilfe call.
+        assert 'cat /tmp/terok-bash-banner.sh >> "$bashrc"' in l1_cli_content
         assert "SSH_KEY_NAME" not in l2_content
         assert "{{DEFAULT_BRANCH}}" not in l2_content
         assert f'CODE_REPO="{UPSTREAM_URL}"' in l2_content

--- a/tests/unit/tui/test_new_task_flow.py
+++ b/tests/unit/tui/test_new_task_flow.py
@@ -253,56 +253,66 @@ class TestTaskLaunchScreen:
 
 
 # ---------------------------------------------------------------------------
-# _build_interactive_agent_command
+# Launch command shape — prompt travels via the on-disk file, not as a CLI arg
 # ---------------------------------------------------------------------------
 
 
-class TestBuildInteractiveAgentCommand:
-    """Tests for _build_interactive_agent_command helper."""
+def _run_launch_with_prompt(agent: str, prompt: str | None) -> tuple[mock.Mock, mock.Mock]:
+    """Drive _on_launch_screen_result for *agent*/*prompt* and return mocks."""
+    _, app_class = import_app()
+    instance = app_class()
+    instance.current_project_id = "proj1"
+    instance.refresh_tasks = mock.AsyncMock()
+    instance._launch_terminal_session = mock.AsyncMock()
 
-    def _import_helper(self) -> Callable[..., str]:
-        """Import the helper function from the freshly loaded module."""
-        _, app_class = import_app()
-        return app_class._start_cli_task_background.__globals__["_build_interactive_agent_command"]
+    fake_provider = mock.Mock()
+    fake_provider.binary = "claude"
+    save = mock.Mock()
+    action_globals = app_class._on_launch_screen_result.__globals__
 
-    def test_no_prompt_returns_binary(self) -> None:
-        build = self._import_helper()
-        provider = mock.Mock()
-        provider.binary = "claude"
-        provider.prompt_flag = "-p"
-        assert build(provider, None) == "claude"
+    with (
+        mock.patch.dict(
+            action_globals,
+            {
+                "get_login_command": mock.Mock(return_value=["podman", "exec", "-it", "c"]),
+                "_save_initial_prompt": save,
+            },
+        ),
+        mock.patch.dict(
+            "terok_executor.provider.providers.AGENT_PROVIDERS",
+            {"claude": fake_provider},
+            clear=True,
+        ),
+    ):
+        result = ("proj1", "5", "task", "proj1-cli-5", agent, prompt)
+        run(app_class._on_launch_screen_result(instance, result))
 
-    def test_empty_prompt_returns_binary(self) -> None:
-        build = self._import_helper()
-        provider = mock.Mock()
-        provider.binary = "claude"
-        provider.prompt_flag = "-p"
-        assert build(provider, "") == "claude"
+    return instance._launch_terminal_session, save
 
-    def test_with_prompt(self) -> None:
-        build = self._import_helper()
-        provider = mock.Mock()
-        provider.binary = "claude"
-        result = build(provider, "fix the bug")
-        assert result == "claude 'fix the bug'"
 
-    def test_simple_prompt_no_quotes(self) -> None:
-        build = self._import_helper()
-        provider = mock.Mock()
-        provider.binary = "codex"
-        result = build(provider, "hello")
-        assert result == "codex hello"
+class TestLaunchCmdShape:
+    """The prompt is delivered via initial-prompt.txt; the cmd never carries it."""
 
-    def test_prompt_with_special_chars_is_quoted(self) -> None:
-        import shlex
+    def test_agent_launch_omits_prompt_from_cli(self) -> None:
+        launch, save = _run_launch_with_prompt("claude", "fix 'the' bug")
+        cmd = launch.call_args[0][0]
+        # Wrapper consumes the file; the spawned binary is a bare invocation.
+        assert cmd == ["podman", "exec", "-it", "c", "bash", "-lc", "claude"]
+        save.assert_called_once_with("proj1", "5", "fix 'the' bug")
 
-        build = self._import_helper()
-        provider = mock.Mock()
-        provider.binary = "claude"
-        prompt = "fix 'the' bug"
-        result = build(provider, prompt)
-        expected = f"claude {shlex.quote(prompt)}"
-        assert result == expected
+    def test_agent_launch_without_prompt(self) -> None:
+        launch, save = _run_launch_with_prompt("claude", None)
+        cmd = launch.call_args[0][0]
+        assert cmd == ["podman", "exec", "-it", "c", "bash", "-lc", "claude"]
+        save.assert_called_once_with("proj1", "5", None)
+
+    def test_bash_launch_uses_base_cmd_directly(self) -> None:
+        # Bash relies on the bashrc banner snippet (terok-executor) to display
+        # the prompt — no per-launch wrapper needed.
+        launch, save = _run_launch_with_prompt("bash", "first message")
+        cmd = launch.call_args[0][0]
+        assert cmd == ["podman", "exec", "-it", "c"]
+        save.assert_called_once_with("proj1", "5", "first message")
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- The TUI no longer plumbs the initial prompt through the agent command line. It writes the prompt to the per-task `initial-prompt.txt` and that's it — the matching wrappers in terok-executor (#257) read the file on a bare invocation and consume it one-shot.
- The bash-agent launch path drops its custom display wrapper too. The in-container bashrc (also in #257) now surfaces the prompt right after `hilfe --kurz`, so a `bash` login shows what the task is supposed to be about and a follow-up `claude` from the same shell still picks the file up cleanly.

Net effect for the user: starting a task with an initial prompt and picking `bash` lets them inspect the prompt after the help banner; running an agent later (or picking the agent directly at launch) actually delivers the prompt as the first message — the bash banner was previously a stub that promised something the wrappers couldn't deliver.

Depends on terok-ai/terok-executor#257; pinned via branch URL until that wheel ships.

## Test plan

- [x] `make lint`, `make tach`, `make docstrings`, `make security`, `make reuse` pass
- [x] `pytest tests/unit/tui/test_new_task_flow.py` passes; the deprecated `_build_interactive_agent_command` tests are replaced with cmd-shape assertions covering bash + agent launches with/without prompt
- [x] Full unit test suite passes (vault integration failures are pre-existing on master, unrelated to this change)
- [ ] In-container smoke: TUI start-task → bash agent → see prompt after banner → run claude → prompt is delivered as first message; `initial-prompt.consumed.txt` left behind

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Bumped task executor dependency to the next development wheel version (v0.0.128).

* **Refactor**
  * Simplified task launch flow by separating prompt persistence from command execution so user prompts are stored separately and no longer interpolated into runtime commands.

* **Tests**
  * Added and updated tests to verify launch command shapes, prompt persistence/consumption from disk, and updated bash startup content expectations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->