### PR TITLE
fix(desktop): shrink Ptyxis gate to PATH presence; degrade gracefully

### DIFF
--- a/src/terok/cli/commands/_desktop_entry.py
+++ b/src/terok/cli/commands/_desktop_entry.py
@@ -30,11 +30,13 @@ when the fallback kicks in.
 
 The passive assets (``.desktop`` template, logo PNG) live under
 ``terok/resources/desktop/`` — this module is the *builder* that
-renders them and delegates to the XDG tool of choice.  When both
-``ptyxis`` and ``xdg-terminal-exec`` are on PATH, `_render_desktop_file`
-routes the launch through the bundled ``terok-xdg-terminal-exec.sh``
-shim to dodge a Ptyxis standalone-mode bug; see that helper and the
-shim's header for the rationale.
+renders them and delegates to the XDG tool of choice.  When ``ptyxis``
+is on PATH, `_render_desktop_file` routes the launch through the
+bundled ``terok-xdg-terminal-exec.sh`` shim to dodge a Ptyxis
+standalone-mode bug — Fedora patches GLib to inject ``ptyxis`` into
+GIO's hardcoded ``known_terminals[]`` (right after ``xdg-terminal-exec``)
+so a vanilla ``Terminal=true`` launcher ends up as ``ptyxis -- terok-tui``,
+which trips the bug.  See the shim's header for the rationale.
 """
 
 from __future__ import annotations
@@ -325,7 +327,19 @@ def _data_home() -> Path:
 
 def _render_desktop_file(bin_str: str) -> str:
     """Render ``terok.desktop`` with the right Exec / TryExec / Terminal values."""
-    if shutil.which("ptyxis") and shutil.which("xdg-terminal-exec"):
+    # We gate on `ptyxis` alone.  A more precise "is this a Fedora-
+    # patched glib" probe exists — `grep -aow ptyxis /lib64/libgio-2.0.so.0`
+    # exits 0 iff Fedora's `default-terminal.patch` injected
+    # { "ptyxis", "--" } into gio's hardcoded `known_terminals[]` — but
+    # it's (a) un-pythonic (shelling out to grep at a fixed sopath) and
+    # (b) not actually sufficient: when `xdg-terminal-exec` is installed
+    # it precedes ptyxis in the glib list and consults the user's
+    # `xdg-terminals.list`, so the rodata literal mis-predicts the
+    # real launch.  Hijacking on PATH-presence is over-eager on hosts
+    # where vanilla glib wouldn't pick ptyxis anyway, but that's fine
+    # — the user installed Ptyxis on purpose; the shim gives them the
+    # container-tabs UI they want.
+    if shutil.which("ptyxis"):
         shim = str(_resource_dir().joinpath(_PTYXIS_SHIM_NAME))
         variables = {
             "EXEC": f"/bin/sh {shim} {bin_str}",

--- a/src/terok/resources/desktop/terok-xdg-terminal-exec.sh
+++ b/src/terok/resources/desktop/terok-xdg-terminal-exec.sh
@@ -23,6 +23,7 @@ _notify() {
             'Terok launcher' "$msg" 2>/dev/null || true
     fi
     printf 'terok-ptyxis-shim: %s\n' "$msg" >&2
+    return 0
 }
 
 if command -v ptyxis >/dev/null 2>&1; then

--- a/src/terok/resources/desktop/terok-xdg-terminal-exec.sh
+++ b/src/terok/resources/desktop/terok-xdg-terminal-exec.sh
@@ -2,17 +2,36 @@
 # SPDX-FileCopyrightText: 2026 Jiri Vyskocil
 # SPDX-License-Identifier: Apache-2.0
 #
-# Ptyxis-aware shim around xdg-terminal-exec.  Used only when the Terok
-# .desktop launcher's install-time gate fires (both `ptyxis` and
-# `xdg-terminal-exec` on PATH).  Background and rationale: see the
-# Ptyxis-shim section of src/terok/cli/commands/_desktop_entry.py.
+# Ptyxis launcher shim — opens the host command in a fresh Ptyxis
+# window with the normal UI (container tabs, sidebar) instead of the
+# standalone single-command mode that GIO's `Terminal=true` path would
+# produce on Fedora.  Used only when the Terok .desktop launcher's
+# install-time gate fires (`ptyxis` on PATH).  Background and rationale:
+# see the Ptyxis-shim section of src/terok/cli/commands/_desktop_entry.py.
+#
+# Runtime degradation: install-time presence of ptyxis is not enough —
+# the operator may uninstall it later without re-running `terok setup`,
+# so the launcher would invoke this shim against a missing binary.
+# Cascade: ptyxis → xdg-terminal-exec → hard failure with a desktop
+# notification (gnome-shell-launched processes have stderr routed to
+# the journal, so an unsurfaced failure looks like nothing happened).
 
-xdg=$(command -v xdg-terminal-exec) || {
-    printf 'terok-xdg-terminal-exec: xdg-terminal-exec not on PATH\n' >&2
-    exit 127
+_notify() {
+    msg=$1
+    if command -v notify-send >/dev/null 2>&1; then
+        notify-send --app-name=Terok --icon=terok --urgency=critical \
+            'Terok launcher' "$msg" 2>/dev/null || true
+    fi
+    printf 'terok-ptyxis-shim: %s\n' "$msg" >&2
 }
 
-case $("$xdg" --print-id 2>/dev/null) in
-    org.gnome.Ptyxis*) exec ptyxis --new-window --title=Terok -- "$@" ;;
-    *)                 exec "$xdg" "$@" ;;
-esac
+if command -v ptyxis >/dev/null 2>&1; then
+    exec ptyxis --new-window --title=Terok -- "$@"
+fi
+
+if command -v xdg-terminal-exec >/dev/null 2>&1; then
+    exec xdg-terminal-exec "$@"
+fi
+
+_notify "Cannot launch Terok: ptyxis is no longer installed and no xdg-terminal-exec fallback is available. Run 'terok setup' again to refresh the launcher."
+exit 127

--- a/tests/unit/cli/test_desktop_entry.py
+++ b/tests/unit/cli/test_desktop_entry.py
@@ -508,12 +508,18 @@ def _which_only(present: set[str]) -> object:
 
 
 class TestPtyxisGate:
-    """When both ptyxis and xdg-terminal-exec are on PATH, route Exec through the shim."""
+    """When ptyxis is on PATH, route Exec through the shim — else standard form.
+
+    The gate fires on ptyxis alone because Fedora patches GLib to inject
+    ptyxis into GIO's hardcoded ``known_terminals[]`` table, so any
+    ``Terminal=true`` launcher on F40+ becomes ``ptyxis -- terok-tui``
+    and trips Ptyxis's standalone-mode bug (no container tabs).
+    """
 
     @pytest.mark.parametrize(
         "present",
-        [set(), {"ptyxis"}, {"xdg-terminal-exec"}],
-        ids=["nothing", "only-ptyxis", "only-xdg-terminal-exec"],
+        [set(), {"xdg-terminal-exec"}],
+        ids=["nothing", "no-ptyxis"],
     )
     def test_gate_inactive_renders_standard_form(
         self,
@@ -531,10 +537,19 @@ class TestPtyxisGate:
         assert "TryExec=/usr/local/bin/terok-tui" in content
         assert "terok-xdg-terminal-exec" not in content
 
-    def test_gate_active_routes_through_shim(self, xdg_data_home: Path) -> None:
+    @pytest.mark.parametrize(
+        "present",
+        [{"ptyxis"}, {"ptyxis", "xdg-terminal-exec"}],
+        ids=["only-ptyxis", "ptyxis-and-xdg-terminal-exec"],
+    )
+    def test_gate_active_routes_through_shim(
+        self,
+        xdg_data_home: Path,
+        present: set[str],
+    ) -> None:
         with mock.patch(
             "terok.cli.commands._desktop_entry.shutil.which",
-            side_effect=_which_only({"ptyxis", "xdg-terminal-exec"}),
+            side_effect=_which_only(present),
         ):
             desktop.install_desktop_entry("/usr/local/bin/terok-tui")
         content = (xdg_data_home / "applications" / "terok.desktop").read_text()


### PR DESCRIPTION
## Summary

- Drop the install-time `xdg-terminal-exec` co-requirement from the desktop-file Ptyxis gate. On Fedora 44 / GNOME Shell 50 `xdg-terminal-exec` isn't installed by default, so the gate stayed inactive and the launcher fell to `Terminal=true` — which Fedora's `default-terminal.patch` for glib2 (injects `{ "ptyxis", "--" }` into gio's hardcoded `known_terminals[]`) translates to `ptyxis -- terok-tui`, landing in Ptyxis's standalone single-command mode (no container tabs).
- New gate: `shutil.which("ptyxis")` alone. The shim is now responsible for one thing — invoke `ptyxis --new-window --title=Terok -- "$@"` so the launcher always opens the full Ptyxis UI.
- Shim cascades **ptyxis → `xdg-terminal-exec` → hard failure with a `notify-send` desktop notification** asking the operator to re-run `terok setup`. gnome-shell-spawned stderr goes to the journal, so an unsurfaced failure looked like nothing happened — the notification gives an actionable hint when ptyxis is uninstalled between setup and a launcher click.
- Inline comment near the gate documents the `grep -aow ptyxis /lib64/libgio-2.0.so.0` rodata probe we considered for Fedora-precision and why it's neither pythonic (shelling out to grep at a fixed sopath) nor sufficient (when `xdg-terminal-exec` is installed, it precedes ptyxis in glib's list and can route to a non-Ptyxis default via `xdg-terminals.list`).

## Test plan

- [x] `pytest tests/unit/cli/test_desktop_entry.py` — 29/29 pass; gate-cases reparametrised to flip `only-ptyxis` from "standard form" to "shim form" and add `ptyxis-and-xdg-terminal-exec` to the active-gate side.
- [x] `pytest tests/unit -q` — 2269/2269 pass.
- [x] `ruff check` clean on touched files.
- [x] `shellcheck terok-xdg-terminal-exec.sh` clean.
- [x] Live verification in an F44 container with ptyxis + xdg-terminal-exec + libnotify installed:
  - happy path → `exec`s `ptyxis --new-window --title=Terok -- ...`
  - PATH stripped of ptyxis → falls through to `xdg-terminal-exec`
  - PATH stripped of both → emits the `notify-send` notification, exits 127

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Terminal launcher now prioritizes `ptyxis` when available, with graceful fallback support
  * Added desktop notifications when terminal initialization fails, improving error visibility to users

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/terok-ai/terok/pull/926)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->