### PR TITLE
docs: convert Sphinx :role: cross-refs to mkdocstrings autoref form

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -64,6 +64,7 @@ make spdx NAME="Real Human Name" FILES="src/terok/new_file.py"  # Add SPDX heade
 - **Imports**: Sorted with isort (part of ruff)
 - **Type hints**: Use Python 3.12+ type hints
 - **Docstrings**: Required for all public functions, classes, and modules (enforced by `docstr-coverage` at 95% minimum in CI)
+- **Cross-references in docstrings**: use mkdocstrings autoref syntax `` [`Name`][module.path.Name] `` — never the Sphinx ``:class:`Name``` / ``:func:`name``` forms. Sphinx roles render as literal text on the rendered docs site (mkdocstrings doesn't process them). Prefer the explicit full path over the bare `` [`Name`][] `` autoref form: explicit paths keep `properdocs build --strict` green even when the symbol's short name isn't unique. For external symbols, use the dependency's own path (e.g. `` [`Sandbox`][terok_sandbox.Sandbox] ``, `` [`StreamReader`][asyncio.StreamReader] ``) — those resolve via the inventories listed in `properdocs.yml`.
 - **Testing**: Add tests for new functionality; maintain coverage
 - **SPDX headers**: Every source file (`.py`, `.sh`, etc.) must have an SPDX header. Use `make spdx` to add or update it — it handles both new files and existing files correctly:
   ```bash

--- a/src/terok/cli/commands/acp.py
+++ b/src/terok/cli/commands/acp.py
@@ -146,7 +146,7 @@ def _check_experimental_ack() -> None:
     here is limited.
 
     Gates on the codebase's standard experimental axis
-    (:func:`is_experimental` — ``--experimental`` flag or
+    ([`is_experimental`][terok.lib.core.config.is_experimental] — ``--experimental`` flag or
     ``experimental: true`` in ``config.yml``); same axis as
     claude-OAuth-proxying, codex-vaulted-OAuth, and friends.
     """
@@ -168,7 +168,7 @@ def _check_experimental_ack() -> None:
 def _cmd_connect(project_id: str, task_id: str) -> None:
     """Bridge the caller's stdio to a task's ACP socket.
 
-    Refuses to run unless :func:`_check_experimental_ack` passes.
+    Refuses to run unless [`_check_experimental_ack`][terok.cli.commands.acp._check_experimental_ack] passes.
     Otherwise spawns the executor's per-container ACP daemon if the
     socket is not already live, waits for it to bind, then runs the
     in-process pump (stdin → AF_UNIX socket, socket → stdout) until
@@ -241,7 +241,7 @@ def _wait_for_socket(
     Polls *daemon* alongside the bind probe so a startup crash surfaces
     immediately with the daemon's exit code instead of stalling the
     full *timeout* and reporting a misleading "did not bind" error.
-    Both failure paths exit via :func:`_fail` so the message reaches
+    Both failure paths exit via [`_fail`][terok.cli.commands.acp._fail] so the message reaches
     stderr (and any ACP client that captures the agent subprocess's
     stderr, like Zed at WARN level), naming *log_path* so the user
     can read the daemon's traceback.
@@ -283,13 +283,13 @@ def _inprocess_pump(sock_path: Path, *, log_path: Path) -> None:
     stdin EOF triggers ``shutdown(SHUT_WR)`` so the daemon can drain
     its final reply; daemon EOF returns from the loop and the
     ``finally`` block closes the socket.  Non-blocking IO with
-    :func:`select` for multiplexing; partial sends/writes are looped
+    [`select`][] for multiplexing; partial sends/writes are looped
     until drained.
 
     A ``ConnectionResetError`` from ``recv`` means the daemon's
     process ended abruptly mid-session — the kernel sends RST when
     there are unread bytes the daemon will never process.  That gets
-    surfaced via :func:`_fail` (stderr-only, exit 1) pointing the
+    surfaced via [`_fail`][terok.cli.commands.acp._fail] (stderr-only, exit 1) pointing the
     user at *log_path* where the daemon's traceback lives, rather
     than letting a bare Python stack from the bridge escape.
     """
@@ -357,7 +357,7 @@ def _forward_socket_to_stdout(sock: socket.socket, stdout_fd: int, log_path: Pat
 
     A ``ConnectionResetError`` from ``recv`` means the daemon process
     died with bytes still in its receive buffer (kernel sends RST,
-    not FIN).  Surface it via :func:`_fail` so the user sees a
+    not FIN).  Surface it via [`_fail`][terok.cli.commands.acp._fail] so the user sees a
     pointer to *log_path* on stderr — never a bare Python traceback.
     """
     try:

--- a/src/terok/lib/domain/project.py
+++ b/src/terok/lib/domain/project.py
@@ -231,7 +231,7 @@ class DeleteProjectResult(TypedDict):
 class ACPEndpoint:
     """One per-task ACP endpoint as visible from the host.
 
-    Constructed by :meth:`Project.acp_endpoints`; consumed by the CLI
+    Constructed by [`acp_endpoints`][terok.lib.domain.project.Project.acp_endpoints]; consumed by the CLI
     (``terok acp list``) and the TUI panel.  Carries enough state to
     render a status row without forcing the listing path to actually
     probe or open the socket.
@@ -247,7 +247,7 @@ class ACPEndpoint:
     """Where the proxy daemon would bind (or has bound) the socket.
 
     The path is computed deterministically from the task id and may not
-    yet exist on disk — :attr:`status` records whether it does.
+    yet exist on disk — [`status`][terok.lib.domain.task.Task.status] records whether it does.
     """
 
     status: ACPEndpointStatus
@@ -628,7 +628,7 @@ class Project:
         return [Task(self._config, m) for m in metas]
 
     def acp_endpoints(self) -> list[ACPEndpoint]:
-        """Return one :class:`ACPEndpoint` per running task.
+        """Return one [`ACPEndpoint`][terok.lib.domain.project.ACPEndpoint] per running task.
 
         Cheap discovery surface — walks running tasks, classifies each
         endpoint as ``active`` (daemon up, socket bound), ``ready``

--- a/src/terok/lib/util/text_wrap.py
+++ b/src/terok/lib/util/text_wrap.py
@@ -3,7 +3,7 @@
 
 """Hanging-indent wrapping for prefix-aligned TUI labels.
 
-Wrapping itself is delegated to :func:`textwrap.wrap` (which already breaks
+Wrapping itself is delegated to [`wrap`][textwrap.wrap] (which already breaks
 on hyphens and folds overlong dashless words). This helper exists only to
 stitch together a cell-aware *prefix* (which may contain wide characters
 like emoji that would throw off ``textwrap``'s char-count accounting), the
@@ -20,7 +20,7 @@ from rich.cells import cell_len
 def wrap_with_hanging_indent(prefix: str, body: str, suffix: str, width: int) -> str:
     """Render ``prefix + body + suffix`` with continuation lines hanging-indented.
 
-    *body* wraps with :func:`textwrap.wrap` (so dashes are break points and
+    *body* wraps with [`wrap`][textwrap.wrap] (so dashes are break points and
     overlong segments fold by character). Continuation lines are prepended
     with spaces aligning to the *cell* width of *prefix*, so they sit
     underneath the start of *body* even when *prefix* contains emoji.

--- a/src/terok/tui/widgets/task_detail.py
+++ b/src/terok/tui/widgets/task_detail.py
@@ -212,7 +212,7 @@ class TaskDetails(Static):
         """Render the cached task into the inner Static at the current width.
 
         Named ``_redraw_content`` (not ``_render``) because Textual's
-        :class:`~textual.widget.Widget` already defines ``_render(self) ->
+        [`Widget`][textual.widget.Widget] already defines ``_render(self) ->
         Visual`` as part of its rendering pipeline; shadowing that method
         crashes the renderer with ``'NoneType' has no attribute
         'render_strips'`` when this Widget gets repainted.


### PR DESCRIPTION
## Summary

Convert every `:class:`/`:func:`/`:meth:`/`:mod:`/`:attr:` Sphinx-style cross-reference in source docstrings to mkdocstrings' `[`Name`][module.path.Name]` autoref form. mkdocstrings doesn't process Sphinx info-field roles, so the originals rendered as **literal text** on the docs site (e.g. "Public surface: :class:ACPRoster, :class:AgentRosterCache, …") instead of as links.

Also adds an AGENTS.md bullet under "Coding Standards" / "Code style" so future changes don't re-introduce the Sphinx forms.

## What changed

- All converted docstrings now produce real `<a class="autorefs autorefs-internal">` links in rendered HTML, with hover tooltips showing the target's signature.
- External symbols (asyncio, terok-sandbox, …) use the dependency's own path so they resolve via the inventories listed in `properdocs.yml`.
- A handful of imprecise docstring refs (e.g. `Sandbox.runtime.exec_stdio` → `terok_sandbox.ContainerRuntime.exec_stdio`, `acp.schema.X` demoted to plain `` `code` `` text since agent-client-protocol publishes no inventory) were corrected by hand.
- AGENTS.md gains one bullet calling out the autoref convention.

## Verification

`poetry run properdocs build --strict` passes locally with **zero autoref warnings** in this repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)