### PR TITLE
ci: PyPI release prep

### DIFF
--- a/.github/workflows/no-git-deps.yml
+++ b/.github/workflows/no-git-deps.yml
@@ -8,6 +8,8 @@ on:
 jobs:
   scan:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v6
       - name: Scan pyproject.toml for git sources
@@ -20,9 +22,13 @@ jobs:
 
           def scan(label, deps):
               for name, spec in deps.items():
-                  if isinstance(spec, dict) and "git" in spec:
+                  if not isinstance(spec, dict):
+                      continue
+                  if "git" in spec:
                       ref = spec.get("branch") or spec.get("rev") or spec.get("tag") or "?"
                       offenders.append(f"{label}.{name} -> {spec['git']}@{ref}")
+                  elif "url" in spec and str(spec["url"]).startswith("git+"):
+                      offenders.append(f"{label}.{name} -> {spec['url']}")
 
           poetry = data.get("tool", {}).get("poetry", {})
           for key in ("dependencies", "dev-dependencies"):

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,15 +1,25 @@
-name: Release
-
 # Pin third-party actions to full commit SHAs for supply-chain security.
 # GitHub-owned actions (actions/*) may use version tags.
+name: Release
 
 on:
   push:
-    tags:
-      - "v*"
+    tags: ["v*.*.*"]
+  workflow_dispatch:
+    inputs:
+      target:
+        description: "What to publish"
+        type: choice
+        options: [pypi, testpypi, gh-only]
+        default: pypi
 
-permissions:
-  contents: write
+# Empty default; each job re-grants only what it needs.
+permissions: {}
+
+# One release at a time per ref; don't cancel a publish mid-flight.
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
 
 jobs:
   no-git-deps:
@@ -18,39 +28,109 @@ jobs:
   build:
     needs: no-git-deps
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v6
         with:
-          fetch-depth: 0
+          fetch-depth: 0    # poetry-dynamic-versioning needs full history
 
-      - name: Set up Python
-        id: setup-python
-        uses: actions/setup-python@v6
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.12"
 
-      - name: Install Poetry
-        uses: snok/install-poetry@76e04a911780d5b312d89783f7b1cd627778900a # v1.4.1
+      - uses: snok/install-poetry@76e04a911780d5b312d89783f7b1cd627778900a # v1.4.1
         with:
           version: "2.3.3"
-          virtualenvs-create: true
-          virtualenvs-in-project: true
           plugins: poetry-dynamic-versioning[plugin]
-
-      - name: Cache virtualenv
-        id: cached-poetry-dependencies
-        uses: actions/cache@v5
-        with:
-          path: .venv
-          key: venv-${{ runner.os }}-py${{ steps.setup-python.outputs.python-version }}-release-${{ hashFiles('**/pyproject.toml', '**/poetry.lock') }}
-
-      - name: Install dependencies
-        run: poetry install --no-interaction
 
       - name: Build distributions
         run: poetry build
 
-      - name: Upload release assets
-        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v2
+      - uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist/
+          retention-days: 90    # cover any realistic re-run window
+
+  github-release:
+    needs: build
+    if: |
+      github.event_name == 'push' ||
+      (github.event_name == 'workflow_dispatch' && inputs.target == 'gh-only')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Verify triggering actor
+        env:
+          ACTOR: ${{ github.triggering_actor }}
+        run: |
+          if [ "$ACTOR" != "terok-warden" ]; then
+            echo "Releases must be triggered by terok-warden (got: $ACTOR)" >&2
+            exit 1
+          fi
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+      - uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v2
         with:
           files: dist/*
+
+  pypi-publish:
+    needs: build
+    if: |
+      github.event_name == 'push' ||
+      (github.event_name == 'workflow_dispatch' && inputs.target == 'pypi')
+    runs-on: ubuntu-latest
+    environment: pypi   # OIDC subject narrowing + required-reviewer gate
+    permissions:
+      id-token: write   # OIDC for PyPI Trusted Publishing
+    steps:
+      - name: Verify triggering actor
+        env:
+          ACTOR: ${{ github.triggering_actor }}
+        run: |
+          if [ "$ACTOR" != "terok-warden" ]; then
+            echo "Releases must be triggered by terok-warden (got: $ACTOR)" >&2
+            exit 1
+          fi
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+      - uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
+        with:
+          attestations: true
+
+  testpypi-publish:
+    needs: build
+    if: github.event_name == 'workflow_dispatch' && inputs.target == 'testpypi'
+    runs-on: ubuntu-latest
+    environment: pypi   # same protection as real PyPI
+    permissions:
+      id-token: write
+    steps:
+      - name: Verify triggering actor
+        env:
+          ACTOR: ${{ github.triggering_actor }}
+        run: |
+          if [ "$ACTOR" != "terok-warden" ]; then
+            echo "Releases must be triggered by terok-warden (got: $ACTOR)" >&2
+            exit 1
+          fi
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+      - uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
+        with:
+          repository-url: https://test.pypi.org/legacy/
+          attestations: true

--- a/README.md
+++ b/README.md
@@ -4,6 +4,11 @@
 [![REUSE compliant](https://api.reuse.software/badge/github.com/terok-ai/terok)](https://api.reuse.software/info/github.com/terok-ai/terok)
 [![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=terok-ai_terok&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=terok-ai_terok)
 
+> [!WARNING]
+> Terok is **alpha**. It is under active development and until version
+> 1.0.0 is released, APIs, internals, and security boundaries may change
+> without deprecation notice. Not recommended for production.
+
 An open, Podman-native runtime for AI coding agents you can let off
 the leash — without giving them the leash to your machine.
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,14 @@
+# Security policy
+
+Terok is currently in alpha stage under active development. Until
+version 1.0.0 is released, security issues and breakages are expected
+to surface.
+
+## Reporting
+
+Do not open public issues for security reports. Use either:
+
+- Email `security@terok.ai`, encrypted with our PGP key at
+  <https://terok.ai/.well-known/openpgpkey.asc>
+  (fingerprint `F178 21C6 5E86 C462 8FA6  AC61 41B9 95B7 F5FB DC9F`).
+- [GitHub Private Vulnerability Reporting](https://github.com/terok-ai/terok/security/advisories/new).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,17 +5,22 @@ build-backend = "poetry_dynamic_versioning.backend"
 [tool.poetry]
 name = "terok"
 version = "0.7.7"
-description = "Manage containerized projects and per-run tasks with Podman"
+description = "Sandboxing for AI coding agents, built on Podman."
 readme = "README.md"
 license = "Apache-2.0"
-authors = ["terok maintainers"]
+authors = ["Jiri Vyskocil <jiri@vyskocil.com>"]
 keywords = ["podman", "containers", "tasks", "developer-tools", "cli"]
 classifiers = [
-  "Programming Language :: Python :: 3",
-  "License :: OSI Approved :: Apache Software License",
-  "Environment :: Console",
-  "Operating System :: POSIX :: Linux",
-  "Topic :: System :: Systems Administration",
+    "Development Status :: 3 - Alpha",
+    "Environment :: Console",
+    "Intended Audience :: Developers",
+    "Intended Audience :: System Administrators",
+    "License :: OSI Approved :: Apache Software License",
+    "Operating System :: POSIX :: Linux",
+    "Programming Language :: Python",
+    "Topic :: Security",
+    "Topic :: System :: Systems Administration",
+    "Typing :: Typed",
 ]
 
 # Use the src/ layout
@@ -32,6 +37,10 @@ include = [
   { path = "docs/*.md" },
   { path = "examples/**" },
 ]
+maintainers = ["Jiri Vyskocil <jiri@vyskocil.com>"]
+homepage = "https://terok.ai/"
+repository = "https://github.com/terok-ai/terok"
+documentation = "https://terok-ai.github.io/terok/"
 
 [tool.poetry.dependencies]
 python = ">=3.12,<3.15"
@@ -81,6 +90,12 @@ mkdocs-gen-files = ">=0.5"
 mkdocs-literate-nav = ">=0.6"
 mkdocs-section-index = ">=0.3"
 mkdocs-terok = {url = "https://github.com/terok-ai/mkdocs-terok/releases/download/v0.5.0/mkdocs_terok-0.5.0-py3-none-any.whl"}
+
+
+[tool.poetry.urls]
+Issues = "https://github.com/terok-ai/terok/issues"
+Changelog = "https://github.com/terok-ai/terok/releases"
+Security = "https://github.com/terok-ai/terok/security/policy"
 
 [tool.pytest.ini_options]
 testpaths = ["tests/unit", "tests/integration"]


### PR DESCRIPTION
PyPI release prep: multi-job `release.yml` (build + github-release + pypi-publish + testpypi-publish), `SECURITY.md` disclosure channels, expanded `pyproject.toml` metadata, alpha-status warning in README. Companion to the rest of the terok-ai family.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added alpha-status warning to README; APIs and security boundaries may change until v1.0.0.
  * New security policy with responsible-disclosure guidance and private reporting options.

* **Chores**
  * Release process tightened: releases now require semantic-version tags, use a single built artifact, prevent overlapping releases, and employ stronger publish authentication and attestations.
  * Project metadata updated (description, maintainers, homepage/repository/documentation links).

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/terok-ai/terok/pull/898)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->