### PR TITLE
feat(wizard): surface gate.enabled escape hatch (#790)

### DIFF
--- a/src/terok/cli/commands/setup.py
+++ b/src/terok/cli/commands/setup.py
@@ -366,5 +366,11 @@ def cmd_project_init(project_id: str) -> None:
     print("==> Syncing git gate...")
     res = make_git_gate(project).sync()
     if not res["success"]:
-        raise SystemExit(f"Gate sync failed: {', '.join(res['errors'])}")
+        raise SystemExit(
+            f"Gate sync failed: {', '.join(res['errors'])}\n\n"
+            "Hint: if the host can't reach upstream but the container can "
+            "(firewall, corporate proxy, offline laptop), set "
+            "'gate.enabled: false' in project.yml to skip the host-side "
+            "mirror entirely."
+        )
     print(f"Gate ready at {res['path']}")

--- a/src/terok/resources/templates/projects/project.yml.template
+++ b/src/terok/resources/templates/projects/project.yml.template
@@ -15,6 +15,13 @@ git:
   upstream_url: "{{UPSTREAM_URL}}"
   default_branch: "{{DEFAULT_BRANCH}}"
 
+# gate:
+#   enabled: false   # uncomment if the host cannot reach upstream
+#                    # (firewall, corporate proxy, offline laptop) but
+#                    # the container's own network path can — terok will
+#                    # then skip the host-side mirror and let the
+#                    # container fetch directly from upstream.
+
 image:
   base_image: "{{BASE_IMAGE}}"
   # Optional: extra Dockerfile commands injected into the project image.

--- a/tests/unit/cli/test_cli_workflows.py
+++ b/tests/unit/cli/test_cli_workflows.py
@@ -138,8 +138,11 @@ class TestProjectInit:
 
         from terok.cli.commands.setup import cmd_project_init
 
-        with pytest.raises(SystemExit, match="Gate sync failed"):
+        with pytest.raises(SystemExit, match="Gate sync failed") as exc_info:
             cmd_project_init("badproj")
+        # The hint pointing at gate.enabled: false is what makes the
+        # failure actionable for users in Andreas' situation (#790).
+        assert "gate.enabled: false" in str(exc_info.value)
 
     @_patch_init_steps
     def test_cmd_project_init_skips_gate_sync_when_disabled(


### PR DESCRIPTION
## Summary

Two complementary discoverability fixes for the case Andreas reported in #790 — host can't reach upstream, container can.

- **Template hint**: project.yml.template now carries a commented `gate.enabled: false` line so users scanning their generated config can see the option exists.
- **Error-path hint**: `cmd_project_init`'s gate-sync failure (the *exact* code path Andreas hit) now appends an actionable hint pointing at the same flag.

## Why the issue stayed open

The escape hatch itself shipped in #792 (`gate.enabled` flag) and is correctly honoured at all three call sites today (`cmd_project_init`, `_cmd_gate_sync`, `environment.py` task setup). What was missing is *discoverability* — a user in Andreas' situation has no way to find the option short of reading the docs.

## Scope

Surgical: one template addition (5 commented lines) + one error-message extension (5 lines) + a one-line test assertion. The standalone `terok project gate-sync` error path is left unchanged on the assumption that someone invoking it directly is more likely to know the option exists; can revisit if that turns out wrong.

## Test plan

- [x] `pytest tests/unit/cli/test_cli_workflows.py` — extended existing `test_cmd_project_init_gate_failure_raises` to assert the hint is present
- [x] `ruff check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced error messages during project initialization when upstream synchronization fails, providing actionable guidance on disabling host-side mirroring for hosts unable to reach upstream repositories.

* **Documentation**
  * Added configuration documentation in project templates explaining optional settings for handling upstream connectivity limitations and host-side mirroring behavior.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/terok-ai/terok/pull/901)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->