### PR TITLE
refactor(lib): introduce terok.lib.api as TUI's single import boundary

### DIFF
--- a/src/terok/lib/api.py
+++ b/src/terok/lib/api.py
@@ -1,0 +1,327 @@
+# SPDX-FileCopyrightText: 2026 Jiri Vyskocil
+# SPDX-License-Identifier: Apache-2.0
+
+"""Public library API — the one stable import boundary for presentation layers.
+
+The TUI (and over time the CLI) should import everything domain-, type-, or
+config-related from this module rather than reaching into ``terok.lib.*``
+internals.  This keeps the consumer surface narrow and lets the internals be
+refactored freely.
+
+Three kinds of exports live here:
+
+1. **Operations** — task/project/image lifecycle functions re-exported from
+   the domain facade (``task_new``, ``build_images``, ``delete_project``, …).
+2. **Types** — value objects and dataclasses consumers pass around
+   (``ProjectConfig``, ``TaskMeta``, ``StatusInfo``, …).
+3. **Snapshots** — [`get_config`][terok.lib.api.get_config] returns a
+   single [`Config`][terok.lib.api.Config] dataclass that bundles the paths,
+   feature flags, and presentation hints scattered across
+   ``core.config``/``core.paths``.
+
+Pure utilities (``util.emoji``, ``util.yaml``, ``util.ansi``, ``util.text_wrap``,
+``util.net``) and ``core.version`` stay importable directly — they are
+genuinely cross-cutting and have no domain coupling worth funnelling.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+from .core import config as _config, paths as _paths, runtime as _runtime
+
+# Side-effecting / factory helpers that don't fit on the frozen Config object.
+from .core.config import (  # noqa: F401 — re-exported public API
+    make_sandbox_config,
+    set_experimental,
+)
+from .core.images import (  # noqa: F401 — re-exported public API
+    installed_agents,
+    installed_agents_for_project,
+)
+
+# Domain value types consumers need to type their own code.
+from .core.projects import (  # noqa: F401 — re-exported public API
+    BrokenProject,
+    ProjectConfig,
+    discover_projects,
+    load_project,
+)
+
+# Presentation tables for status/mode/badge rendering.
+from .core.task_display import (  # noqa: F401 — re-exported public API
+    GPU_DISPLAY,
+    ISOLATION_DISPLAY,
+    MODE_DISPLAY,
+    SECURITY_CLASS_DISPLAY,
+    STATUS_DISPLAY,
+    ModeInfo,
+    ProjectBadge,
+    StatusInfo,
+    mode_info,
+)
+from .core.task_state import (  # noqa: F401 — re-exported public API
+    CONTAINER_MODES,
+    TaskState,
+    container_name,
+    effective_status,
+    has_gpu,
+)
+
+# Operations + rich domain objects re-exported from the existing facade.
+from .domain.facade import (  # noqa: F401 — re-exported public API
+    DeleteProjectResult,
+    HeadlessRunRequest,
+    LogViewOptions,
+    Project,
+    Task,
+    TaskDeleteResult,
+    authenticate,
+    build_images,
+    cleanup_images,
+    delete_project,
+    derive_project,
+    find_orphaned_images,
+    find_projects_sharing_gate,
+    generate_dockerfiles,
+    get_project,
+    get_project_state,
+    get_tasks,
+    is_task_image_old,
+    list_images,
+    list_projects,
+    make_git_gate,
+    make_ssh_manager,
+    maybe_pause_for_ssh_key_registration,
+    project_image_exists,
+    project_needs_key_registration,
+    provision_ssh_key,
+    register_ssh_key,
+    summarize_ssh_init,
+    task_archive_list,
+    task_archive_logs,
+    task_delete,
+    task_followup_headless,
+    task_list,
+    task_login,
+    task_logs,
+    task_new,
+    task_rename,
+    task_restart,
+    task_run_cli,
+    task_run_headless,
+    task_run_toad,
+    task_status,
+    task_stop,
+    vault_db,
+)
+
+# Cross-project lockdown.
+from .domain.panic import (  # noqa: F401 — re-exported public API
+    execute_panic,
+    format_panic_report,
+    panic_stop_containers,
+)
+
+# Wizard pieces shared between CLI prompts and TUI screens.
+from .domain.wizards.new_project import (  # noqa: F401 — re-exported public API
+    QUESTIONS,
+    Question,
+    render_project_yaml,
+    validate_answer,
+    write_project_yaml,
+)
+from .orchestration.agent_config import (  # noqa: F401 — re-exported public API
+    resolve_agent_config,
+)
+from .orchestration.autopilot import (  # noqa: F401 — re-exported public API
+    wait_for_container_exit,
+)
+
+# Task orchestration helpers used by TUI workers.
+from .orchestration.tasks import (  # noqa: F401 — re-exported public API
+    TaskMeta,
+    agent_config_dir,
+    generate_task_name,
+    get_all_task_states,
+    get_login_command,
+    get_task_meta,
+    get_workspace_git_diff,
+    mark_task_deleting,
+    sanitize_task_name,
+    validate_task_name,
+)
+
+# ── Config snapshot ────────────────────────────────────────────────────
+
+
+@dataclass(frozen=True)
+class Config:
+    """Snapshot of the global config values consumers read at startup.
+
+    Bundles the paths, feature flags, and presentation hints that the TUI
+    (and CLI) previously pulled from a dozen scattered getters in
+    [`terok.lib.core.config`][terok.lib.core.config] and
+    [`terok.lib.core.paths`][terok.lib.core.paths].  Capture once with
+    [`get_config`][terok.lib.api.get_config]; pass the result around.
+
+    Side-effecting helpers — ``set_experimental``, ``make_sandbox_config`` —
+    stay as functions on the [`api`][terok.lib.api] module; they don't
+    belong on a frozen value object.
+    """
+
+    # Paths
+    config_root: Path
+    core_state_dir: Path
+    runtime_dir: Path
+    archive_dir: Path
+    vault_dir: Path
+    user_projects_dir: Path
+    global_config_path: Path
+    # Settings
+    public_host: str
+    shield_bypass_firewall_no_protection: bool
+    tui_default_tmux: bool
+    # Presentation hints
+    shield_security_hint: str
+
+
+def get_config() -> Config:
+    """Snapshot the global config into a single [`Config`][terok.lib.api.Config] value."""
+    return Config(
+        config_root=_paths.config_root(),
+        core_state_dir=_paths.core_state_dir(),
+        runtime_dir=_paths.runtime_dir(),
+        archive_dir=_config.archive_dir(),
+        vault_dir=_config.vault_dir(),
+        user_projects_dir=_config.user_projects_dir(),
+        global_config_path=_config.global_config_path(),
+        public_host=_config.get_public_host(),
+        shield_bypass_firewall_no_protection=_config.get_shield_bypass_firewall_no_protection(),
+        tui_default_tmux=_config.get_tui_default_tmux(),
+        shield_security_hint=_config.SHIELD_SECURITY_HINT,
+    )
+
+
+# ── Runtime peek ───────────────────────────────────────────────────────
+
+
+def get_container_state(cname: str) -> str | None:
+    """Return the live podman state for a container, or ``None`` if not found.
+
+    Thin wrapper around the runtime driver so callers do not need to
+    reach into [`terok.lib.core.runtime`][terok.lib.core.runtime] for
+    one-shot state lookups.
+    """
+    return _runtime.get_runtime().container(cname).state
+
+
+__all__ = [
+    # Snapshot
+    "Config",
+    "get_config",
+    # Side-effecting helpers
+    "make_sandbox_config",
+    "set_experimental",
+    "get_container_state",
+    # Project factories + rich aggregates
+    "get_project",
+    "list_projects",
+    "derive_project",
+    "Project",
+    "Task",
+    "project_image_exists",
+    # Project types
+    "ProjectConfig",
+    "BrokenProject",
+    "discover_projects",
+    "load_project",
+    # Image management
+    "generate_dockerfiles",
+    "build_images",
+    "list_images",
+    "find_orphaned_images",
+    "cleanup_images",
+    "installed_agents",
+    "installed_agents_for_project",
+    # Project lifecycle
+    "delete_project",
+    "DeleteProjectResult",
+    "find_projects_sharing_gate",
+    # Task lifecycle
+    "TaskDeleteResult",
+    "task_new",
+    "task_delete",
+    "task_rename",
+    "task_login",
+    "task_list",
+    "task_status",
+    "task_stop",
+    "task_archive_list",
+    "task_archive_logs",
+    "get_tasks",
+    # Task runners
+    "task_run_cli",
+    "task_run_toad",
+    "task_run_headless",
+    "HeadlessRunRequest",
+    "task_restart",
+    "task_followup_headless",
+    # Task helpers
+    "TaskMeta",
+    "TaskState",
+    "CONTAINER_MODES",
+    "container_name",
+    "agent_config_dir",
+    "generate_task_name",
+    "get_all_task_states",
+    "get_login_command",
+    "get_task_meta",
+    "get_workspace_git_diff",
+    "mark_task_deleting",
+    "sanitize_task_name",
+    "validate_task_name",
+    "effective_status",
+    "has_gpu",
+    "wait_for_container_exit",
+    # Task logs
+    "task_logs",
+    "LogViewOptions",
+    # Display tables
+    "STATUS_DISPLAY",
+    "MODE_DISPLAY",
+    "SECURITY_CLASS_DISPLAY",
+    "ISOLATION_DISPLAY",
+    "GPU_DISPLAY",
+    "StatusInfo",
+    "ModeInfo",
+    "ProjectBadge",
+    "mode_info",
+    # Security setup
+    "make_ssh_manager",
+    "make_git_gate",
+    "provision_ssh_key",
+    "register_ssh_key",
+    "summarize_ssh_init",
+    "vault_db",
+    "maybe_pause_for_ssh_key_registration",
+    "project_needs_key_registration",
+    # Auth
+    "authenticate",
+    # Project state
+    "get_project_state",
+    "is_task_image_old",
+    # Wizards
+    "QUESTIONS",
+    "Question",
+    "render_project_yaml",
+    "validate_answer",
+    "write_project_yaml",
+    # Agent config
+    "resolve_agent_config",
+    # Emergency
+    "execute_panic",
+    "format_panic_report",
+    "panic_stop_containers",
+]

--- a/src/terok/lib/core/task_display.py
+++ b/src/terok/lib/core/task_display.py
@@ -1,43 +1,23 @@
 # SPDX-FileCopyrightText: 2026 Jiri Vyskocil
 # SPDX-License-Identifier: Apache-2.0
 
-"""Render task lifecycle, mode, and project badges as labels and emoji.
+"""Presentation tables for task lifecycle, mode, and project badges.
 
-Houses the dataclasses and lookup tables that turn raw container state
-into display strings, plus the small bit of logic that computes the
-"effective" status from a task's lifecycle fields.
+Maps the domain status keys produced by
+[`effective_status`][terok.lib.core.task_state.effective_status] (and
+the mode/security-class strings carried by project metadata) to display
+attributes — emoji, color, label.
 
-Split from ``tasks.py`` so presentation data does not pull in task
-metadata I/O.
+Domain logic (``TaskState``, ``effective_status``, ``container_name``,
+``has_gpu``) lives in
+[`task_state`][terok.lib.core.task_state].
 """
 
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Any
-
-from ..util.yaml import YAMLError, load as _yaml_load
 
 # ── Display value objects ──────────────────────────────────────────────
-
-
-@dataclass
-class TaskState:
-    """Container lifecycle state used for display status computation.
-
-    Orchestration-level ``TaskMeta`` inherits from this to add identity,
-    configuration, and runtime metadata fields.
-    """
-
-    container_state: str | None = None
-    exit_code: int | None = None
-    deleting: bool = False
-    initialized: bool = False
-    # UI-only flag the TUI flips while a launch worker is in flight but
-    # podman has not yet created the container.  Bridges the gap between
-    # "task created" and "container running (init)" so users see ⏳
-    # instead of an ambiguous 🆕.
-    starting: bool = False
 
 
 @dataclass(frozen=True)
@@ -103,88 +83,7 @@ GPU_DISPLAY: dict[bool, ProjectBadge] = {
 }
 
 
-# ── Effective status ───────────────────────────────────────────────────
-
-
-def effective_status(task: TaskState) -> str:
-    """Compute the display status from task lifecycle state.
-
-    Reads the following fields from a ``TaskState`` instance:
-
-    - ``container_state`` (str | None): live podman state, or None
-    - ``exit_code`` (int | None): process exit code, or None
-    - ``deleting`` (bool): persisted to YAML before deletion starts
-    - ``initialized`` (bool): True once ``ready_at`` is persisted to YAML
-
-    Returns one of: ``"deleting"``, ``"running"``, ``"init"``,
-    ``"starting"``, ``"stopped"``, ``"completed"``, ``"failed"``,
-    ``"created"``, ``"not found"``.
-    """
-    if task.deleting:
-        return "deleting"
-
-    cs = task.container_state
-
-    if cs == "running":
-        return "running" if task.initialized else "init"
-
-    if cs is not None:
-        return _exit_code_status(task.exit_code) or "stopped"
-
-    # No container yet — ``starting`` fills the launch-worker gap
-    # before podman has created the container.  Once it's up, the
-    # ``cs == "running"`` branch above takes over with ``init``.
-    if task.starting:
-        return "starting"
-    if not task.initialized:
-        return "created"
-    return _exit_code_status(task.exit_code) or "not found"
-
-
-def _exit_code_status(exit_code: int | None) -> str | None:
-    """Map an exit code to a terminal status, or ``None`` if not terminal."""
-    if exit_code is None:
-        return None
-    return "completed" if exit_code == 0 else "failed"
-
-
 def mode_info(mode: str | None) -> ModeInfo:
     """Return the display info for a task mode string."""
     info = MODE_DISPLAY.get(mode if isinstance(mode, str) else None)
     return info if info else MODE_DISPLAY[None]
-
-
-# ── Project queries ────────────────────────────────────────────────────
-
-
-def has_gpu(project: Any) -> bool:
-    """True when the project's ``project.yml`` opts into GPU passthrough.
-
-    Accepts any object with a ``root`` attribute pointing to the project
-    directory (typically a ``Project`` instance).  Returns ``False`` on
-    any I/O or parse error.
-    """
-    root = getattr(project, "root", None)
-    if root is None:
-        return False
-    try:
-        cfg = _yaml_load((root / "project.yml").read_text()) or {}
-    except (OSError, TypeError, AttributeError, YAMLError):
-        return False
-    gpus = (cfg.get("run") or {}).get("gpus")
-    if isinstance(gpus, str):
-        return gpus.lower() == "all"
-    if isinstance(gpus, bool):
-        return gpus
-    return False
-
-
-# ── Container naming ───────────────────────────────────────────────────
-
-CONTAINER_MODES = ("cli", "web", "run", "toad")
-"""All valid container mode suffixes used in container naming."""
-
-
-def container_name(project_id: str, mode: str, task_id: str) -> str:
-    """Return the canonical container name for a task."""
-    return f"{project_id}-{mode}-{task_id}"

--- a/src/terok/lib/core/task_state.py
+++ b/src/terok/lib/core/task_state.py
@@ -1,0 +1,123 @@
+# SPDX-FileCopyrightText: 2026 Jiri Vyskocil
+# SPDX-License-Identifier: Apache-2.0
+
+"""Task lifecycle state — pure domain, no presentation.
+
+Holds the [`TaskState`][terok.lib.core.task_state.TaskState] value object,
+the [`effective_status`][terok.lib.core.task_state.effective_status]
+computation, container-name conventions, and project-level capability
+queries that ``orchestration`` and ``domain`` modules need without
+pulling in display tables.
+
+The presentation-layer lookup tables (emoji, colors, labels) live in
+[`task_display`][terok.lib.core.task_display].
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from ..util.yaml import YAMLError, load as _yaml_load
+
+# ── Value object ───────────────────────────────────────────────────────
+
+
+@dataclass
+class TaskState:
+    """Container lifecycle state used for display status computation.
+
+    Orchestration-level ``TaskMeta`` inherits from this to add identity,
+    configuration, and runtime metadata fields.
+    """
+
+    container_state: str | None = None
+    exit_code: int | None = None
+    deleting: bool = False
+    initialized: bool = False
+    # UI-only flag the TUI flips while a launch worker is in flight but
+    # podman has not yet created the container.  Bridges the gap between
+    # "task created" and "container running (init)" so users see ⏳
+    # instead of an ambiguous 🆕.
+    starting: bool = False
+
+
+# ── Effective status ───────────────────────────────────────────────────
+
+
+def effective_status(task: TaskState) -> str:
+    """Compute the display status from task lifecycle state.
+
+    Reads the following fields from a ``TaskState`` instance:
+
+    - ``container_state`` (str | None): live podman state, or None
+    - ``exit_code`` (int | None): process exit code, or None
+    - ``deleting`` (bool): persisted to YAML before deletion starts
+    - ``initialized`` (bool): True once ``ready_at`` is persisted to YAML
+
+    Returns one of: ``"deleting"``, ``"running"``, ``"init"``,
+    ``"starting"``, ``"stopped"``, ``"completed"``, ``"failed"``,
+    ``"created"``, ``"not found"``.
+    """
+    if task.deleting:
+        return "deleting"
+
+    cs = task.container_state
+
+    if cs == "running":
+        return "running" if task.initialized else "init"
+
+    if cs is not None:
+        return _exit_code_status(task.exit_code) or "stopped"
+
+    # No container yet — ``starting`` fills the launch-worker gap
+    # before podman has created the container.  Once it's up, the
+    # ``cs == "running"`` branch above takes over with ``init``.
+    if task.starting:
+        return "starting"
+    if not task.initialized:
+        return "created"
+    return _exit_code_status(task.exit_code) or "not found"
+
+
+def _exit_code_status(exit_code: int | None) -> str | None:
+    """Map an exit code to a terminal status, or ``None`` if not terminal."""
+    if exit_code is None:
+        return None
+    return "completed" if exit_code == 0 else "failed"
+
+
+# ── Container naming ───────────────────────────────────────────────────
+
+CONTAINER_MODES = ("cli", "web", "run", "toad")
+"""All valid container mode suffixes used in container naming."""
+
+
+def container_name(project_id: str, mode: str, task_id: str) -> str:
+    """Return the canonical container name for a task."""
+    return f"{project_id}-{mode}-{task_id}"
+
+
+# ── Project queries ────────────────────────────────────────────────────
+
+
+def has_gpu(project: Any) -> bool:
+    """True when the project's ``project.yml`` opts into GPU passthrough.
+
+    Accepts any object with a ``root`` attribute pointing to the project
+    directory (typically a ``Project`` instance).  Returns ``False`` on
+    any I/O or parse error.
+    """
+    root = getattr(project, "root", None)
+    if root is None:
+        return False
+    try:
+        cfg = _yaml_load((root / "project.yml").read_text()) or {}
+    except (OSError, TypeError, AttributeError, YAMLError):
+        return False
+    gpus = (cfg.get("run") or {}).get("gpus")
+    if isinstance(gpus, str):
+        return gpus.lower() == "all"
+    if isinstance(gpus, bool):
+        return gpus
+    return False

--- a/src/terok/lib/domain/project_state.py
+++ b/src/terok/lib/domain/project_state.py
@@ -15,7 +15,7 @@ from ..core import runtime as _rt
 from ..core.config import build_dir
 from ..core.images import project_cli_image
 from ..core.projects import load_project
-from ..core.task_display import container_name as _container_name
+from ..core.task_state import container_name as _container_name
 
 
 def _scope_has_vault_key(scope: str) -> bool:

--- a/src/terok/lib/orchestration/container_exec.py
+++ b/src/terok/lib/orchestration/container_exec.py
@@ -11,7 +11,7 @@ poisoned git hooks or scripts executing with host privileges.
 from subprocess import TimeoutExpired
 
 from ..core import runtime as _rt
-from ..core.task_display import container_name as _container_name
+from ..core.task_state import container_name as _container_name
 from ..util.logging_utils import _log_debug
 
 

--- a/src/terok/lib/orchestration/task_runners.py
+++ b/src/terok/lib/orchestration/task_runners.py
@@ -39,7 +39,7 @@ from ..core.config import (
 )
 from ..core.images import project_cli_image, require_agent_installed
 from ..core.projects import load_project
-from ..core.task_display import has_gpu
+from ..core.task_state import has_gpu
 from ..util.ansi import (
     blue as _blue,
     green as _green,

--- a/src/terok/lib/orchestration/tasks.py
+++ b/src/terok/lib/orchestration/tasks.py
@@ -24,8 +24,9 @@ both files atomically.  Pre-self-describing names (``<id>.json`` /
 
 Container runner functions (``task_run_cli``, ``task_run_headless``,
 ``task_restart``) live in the companion ``task_runners`` module.
-Display types and status computation live in ``task_display``.  Log
-viewing lives in ``task_logs``.
+Status computation and domain value objects live in ``task_state``;
+their presentation tables live in ``task_display``.  Log viewing lives
+in ``task_logs``.
 """
 
 import json
@@ -47,13 +48,12 @@ from ..core import runtime as _rt
 from ..core.config import archive_dir
 from ..core.paths import core_state_dir
 from ..core.projects import ProjectConfig, load_project
-from ..core.task_display import (
+from ..core.task_display import STATUS_DISPLAY, mode_info
+from ..core.task_state import (
     CONTAINER_MODES,
-    STATUS_DISPLAY,
     TaskState,
     container_name,
     effective_status,
-    mode_info,
 )
 from ..core.work_status import read_work_status
 from ..util.ansi import (
@@ -484,7 +484,7 @@ class TaskMeta(TaskState):
     """Lightweight metadata snapshot for a single task.
 
     Inherits lifecycle fields (``container_state``, ``exit_code``,
-    ``deleting``, ``initialized``) from [`TaskState`][terok.lib.core.task_display.TaskState].
+    ``deleting``, ``initialized``) from [`TaskState`][terok.lib.core.task_state.TaskState].
     """
 
     task_id: str

--- a/src/terok/tui/app.py
+++ b/src/terok/tui/app.py
@@ -1596,12 +1596,16 @@ if _HAS_TEXTUAL:
         and mask the fallback in [`main`][terok.tui.app.main].
         """
         parser = argparse.ArgumentParser(prog="terok-tui")
-        parser.add_argument(
+        # Mutually exclusive: passing both raises before parse_args returns.
+        # ``set_defaults(tmux=None)`` keeps the destination tri-state when
+        # neither flag is passed so ``main`` can defer to the config setting.
+        tmux_group = parser.add_mutually_exclusive_group()
+        tmux_group.add_argument(
             "--tmux",
             action="store_true",
             help="Launch TUI inside a managed tmux session",
         )
-        parser.add_argument(
+        tmux_group.add_argument(
             "--no-tmux",
             dest="tmux",
             action="store_false",
@@ -1625,12 +1629,14 @@ if _HAS_TEXTUAL:
     def main() -> None:
         """CLI entry-point for launching the terok TUI.
 
-        Supports ``--tmux`` to wrap the TUI in a managed host tmux session
-        (blue status bar, login windows as extra tmux windows).  Without the
-        flag the TUI runs directly in the current terminal.
+        Three-way control of tmux wrapping:
 
-        If neither --tmux nor --no-tmux is specified, the behavior is controlled
-        by the global config setting `tui.default_tmux` (defaults to False).
+        - ``--tmux`` forces the TUI into a managed host tmux session
+          (blue status bar, login windows as extra tmux windows).
+        - ``--no-tmux`` forces the TUI to run directly in the current
+          terminal.
+        - When neither flag is passed, the global config setting
+          ``tui.default_tmux`` decides (defaults to ``False``).
         """
         args = _build_arg_parser().parse_args()
         set_experimental(args.experimental)

--- a/src/terok/tui/app.py
+++ b/src/terok/tui/app.py
@@ -79,16 +79,22 @@ if _HAS_TEXTUAL:
     from textual.widgets import Footer, Header
     from textual.worker import Worker, WorkerState
 
-    from ..lib.core.config import (
-        get_tui_default_tmux,
-        set_experimental,
-    )
-    from ..lib.core.paths import core_state_dir
-    from ..lib.core.projects import (
+    from ..lib.api import (
         BrokenProject,
+        Config,
         ProjectConfig,
+        container_name,
         discover_projects,
+        execute_panic,
+        format_panic_report,
+        get_config,
+        get_project_state,
+        get_tasks,
+        is_task_image_old,
         load_project,
+        make_git_gate,
+        panic_stop_containers,
+        set_experimental,
     )
 
     # Import version info function (shared with CLI --version)
@@ -96,11 +102,6 @@ if _HAS_TEXTUAL:
         get_version_info as _get_version_info,
         short_version as _short_version,
     )
-    from ..lib.domain.facade import (
-        get_project_state,
-        is_task_image_old,
-    )
-    from ..lib.orchestration.tasks import get_tasks
 
     @dataclass(frozen=True)
     class ProjectStateResult:
@@ -280,6 +281,8 @@ if _HAS_TEXTUAL:
         def __init__(self) -> None:
             """Initialize the TUI, setting up internal state and dynamic title."""
             super().__init__()
+            # Snapshot the global config once; reuse via ``self._config``.
+            self._config: Config = get_config()
             # Set dynamic title with version and branch info
             self._update_title()
 
@@ -532,7 +535,7 @@ if _HAS_TEXTUAL:
             not be visible even though the widgets exist.
             """
             try:
-                log_path = core_state_dir() / "terok.log"
+                log_path = self._config.core_state_dir / "terok.log"
                 log_path.parent.mkdir(parents=True, exist_ok=True)
 
                 left_pane = self.query_one("#left-pane")
@@ -570,7 +573,7 @@ if _HAS_TEXTUAL:
             try:
                 from datetime import datetime as _dt
 
-                log_path = core_state_dir() / "terok.log"
+                log_path = self._config.core_state_dir / "terok.log"
                 log_path.parent.mkdir(parents=True, exist_ok=True)
                 ts = _dt.now().isoformat(timespec="seconds")
                 with log_path.open("a", encoding="utf-8") as _f:
@@ -584,7 +587,7 @@ if _HAS_TEXTUAL:
             try:
                 import json
 
-                state_path = core_state_dir() / "terok-state.json"
+                state_path = self._config.core_state_dir / "terok-state.json"
                 if state_path.exists():
                     with state_path.open("r", encoding="utf-8") as f:
                         state = json.load(f)
@@ -602,7 +605,7 @@ if _HAS_TEXTUAL:
             try:
                 import json
 
-                state_path = core_state_dir() / "terok-state.json"
+                state_path = self._config.core_state_dir / "terok-state.json"
                 state_path.parent.mkdir(parents=True, exist_ok=True)
                 state = {
                     "last_project": self.current_project_id,
@@ -836,8 +839,6 @@ if _HAS_TEXTUAL:
             """Load project infrastructure state in a background thread."""
             try:
                 project = load_project(project_id)
-                from ..lib.domain.project import make_git_gate
-
                 gate = make_git_gate(project)
 
                 def _gate_commit_provider(_pid: str) -> dict | None:
@@ -920,8 +921,6 @@ if _HAS_TEXTUAL:
             try:
                 project = load_project(project_id)
                 mode = task.mode or "cli"
-                from ..lib.orchestration.tasks import container_name
-
                 cname = container_name(project_id, mode, task.task_id)
                 task_dir = project.tasks_root / str(task.task_id)
                 st = _shield_state(cname, task_dir)
@@ -1191,9 +1190,9 @@ if _HAS_TEXTUAL:
                     parts = (worker.name or "").split(":")
                     action = parts[1] if len(parts) >= 2 else ""
                     if action == "down":
-                        from ..lib.core.config import SHIELD_SECURITY_HINT
-
-                        self.notify(f"Shield dropped for task {task_id}. {SHIELD_SECURITY_HINT}")
+                        self.notify(
+                            f"Shield dropped for task {task_id}. {self._config.shield_security_hint}"
+                        )
                     elif action == "up":
                         self.notify(f"Shield up for task {task_id}")
                 # Refresh shield state after action
@@ -1220,8 +1219,6 @@ if _HAS_TEXTUAL:
                 return
 
             if worker.group == "panic":
-                from ..lib.domain.panic import format_panic_report
-
                 panic_result = worker.result
                 if not panic_result:
                     return
@@ -1289,8 +1286,6 @@ if _HAS_TEXTUAL:
 
         async def _execute_panic_phase1(self) -> None:
             """Launch Phase 1 panic: shields up, stop proxy and gate."""
-            from ..lib.domain.panic import execute_panic
-
             self.run_worker(
                 lambda: execute_panic(stop_containers=False),
                 name="panic-lockdown",
@@ -1310,8 +1305,6 @@ if _HAS_TEXTUAL:
                 else:
                     self.notify("Containers left running (shields are up)")
                 return
-            from ..lib.domain.panic import panic_stop_containers
-
             self.run_worker(
                 panic_stop_containers,
                 name="panic-stop-containers",
@@ -1639,7 +1632,9 @@ if _HAS_TEXTUAL:
         # Determine tmux mode: explicit flag > config default > False
         # Web mode (textual-serve) is never wrapped in tmux.
         use_tmux = (
-            args.tmux if hasattr(args, "tmux") and args.tmux is not None else get_tui_default_tmux()
+            args.tmux
+            if hasattr(args, "tmux") and args.tmux is not None
+            else get_config().tui_default_tmux
         )
 
         from .shell_launch import is_web_mode

--- a/src/terok/tui/app.py
+++ b/src/terok/tui/app.py
@@ -1585,18 +1585,16 @@ if _HAS_TEXTUAL:
                 ],
             )
 
-    def main() -> None:
-        """CLI entry-point for launching the terok TUI.
+    import argparse
 
-        Supports ``--tmux`` to wrap the TUI in a managed host tmux session
-        (blue status bar, login windows as extra tmux windows).  Without the
-        flag the TUI runs directly in the current terminal.
+    def _build_arg_parser() -> argparse.ArgumentParser:
+        """Build the ``terok-tui`` argument parser.
 
-        If neither --tmux nor --no-tmux is specified, the behavior is controlled
-        by the global config setting `tui.default_tmux` (defaults to False).
+        ``--tmux`` / ``--no-tmux`` share a single tri-state destination:
+        ``None`` means "user passed neither flag — fall back to config".
+        ``store_true``/``store_false`` would otherwise leave a bool there
+        and mask the fallback in [`main`][terok.tui.app.main].
         """
-        import argparse
-
         parser = argparse.ArgumentParser(prog="terok-tui")
         parser.add_argument(
             "--tmux",
@@ -1609,6 +1607,7 @@ if _HAS_TEXTUAL:
             action="store_false",
             help="Launch TUI directly in current terminal (default if not configured)",
         )
+        parser.set_defaults(tmux=None)
         parser.add_argument(
             "--experimental",
             action="store_true",
@@ -1621,7 +1620,19 @@ if _HAS_TEXTUAL:
             default=False,
             help="Replace emojis with text labels (e.g. [gate] instead of \U0001f6aa)",
         )
-        args = parser.parse_args()
+        return parser
+
+    def main() -> None:
+        """CLI entry-point for launching the terok TUI.
+
+        Supports ``--tmux`` to wrap the TUI in a managed host tmux session
+        (blue status bar, login windows as extra tmux windows).  Without the
+        flag the TUI runs directly in the current terminal.
+
+        If neither --tmux nor --no-tmux is specified, the behavior is controlled
+        by the global config setting `tui.default_tmux` (defaults to False).
+        """
+        args = _build_arg_parser().parse_args()
         set_experimental(args.experimental)
 
         if args.no_emoji:

--- a/src/terok/tui/askpass_service.py
+++ b/src/terok/tui/askpass_service.py
@@ -20,7 +20,7 @@ terminal frame or silently failing:
   env vars when we *do* want our own askpass to run.
 
 The service is reachable only via a unix socket under terok's runtime
-namespace ([`terok.lib.core.paths.runtime_dir`][terok.lib.core.paths.runtime_dir]) with mode
+namespace ([`Config.runtime_dir`][terok.lib.api.Config]) with mode
 ``0600`` — the filesystem is the auth boundary.  No socket is ever
 bound until a project with ``use_personal_ssh=true`` actually spawns
 a subprocess *and* lacks a usable GUI askpass, so users who don't opt
@@ -45,7 +45,7 @@ from textual.containers import Horizontal, Vertical
 from textual.screen import ModalScreen
 from textual.widgets import Button, Input, Static
 
-from ..lib.core.paths import runtime_dir
+from ..lib.api import get_config
 from . import askpass_protocol as proto
 
 if TYPE_CHECKING:
@@ -108,13 +108,14 @@ def build_askpass_env(
 def default_socket_path(*, pid: int | None = None) -> Path:
     """Return a per-process socket path under terok's runtime namespace.
 
-    Delegates to [`terok.lib.core.paths.runtime_dir`][terok.lib.core.paths.runtime_dir] — the
-    boundary-respecting wrapper around the sandbox's namespace
-    resolver (``$XDG_RUNTIME_DIR/terok/`` → ``$XDG_STATE_HOME/terok/``
-    → ``~/.local/state/terok/``).  No ``/tmp`` fallback means no
-    predictable-temp-path surface (bandit B108).
+    Reads ``runtime_dir`` from the [`Config`][terok.lib.api.Config]
+    snapshot — the boundary-respecting wrapper around the sandbox's
+    namespace resolver (``$XDG_RUNTIME_DIR/terok/`` →
+    ``$XDG_STATE_HOME/terok/`` → ``~/.local/state/terok/``).  No
+    ``/tmp`` fallback means no predictable-temp-path surface (bandit
+    B108).
     """
-    return runtime_dir() / f"askpass-{pid or os.getpid()}.sock"
+    return get_config().runtime_dir / f"askpass-{pid or os.getpid()}.sock"
 
 
 def locate_helper_bin() -> Path:

--- a/src/terok/tui/polling.py
+++ b/src/terok/tui/polling.py
@@ -12,11 +12,11 @@ from the main app module into a reusable mixin class.
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
+    from terok_sandbox import GateStalenessInfo
     from textual.app import App
     from textual.timer import Timer
 
-    from ..lib.domain.staleness import GateStalenessInfo
-    from ..lib.orchestration.tasks import TaskMeta
+    from ..lib.api import TaskMeta
 
     # At type-check time only, inherit from textual.App so all of its methods
     # (run_worker, set_interval, notify, …) resolve naturally on `self` with
@@ -56,7 +56,7 @@ class PollingMixin(_MixinBase):
 
         Only polls for gatekeeping projects with polling enabled and a gate initialized.
         """
-        from ..lib.core.projects import load_project
+        from ..lib.api import load_project
 
         self._stop_upstream_polling()  # Stop any existing timer
         self._staleness_info = None
@@ -166,7 +166,7 @@ class PollingMixin(_MixinBase):
         """Background worker to batch-query all container states for a project."""
         import asyncio
 
-        from ..lib.orchestration.tasks import get_all_task_states, get_tasks
+        from ..lib.api import get_all_task_states, get_tasks
 
         try:
             tasks = await asyncio.get_event_loop().run_in_executor(None, get_tasks, project_id)
@@ -200,8 +200,7 @@ class PollingMixin(_MixinBase):
         """Background worker to check upstream (runs in thread pool)."""
         import asyncio
 
-        from ..lib.core.projects import load_project
-        from ..lib.domain.project import make_git_gate
+        from ..lib.api import load_project, make_git_gate
 
         try:
             # Run blocking call in thread pool
@@ -254,7 +253,7 @@ class PollingMixin(_MixinBase):
         """
         import time
 
-        from ..lib.core.projects import load_project
+        from ..lib.api import load_project
 
         if not project_id or project_id != self.current_project_id:
             return
@@ -294,8 +293,7 @@ class PollingMixin(_MixinBase):
         """Background worker to sync gate from upstream."""
         import asyncio
 
-        from ..lib.core.projects import load_project
-        from ..lib.domain.project import make_git_gate
+        from ..lib.api import load_project, make_git_gate
 
         try:
             # Run blocking sync in thread pool

--- a/src/terok/tui/project_actions.py
+++ b/src/terok/tui/project_actions.py
@@ -24,18 +24,18 @@ from terok_sandbox import (
 )
 from textual import work
 
-from ..lib.core.projects import load_project
-from ..lib.domain.facade import (
+from ..lib.api import (
     authenticate,
     build_images,
     delete_project,
     find_projects_sharing_gate,
     generate_dockerfiles,
+    load_project,
+    make_git_gate,
     maybe_pause_for_ssh_key_registration,
     provision_ssh_key,
     summarize_ssh_init,
 )
-from ..lib.domain.project import make_git_gate
 from .shell_launch import launch_login
 
 if TYPE_CHECKING:
@@ -50,7 +50,7 @@ def _lookup_vault_pub_line(scope: str) -> str | None:
     """Return the scope's most-recent public key line, or ``None`` if unassigned."""
     from terok_sandbox import public_line_of
 
-    from ..lib.domain.facade import vault_db
+    from ..lib.api import vault_db
 
     with vault_db() as db:
         records = db.load_ssh_keys_for_scope(scope)
@@ -247,7 +247,7 @@ class ProjectActionsMixin(_MixinBase):
         which a rebuild reuses — so without this, the picker would keep
         showing the previous agent set until the TUI restarts.
         """
-        from terok.lib.core.images import installed_agents
+        from ..lib.api import installed_agents
 
         installed_agents.cache_clear()
 
@@ -442,7 +442,7 @@ class ProjectActionsMixin(_MixinBase):
             """Resolve and print the effective instructions."""
             from terok_executor import resolve_instructions
 
-            from ..lib.orchestration.agent_config import resolve_agent_config
+            from ..lib.api import resolve_agent_config
 
             project = load_project(pid)
             effective = resolve_agent_config(
@@ -463,9 +463,9 @@ class ProjectActionsMixin(_MixinBase):
 
         def work() -> None:
             """Open global instructions file in $EDITOR."""
-            from ..lib.core.config import global_config_path
+            from ..lib.api import get_config
 
-            global_instr = global_config_path().parent / "instructions.md"
+            global_instr = get_config().global_config_path.parent / "instructions.md"
             global_instr.parent.mkdir(parents=True, exist_ok=True)
             editor = os.environ.get("EDITOR", "").strip() or "vi"
             editor_cmd = shlex.split(editor)
@@ -542,7 +542,7 @@ class ProjectActionsMixin(_MixinBase):
 
     async def _run_wizard_flow_body(self) -> None:
         """Inner wizard orchestration — see the decorator wrapper for docs."""
-        from ..lib.domain.wizards.new_project import render_project_yaml
+        from ..lib.api import render_project_yaml
         from .wizard_screens import (
             REVIEW_BACK,
             InitOutcome,
@@ -632,9 +632,9 @@ class ProjectActionsMixin(_MixinBase):
             names = ", ".join(p for p, _ in sharing)
             lines.append(f"\nNote: gate is shared with: {names} (will NOT be deleted)")
 
-        from ..lib.core.config import archive_dir as _archive_dir
+        from ..lib.api import get_config
 
-        archive_path = _archive_dir()
+        archive_path = get_config().archive_dir
         lines.append("\nAll project data will be permanently deleted.")
         lines.append("Project config, task data, and build artifacts will be archived at:")
         lines.append(f"{archive_path}")
@@ -675,7 +675,7 @@ class ProjectActionsMixin(_MixinBase):
 
     async def _action_gate_install(self) -> None:
         """Install systemd socket units for the gate server."""
-        from ..lib.core.config import make_sandbox_config
+        from ..lib.api import make_sandbox_config
 
         await self._run_suspended(
             lambda: GateServerManager(make_sandbox_config()).install_systemd_units(),
@@ -684,7 +684,7 @@ class ProjectActionsMixin(_MixinBase):
 
     async def _action_gate_uninstall(self) -> None:
         """Uninstall systemd units for the gate server."""
-        from ..lib.core.config import make_sandbox_config
+        from ..lib.api import make_sandbox_config
 
         await self._run_suspended(
             lambda: GateServerManager(make_sandbox_config()).uninstall_systemd_units(),
@@ -730,7 +730,7 @@ class ProjectActionsMixin(_MixinBase):
         """Install systemd socket activation for the vault."""
         from terok_executor import ensure_vault_routes
 
-        from ..lib.core.config import make_sandbox_config
+        from ..lib.api import make_sandbox_config
 
         def _install() -> None:
             cfg = make_sandbox_config()
@@ -744,7 +744,7 @@ class ProjectActionsMixin(_MixinBase):
 
     async def _action_vault_uninstall(self) -> None:
         """Uninstall vault systemd units."""
-        from ..lib.core.config import make_sandbox_config
+        from ..lib.api import make_sandbox_config
 
         await self._run_suspended(
             lambda: VaultManager(make_sandbox_config()).uninstall_systemd_units(),
@@ -755,7 +755,7 @@ class ProjectActionsMixin(_MixinBase):
         """Generate routes and start the vault daemon."""
         from terok_executor import ensure_vault_routes
 
-        from ..lib.core.config import make_sandbox_config
+        from ..lib.api import make_sandbox_config
 
         def _start() -> None:
             ensure_vault_routes(cfg=make_sandbox_config())

--- a/src/terok/tui/screens.py
+++ b/src/terok/tui/screens.py
@@ -72,8 +72,7 @@ from terok_sandbox import (
     is_systemd_available,
 )
 
-from ..lib.core.projects import ProjectConfig
-from ..lib.orchestration.tasks import sanitize_task_name, validate_task_name
+from ..lib.api import ProjectConfig, sanitize_task_name, validate_task_name
 from .widgets import TaskMeta, render_project_details, render_project_loading, render_task_details
 
 
@@ -620,7 +619,7 @@ class OpenCodeConfigScreen(screen.ModalScreen[str | None]):
         import shutil
         from pathlib import Path
 
-        from ..lib.core.config import vault_dir
+        from ..lib.api import get_config
 
         inp = self.query_one("#opencode-config-input", Input)
         raw = inp.value.strip()
@@ -643,7 +642,7 @@ class OpenCodeConfigScreen(screen.ModalScreen[str | None]):
             return
 
         try:
-            dest_dir = vault_dir() / "_opencode-config"
+            dest_dir = get_config().vault_dir / "_opencode-config"
             dest_dir.mkdir(parents=True, exist_ok=True)
             dest = dest_dir / "opencode.json"
             shutil.copy2(str(src), str(dest))
@@ -1312,10 +1311,9 @@ class TaskLaunchScreen(screen.ModalScreen["tuple[str, str, str, str, str, str | 
         freshly built image is referenced; doing it here keeps the event
         loop free so the modal stays dismissible.
         """
-        from ..lib.core import runtime as _rt
-        from ..lib.orchestration.tasks import get_task_meta
+        from ..lib.api import get_container_state, get_task_meta
 
-        state = _rt.get_runtime().container(self._container_name).state
+        state = get_container_state(self._container_name)
         has_mode = False
         if state == "running":
             try:
@@ -1572,11 +1570,11 @@ class TaskDetailsScreen(screen.Screen[str | None]):
             options.append(Option("re\\[n]ame task", id="rename"))
             options.append(Option("delete task  \\[X]", id="delete"))
             options.append(None)
-            from ..lib.core.config import get_shield_bypass_firewall_no_protection
+            from ..lib.api import get_config
 
             options.append(Option("shield \\[d]own (bypass)", id="shield_down"))
             options.append(Option("shield \\[D]own --all (+ private ranges)", id="shield_down_all"))
-            if not get_shield_bypass_firewall_no_protection():
+            if not get_config().shield_bypass_firewall_no_protection:
                 options.append(Option("\\[s]hield up (deny-all)", id="shield_up"))
             options.append(
                 Option("shield \\[i]nteractive (verdict handler)", id="shield_interactive")

--- a/src/terok/tui/serve.py
+++ b/src/terok/tui/serve.py
@@ -27,7 +27,7 @@ from base64 import b64decode, urlsafe_b64decode, urlsafe_b64encode
 from pathlib import Path
 from typing import TYPE_CHECKING
 
-from ..lib.core.paths import config_root
+from ..lib.api import get_config
 from ..lib.util.ansi import red, supports_color
 from ..lib.util.net import url_host
 
@@ -310,7 +310,7 @@ def _prompt_password() -> str:
 
 def _password_path() -> Path:
     """Path of the scrypt-hashed serve password (creating its config dir if needed)."""
-    root = config_root()
+    root = get_config().config_root
     root.mkdir(mode=0o700, parents=True, exist_ok=True)
     return root / "serve.password"
 

--- a/src/terok/tui/task_actions.py
+++ b/src/terok/tui/task_actions.py
@@ -16,12 +16,18 @@ from typing import TYPE_CHECKING, Any
 from terok_executor import parse_md_agent
 from terok_sandbox import down as shield_down, up as shield_up
 
-from ..lib.core import runtime as _rt
-from ..lib.core.config import get_shield_bypass_firewall_no_protection
-from ..lib.core.projects import load_project
-from ..lib.core.task_display import effective_status
-from ..lib.domain.facade import (
+from ..lib.api import (
     HeadlessRunRequest,
+    agent_config_dir,
+    container_name,
+    effective_status,
+    generate_task_name,
+    get_config,
+    get_container_state,
+    get_login_command,
+    get_workspace_git_diff,
+    load_project,
+    mark_task_deleting,
     task_delete,
     task_followup_headless,
     task_new,
@@ -31,15 +37,7 @@ from ..lib.domain.facade import (
     task_run_headless,
     task_run_toad,
     task_stop,
-)
-from ..lib.orchestration.autopilot import wait_for_container_exit
-from ..lib.orchestration.tasks import (
-    agent_config_dir,
-    container_name,
-    generate_task_name,
-    get_login_command,
-    get_workspace_git_diff,
-    mark_task_deleting,
+    wait_for_container_exit,
 )
 from .clipboard import copy_to_clipboard_detailed
 from .screens import (
@@ -254,7 +252,7 @@ class TaskActionsMixin(_MixinBase):
             # podman inspect would block the event loop; offload it.
             import asyncio
 
-            from terok.lib.core.images import installed_agents_for_project
+            from ..lib.api import installed_agents_for_project
 
             installed = await asyncio.to_thread(installed_agents_for_project, project)
         except (SystemExit, Exception):
@@ -398,7 +396,7 @@ class TaskActionsMixin(_MixinBase):
         # podman inspect would block the event loop; offload it.
         import asyncio
 
-        from terok.lib.core.images import installed_agents_for_project
+        from ..lib.api import installed_agents_for_project
 
         installed: frozenset[str] | None = None
         try:
@@ -573,7 +571,7 @@ class TaskActionsMixin(_MixinBase):
         tid = task.task_id
         cname = container_name(pid, task.mode, tid)
 
-        state = _rt.get_runtime().container(cname).state
+        state = get_container_state(cname)
         if state is None:
             self.notify(f"No container found for task {tid}.")
             return
@@ -768,11 +766,12 @@ class TaskActionsMixin(_MixinBase):
 
     def _notify_shield_bypassed(self) -> bool:
         """Warn the user and return ``True`` if the shield bypass is active."""
-        if not get_shield_bypass_firewall_no_protection():
+        cfg = get_config()
+        if not cfg.shield_bypass_firewall_no_protection:
             return False
-        from ..lib.core.config import SHIELD_SECURITY_HINT
-
-        self.notify(f"Shield unavailable (bypass_firewall_no_protection). {SHIELD_SECURITY_HINT}")
+        self.notify(
+            f"Shield unavailable (bypass_firewall_no_protection). {cfg.shield_security_hint}"
+        )
         return True
 
     def _action_shield_up(self) -> None:

--- a/src/terok/tui/widgets/__init__.py
+++ b/src/terok/tui/widgets/__init__.py
@@ -6,7 +6,7 @@
 Re-exports widget classes and render helpers from focused submodules.
 """
 
-from ...lib.orchestration.tasks import TaskMeta  # noqa: F401 — re-exported public API
+from ...lib.api import TaskMeta  # noqa: F401 — re-exported public API
 from .panic_button import PanicButton  # noqa: F401
 from .project_list import ProjectActions, ProjectList, ProjectListItem  # noqa: F401
 from .project_state import (  # noqa: F401

--- a/src/terok/tui/widgets/project_list.py
+++ b/src/terok/tui/widgets/project_list.py
@@ -11,8 +11,14 @@ from textual.containers import Horizontal
 from textual.message import Message
 from textual.widgets import Button, ListItem, ListView, Static
 
-from ...lib.core.projects import BrokenProject, ProjectConfig
-from ...lib.core.task_display import GPU_DISPLAY, SECURITY_CLASS_DISPLAY, StatusInfo, has_gpu
+from ...lib.api import (
+    GPU_DISPLAY,
+    SECURITY_CLASS_DISPLAY,
+    BrokenProject,
+    ProjectConfig,
+    StatusInfo,
+    has_gpu,
+)
 from ...lib.util.emoji import render_emoji
 
 # Reuse the existing "failed" status badge for broken-project rows so the

--- a/src/terok/tui/widgets/project_state.py
+++ b/src/terok/tui/widgets/project_state.py
@@ -12,8 +12,13 @@ from rich.text import Text
 from terok_sandbox import EnvironmentCheck, GateServerStatus, GateStalenessInfo
 from textual.widgets import Static
 
-from ...lib.core.projects import BrokenProject, ProjectConfig
-from ...lib.core.task_display import GPU_DISPLAY, SECURITY_CLASS_DISPLAY, has_gpu
+from ...lib.api import (
+    GPU_DISPLAY,
+    SECURITY_CLASS_DISPLAY,
+    BrokenProject,
+    ProjectConfig,
+    has_gpu,
+)
 from ...lib.util.emoji import render_emoji
 from .task_detail import _get_css_variables
 

--- a/src/terok/tui/widgets/task_detail.py
+++ b/src/terok/tui/widgets/task_detail.py
@@ -11,9 +11,7 @@ from textual import events
 from textual.app import ComposeResult
 from textual.widgets import Static
 
-from ...lib.core.config import SHIELD_SECURITY_HINT, get_public_host
-from ...lib.core.task_display import STATUS_DISPLAY, mode_info
-from ...lib.orchestration.tasks import TaskMeta
+from ...lib.api import STATUS_DISPLAY, TaskMeta, get_config, mode_info
 from ...lib.util.emoji import render_emoji
 from ...lib.util.net import url_host
 from ...lib.util.text_wrap import wrap_with_hanging_indent
@@ -86,7 +84,7 @@ def render_task_details(
     if task.status == "running" and image_old:
         lines.append(Text.assemble("Image:     ", Text("old", style=warning_style)))
     if task.web_port:
-        base_url = f"http://{url_host(get_public_host())}:{task.web_port}/"
+        base_url = f"http://{url_host(get_config().public_host)}:{task.web_port}/"
         # Token in the query is what Caddy trades for its auth cookie.
         # Render the full URL verbatim so users without OSC-8 support
         # (and copy-paste) still get the tokenised URL.
@@ -144,7 +142,10 @@ def render_task_details(
             )
             if task.shield_state in {"DISABLED", "INACTIVE"}:
                 lines.append(
-                    Text(f"           {SHIELD_SECURITY_HINT}", style=Style(color=error_color))
+                    Text(
+                        f"           {get_config().shield_security_hint}",
+                        style=Style(color=error_color),
+                    )
                 )
     if task.mode == "run":
         if task.exit_code is not None:

--- a/src/terok/tui/widgets/task_list.py
+++ b/src/terok/tui/widgets/task_list.py
@@ -9,8 +9,7 @@ from textual import events
 from textual.message import Message
 from textual.widgets import ListItem, ListView, Static
 
-from ...lib.core.task_display import STATUS_DISPLAY, mode_info
-from ...lib.orchestration.tasks import TaskMeta
+from ...lib.api import STATUS_DISPLAY, TaskMeta, mode_info
 from ...lib.util.emoji import render_emoji
 from ...lib.util.text_wrap import wrap_with_hanging_indent
 

--- a/src/terok/tui/wizard_screens.py
+++ b/src/terok/tui/wizard_screens.py
@@ -41,10 +41,10 @@ from textual.css.query import NoMatches
 from textual.screen import ModalScreen
 from textual.widgets import Button, Input, Label, RadioButton, RadioSet, RichLog, Static, TextArea
 
-from ..lib.domain.facade import project_needs_key_registration
-from ..lib.domain.wizards.new_project import (
+from ..lib.api import (
     QUESTIONS,
     Question,
+    project_needs_key_registration,
     validate_answer,
     write_project_yaml,
 )
@@ -620,9 +620,9 @@ class InitProgressScreen(ModalScreen[InitOutcome]):
 
     def _existing_project_yaml_path(self) -> Path | None:
         """Return the on-disk ``project.yml`` path if it already exists, else None."""
-        from ..lib.core.config import user_projects_dir
+        from ..lib.api import get_config
 
-        candidate = user_projects_dir() / self._project_id / "project.yml"
+        candidate = get_config().user_projects_dir / self._project_id / "project.yml"
         return candidate if candidate.is_file() else None
 
     async def _confirm_overwrite(self, path: Path) -> bool:
@@ -742,9 +742,9 @@ class InitProgressScreen(ModalScreen[InitOutcome]):
         """
         import asyncio
 
-        from terok.lib.core.projects import load_project
-        from terok.lib.domain.facade import (
+        from ..lib.api import (
             generate_dockerfiles,
+            load_project,
             provision_ssh_key,
             summarize_ssh_init,
         )
@@ -1048,7 +1048,7 @@ def _run_isolated(
 def _build_in_subprocess(project_id: str, *, env: dict[str, str] | None = None) -> None:
     """Run [`build_images`][terok.cli.commands.project.build_images] in a child Python process."""
     # Literal repr keeps project_id safely escaped into the -c body.
-    child_body = f"from terok.lib.domain.facade import build_images; build_images({project_id!r})"
+    child_body = f"from terok.lib.api import build_images; build_images({project_id!r})"
     _run_isolated(child_body, label="build_images", env=env)
 
 
@@ -1070,8 +1070,7 @@ def _gate_sync_in_subprocess(
     try:
         child_body = (
             "import json\n"
-            "from terok.lib.core.projects import load_project\n"
-            "from terok.lib.domain.facade import make_git_gate\n"
+            "from terok.lib.api import load_project, make_git_gate\n"
             f"_project = load_project({project_id!r})\n"
             "_result = make_git_gate(_project).sync()\n"
             f"json.dump(_result, open({str(result_path)!r}, 'w'))\n"

--- a/tach.toml
+++ b/tach.toml
@@ -66,21 +66,22 @@ depends_on = [
 ]
 
 # TUI frontend
+#
+# The TUI talks to the library only through the [`terok.lib.api`][terok.lib.api]
+# front door, plus pure utilities (``util.*``) and the version helpers.
+# New TUI features that need internal modules should extend ``api`` first;
+# extending this allowlist is a design smell.
 [[modules]]
 path = "terok.tui"
 layer = "presentation"
 depends_on = [
-    "terok.lib.orchestration.autopilot",
-    "terok.lib.core.task_display",
-    "terok.lib.domain.panic",
-    "terok.lib.orchestration.tasks",
-    "terok.lib.core.config",
-    "terok.lib.core.projects",
-    "terok.lib.core.runtime",
+    "terok.lib.api",
     "terok.lib.core.version",
-    "terok.lib.domain.facade",
-    "terok.lib.domain.wizards.new_project",
+    "terok.lib.util.ansi",
     "terok.lib.util.emoji",
+    "terok.lib.util.logging_utils",
+    "terok.lib.util.net",
+    "terok.lib.util.text_wrap",
     "terok.lib.util.yaml",
 ]
 
@@ -117,6 +118,30 @@ depends_on = [
     "terok.lib.core.projects",
     "terok.lib.domain.project",
     "terok.lib.domain.task",
+]
+
+# Public library API — single stable import boundary for presentation layers.
+# Re-exports operations from the facade, the domain types they manipulate,
+# the presentation tables, and a snapshot ``Config`` so consumers never
+# need to reach into internal modules.  Extending this is a design decision;
+# it should not grow opportunistically.
+[[modules]]
+path = "terok.lib.api"
+layer = "domain"
+depends_on = [
+    "terok.lib.domain.facade",
+    "terok.lib.domain.panic",
+    "terok.lib.domain.wizards.new_project",
+    "terok.lib.orchestration.agent_config",
+    "terok.lib.orchestration.autopilot",
+    "terok.lib.orchestration.tasks",
+    "terok.lib.core.config",
+    "terok.lib.core.images",
+    "terok.lib.core.paths",
+    "terok.lib.core.projects",
+    "terok.lib.core.runtime",
+    "terok.lib.core.task_display",
+    "terok.lib.core.task_state",
 ]
 
 # Vault access primitive (shared open/close handshake)
@@ -222,7 +247,7 @@ depends_on = [
     "terok.lib.core.images",
     "terok.lib.core.projects",
     "terok.lib.core.runtime",
-    "terok.lib.core.task_display",
+    "terok.lib.core.task_state",
     "terok.lib.domain.vault",
 ]
 
@@ -257,7 +282,7 @@ depends_on = [
     "terok.lib.core.images",
     "terok.lib.core.projects",
     "terok.lib.core.runtime",
-    "terok.lib.core.task_display",
+    "terok.lib.core.task_state",
     "terok.lib.util.ansi",
     "terok.lib.util.yaml",
 ]
@@ -272,6 +297,7 @@ depends_on = [
     "terok.lib.orchestration.ports",
     "terok.lib.core.runtime",
     "terok.lib.core.task_display",
+    "terok.lib.core.task_state",
     "terok.lib.core.work_status",
     "terok.lib.core.config",
     "terok.lib.core.projects",
@@ -324,7 +350,7 @@ path = "terok.lib.orchestration.container_exec"
 layer = "orchestration"
 depends_on = [
     "terok.lib.core.runtime",
-    "terok.lib.core.task_display",
+    "terok.lib.core.task_state",
     "terok.lib.util.logging_utils",
 ]
 
@@ -421,11 +447,17 @@ path = "terok.lib.core.runtime"
 layer = "core"
 depends_on = []
 
-# Task display types and status computation
+# Task lifecycle state — domain value object, status computation, container naming
+[[modules]]
+path = "terok.lib.core.task_state"
+layer = "core"
+depends_on = ["terok.lib.util.yaml"]
+
+# Presentation tables for task lifecycle, mode, and project badges
 [[modules]]
 path = "terok.lib.core.task_display"
 layer = "core"
-depends_on = ["terok.lib.util.yaml"]
+depends_on = []
 
 # Agent work status reading
 [[modules]]
@@ -547,18 +579,24 @@ expose = [
     "StatusInfo",
     "ModeInfo",
     "ProjectBadge",
-    "TaskState",
     "STATUS_DISPLAY",
     "MODE_DISPLAY",
     "SECURITY_CLASS_DISPLAY",
+    "ISOLATION_DISPLAY",
     "GPU_DISPLAY",
-    "effective_status",
     "mode_info",
+]
+from = ["terok.lib.core.task_display"]
+
+[[interfaces]]
+expose = [
+    "TaskState",
+    "effective_status",
     "has_gpu",
     "CONTAINER_MODES",
     "container_name",
 ]
-from = ["terok.lib.core.task_display"]
+from = ["terok.lib.core.task_state"]
 
 [[interfaces]]
 expose = [

--- a/tests/unit/lib/test_api.py
+++ b/tests/unit/lib/test_api.py
@@ -1,0 +1,93 @@
+# SPDX-FileCopyrightText: 2026 Jiri Vyskocil
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the public [`terok.lib.api`][terok.lib.api] front door.
+
+Covers the two pieces of behaviour the module owns directly:
+
+- [`get_config`][terok.lib.api.get_config] snapshots every path, flag,
+  and presentation hint into a frozen [`Config`][terok.lib.api.Config]
+  by reading the underlying ``core.config`` / ``core.paths`` helpers
+  exactly once each.
+- [`get_container_state`][terok.lib.api.get_container_state] delegates
+  one-shot state lookups to the runtime driver without dragging
+  consumers into ``core.runtime``.
+
+Re-exported facade symbols are not retested here — they are validated by
+the tests against their canonical modules.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from terok.lib.api import Config, get_config, get_container_state
+
+
+class TestGetConfig:
+    """``get_config()`` should snapshot each underlying getter exactly once."""
+
+    def test_returns_frozen_config_with_all_fields(self) -> None:
+        """Snapshot is a frozen dataclass with every field populated."""
+        with (
+            patch("terok.lib.api._paths.config_root", return_value=Path("/cfg")),
+            patch("terok.lib.api._paths.core_state_dir", return_value=Path("/state")),
+            patch("terok.lib.api._paths.runtime_dir", return_value=Path("/run")),
+            patch("terok.lib.api._config.archive_dir", return_value=Path("/arch")),
+            patch("terok.lib.api._config.vault_dir", return_value=Path("/vault")),
+            patch("terok.lib.api._config.user_projects_dir", return_value=Path("/proj")),
+            patch("terok.lib.api._config.global_config_path", return_value=Path("/cfg/g.yml")),
+            patch("terok.lib.api._config.get_public_host", return_value="1.2.3.4"),
+            patch(
+                "terok.lib.api._config.get_shield_bypass_firewall_no_protection",
+                return_value=True,
+            ),
+            patch("terok.lib.api._config.get_tui_default_tmux", return_value=True),
+            patch("terok.lib.api._config.SHIELD_SECURITY_HINT", "HINT"),
+        ):
+            cfg = get_config()
+
+        assert isinstance(cfg, Config)
+        assert cfg.config_root == Path("/cfg")
+        assert cfg.core_state_dir == Path("/state")
+        assert cfg.runtime_dir == Path("/run")
+        assert cfg.archive_dir == Path("/arch")
+        assert cfg.vault_dir == Path("/vault")
+        assert cfg.user_projects_dir == Path("/proj")
+        assert cfg.global_config_path == Path("/cfg/g.yml")
+        assert cfg.public_host == "1.2.3.4"
+        assert cfg.shield_bypass_firewall_no_protection is True
+        assert cfg.tui_default_tmux is True
+        assert cfg.shield_security_hint == "HINT"
+
+    def test_config_is_immutable(self) -> None:
+        """``Config`` is frozen — callers can't mutate the snapshot."""
+        import dataclasses
+
+        cfg = get_config()
+        with pytest.raises(dataclasses.FrozenInstanceError):
+            cfg.public_host = "evil"  # type: ignore[misc]
+
+
+class TestGetContainerState:
+    """One-shot container state lookup must go through the runtime driver."""
+
+    def test_returns_state_from_runtime(self) -> None:
+        """Returns whatever ``runtime.container(name).state`` reports."""
+        fake_container = MagicMock(state="running")
+        fake_runtime = MagicMock()
+        fake_runtime.container.return_value = fake_container
+        with patch("terok.lib.api._runtime.get_runtime", return_value=fake_runtime):
+            assert get_container_state("proj-cli-42") == "running"
+        fake_runtime.container.assert_called_once_with("proj-cli-42")
+
+    def test_returns_none_when_container_absent(self) -> None:
+        """Driver reports ``state=None`` for unknown containers — pass it through."""
+        fake_container = MagicMock(state=None)
+        fake_runtime = MagicMock()
+        fake_runtime.container.return_value = fake_container
+        with patch("terok.lib.api._runtime.get_runtime", return_value=fake_runtime):
+            assert get_container_state("ghost") is None

--- a/tests/unit/lib/test_api.py
+++ b/tests/unit/lib/test_api.py
@@ -31,21 +31,37 @@ class TestGetConfig:
     """``get_config()`` should snapshot each underlying getter exactly once."""
 
     def test_returns_frozen_config_with_all_fields(self) -> None:
-        """Snapshot is a frozen dataclass with every field populated."""
+        """Snapshot populates every field by calling each getter exactly once."""
         with (
-            patch("terok.lib.api._paths.config_root", return_value=Path("/cfg")),
-            patch("terok.lib.api._paths.core_state_dir", return_value=Path("/state")),
-            patch("terok.lib.api._paths.runtime_dir", return_value=Path("/run")),
-            patch("terok.lib.api._config.archive_dir", return_value=Path("/arch")),
-            patch("terok.lib.api._config.vault_dir", return_value=Path("/vault")),
-            patch("terok.lib.api._config.user_projects_dir", return_value=Path("/proj")),
-            patch("terok.lib.api._config.global_config_path", return_value=Path("/cfg/g.yml")),
-            patch("terok.lib.api._config.get_public_host", return_value="1.2.3.4"),
+            patch(
+                "terok.lib.api._paths.config_root", return_value=Path("/cfg")
+            ) as config_root_mock,
+            patch(
+                "terok.lib.api._paths.core_state_dir", return_value=Path("/state")
+            ) as core_state_dir_mock,
+            patch(
+                "terok.lib.api._paths.runtime_dir", return_value=Path("/run")
+            ) as runtime_dir_mock,
+            patch(
+                "terok.lib.api._config.archive_dir", return_value=Path("/arch")
+            ) as archive_dir_mock,
+            patch("terok.lib.api._config.vault_dir", return_value=Path("/vault")) as vault_dir_mock,
+            patch(
+                "terok.lib.api._config.user_projects_dir", return_value=Path("/proj")
+            ) as user_projects_dir_mock,
+            patch(
+                "terok.lib.api._config.global_config_path", return_value=Path("/cfg/g.yml")
+            ) as global_config_path_mock,
+            patch(
+                "terok.lib.api._config.get_public_host", return_value="1.2.3.4"
+            ) as get_public_host_mock,
             patch(
                 "terok.lib.api._config.get_shield_bypass_firewall_no_protection",
                 return_value=True,
-            ),
-            patch("terok.lib.api._config.get_tui_default_tmux", return_value=True),
+            ) as get_shield_bypass_firewall_no_protection_mock,
+            patch(
+                "terok.lib.api._config.get_tui_default_tmux", return_value=True
+            ) as get_tui_default_tmux_mock,
             patch("terok.lib.api._config.SHIELD_SECURITY_HINT", "HINT"),
         ):
             cfg = get_config()
@@ -62,6 +78,21 @@ class TestGetConfig:
         assert cfg.shield_bypass_firewall_no_protection is True
         assert cfg.tui_default_tmux is True
         assert cfg.shield_security_hint == "HINT"
+
+        # ``SHIELD_SECURITY_HINT`` is a constant, not a callable — exclude it.
+        for getter_mock in (
+            config_root_mock,
+            core_state_dir_mock,
+            runtime_dir_mock,
+            archive_dir_mock,
+            vault_dir_mock,
+            user_projects_dir_mock,
+            global_config_path_mock,
+            get_public_host_mock,
+            get_shield_bypass_firewall_no_protection_mock,
+            get_tui_default_tmux_mock,
+        ):
+            getter_mock.assert_called_once()
 
     def test_config_is_immutable(self) -> None:
         """``Config`` is frozen — callers can't mutate the snapshot."""
@@ -80,8 +111,11 @@ class TestGetContainerState:
         fake_container = MagicMock(state="running")
         fake_runtime = MagicMock()
         fake_runtime.container.return_value = fake_container
-        with patch("terok.lib.api._runtime.get_runtime", return_value=fake_runtime):
+        with patch(
+            "terok.lib.api._runtime.get_runtime", return_value=fake_runtime
+        ) as mock_get_runtime:
             assert get_container_state("proj-cli-42") == "running"
+        mock_get_runtime.assert_called_once()
         fake_runtime.container.assert_called_once_with("proj-cli-42")
 
     def test_returns_none_when_container_absent(self) -> None:
@@ -89,5 +123,9 @@ class TestGetContainerState:
         fake_container = MagicMock(state=None)
         fake_runtime = MagicMock()
         fake_runtime.container.return_value = fake_container
-        with patch("terok.lib.api._runtime.get_runtime", return_value=fake_runtime):
+        with patch(
+            "terok.lib.api._runtime.get_runtime", return_value=fake_runtime
+        ) as mock_get_runtime:
             assert get_container_state("ghost") is None
+        mock_get_runtime.assert_called_once()
+        fake_runtime.container.assert_called_once_with("ghost")

--- a/tests/unit/lib/test_effective_status.py
+++ b/tests/unit/lib/test_effective_status.py
@@ -11,12 +11,8 @@ from unittest.mock import patch
 import pytest
 from terok_sandbox import PodmanRuntime
 
-from terok.lib.core.task_display import (
-    STATUS_DISPLAY,
-    TaskState,
-    effective_status,
-    mode_info,
-)
+from terok.lib.core.task_display import STATUS_DISPLAY, mode_info
+from terok.lib.core.task_state import TaskState, effective_status
 from terok.lib.orchestration.tasks import TaskMeta, get_all_task_states
 
 

--- a/tests/unit/lib/test_task_ids.py
+++ b/tests/unit/lib/test_task_ids.py
@@ -10,7 +10,7 @@ import unittest.mock
 
 import pytest
 
-from terok.lib.core.task_display import CONTAINER_MODES, container_name
+from terok.lib.core.task_state import CONTAINER_MODES, container_name
 from terok.lib.orchestration.tasks import (
     _TASK_ID_BODY_CHARS,
     _TASK_ID_HEAD_CHARS,

--- a/tests/unit/lib/test_task_state.py
+++ b/tests/unit/lib/test_task_state.py
@@ -1,0 +1,81 @@
+# SPDX-FileCopyrightText: 2026 Jiri Vyskocil
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for [`terok.lib.core.task_state.has_gpu`][terok.lib.core.task_state.has_gpu].
+
+Other domain helpers from this module (``TaskState``, ``effective_status``,
+``container_name``, ``CONTAINER_MODES``) are exercised by
+``test_effective_status`` and ``test_task_ids`` — this file only covers the
+GPU opt-in detector, whose branches were unreachable through the other suites.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from terok.lib.core.task_state import has_gpu
+
+
+def _project(root: Path | None) -> Any:
+    """Build a stand-in for a ``Project`` carrying just ``root``."""
+    return SimpleNamespace(root=root)
+
+
+def _write_project_yml(root: Path, body: str) -> None:
+    """Materialise a minimal ``project.yml`` for ``has_gpu`` to read."""
+    root.mkdir(parents=True, exist_ok=True)
+    (root / "project.yml").write_text(body)
+
+
+class TestHasGpu:
+    """Map every ``run.gpus`` shape to the expected boolean verdict."""
+
+    def test_returns_false_without_root_attr(self) -> None:
+        """An object without a usable ``root`` attribute never opts into GPU."""
+        assert has_gpu(SimpleNamespace()) is False
+        assert has_gpu(_project(root=None)) is False
+
+    def test_returns_false_when_project_yml_missing(self, tmp_path: Path) -> None:
+        """Missing ``project.yml`` — treat as no GPU rather than raising."""
+        # tmp_path exists but no project.yml inside
+        assert has_gpu(_project(root=tmp_path)) is False
+
+    def test_returns_false_on_malformed_yaml(self, tmp_path: Path) -> None:
+        """Parse errors are swallowed — GPU stays off."""
+        _write_project_yml(tmp_path, "run: [not-a-mapping")
+        assert has_gpu(_project(root=tmp_path)) is False
+
+    def test_returns_true_when_gpus_string_all(self, tmp_path: Path) -> None:
+        """``run.gpus: all`` (lowercase) opts in."""
+        _write_project_yml(tmp_path, "run:\n  gpus: all\n")
+        assert has_gpu(_project(root=tmp_path)) is True
+
+    def test_string_all_is_case_insensitive(self, tmp_path: Path) -> None:
+        """``run.gpus: ALL`` and friends count — the model lowercases."""
+        _write_project_yml(tmp_path, "run:\n  gpus: ALL\n")
+        assert has_gpu(_project(root=tmp_path)) is True
+
+    def test_returns_false_when_gpus_string_other(self, tmp_path: Path) -> None:
+        """Any other string value is treated as off (single-GPU specifiers aren't supported here)."""
+        _write_project_yml(tmp_path, "run:\n  gpus: '0,1'\n")
+        assert has_gpu(_project(root=tmp_path)) is False
+
+    @pytest.mark.parametrize("value", [True, False])
+    def test_bool_gpus_passes_through(self, tmp_path: Path, value: bool) -> None:
+        """``run.gpus: true`` opts in; ``false`` opts out."""
+        _write_project_yml(tmp_path, f"run:\n  gpus: {str(value).lower()}\n")
+        assert has_gpu(_project(root=tmp_path)) is value
+
+    def test_returns_false_when_run_section_absent(self, tmp_path: Path) -> None:
+        """No ``run`` section → no GPU."""
+        _write_project_yml(tmp_path, "id: demo\n")
+        assert has_gpu(_project(root=tmp_path)) is False
+
+    def test_returns_false_when_gpus_key_absent(self, tmp_path: Path) -> None:
+        """``run`` section without ``gpus`` → no GPU."""
+        _write_project_yml(tmp_path, "run:\n  cmd: bash\n")
+        assert has_gpu(_project(root=tmp_path)) is False

--- a/tests/unit/tui/test_app_arg_parser.py
+++ b/tests/unit/tui/test_app_arg_parser.py
@@ -31,6 +31,12 @@ class TestTmuxTriState:
         """No flag → ``None`` so ``main`` can fall back to ``tui.default_tmux``."""
         assert _build_arg_parser().parse_args(argv).tmux is expected
 
+    def test_passing_both_flags_is_rejected(self, capsys: pytest.CaptureFixture[str]) -> None:
+        """Mutual exclusion: ``--tmux`` and ``--no-tmux`` together is an argparse error."""
+        with pytest.raises(SystemExit):
+            _build_arg_parser().parse_args(["--tmux", "--no-tmux"])
+        assert "not allowed with" in capsys.readouterr().err
+
 
 class TestOtherFlags:
     """Sibling flags use their natural argparse defaults — covered to lock the contract."""

--- a/tests/unit/tui/test_app_arg_parser.py
+++ b/tests/unit/tui/test_app_arg_parser.py
@@ -1,0 +1,52 @@
+# SPDX-FileCopyrightText: 2026 Jiri Vyskocil
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the [`terok-tui`][terok.tui.app] argument parser.
+
+The ``--tmux`` / ``--no-tmux`` pair shares one destination and must stay
+tri-state (``None`` / ``True`` / ``False``).  Earlier the parser left
+``args.tmux`` as a bool when neither flag was given, silently masking the
+fallback to the global ``tui.default_tmux`` config setting.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from terok.tui.app import _build_arg_parser
+
+
+class TestTmuxTriState:
+    """``args.tmux`` must distinguish "no flag" from "--no-tmux"."""
+
+    @pytest.mark.parametrize(
+        ("argv", "expected"),
+        [
+            pytest.param([], None, id="neither-flag-set"),
+            pytest.param(["--tmux"], True, id="explicit-tmux"),
+            pytest.param(["--no-tmux"], False, id="explicit-no-tmux"),
+        ],
+    )
+    def test_tmux_destination(self, argv: list[str], expected: bool | None) -> None:
+        """No flag → ``None`` so ``main`` can fall back to ``tui.default_tmux``."""
+        assert _build_arg_parser().parse_args(argv).tmux is expected
+
+
+class TestOtherFlags:
+    """Sibling flags use their natural argparse defaults — covered to lock the contract."""
+
+    def test_experimental_defaults_to_false(self) -> None:
+        """``--experimental`` is off unless asked for."""
+        assert _build_arg_parser().parse_args([]).experimental is False
+
+    def test_experimental_can_be_enabled(self) -> None:
+        """``--experimental`` flips on the experimental gate."""
+        assert _build_arg_parser().parse_args(["--experimental"]).experimental is True
+
+    def test_no_emoji_defaults_to_false(self) -> None:
+        """``--no-emoji`` is off unless asked for."""
+        assert _build_arg_parser().parse_args([]).no_emoji is False
+
+    def test_no_emoji_can_be_enabled(self) -> None:
+        """``--no-emoji`` swaps emojis for plain-text labels."""
+        assert _build_arg_parser().parse_args(["--no-emoji"]).no_emoji is True

--- a/tests/unit/tui/test_askpass_service.py
+++ b/tests/unit/tui/test_askpass_service.py
@@ -114,10 +114,29 @@ class TestSocketPath:
     """Per-process socket path under terok's namespace runtime dir.
 
     We delegate to [`terok_sandbox.paths.namespace_runtime_dir`][terok_sandbox.paths.namespace_runtime_dir]
-    for the XDG resolution order — patching it out lets us pin the
-    path regardless of the host's env and ensures no ``/tmp`` fallback
-    leaks back in.
+    for the XDG resolution order — patching the [`Config`][terok.lib.api.Config]
+    snapshot lets us pin the path regardless of the host's env and
+    ensures no ``/tmp`` fallback leaks back in.
     """
+
+    @staticmethod
+    def _config_with_runtime_dir(tmp_path: Path) -> object:
+        """Build a minimal [`Config`][terok.lib.api.Config] with ``runtime_dir`` pinned."""
+        from terok.lib.api import Config
+
+        return Config(
+            config_root=tmp_path,
+            core_state_dir=tmp_path,
+            runtime_dir=tmp_path,
+            archive_dir=tmp_path,
+            vault_dir=tmp_path,
+            user_projects_dir=tmp_path,
+            global_config_path=tmp_path / "config.yml",
+            public_host="127.0.0.1",
+            shield_bypass_firewall_no_protection=False,
+            tui_default_tmux=False,
+            shield_security_hint="",
+        )
 
     def test_uses_namespace_runtime_dir(self, tmp_path: Path) -> None:
         """Socket sits inside whatever ``namespace_runtime_dir`` returns — always.
@@ -129,7 +148,8 @@ class TestSocketPath:
         ``~/.local/state/terok``).  Delegating here means any future
         change to that chain lands transparently.
         """
-        with patch("terok.tui.askpass_service.runtime_dir", return_value=tmp_path):
+        cfg = self._config_with_runtime_dir(tmp_path)
+        with patch("terok.tui.askpass_service.get_config", return_value=cfg):
             path = default_socket_path(pid=12345)
         assert path == tmp_path / "askpass-12345.sock"
 
@@ -141,7 +161,8 @@ class TestSocketPath:
         Proves we're not reimplementing the XDG chain locally.
         """
         monkeypatch.setenv("XDG_RUNTIME_DIR", "/tmp/unused-should-be-ignored")
-        with patch("terok.tui.askpass_service.runtime_dir", return_value=tmp_path):
+        cfg = self._config_with_runtime_dir(tmp_path)
+        with patch("terok.tui.askpass_service.get_config", return_value=cfg):
             assert default_socket_path(pid=1).parent == tmp_path
 
 

--- a/tests/unit/tui/test_project_state_staleness.py
+++ b/tests/unit/tui/test_project_state_staleness.py
@@ -31,7 +31,7 @@ def test_staleness_checked_for_online_and_gatekeeping(security_class: str) -> No
     with (
         mock.patch.object(app, "load_project", return_value=project),
         mock.patch.object(app, "get_project_state", return_value=state),
-        mock.patch("terok.lib.domain.project.make_git_gate", return_value=mock_gate),
+        mock.patch.object(app, "make_git_gate", return_value=mock_gate),
     ):
         result = app.TerokTUI._load_project_state(mock.Mock(), "proj1")
 

--- a/tests/unit/tui/test_wizard_screens.py
+++ b/tests/unit/tui/test_wizard_screens.py
@@ -447,8 +447,8 @@ async def test_ssh_panel_shows_fingerprint_alongside_pubkey() -> None:
         patch.object(InitProgressScreen, "_existing_project_yaml_path", return_value=None),
         patch("terok.tui.wizard_screens.write_project_yaml"),
         patch("terok.tui.wizard_screens.project_needs_key_registration", return_value=True),
-        patch("terok.lib.domain.facade.provision_ssh_key", return_value=minted),
-        patch("terok.lib.domain.facade.summarize_ssh_init"),
+        patch("terok.lib.api.provision_ssh_key", return_value=minted),
+        patch("terok.lib.api.summarize_ssh_init"),
     ):
         async with app.run_test() as pilot:
             # Give the worker a chance to reach the ssh_continue wait.
@@ -509,8 +509,8 @@ async def test_init_screen_esc_cancels_mid_run() -> None:
         patch.object(InitProgressScreen, "_existing_project_yaml_path", return_value=None),
         patch("terok.tui.wizard_screens.write_project_yaml"),
         patch("terok.tui.wizard_screens.project_needs_key_registration", return_value=True),
-        patch("terok.lib.domain.facade.provision_ssh_key", return_value=minted),
-        patch("terok.lib.domain.facade.summarize_ssh_init"),
+        patch("terok.lib.api.provision_ssh_key", return_value=minted),
+        patch("terok.lib.api.summarize_ssh_init"),
     ):
         async with app.run_test() as pilot:
             # Let the worker reach the ssh_continue.wait() park state —


### PR DESCRIPTION
## Summary

- Promote a single front-door module `terok.lib.api` that re-exports the facade operations, the domain value types consumers pass around (`ProjectConfig`, `BrokenProject`, `TaskMeta`, `StatusInfo`, …), the presentation tables, and a snapshot `Config` dataclass bundling the previously scattered config getters.
- Route every TUI import through it. `terok.tui.depends_on` shrinks from **13 internal modules to 3** (`api` + `core.version` + `util.*`).
- Split `core/task_display` along its layering seam: the domain half (`TaskState`, `effective_status`, `container_name`, `has_gpu`, `CONTAINER_MODES`) moves to a new `core/task_state` module; `core/task_display` keeps only the presentation tables.

## Motivation

Before this PR the TUI was importing ~84 symbols across **20** distinct `terok.lib.*` submodules, and `tach.toml` allow-listed 13 of them as TUI dependencies — every new TUI feature could quietly add another. The `domain.facade` module was doing the operations-facade job well but did not expose the types those operations operate on, so consumers reached past it for `ProjectConfig`, `BrokenProject`, `TaskMeta` etc.

After the refactor:

| | Before | After |
|---|---|---|
| Distinct `terok.lib.*` submodules TUI imports from | 20 | 3 |
| `terok.tui.depends_on` entries in `tach.toml` | 13 | 8 (1 api + 1 version + 6 util) |
| Config getter callsites in TUI | ~17 across `core.config` + `core.paths` | 1 `Config` snapshot stashed on the app |

Pure utilities (`util.emoji`, `util.yaml`, `util.ansi`, `util.text_wrap`, `util.net`, `util.logging_utils`) and `core.version` stay importable directly — they are genuinely cross-cutting with no domain coupling worth funnelling.

Mechanism: any future TUI feature that wants a deeper import now has to extend `api` first, which CI (`tach check`) rejects automatically. Without this enforcement, the surface would grow back.

## Compatibility

CLI continues to import from `domain.facade` as before; the facade is unchanged. `terok.lib.api` is purely additive for now — migrating the CLI to it is a follow-up, not a blocker.

## Test plan

- [x] `ruff check` + `ruff format --check` — clean
- [x] `mypy src/terok/` (strict mode, 104 files) — no issues
- [x] `tach check` — all modules validated
- [x] `lint-imports` — 4/4 contracts kept
- [x] `pytest tests/unit` — 2247 passed
- [x] `bandit -r src/ -ll` — no medium/high issues
- [x] `docstr-coverage src/terok` — 97.5%
- [x] `vulture` — clean
- [x] `reuse lint` — REUSE 3.3 compliant

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * UI now uses a single cached configuration snapshot for consistent paths and security hints.
  * Container runtime state is retrieved via a centralized accessor for readiness and log-following flows.
  * CLI tmux flag supports tri-state semantics (unset/enable/disable).

* **Refactor**
  * Domain vs presentation boundaries reorganized and a consolidated public library API introduced; UI, wizards and widgets now use the unified API.

* **Tests**
  * Added and updated unit tests for the new API surface, task-state GPU detection, and the tmux arg parser.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/terok-ai/terok/pull/904)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->