### PR TITLE
fix(tui): run action_run_setup on a worker so push_screen_wait works

### DIFF
--- a/src/terok/tui/app.py
+++ b/src/terok/tui/app.py
@@ -506,12 +506,16 @@ if _HAS_TEXTUAL:
             )
             return False
 
+        @work(exclusive=True, group="first-run-flow", exit_on_error=False)
         async def action_run_setup(self) -> None:
             """Open the setup flow on demand (command palette / re-run).
 
             Always probes the current verdict so the user sees the live
             state — useful even on a healthy install when they want to
             re-apply the (idempotent) systemd cycle after an upgrade.
+
+            Runs on a worker because ``_run_setup_flow`` calls
+            ``push_screen_wait``, which requires a worker context.
             """
             try:
                 verdict = needs_setup()


### PR DESCRIPTION
## Summary

- Invoking **Run terok setup** from the command palette crashed with `NoActiveWorker: push_screen must be run from a worker when wait_for_dismiss is True`. `_run_setup_flow` calls `push_screen_wait`, which Textual only allows from inside a worker.
- The first-run path worked because `_run_first_run_flow` is decorated with `@work`; the command-palette entry point was a plain `async` action and was missing the same decoration.
- Decorate `action_run_setup` with `@work(exclusive=True, group="first-run-flow", exit_on_error=False)` — same group as the first-run flow, so a manual re-run cancels and replaces an in-flight first-run wizard instead of stacking screens.

## Test plan

- [x] `make lint` passes
- [x] `poetry run pytest tests/unit/tui/` — 460 passed
- [ ] Manually trigger the command palette → **Run terok setup** entry on a stale-stamp install and confirm the setup screen opens without a traceback

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Enhanced setup process execution with better context management for more reliable system initialization and upgrade handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->