### PR TITLE
feat(cli): add `terok project gate-path <project>`

### DIFF
--- a/src/terok/cli/commands/project.py
+++ b/src/terok/cli/commands/project.py
@@ -129,6 +129,16 @@ def register(subparsers: argparse._SubParsersAction[argparse.ArgumentParser]) ->
         help="Rotate — unassign existing keys from the project and generate fresh",
     )
 
+    # gate-path
+    p_gate_path = sub.add_parser(
+        "gate-path",
+        help=(
+            "Print the absolute path of the project's host-side git gate "
+            "(suitable for use as a git remote URL via ssh://host<path>)"
+        ),
+    )
+    _add_project_arg(p_gate_path)
+
     # gate-sync
     p_gate = sub.add_parser(
         "gate-sync",
@@ -187,6 +197,8 @@ def dispatch(args: argparse.Namespace) -> bool:
             )
         case "ssh-init":
             _cmd_ssh_init(args)
+        case "gate-path":
+            _cmd_gate_path(args.project_id)
         case "gate-sync":
             _cmd_gate_sync(args)
         case "presets":
@@ -282,6 +294,20 @@ def _cmd_ssh_init(args: argparse.Namespace) -> None:
         force=getattr(args, "force", False),
     )
     summarize_ssh_init(result)
+
+
+def _cmd_gate_path(project_id: str) -> None:
+    """Print the absolute path of the project's host-side git gate.
+
+    Plain stdout so callers can splice the path into a git URL, e.g.::
+
+        git remote add spark "ssh://you@host$(terok project gate-path myproj)"
+
+    The path is computed deterministically from project config — it is
+    printed even if the bare repo doesn't exist yet (run ``gate-sync``
+    to create it).
+    """
+    print(load_project(project_id).gate_path)
 
 
 def _cmd_gate_sync(args: argparse.Namespace) -> None:

--- a/src/terok/cli/commands/project.py
+++ b/src/terok/cli/commands/project.py
@@ -299,9 +299,15 @@ def _cmd_ssh_init(args: argparse.Namespace) -> None:
 def _cmd_gate_path(project_id: str) -> None:
     """Print the absolute path of the project's host-side git gate.
 
-    Plain stdout so callers can splice the path into a git URL, e.g.::
+    Plain stdout so callers can paste the path into a git remote URL.
+    Typical flow when terok lives on a different host than the IDE::
 
-        git remote add spark "ssh://you@host$(terok project gate-path myproj)"
+        # On the host running terok:
+        $ terok project gate-path myproj
+        /home/you/.local/share/terok/core/gate/myproj.git
+
+        # On your workstation:
+        $ git remote add spark ssh://you@host/home/you/.local/share/terok/core/gate/myproj.git
 
     The path is computed deterministically from project config — it is
     printed even if the bare repo doesn't exist yet (run ``gate-sync``

--- a/tests/unit/cli/test_cli_project.py
+++ b/tests/unit/cli/test_cli_project.py
@@ -356,10 +356,13 @@ def test_delete_lists_removed_and_skipped(
 
 def test_gate_path_prints_project_gate_path(capsys: pytest.CaptureFixture[str]) -> None:
     """Output is the gate path verbatim — pipeable into ``git remote add``."""
-    fake = MagicMock(gate_path="/var/lib/terok/gate/p1.git")
+    from tests.testfs import FAKE_GATE_DIR
+
+    expected = FAKE_GATE_DIR / "p1.git"
+    fake = MagicMock(gate_path=expected)
     with patch("terok.cli.commands.project.load_project", return_value=fake):
         _cmd_gate_path("p1")
-    assert capsys.readouterr().out.strip() == "/var/lib/terok/gate/p1.git"
+    assert capsys.readouterr().out.strip() == str(expected)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/cli/test_cli_project.py
+++ b/tests/unit/cli/test_cli_project.py
@@ -12,6 +12,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from terok.cli.commands.project import (
+    _cmd_gate_path,
     _cmd_gate_sync,
     _cmd_presets,
     _cmd_project_delete,
@@ -92,6 +93,13 @@ from terok.cli.commands.project import (
             "terok.cli.commands.project._cmd_ssh_init",
             {"positional_is_args": True},
             id="ssh-init",
+        ),
+        pytest.param(
+            "gate-path",
+            {"project_id": "p1"},
+            "terok.cli.commands.project._cmd_gate_path",
+            {"positional": ("p1",)},
+            id="gate-path",
         ),
         pytest.param(
             "gate-sync",
@@ -339,6 +347,19 @@ def test_delete_lists_removed_and_skipped(
     out = capsys.readouterr().out
     assert "Removed:" in out and "/path/a" in out and "/path/b" in out
     assert "Skipped:" in out and "in use by task 1" in out
+
+
+# ---------------------------------------------------------------------------
+# _cmd_gate_path — bare path passthrough
+# ---------------------------------------------------------------------------
+
+
+def test_gate_path_prints_project_gate_path(capsys: pytest.CaptureFixture[str]) -> None:
+    """Output is the gate path verbatim — pipeable into ``git remote add``."""
+    fake = MagicMock(gate_path="/var/lib/terok/gate/p1.git")
+    with patch("terok.cli.commands.project.load_project", return_value=fake):
+        _cmd_gate_path("p1")
+    assert capsys.readouterr().out.strip() == "/var/lib/terok/gate/p1.git"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- New CLI subcommand `terok project gate-path <project>` prints the absolute on-disk path of a project's host-side git gate.
- Plain stdout (no decoration) so the path is pipeable into a git URL:
  ```bash
  git remote add terok-hostname "ssh://username@hostname$(terok project gate-path myproj)"
  ```

## Why

Users running terok on a remote host (e.g. a home server) often want to mount the gate as a git remote in a desktop IDE. The gate's HTTP listener is bound to `127.0.0.1` and uses per-task Basic-Auth tokens — designed for container→gate pushes, not long-lived IDE access. The bare repo on disk, however, is reachable via plain SSH and just needs its path.

Today the path can only be discovered as a side effect of `terok project gate-sync` (which re-runs the mirror sync) or by reading `terok config paths` and appending `<project>.git` by convention. A direct lookup is a cheap usability win.

## Design

- Lives under `project` for symmetry with `gate-sync` and because the gate is a per-project artifact in terok's mental model.
- `terok-sandbox`'s `GATE_COMMANDS` (wired as `terok gate ...`) are server-lifecycle only (`start`/`stop`/`status`) and intentionally project-agnostic — `GitGate` takes a plain `gate_path: Path` rather than any project-aware identifier. Adding a project lookup there would leak terok's abstraction down a layer.
- The current `<project_id> == gate_repo_basename` equality is a terok convention, not invariant. If a future change adds multiple gated repos per project, this command can extend with `--repo <name>` without breaking the call shape.

## Test plan

- [x] `pytest tests/unit/cli/test_cli_project.py` — new dispatch routing case + handler test, all 30 cases pass
- [x] `pytest tests/unit` — full unit suite green (2244 passed)
- [x] `ruff check` / `ruff format --check` — clean
- [x] `docstr-coverage` — 100% on the changed module
- [x] `tach check` — no boundary changes
- [x] `bandit` — no findings
- [x] `terok project --help` and `terok project gate-path --help` render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `terok project gate-path` subcommand that prints a project's git gate absolute path as plain text for composing remote URLs or piping into other commands.
* **Tests**
  * Added a unit test confirming the subcommand outputs the gate path verbatim (whitespace-trimmed).
* **Chores**
  * No other CLI behaviors changed.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/terok-ai/terok/pull/899)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->