### PR TITLE
chore(no-git-deps): repurpose as post-merge alarm + release gate

### DIFF
--- a/.github/workflows/no-git-deps.yml
+++ b/.github/workflows/no-git-deps.yml
@@ -1,17 +1,12 @@
 name: no-git-deps
 
-# Inert until merge queue is enabled on `master` and `no-git-deps` is
-# listed as a required status check in the master ruleset.
-# Settings → Rules → Rulesets → (master ruleset): add "Require merge queue"
-# and add `no-git-deps` under "Require status checks to pass".
-
 on:
-  pull_request:
-  merge_group:
+  push:
+    branches: [master]
+  workflow_call:
 
 jobs:
-  no-git-deps:
-    if: github.event_name == 'merge_group'
+  scan:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -48,7 +43,6 @@ jobs:
               print("Git sources found in pyproject.toml:")
               for o in offenders:
                   print(f"  - {o}")
-              print("\nSwap to released wheels before merging.")
               sys.exit(1)
           print("No git sources - OK.")
           PY

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,11 @@ permissions:
   contents: write
 
 jobs:
+  no-git-deps:
+    uses: ./.github/workflows/no-git-deps.yml
+
   build:
+    needs: no-git-deps
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
## Why

Required-check enforcement (#721, #879) turned out to poison the "is this PR healthy?" signal that downstream tooling consumes — a chain PR with legitimate git deps would force every external tool to inspect individual check identities to decide whether to act on the PR. That fallout is bigger than the cost of an occasional bad merge that needs a revert.

Move protection to where the damage actually persists (the published artifact), and keep a visible-but-non-blocking alarm on master.

## What

`no-git-deps.yml`:
- Trigger flips from `pull_request:` + `merge_group:` to `push: branches: [master]` + `workflow_call:`.
- The `if: github.event_name == 'merge_group'` gate is gone — the job now runs unconditionally on whichever ref the trigger provides.
- Job renamed `no-git-deps` → `scan` (the workflow itself is `no-git-deps`; the job inside is the scan).

`release.yml`:
- New `no-git-deps` job that calls the reusable workflow.
- `build` job declares `needs: no-git-deps`, so the wheel build is skipped (not just failed-after-upload) if the tagged ref carries git sources.

Two failure modes, two effects:
- **Post-merge alarm**: red X on the master commit. No required-check pollution. Visible signal that someone needs to revert or fix forward.
- **Release-time gate**: `build` never runs if the scan trips, so no artifact is published from a dirty tag.

Single source of truth for the scan; same code runs in both contexts.

## Companion ruleset changes (manual, on the upstream repo)

After merge:
- Remove "Require merge queue" from the master ruleset.
- Remove `no-git-deps` from "Require status checks to pass" in the master ruleset.
- Close canary PR #878.

## Test plan

- [ ] After merge, push to master triggers `no-git-deps / scan`; with the current clean `pyproject.toml` it passes (green).
- [ ] On the next tag push, `release.yml` shows two jobs: `no-git-deps` runs first, `build` waits on it.
- [ ] (Optional) Open a throwaway tag against a deliberately-dirty pyproject and confirm `build` is skipped and no GitHub Release is created.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated CI/CD workflow configuration to enforce git dependency checks during the release pipeline, ensuring releases contain only published dependencies rather than development references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->