### PR TITLE
chore(no-git-deps): skip on pull_request, run on merge_group

### DIFF
--- a/.github/workflows/no-git-deps.yml
+++ b/.github/workflows/no-git-deps.yml
@@ -6,10 +6,12 @@ name: no-git-deps
 # and add `no-git-deps` under "Require status checks to pass".
 
 on:
+  pull_request:
   merge_group:
 
 jobs:
   no-git-deps:
+    if: github.event_name == 'merge_group'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
## Why

Follow-up to #721. With `no-git-deps` listed as a required status check and the workflow firing only on `merge_group:`, every open PR shows `no-git-deps — Expected — Waiting for status to be reported` indefinitely, because the required-check evaluator expects a status on the PR head and never gets one. Downstream tooling that keys off "all checks finished" stalls on this.

GitHub rulesets don't expose a queue-only required-check toggle (verified against current docs) — the standalone "Require status checks to pass" rule applies at both PR and queue contexts.

## What

Trigger the workflow on both `pull_request:` and `merge_group:`, gated with `if: github.event_name == 'merge_group'`. On PR events the job is skipped — a terminal status that the required-check evaluator counts as success. On merge-queue entry the scan runs for real and blocks bad deps as today.

Chain PRs with legitimate git deps stay non-red (Skipped, gray), preserving the design intent from #721.

## Test plan

- [ ] After merge, open-PR view of any PR shows `no-git-deps — Skipped` (gray, terminal), not `Expected — Waiting`.
- [ ] Rebase the canary PR #878 onto new master and confirm the merge queue still rejects it on the chain git deps.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced workflow automation configuration to improve build pipeline management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->