### PR TITLE
fix(types): align with stricter sandbox/executor wheels — unblock typecheck CI

### DIFF
--- a/src/terok/cli/commands/setup.py
+++ b/src/terok/cli/commands/setup.py
@@ -217,7 +217,6 @@ def _run_image_build(*, base: str, family: str | None) -> bool:
             return False
         s.ok("built")
         return True
-    return False  # stage_line suppressed an unforeseen exception
 
 
 # ── Desktop entry phase (terok-specific, not in sandbox aggregator) ───
@@ -296,7 +295,6 @@ def _ensure_desktop_entry(*, policy: str) -> bool:
                 "install it for standard XDG registration"
             )
         return True
-    return False  # stage_line suppressed an unforeseen exception
 
 
 # ── Shell completions phase (best-effort, skipped silently if installed) ──

--- a/src/terok/cli/commands/uninstall.py
+++ b/src/terok/cli/commands/uninstall.py
@@ -130,7 +130,6 @@ def _uninstall_desktop_entry() -> bool:
             return False
         s.ok("removed")
         return True
-    return False  # stage_line suppressed an unforeseen exception
 
 
 def _uninstall_sandbox_stack(*, root: bool) -> bool:
@@ -153,7 +152,6 @@ def _uninstall_sandbox_stack(*, root: bool) -> bool:
             return False
         s.ok("clearance + gate + vault + shield removed")
         return True
-    return False  # stage_line suppressed an unforeseen exception
 
 
 def _purge_credential_db() -> bool:
@@ -172,4 +170,3 @@ def _purge_credential_db() -> bool:
             return False
         s.ok(f"removed {db_path}")
         return True
-    return False  # stage_line suppressed an unforeseen exception

--- a/src/terok/lib/orchestration/container_doctor.py
+++ b/src/terok/lib/orchestration/container_doctor.py
@@ -272,10 +272,11 @@ def _collect_all_checks(
     ssh_signer_port = get_ssh_signer_port(cfg)
     desired_shield = _read_desired_shield_state(task_dir)
 
-    if cfg.gate_port is None:
+    if cfg.gate_port is None or token_broker_port is None or ssh_signer_port is None:
         raise SystemExit(
-            "Gate server port is not configured — sickbay needs an explicit "
-            "gate.port in config.yml or auto-allocation enabled."
+            "Sandbox service ports are not all configured — sickbay needs "
+            "gate.port / vault.token_broker_port / vault.ssh_signer_port in "
+            "config.yml or auto-allocation enabled."
         )
 
     checks: list[DoctorCheck] = []


### PR DESCRIPTION
## Summary

PR #907 bumped the sibling wheels and introduced 7 mypy errors that turned the `typecheck` CI red on master.  Three orthogonal fixes, all surgical:

| File                                              | Error                                    | Fix                                                                                                                                                                                  |
|---------------------------------------------------|------------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
| `cli/commands/uninstall.py` (×3)                   | `unreachable`                            | `StageLine.__exit__` is now typed `-> None` (sandbox v0.0.115), so the defensive `return False` after each `with stage_line(...):` block is genuinely unreachable.  Dead lines deleted. |
| `cli/commands/setup.py` (×2)                       | `unreachable`                            | Same story.                                                                                                                                                                          |
| `lib/orchestration/container_doctor.py:291` (×2)   | `int \| None` passed where `int` expected | `get_token_broker_port` / `get_ssh_signer_port` now correctly return `int \| None` (was `int`).  Widen the existing `gate_port is None` guard in `_collect_all_checks` to cover all three sandbox service ports — same shape, same error message style. |

Net diff: **+4 / -8** across 3 files.

## Test plan

- [x] `make typecheck` — **Success: no issues found in 104 source files**
- [x] `make lint`, `make format --check`, `make tach` — green on changed files
- [x] Unit suite — **2269 / 2269 passing** locally
- [ ] CI on this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced validation in container health checks to require all sandbox service ports (gate, token broker, SSH signer) to be configured before proceeding.
  * Improved error handling in image-build helper to properly surface configuration issues.

* **Chores**
  * Code cleanup and minor documentation improvements.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/terok-ai/terok/pull/908)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->