### PR TITLE
ci(release): set GH prerelease flag for alpha tags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -70,6 +70,20 @@ jobs:
       # for the GH release.  The actor check stays on pypi-publish /
       # testpypi-publish where the consequence is external publication.
 
+      # Alpha tags (vX.Y.ZaN, PEP 440 pre-release) get the GH prerelease
+      # flag; final vX.Y.Z tags do not.  Belt-and-suspenders alongside
+      # the release-chain script's `gh release create --prerelease`.
+      - name: Classify tag (final vs prerelease)
+        id: classify
+        env:
+          REF_NAME: ${{ github.ref_name }}
+        run: |
+          if [[ "$REF_NAME" =~ ^v[0-9]+\.[0-9]+\.[0-9]+a[0-9]+$ ]]; then
+            echo "prerelease=true"  >> "$GITHUB_OUTPUT"
+          else
+            echo "prerelease=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - uses: actions/download-artifact@v4
         with:
           name: dist
@@ -78,6 +92,7 @@ jobs:
       - uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v2
         with:
           files: dist/*
+          prerelease: ${{ steps.classify.outputs.prerelease }}
 
   pypi-publish:
     needs: build


### PR DESCRIPTION
## Summary
- Add a classify step to `release.yml`'s `github-release` job that derives a `prerelease` boolean from `${{ github.ref_name }}` using the regex `^v[0-9]+\.[0-9]+\.[0-9]+a[0-9]+$`.
- Pass the result to `softprops/action-gh-release` so alpha tags (`vX.Y.ZaN`) land as GH prereleases; final `vX.Y.Z` tags remain regular releases.

## Why
Companion to [terok-warden/terok-toolbox#15](https://github.com/terok-warden/terok-toolbox/pull/15) which adds `--version-step=alpha` to the release-chain script. The script already calls `gh release create --prerelease` itself, but the workflow change makes the `prerelease` flag correct regardless of:
- whether the script wins the race against the workflow's gh-release step
- whether the tag was pushed manually (outside the script)

## Test plan
- [x] Existing v0.x.y final tags continue to classify as `prerelease=false`.
- [ ] First alpha cut (next dev cycle) produces a release with the prerelease badge.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved release workflow to better classify and handle version releases.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/terok-ai/terok/pull/913)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->