### PR TITLE
feat(docs): generate coverage treemap locally instead of fetching from codecov

### DIFF
--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -51,11 +51,13 @@ jobs:
       - name: Run unit tests
         run: make test-unit
 
-      - name: Upload coverage for SonarQube Cloud
+      - name: Upload coverage for SonarQube Cloud and docs treemap
         uses: actions/upload-artifact@v7
         with:
           name: coverage
-          path: reports/coverage.xml
+          path: |
+            reports/coverage.xml
+            reports/coverage.json
           retention-days: 1
 
       - name: Save PR metadata

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -45,7 +45,7 @@ jobs:
           key: venv-${{ runner.os }}-py${{ steps.setup-python.outputs.python-version }}-docs-${{ hashFiles('**/pyproject.toml', '**/poetry.lock') }}
 
       - name: Install dependencies
-        run: poetry install --with dev,docs --no-interaction
+        run: poetry install --with dev,docs,test --no-interaction
 
       - name: Install scc (lines of code counter)
         run: |
@@ -54,13 +54,12 @@ jobs:
           echo "6c31f4d0cf3b7a8c5ca910fa4e451949434798f6541ec5dea4b83f4973e13772  scc_Linux_x86_64.tar.gz" | sha256sum -c
           sudo tar xzf scc_Linux_x86_64.tar.gz -C /usr/local/bin scc
 
-      - name: Fetch Codecov coverage treemap
-        run: |
-          mkdir -p docs/assets
-          curl -sfL "https://codecov.io/gh/terok-ai/terok/graphs/tree.svg?token=zfJUmuTAqG" \
-            -o docs/assets/coverage_treemap.svg
-          # Intentionally fatal: if the download fails, rerun the job manually.
-          [ -s docs/assets/coverage_treemap.svg ]
+      - name: Generate coverage data for treemap
+        # Unit tests produce reports/coverage.json, which mkdocs-terok's
+        # code_metrics generator turns into a local treemap SVG. Replaces
+        # the previous curl from codecov.io/.../tree.svg, which intermittently
+        # failed and required a manual workflow rerun.
+        run: make test-unit
 
       - name: Build documentation
         run: poetry run properdocs build --strict

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@
 
 REPORTS_DIR ?= reports
 COVERAGE_XML ?= $(REPORTS_DIR)/coverage.xml
+COVERAGE_JSON ?= $(REPORTS_DIR)/coverage.json
 UNIT_JUNIT_XML ?= $(REPORTS_DIR)/unit.junit.xml
 INTEGRATION_HOST_JUNIT_XML ?= $(REPORTS_DIR)/integration-host.junit.xml
 INTEGRATION_NETWORK_JUNIT_XML ?= $(REPORTS_DIR)/integration-network.junit.xml
@@ -29,7 +30,7 @@ test: test-unit
 
 test-unit:
 	mkdir -p $(REPORTS_DIR)
-	poetry run pytest tests/unit/ --cov=terok --cov-report=term-missing --cov-report=xml:$(COVERAGE_XML) --junitxml=$(UNIT_JUNIT_XML) -o junit_family=legacy
+	poetry run pytest tests/unit/ --cov=terok --cov-report=term-missing --cov-report=xml:$(COVERAGE_XML) --cov-report=json:$(COVERAGE_JSON) --junitxml=$(UNIT_JUNIT_XML) -o junit_family=legacy
 
 # Write Ruff's JSON report without failing on findings.
 ruff-report:

--- a/properdocs.yml
+++ b/properdocs.yml
@@ -62,6 +62,7 @@ plugins:
       code_metrics: true
       code_metrics_include_layer_overview: true
       code_metrics_include_graph_coarsening: true
+      code_metrics_coverage_json_path: reports/coverage.json
       code_metrics_src_label: "Source (`src/terok/`)"
       code_metrics_tests_label: "Tests (`tests/`)"
       test_map: true


### PR DESCRIPTION
## Summary
- Replace the brittle ``curl https://codecov.io/.../tree.svg`` step in ``docs.yml`` with mkdocs-terok's new local SVG treemap generator (shipped in v0.5.7a5, already pinned on master).
- ``test-unit`` now emits ``reports/coverage.json`` alongside ``coverage.xml``; ``analysis.yml`` bundles both into the ``coverage`` artifact for any downstream consumer.
- ``properdocs.yml`` adds ``code_metrics_coverage_json_path: reports/coverage.json`` to wire the generator.

## Why
Codecov's tree.svg endpoint flakes out semi-regularly and requires a manual workflow rerun to ship docs. Generating the treemap from our own coverage data — which we already collect for Sonar/Codecov uploads — removes that external dependency entirely.

## Test plan
- [x] ``ruff check .``
- [ ] CI: ``make test-unit`` still produces ``reports/coverage.xml`` (Sonar/Codecov inputs unchanged)
- [ ] CI: docs build produces ``coverage_treemap.svg`` via the new generator (no codecov curl)
- [ ] Visual: deployed pages site renders the local treemap correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Extended coverage reporting workflow to generate and upload coverage metrics in JSON format alongside existing coverage report formats for improved tooling integration.
  * Refactored documentation build process to generate coverage metrics locally, eliminating dependency on external coverage data sources and improving build consistency.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/terok-ai/terok/pull/909)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->