### PR TITLE
docs: seed CHANGELOG.md for the first PyPI release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Changelog
+
+Per-release notes live on the [GitHub Releases page][rel], which is
+also the "Changelog" link in PyPI metadata.
+
+[rel]: https://github.com/terok-ai/terok/releases
+
+## v0.8.0 — first PyPI release
+
+`terok` joined PyPI in v0.8.0. Versions before that were GitHub Release
+wheels only.

--- a/README.md
+++ b/README.md
@@ -83,8 +83,7 @@ Optional but recommended:
 ### Installation
 
 ```bash
-# Install the latest release wheel (download from GitHub Releases page)
-pipx install ./terok-*.whl
+pipx install terok
 ```
 
 ### One-time setup

--- a/docs/index.md
+++ b/docs/index.md
@@ -57,8 +57,7 @@ Python packages.
 ### Installation
 
 ```bash
-# Download the latest .whl from the GitHub Releases page, then:
-pipx install ./terok-*.whl
+pipx install terok
 ```
 
 ### One-time setup

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -25,14 +25,13 @@ Complete guide to installing, configuring, and using terok.
 ### Recommended: pipx
 
 ```bash
-# Download the latest .whl from the GitHub Releases page, then:
-pipx install ./terok-*.whl
+pipx install terok
 ```
 
 ### Alternative: pip
 
 ```bash
-pip install ./terok-*.whl
+pip install terok
 ```
 
 After install, the `terok` command is on `$PATH`.  Run it with no arguments


### PR DESCRIPTION
Adds a minimal `CHANGELOG.md` stub pointing at the GH Releases page (which is also the 'Changelog' link in our `pyproject.toml` `[project.urls]`), with a single forward-looking entry for the upcoming first PyPI release of this package as a minor bump.

Once the prep+notes editor flow ([terok-warden/terok-toolbox#2](https://github.com/terok-warden/terok-toolbox/issues/2)) lands, the chain script will write executive-summary text into both this file and the GH release body simultaneously.

Companion to the analogous PRs on the rest of the terok-ai family.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Initialized `CHANGELOG.md` with project release notes documentation and instructions directing users to the GitHub Releases page for detailed per-release information. Added first documented release entry for v0.8.0.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/terok-ai/terok/pull/910)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->