### PR TITLE
docs(readme): align REUSE badge alt text with sibling repos

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # terok
 
 [![License: Apache-2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
-[![REUSE compliant](https://api.reuse.software/badge/github.com/terok-ai/terok)](https://api.reuse.software/info/github.com/terok-ai/terok)
+[![REUSE status](https://api.reuse.software/badge/github.com/terok-ai/terok)](https://api.reuse.software/info/github.com/terok-ai/terok)
 [![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=terok-ai_terok&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=terok-ai_terok)
 
 > [!WARNING]


### PR DESCRIPTION
## Summary
- Use \`REUSE status\` (matching every other terok-ai repo) instead of \`REUSE compliant\`.