### PR TITLE
feat(tui): encrypted credential DB in terok-sandbox vault

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1445,6 +1445,85 @@ files = [
 ]
 
 [[package]]
+name = "jaraco-classes"
+version = "3.4.0"
+description = "Utility functions for Python class constructs"
+optional = false
+python-versions = ">=3.8"
+groups = ["main"]
+files = [
+    {file = "jaraco.classes-3.4.0-py3-none-any.whl", hash = "sha256:f662826b6bed8cace05e7ff873ce0f9283b5c924470fe664fff1c2f00f581790"},
+    {file = "jaraco.classes-3.4.0.tar.gz", hash = "sha256:47a024b51d0239c0dd8c8540c6c7f484be3b8fcf0b2d85c13825780d3b3f3acd"},
+]
+
+[package.dependencies]
+more-itertools = "*"
+
+[package.extras]
+docs = ["furo", "jaraco.packaging (>=9.3)", "jaraco.tidelift (>=1.4)", "rst.linker (>=1.9)", "sphinx (>=3.5)", "sphinx-lint"]
+testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=2.2)", "pytest-mypy", "pytest-ruff (>=0.2.1)"]
+
+[[package]]
+name = "jaraco-context"
+version = "6.1.2"
+description = "Useful decorators and context managers"
+optional = false
+python-versions = ">=3.10"
+groups = ["main"]
+files = [
+    {file = "jaraco_context-6.1.2-py3-none-any.whl", hash = "sha256:bf8150b79a2d5d91ae48629d8b427a8f7ba0e1097dd6202a9059f29a36379535"},
+    {file = "jaraco_context-6.1.2.tar.gz", hash = "sha256:f1a6c9d391e661cc5b8d39861ff077a7dc24dc23833ccee564b234b81c82dfe3"},
+]
+
+[package.extras]
+check = ["pytest-checkdocs (>=2.14)", "pytest-ruff (>=0.2.1) ; sys_platform != \"cygwin\""]
+cover = ["pytest-cov"]
+doc = ["furo", "jaraco.packaging (>=9.3)", "jaraco.tidelift (>=1.4)", "rst.linker (>=1.9)", "sphinx (>=3.5)", "sphinx-lint"]
+enabler = ["pytest-enabler (>=3.4)"]
+test = ["jaraco.test (>=5.6.0)", "portend", "pytest (>=6,!=8.1.*)"]
+type = ["pytest-mypy (>=1.0.1) ; platform_python_implementation != \"PyPy\""]
+
+[[package]]
+name = "jaraco-functools"
+version = "4.4.0"
+description = "Functools like those found in stdlib"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+files = [
+    {file = "jaraco_functools-4.4.0-py3-none-any.whl", hash = "sha256:9eec1e36f45c818d9bf307c8948eb03b2b56cd44087b3cdc989abca1f20b9176"},
+    {file = "jaraco_functools-4.4.0.tar.gz", hash = "sha256:da21933b0417b89515562656547a77b4931f98176eb173644c0d35032a33d6bb"},
+]
+
+[package.dependencies]
+more_itertools = "*"
+
+[package.extras]
+check = ["pytest-checkdocs (>=2.4)", "pytest-ruff (>=0.2.1) ; sys_platform != \"cygwin\""]
+cover = ["pytest-cov"]
+doc = ["furo", "jaraco.packaging (>=9.3)", "jaraco.tidelift (>=1.4)", "rst.linker (>=1.9)", "sphinx (>=3.5)", "sphinx-lint"]
+enabler = ["pytest-enabler (>=3.4)"]
+test = ["jaraco.classes", "pytest (>=6,!=8.1.*)"]
+type = ["mypy (<1.19) ; platform_python_implementation == \"PyPy\"", "pytest-mypy (>=1.0.1)"]
+
+[[package]]
+name = "jeepney"
+version = "0.9.0"
+description = "Low-level, pure Python DBus protocol wrapper."
+optional = false
+python-versions = ">=3.7"
+groups = ["main"]
+markers = "sys_platform == \"linux\""
+files = [
+    {file = "jeepney-0.9.0-py3-none-any.whl", hash = "sha256:97e5714520c16fc0a45695e5365a2e11b81ea79bba796e26f9f1d178cb182683"},
+    {file = "jeepney-0.9.0.tar.gz", hash = "sha256:cf0e9e845622b81e4a28df94c40345400256ec608d0e55bb8a3feaa9163f5732"},
+]
+
+[package.extras]
+test = ["async-timeout ; python_version < \"3.11\"", "pytest", "pytest-asyncio (>=0.17)", "pytest-trio", "testpath", "trio"]
+trio = ["trio"]
+
+[[package]]
 name = "jinja2"
 version = "3.1.6"
 description = "A very fast and expressive template engine."
@@ -1461,6 +1540,35 @@ MarkupSafe = ">=2.0"
 
 [package.extras]
 i18n = ["Babel (>=2.7)"]
+
+[[package]]
+name = "keyring"
+version = "25.7.0"
+description = "Store and access your passwords safely."
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+files = [
+    {file = "keyring-25.7.0-py3-none-any.whl", hash = "sha256:be4a0b195f149690c166e850609a477c532ddbfbaed96a404d4e43f8d5e2689f"},
+    {file = "keyring-25.7.0.tar.gz", hash = "sha256:fe01bd85eb3f8fb3dd0405defdeac9a5b4f6f0439edbb3149577f244a2e8245b"},
+]
+
+[package.dependencies]
+"jaraco.classes" = "*"
+"jaraco.context" = "*"
+"jaraco.functools" = "*"
+jeepney = {version = ">=0.4.2", markers = "sys_platform == \"linux\""}
+pywin32-ctypes = {version = ">=0.2.0", markers = "sys_platform == \"win32\""}
+SecretStorage = {version = ">=3.2", markers = "sys_platform == \"linux\""}
+
+[package.extras]
+check = ["pytest-checkdocs (>=2.4)", "pytest-ruff (>=0.2.1) ; sys_platform != \"cygwin\""]
+completion = ["shtab (>=1.1.0)"]
+cover = ["pytest-cov"]
+doc = ["furo", "jaraco.packaging (>=9.3)", "jaraco.tidelift (>=1.4)", "rst.linker (>=1.9)", "sphinx (>=3.5)", "sphinx-lint"]
+enabler = ["pytest-enabler (>=3.4)"]
+test = ["pyfakefs", "pytest (>=6,!=8.1.*)"]
+type = ["pygobject-stubs", "pytest-mypy (>=1.0.1)", "shtab", "types-pywin32"]
 
 [[package]]
 name = "librt"
@@ -2000,6 +2108,18 @@ files = [
 griffelib = ">=2.0"
 mkdocs-autorefs = ">=1.4"
 mkdocstrings = ">=0.30"
+
+[[package]]
+name = "more-itertools"
+version = "11.0.2"
+description = "More routines for operating on iterables, beyond itertools"
+optional = false
+python-versions = ">=3.10"
+groups = ["main"]
+files = [
+    {file = "more_itertools-11.0.2-py3-none-any.whl", hash = "sha256:6e35b35f818b01f691643c6c611bc0902f2e92b46c18fffa77ae1e7c46e912e4"},
+    {file = "more_itertools-11.0.2.tar.gz", hash = "sha256:392a9e1e362cbc106a2457d37cabf9b36e5e12efd4ebff1654630e76597df804"},
+]
 
 [[package]]
 name = "msgpack"
@@ -2990,6 +3110,19 @@ files = [
 ]
 
 [[package]]
+name = "pywin32-ctypes"
+version = "0.2.3"
+description = "A (partial) reimplementation of pywin32 using ctypes/cffi"
+optional = false
+python-versions = ">=3.6"
+groups = ["main"]
+markers = "sys_platform == \"win32\""
+files = [
+    {file = "pywin32-ctypes-0.2.3.tar.gz", hash = "sha256:d162dc04946d704503b2edc4d55f3dba5c1d539ead017afa00142c38b9885755"},
+    {file = "pywin32_ctypes-0.2.3-py3-none-any.whl", hash = "sha256:8a1513379d709975552d202d942d9837758905c8d01eb82b8bcc30918929e7b8"},
+]
+
+[[package]]
 name = "pyyaml"
 version = "6.0.3"
 description = "YAML parser and emitter for Python"
@@ -3201,6 +3334,23 @@ files = [
 ]
 
 [[package]]
+name = "secretstorage"
+version = "3.5.0"
+description = "Python bindings to FreeDesktop.org Secret Service API"
+optional = false
+python-versions = ">=3.10"
+groups = ["main"]
+markers = "sys_platform == \"linux\""
+files = [
+    {file = "secretstorage-3.5.0-py3-none-any.whl", hash = "sha256:0ce65888c0725fcb2c5bc0fdb8e5438eece02c523557ea40ce0703c266248137"},
+    {file = "secretstorage-3.5.0.tar.gz", hash = "sha256:f04b8e4689cbce351744d5537bf6b1329c6fc68f91fa666f60a380edddcd11be"},
+]
+
+[package.dependencies]
+cryptography = ">=2.0"
+jeepney = ">=0.6"
+
+[[package]]
 name = "shellingham"
 version = "1.5.4"
 description = "Tool to Detect Surrounding Shell"
@@ -3234,6 +3384,94 @@ groups = ["dev"]
 files = [
     {file = "smmap-5.0.3-py3-none-any.whl", hash = "sha256:c106e05d5a61449cf6ba9a1e650227ecfb141590d2a98412103ff35d89fc7b2f"},
     {file = "smmap-5.0.3.tar.gz", hash = "sha256:4d9debb8b99007ae47165abc08670bd74cb74b5227dda7f643eccc4e9eb5642c"},
+]
+
+[[package]]
+name = "sqlcipher3"
+version = "0.6.2"
+description = "DB-API 2.0 interface for SQLCipher 4.x"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+files = [
+    {file = "sqlcipher3-0.6.2-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:42df4c5e4b8843a658a36f11d1158227c078efa8d36ab9b4b2389a0c76163be3"},
+    {file = "sqlcipher3-0.6.2-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:046b9b9ca206b3e4490e1ce31826a7f8128895c524b1d763bba16a2a22d27409"},
+    {file = "sqlcipher3-0.6.2-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:a37967693e4a3bc40a532ced0e333293b3b856a0b261958c82313a9bb0517cf9"},
+    {file = "sqlcipher3-0.6.2-cp310-cp310-manylinux_2_28_aarch64.whl", hash = "sha256:c36bcb87969a7a1176106e1f97d9e6552823c09c72237293edf1598019919e46"},
+    {file = "sqlcipher3-0.6.2-cp310-cp310-manylinux_2_28_i686.whl", hash = "sha256:78ed6d21df4b4742c9fc0bc1e6fe7f675af11f812e028530eb41daa12abed6fe"},
+    {file = "sqlcipher3-0.6.2-cp310-cp310-manylinux_2_28_x86_64.whl", hash = "sha256:cc76dd6dbdbb82383dcd746116f7f83ecc9f1d49d590fd556462ecb3aefc1678"},
+    {file = "sqlcipher3-0.6.2-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:c67330d041b174884dc8498d06c41ed3c88386f05b340a055b10ce1ad96a853c"},
+    {file = "sqlcipher3-0.6.2-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:9929444703eec43728f0a1f0dcfdf8cebf732c7b880c6af8e03bf1cf3a62e4d9"},
+    {file = "sqlcipher3-0.6.2-cp310-cp310-win32.whl", hash = "sha256:931309d6bfdfd43b8453a284ea57185c6a415b15f8849680ab17fc82bd4c43fa"},
+    {file = "sqlcipher3-0.6.2-cp310-cp310-win_amd64.whl", hash = "sha256:f58db62e3e3324c2c6b3816dbcdb2416935be4703417b8956070754fd7b03d0b"},
+    {file = "sqlcipher3-0.6.2-cp310-cp310-win_arm64.whl", hash = "sha256:cf5ff0786b0a2a36dd0974264a7be182db5610eba1c14ce2745ed25c37a074ad"},
+    {file = "sqlcipher3-0.6.2-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:87432804bf88e9017fc174bdd3d0862a1d1e9ef3c755517595c91da2c59e3808"},
+    {file = "sqlcipher3-0.6.2-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:eece737c583c285e9bbe3bf829eee3b6624eb6e9dad8ccff7821a45641f436dd"},
+    {file = "sqlcipher3-0.6.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:22e6502c364706fe64695219877f2bb01cdb25450bec81e69c8a08deff8c14ee"},
+    {file = "sqlcipher3-0.6.2-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:0ca92202881bcb69b3703b744b40a3a3476e122d4612a82eb2b0a36f2f78de1d"},
+    {file = "sqlcipher3-0.6.2-cp311-cp311-manylinux_2_28_i686.whl", hash = "sha256:15abe3de01faa194f1aaea144ff9ecbfdce2991964dcc7ce8ec1ecc5950a4bc4"},
+    {file = "sqlcipher3-0.6.2-cp311-cp311-manylinux_2_28_x86_64.whl", hash = "sha256:0f08e5bb5eb1ab93819c444ebec61fa3349e9690c14f5d0276fd4f61c3049fd9"},
+    {file = "sqlcipher3-0.6.2-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:dfe90f1e0e81a8c6c8c4129a8439ed6b9b27a8e32077c59ed3b7f1263e3c5544"},
+    {file = "sqlcipher3-0.6.2-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:a5f805c1f156634e4e91f1b073d95930756fdf23eeeeb7b85c511a5cf165b10c"},
+    {file = "sqlcipher3-0.6.2-cp311-cp311-win32.whl", hash = "sha256:fc08ff475ab0e0f43adca0647d827e81da5fa406bbb6bd04471e28a3ad2864d9"},
+    {file = "sqlcipher3-0.6.2-cp311-cp311-win_amd64.whl", hash = "sha256:4ad7e4a32de907011ea22ac2012c9bca1bb414e2f599c56a55c8b0fe6445b932"},
+    {file = "sqlcipher3-0.6.2-cp311-cp311-win_arm64.whl", hash = "sha256:3ad6b39a7fa8c2f7ec471dd29fadbffa19c194fbae1730f013f0d29f5b96fae0"},
+    {file = "sqlcipher3-0.6.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:a51b18bd782652a2282f9cb1b03b840ba5a6c0c675de6cefb76262c9789c8f06"},
+    {file = "sqlcipher3-0.6.2-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:fea0f1264f09d219dd6ce699ffca8cc9022a914661c6efa4390e85a2bf78acf9"},
+    {file = "sqlcipher3-0.6.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:bc2edd981e65783bc0d4e337704a9eb436871ab91c68af02ed76354876087642"},
+    {file = "sqlcipher3-0.6.2-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:50f64086da0a5f14281f2b0b459c4d9923b50055813a48ad29baf8c41c7fa56c"},
+    {file = "sqlcipher3-0.6.2-cp312-cp312-manylinux_2_28_i686.whl", hash = "sha256:2288215f462a16996689e1c22d611c94dd865faddb703cb105981dc3c0307b23"},
+    {file = "sqlcipher3-0.6.2-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:6b26d28ca844dc2a69b8f74b390e940db47760f0be4c96d93337c57ae8250a48"},
+    {file = "sqlcipher3-0.6.2-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:11e85c1fa4dfe6bf031af8ada500e94b5a77762355b500580360aa162896cecd"},
+    {file = "sqlcipher3-0.6.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:80ae14562d98419b32149e8d66eea567eb3792e149b103ee5c8e1e5c67c5d799"},
+    {file = "sqlcipher3-0.6.2-cp312-cp312-win32.whl", hash = "sha256:fb15c43f8a4f8b6b0ebe62ad2ab97a7946e3b75cb98a02069ff56b7d5a96c415"},
+    {file = "sqlcipher3-0.6.2-cp312-cp312-win_amd64.whl", hash = "sha256:8bd60ffb7bfa65bd0e51da3d5c308553d7149f0091d4ea9f754c33d5ebbf0a66"},
+    {file = "sqlcipher3-0.6.2-cp312-cp312-win_arm64.whl", hash = "sha256:99148bf4bf8e73c2c35f810f80de776d7de09b6cf277322c07759026400e90d0"},
+    {file = "sqlcipher3-0.6.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:8093773cd59b2a205d2cdb21383a93f7725126497032c269983ed89a89993631"},
+    {file = "sqlcipher3-0.6.2-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:29f39d50bea02d78a824022989164c171e865bfeced3f9b84d1d45193dae074c"},
+    {file = "sqlcipher3-0.6.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:8e1ff6079603dfd955d57c26dad5eab14f6baacdc643d8753dd651913ba789cf"},
+    {file = "sqlcipher3-0.6.2-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:35ae605f7594fca64a6d71007795dd39effd625cdc2a181d47f7d9fc8a5e1965"},
+    {file = "sqlcipher3-0.6.2-cp313-cp313-manylinux_2_28_i686.whl", hash = "sha256:8a3e39ad5f73060232b17715aa3b757e82ec4b67bb6acfc081147f66d00c2659"},
+    {file = "sqlcipher3-0.6.2-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:9fb7109981583b631ac795e7e955d4bf78058f64b54c7f334ccc437adc322d4b"},
+    {file = "sqlcipher3-0.6.2-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:1ab63dcba15868853cb4d318cceb50dc47b94095e0c434f2785b9b098f3f5b42"},
+    {file = "sqlcipher3-0.6.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:16d54822ad2fe44e49818a27f4862ba041f2d4a6aeb69422186379f9af97ced0"},
+    {file = "sqlcipher3-0.6.2-cp313-cp313-win32.whl", hash = "sha256:31789ce5ec7dd3f6c4ebd612c9cd9f7079a1d3698829111f7a382b0c10da3a87"},
+    {file = "sqlcipher3-0.6.2-cp313-cp313-win_amd64.whl", hash = "sha256:9dc959ff792228c6df836cfd3667c713ae13e6e18dc2905c9d5666558606e832"},
+    {file = "sqlcipher3-0.6.2-cp313-cp313-win_arm64.whl", hash = "sha256:30eeac16e755e5b0cff584ff541d3001bfcfc20be0ae364ff5305bbaeccbb3f1"},
+    {file = "sqlcipher3-0.6.2-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:dae7ce66554f2416d9e9012cc78dfe4d4053385e7fa289a8d0bd7772e5f5a702"},
+    {file = "sqlcipher3-0.6.2-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:be137cc92c9a039e469a758ee55e27e2385f419d1387f24e2029c536aa5d9736"},
+    {file = "sqlcipher3-0.6.2-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:5c1f4a5805faa418c9c7290e6a556a8c5abae40ea59b04d76e960e33c257e618"},
+    {file = "sqlcipher3-0.6.2-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:e2328f0848ffb78807cf0898749dc22ff3f5aa95ab0d5a8a253628de20c11a1c"},
+    {file = "sqlcipher3-0.6.2-cp314-cp314-manylinux_2_28_i686.whl", hash = "sha256:a1fbb693bf7c2f6f46ed038544b0bf76ea43dcc3231905cf5a686af15dc9b424"},
+    {file = "sqlcipher3-0.6.2-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:e00988174ecd67ecd4537504c3df55bf8daeb75fce98401f099dff8e22c43ae1"},
+    {file = "sqlcipher3-0.6.2-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:a105e816579bb7cce6f03e7e208b06d6d886c6445e1c738ed9aa2febabff3041"},
+    {file = "sqlcipher3-0.6.2-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:e3a936d7414ae62f40880668bc036b0fde1ef0f48ed86cfe6564340f780ceea4"},
+    {file = "sqlcipher3-0.6.2-cp314-cp314-win32.whl", hash = "sha256:7a07dafe752e013d4030accf218e80472d08de1309ddaf26df6f02d0850b2cec"},
+    {file = "sqlcipher3-0.6.2-cp314-cp314-win_amd64.whl", hash = "sha256:7de6133b19aec27b30698267cc2a0ea6e82c21d9a81d349cf0b480439fb549ac"},
+    {file = "sqlcipher3-0.6.2-cp314-cp314-win_arm64.whl", hash = "sha256:765e133bd4ddda5596275f1221fa63b2b5d7d2b6e3670809bbf630edb705e27a"},
+    {file = "sqlcipher3-0.6.2-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:83533b5b7622ec9b78bec7596d96534e30015136f3e3e69a22f836fc59e393bc"},
+    {file = "sqlcipher3-0.6.2-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:310d7adbea382bda31007ee7d3dc63ba6ca86fcf7c0626ea804161fad2efce5e"},
+    {file = "sqlcipher3-0.6.2-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:1010c4ff1ff13a7e53284a3b03980754dbd37e6eea6faed9c6409e52bac082e6"},
+    {file = "sqlcipher3-0.6.2-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:d437215611b620b32cb6b68dbc66dbeaccdfb3f76a7b6d8118a40849f8612088"},
+    {file = "sqlcipher3-0.6.2-cp314-cp314t-manylinux_2_28_i686.whl", hash = "sha256:09e4170b1b2744b02b1c9315996a228d0b8d8a3ec1a0f7d4d41db0e79872fcea"},
+    {file = "sqlcipher3-0.6.2-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:bb4eaa9093bd46a7d51a65b9f63bac29ec4fc6b4ac794083e53eeb49f6db7e2c"},
+    {file = "sqlcipher3-0.6.2-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:782111277cbd999b7bc4e9e910396492ee28397c2c60ef7287b6dbc36a0b6a24"},
+    {file = "sqlcipher3-0.6.2-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:a01424f0d0120e8d9d3e0e1751ef78e70867bbce91f283b56911e8c6adaafddb"},
+    {file = "sqlcipher3-0.6.2-cp314-cp314t-win32.whl", hash = "sha256:311fa50be627a4d1566bed31fd7725dec535a71332dcefdcdf9ec2472c4f824d"},
+    {file = "sqlcipher3-0.6.2-cp314-cp314t-win_amd64.whl", hash = "sha256:7ac16581a5b80c54237c5f08f2e488051dfa7f52e3890e7765a6364d5bb3a2c6"},
+    {file = "sqlcipher3-0.6.2-cp314-cp314t-win_arm64.whl", hash = "sha256:76125dd222f4946302f70281e155ae9336efa4bc6fabdc81a7ae9bd4dfce9180"},
+    {file = "sqlcipher3-0.6.2-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:8d6300bc294a9dfeee5a5696f4b3c8de311d1bc63591cf908581e29c60d500e0"},
+    {file = "sqlcipher3-0.6.2-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:17268ccb657bde0f4588837b480d1e512f5ca762faf795010dac6ed8f83d6a85"},
+    {file = "sqlcipher3-0.6.2-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:7634c16e937c42f3570b41bf2a5032fbec8413cd221e84782ff567f850a0f76c"},
+    {file = "sqlcipher3-0.6.2-cp39-cp39-manylinux_2_28_aarch64.whl", hash = "sha256:c14ba97592547e1a47fcdf5ba801626c4648d5205da9091029515e5a554d98aa"},
+    {file = "sqlcipher3-0.6.2-cp39-cp39-manylinux_2_28_i686.whl", hash = "sha256:1e785c594ee98bb3aba88b93e63ee31fdc6bcb09351df23b301449fbf8b17ab2"},
+    {file = "sqlcipher3-0.6.2-cp39-cp39-manylinux_2_28_x86_64.whl", hash = "sha256:3a8ced91852c599a19a1e223436ef2e43f6727141958880183aea02b6ad5b375"},
+    {file = "sqlcipher3-0.6.2-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:e8055ebe76ecdbd77ce49da32bfa367319381cbd8a656230d793a6953048ef0b"},
+    {file = "sqlcipher3-0.6.2-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:0df26d51513ddd07e0fb0f311046b2e798e3040032ebed6e670381cf26e89215"},
+    {file = "sqlcipher3-0.6.2-cp39-cp39-win32.whl", hash = "sha256:e73a690b8652a17365112a75883aaf965ca6e8a4c190c7c7a9eb38e154ca223e"},
+    {file = "sqlcipher3-0.6.2-cp39-cp39-win_amd64.whl", hash = "sha256:c1585d88b38a8e6969ec60fbaaafaa3c6eaa6b61e4411d0e25ffdb387b2629c7"},
+    {file = "sqlcipher3-0.6.2-cp39-cp39-win_arm64.whl", hash = "sha256:84f02bde14b64810e0a4d472cecae0a63f359247f06a62544b6ef0cec85826b4"},
+    {file = "sqlcipher3-0.6.2.tar.gz", hash = "sha256:a2b675289ba8889f389625a21f3a01f1ff159a551b5b88fba8fd92da0e02380a"},
 ]
 
 [[package]]
@@ -3325,9 +3563,8 @@ description = "Single-agent task runner for hardened Podman containers"
 optional = false
 python-versions = ">=3.12,<3.15"
 groups = ["main"]
-files = [
-    {file = "terok_executor-0.0.141-py3-none-any.whl", hash = "sha256:e09fed0720af473138f0274fa1ef2cc75a1f2c201dec09b454a8fd593ba6f8c9"},
-]
+files = []
+develop = false
 
 [package.dependencies]
 agent-client-protocol = ">=0.7"
@@ -3336,12 +3573,14 @@ prompt-toolkit = ">=3.0"
 pydantic = ">=2.9"
 rich = ">=13.0"
 "ruamel.yaml" = ">=0.18"
-terok_sandbox = {url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.0.116/terok_sandbox-0.0.116-py3-none-any.whl"}
+terok-sandbox = {git = "https://github.com/sliwowitz/terok-sandbox.git", rev = "feat/credentials-encryption"}
 tomli-w = ">=1.0"
 
 [package.source]
-type = "url"
-url = "https://github.com/terok-ai/terok-executor/releases/download/v0.0.141/terok_executor-0.0.141-py3-none-any.whl"
+type = "git"
+url = "https://github.com/sliwowitz/terok-executor.git"
+reference = "chore/sandbox-encryption-pin"
+resolved_reference = "fd4a00b87d1288d7cac1c85a99af794663d74aeb"
 
 [[package]]
 name = "terok-sandbox"
@@ -3350,22 +3589,27 @@ description = "Hardened Podman container runner with gate server and shield inte
 optional = false
 python-versions = ">=3.12,<4.0"
 groups = ["main"]
-files = [
-    {file = "terok_sandbox-0.0.116-py3-none-any.whl", hash = "sha256:a3f1f1fc4472562b32d0deb1cc452962dbe8fd3471140c689087b2181cb0f811"},
-]
+files = []
+develop = false
 
 [package.dependencies]
 aiohttp = ">=3.9"
 cryptography = ">=46.0.7"
+keyring = ">=25.0"
 packaging = ">=24"
 platformdirs = ">=4.9.6"
+prompt-toolkit = ">=3.0"
 pydantic = ">=2.9"
-terok_clearance = {url = "https://github.com/terok-ai/terok-clearance/releases/download/v0.6.11/terok_clearance-0.6.11-py3-none-any.whl"}
-terok_shield = {url = "https://github.com/terok-ai/terok-shield/releases/download/v0.6.39/terok_shield-0.6.39-py3-none-any.whl"}
+"ruamel.yaml" = ">=0.18"
+sqlcipher3 = ">=0.6.2"
+terok-clearance = {url = "https://github.com/terok-ai/terok-clearance/releases/download/v0.6.11/terok_clearance-0.6.11-py3-none-any.whl"}
+terok-shield = {url = "https://github.com/terok-ai/terok-shield/releases/download/v0.6.39/terok_shield-0.6.39-py3-none-any.whl"}
 
 [package.source]
-type = "url"
-url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.0.116/terok_sandbox-0.0.116-py3-none-any.whl"
+type = "git"
+url = "https://github.com/sliwowitz/terok-sandbox.git"
+reference = "feat/credentials-encryption"
+resolved_reference = "254595378f3172b8487dbb72e9d17085a9c32045"
 
 [[package]]
 name = "terok-shield"
@@ -4264,4 +4508,4 @@ propcache = ">=0.2.1"
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.12,<3.15"
-content-hash = "1252f822117727da17bc8503f3492baf559c659ef520d8d115c93d2f859a31b0"
+content-hash = "5e46990192786cc5643ac614f2ea1258dda277f99d87d0dd6c860db0181303e2"

--- a/poetry.lock
+++ b/poetry.lock
@@ -3573,14 +3573,14 @@ prompt-toolkit = ">=3.0"
 pydantic = ">=2.9"
 rich = ">=13.0"
 "ruamel.yaml" = ">=0.18"
-terok-sandbox = {git = "https://github.com/sliwowitz/terok-sandbox.git", rev = "feat/credentials-encryption"}
+terok-sandbox = {git = "https://github.com/sliwowitz/terok-sandbox.git", rev = "7937e5c1dc4737831c4d322c7c17aa685d30d064"}
 tomli-w = ">=1.0"
 
 [package.source]
 type = "git"
 url = "https://github.com/sliwowitz/terok-executor.git"
-reference = "chore/sandbox-encryption-pin"
-resolved_reference = "fd4a00b87d1288d7cac1c85a99af794663d74aeb"
+reference = "221a840"
+resolved_reference = "221a840ba6d40770160b9640abe22b04c2d1aa3e"
 
 [[package]]
 name = "terok-sandbox"
@@ -3608,8 +3608,8 @@ terok-shield = {url = "https://github.com/terok-ai/terok-shield/releases/downloa
 [package.source]
 type = "git"
 url = "https://github.com/sliwowitz/terok-sandbox.git"
-reference = "feat/credentials-encryption"
-resolved_reference = "254595378f3172b8487dbb72e9d17085a9c32045"
+reference = "7937e5c1dc4737831c4d322c7c17aa685d30d064"
+resolved_reference = "7937e5c1dc4737831c4d322c7c17aa685d30d064"
 
 [[package]]
 name = "terok-shield"
@@ -4508,4 +4508,4 @@ propcache = ">=0.2.1"
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.12,<3.15"
-content-hash = "5e46990192786cc5643ac614f2ea1258dda277f99d87d0dd6c860db0181303e2"
+content-hash = "a3da1a24ec1c8b1f4d0deb71ab06807227a7e7ba39b78dc98019b8d03241549c"

--- a/poetry.lock
+++ b/poetry.lock
@@ -3558,13 +3558,14 @@ url = "https://github.com/terok-ai/terok-clearance/releases/download/v0.6.11/ter
 
 [[package]]
 name = "terok-executor"
-version = "0.0.141"
+version = "0.0.142"
 description = "Single-agent task runner for hardened Podman containers"
 optional = false
 python-versions = ">=3.12,<3.15"
 groups = ["main"]
-files = []
-develop = false
+files = [
+    {file = "terok_executor-0.0.142-py3-none-any.whl", hash = "sha256:c6a9218d120b76bea2beebef866b66c95f96604aa8735e3b5d0b21edda4c9deb"},
+]
 
 [package.dependencies]
 agent-client-protocol = ">=0.7"
@@ -3573,24 +3574,23 @@ prompt-toolkit = ">=3.0"
 pydantic = ">=2.9"
 rich = ">=13.0"
 "ruamel.yaml" = ">=0.18"
-terok-sandbox = {git = "https://github.com/sliwowitz/terok-sandbox.git", rev = "7937e5c1dc4737831c4d322c7c17aa685d30d064"}
+terok_sandbox = {url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.0.117/terok_sandbox-0.0.117-py3-none-any.whl"}
 tomli-w = ">=1.0"
 
 [package.source]
-type = "git"
-url = "https://github.com/sliwowitz/terok-executor.git"
-reference = "221a840"
-resolved_reference = "221a840ba6d40770160b9640abe22b04c2d1aa3e"
+type = "url"
+url = "https://github.com/terok-ai/terok-executor/releases/download/v0.0.142/terok_executor-0.0.142-py3-none-any.whl"
 
 [[package]]
 name = "terok-sandbox"
-version = "0.0.116"
+version = "0.0.117"
 description = "Hardened Podman container runner with gate server and shield integration"
 optional = false
 python-versions = ">=3.12,<4.0"
 groups = ["main"]
-files = []
-develop = false
+files = [
+    {file = "terok_sandbox-0.0.117-py3-none-any.whl", hash = "sha256:95ab04beedd1439e599378dcdad20623b342973027d57279f8763e86f002c8a8"},
+]
 
 [package.dependencies]
 aiohttp = ">=3.9"
@@ -3602,14 +3602,12 @@ prompt-toolkit = ">=3.0"
 pydantic = ">=2.9"
 "ruamel.yaml" = ">=0.18"
 sqlcipher3 = ">=0.6.2"
-terok-clearance = {url = "https://github.com/terok-ai/terok-clearance/releases/download/v0.6.11/terok_clearance-0.6.11-py3-none-any.whl"}
-terok-shield = {url = "https://github.com/terok-ai/terok-shield/releases/download/v0.6.39/terok_shield-0.6.39-py3-none-any.whl"}
+terok_clearance = {url = "https://github.com/terok-ai/terok-clearance/releases/download/v0.6.11/terok_clearance-0.6.11-py3-none-any.whl"}
+terok_shield = {url = "https://github.com/terok-ai/terok-shield/releases/download/v0.6.39/terok_shield-0.6.39-py3-none-any.whl"}
 
 [package.source]
-type = "git"
-url = "https://github.com/sliwowitz/terok-sandbox.git"
-reference = "7937e5c1dc4737831c4d322c7c17aa685d30d064"
-resolved_reference = "7937e5c1dc4737831c4d322c7c17aa685d30d064"
+type = "url"
+url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.0.117/terok_sandbox-0.0.117-py3-none-any.whl"
 
 [[package]]
 name = "terok-shield"
@@ -4508,4 +4506,4 @@ propcache = ">=0.2.1"
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.12,<3.15"
-content-hash = "a3da1a24ec1c8b1f4d0deb71ab06807227a7e7ba39b78dc98019b8d03241549c"
+content-hash = "f26e8d385bef83007b23658ec3c3fb5b894ad3c6842b24ff8f6f749a8e5c8541"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,8 +58,8 @@ platformdirs = ">=4.5.1"
 unique-namer = ">=1.3"
 textual-serve = ">=1.1.0"
 jinja2 = "^3.1"
-terok-executor = {git = "https://github.com/sliwowitz/terok-executor.git", rev = "chore/sandbox-encryption-pin"}
-terok-sandbox = {git = "https://github.com/sliwowitz/terok-sandbox.git", rev = "feat/credentials-encryption"}
+terok-executor = {git = "https://github.com/sliwowitz/terok-executor.git", rev = "221a840"}
+terok-sandbox = {git = "https://github.com/sliwowitz/terok-sandbox.git", rev = "7937e5c1dc4737831c4d322c7c17aa685d30d064"}
 terok-shield = {url = "https://github.com/terok-ai/terok-shield/releases/download/v0.6.39/terok_shield-0.6.39-py3-none-any.whl"}
 terok-clearance = {url = "https://github.com/terok-ai/terok-clearance/releases/download/v0.6.11/terok_clearance-0.6.11-py3-none-any.whl"}
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,8 +58,8 @@ platformdirs = ">=4.5.1"
 unique-namer = ">=1.3"
 textual-serve = ">=1.1.0"
 jinja2 = "^3.1"
-terok-executor = {git = "https://github.com/sliwowitz/terok-executor.git", rev = "221a840"}
-terok-sandbox = {git = "https://github.com/sliwowitz/terok-sandbox.git", rev = "7937e5c1dc4737831c4d322c7c17aa685d30d064"}
+terok-executor = {url = "https://github.com/terok-ai/terok-executor/releases/download/v0.0.142/terok_executor-0.0.142-py3-none-any.whl"}
+terok-sandbox = {url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.0.117/terok_sandbox-0.0.117-py3-none-any.whl"}
 terok-shield = {url = "https://github.com/terok-ai/terok-shield/releases/download/v0.6.39/terok_shield-0.6.39-py3-none-any.whl"}
 terok-clearance = {url = "https://github.com/terok-ai/terok-clearance/releases/download/v0.6.11/terok_clearance-0.6.11-py3-none-any.whl"}
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,8 +58,8 @@ platformdirs = ">=4.5.1"
 unique-namer = ">=1.3"
 textual-serve = ">=1.1.0"
 jinja2 = "^3.1"
-terok-executor = {url = "https://github.com/terok-ai/terok-executor/releases/download/v0.0.141/terok_executor-0.0.141-py3-none-any.whl"}
-terok-sandbox = {url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.0.116/terok_sandbox-0.0.116-py3-none-any.whl"}
+terok-executor = {git = "https://github.com/sliwowitz/terok-executor.git", rev = "chore/sandbox-encryption-pin"}
+terok-sandbox = {git = "https://github.com/sliwowitz/terok-sandbox.git", rev = "feat/credentials-encryption"}
 terok-shield = {url = "https://github.com/terok-ai/terok-shield/releases/download/v0.6.39/terok_shield-0.6.39-py3-none-any.whl"}
 terok-clearance = {url = "https://github.com/terok-ai/terok-clearance/releases/download/v0.6.11/terok_clearance-0.6.11-py3-none-any.whl"}
 

--- a/src/terok/lib/domain/project.py
+++ b/src/terok/lib/domain/project.py
@@ -413,10 +413,25 @@ def _archive_project(project_id: str) -> str | None:
 
 
 def _unassign_vault_ssh_keys(scope: str, deleted: list[str]) -> None:
-    """Drop every SSH-key assignment for *scope*; record the count in *deleted*."""
-    from .vault import vault_db
+    """Drop every SSH-key assignment for *scope*; record the count in *deleted*.
 
-    with vault_db() as db:
+    A locked vault (no resolvable passphrase) skips the unassignment
+    and records a one-liner so the operator knows residual key
+    assignments are still in the DB — they can be cleaned up after a
+    ``terok-sandbox vault unlock``.  Blocking project deletion behind
+    a locked vault would be worse: the on-disk project state would
+    stay intact, the operator may not even know which passphrase the
+    DB was encrypted with, and the project they're trying to delete
+    can include the very SSH key they would have needed.
+    """
+    from .vault import maybe_vault_db
+
+    with maybe_vault_db() as db:
+        if db is None:
+            deleted.append(
+                f"vault locked — SSH key assignments for scope {scope!r} remain in the encrypted DB"
+            )
+            return
         count = db.unassign_all_ssh_keys(scope)
     if count:
         deleted.append(f"{count} SSH key assignment(s) for project (scope) {scope!r}")

--- a/src/terok/lib/domain/project.py
+++ b/src/terok/lib/domain/project.py
@@ -412,23 +412,27 @@ def _archive_project(project_id: str) -> str | None:
         return None
 
 
-def _unassign_vault_ssh_keys(scope: str, deleted: list[str]) -> None:
+def _unassign_vault_ssh_keys(scope: str, deleted: list[str], skipped: list[str]) -> None:
     """Drop every SSH-key assignment for *scope*; record the count in *deleted*.
 
     A locked vault (no resolvable passphrase) skips the unassignment
-    and records a one-liner so the operator knows residual key
-    assignments are still in the DB — they can be cleaned up after a
-    ``terok-sandbox vault unlock``.  Blocking project deletion behind
-    a locked vault would be worse: the on-disk project state would
-    stay intact, the operator may not even know which passphrase the
-    DB was encrypted with, and the project they're trying to delete
-    can include the very SSH key they would have needed.
+    and records into *skipped* so the operator knows residual key
+    assignments remain in the encrypted DB — they can be cleaned up
+    after a ``terok-sandbox vault unlock``.  *deleted* is reserved
+    for actual deletions; conflating the two lists would surface
+    the locked-vault notice as if it were a successful drop.
+
+    Blocking project deletion behind a locked vault would be worse:
+    the on-disk project state would stay intact, the operator may not
+    even know which passphrase the DB was encrypted with, and the
+    project they're trying to delete can include the very SSH key
+    they would have needed.
     """
     from .vault import maybe_vault_db
 
     with maybe_vault_db() as db:
         if db is None:
-            deleted.append(
+            skipped.append(
                 f"vault locked — SSH key assignments for scope {scope!r} remain in the encrypted DB"
             )
             return
@@ -488,7 +492,7 @@ def delete_project(project_id: str) -> DeleteProjectResult:
             deleted.append(str(d))
 
     # 5. SSH credentials — unassign from vault; orphan keys cascade-delete.
-    _unassign_vault_ssh_keys(pid, deleted)
+    _unassign_vault_ssh_keys(pid, deleted, skipped)
 
     # 6. Git gate (skip if shared with other projects)
     sharing = find_projects_sharing_gate(project.gate_path, exclude_project=pid)

--- a/src/terok/lib/domain/project.py
+++ b/src/terok/lib/domain/project.py
@@ -211,7 +211,9 @@ def make_ssh_manager(config: ProjectConfig) -> SSHManager:
     Use it as a context manager (``with make_ssh_manager(cfg) as m: ...``);
     the DB connection closes on exit.
     """
-    return SSHManager.open(scope=config.id, db_path=make_sandbox_config().db_path)
+    return SSHManager.open_for_config(
+        scope=config.id, cfg=make_sandbox_config(), prompt_on_tty=True
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/src/terok/lib/domain/project_state.py
+++ b/src/terok/lib/domain/project_state.py
@@ -27,15 +27,12 @@ def _scope_has_vault_key(scope: str) -> bool:
     care of nudging the operator to unlock; for the SSH-tile readout
     "no keys visible right now" is the truthful answer.
     """
-    from terok_sandbox.credentials.db import NoPassphraseError, WrongPassphraseError
+    from .vault import maybe_vault_db
 
-    from .vault import vault_db
-
-    try:
-        with vault_db() as db:
-            return bool(db.list_ssh_keys_for_scope(scope))
-    except (NoPassphraseError, WrongPassphraseError):
-        return False
+    with maybe_vault_db() as db:
+        if db is None:
+            return False
+        return bool(db.list_ssh_keys_for_scope(scope))
 
 
 if TYPE_CHECKING:

--- a/src/terok/lib/domain/project_state.py
+++ b/src/terok/lib/domain/project_state.py
@@ -19,11 +19,23 @@ from ..core.task_state import container_name as _container_name
 
 
 def _scope_has_vault_key(scope: str) -> bool:
-    """Return ``True`` iff the vault has at least one SSH key assigned to *scope*."""
+    """Return ``True`` iff the vault has at least one SSH key assigned to *scope*.
+
+    A locked vault (no resolvable passphrase) reports ``False`` rather
+    than raising — the project overview can still render every other
+    tile.  The dedicated "vault locked" surface (issue terok#877) takes
+    care of nudging the operator to unlock; for the SSH-tile readout
+    "no keys visible right now" is the truthful answer.
+    """
+    from terok_sandbox.credentials.db import NoPassphraseError, WrongPassphraseError
+
     from .vault import vault_db
 
-    with vault_db() as db:
-        return bool(db.list_ssh_keys_for_scope(scope))
+    try:
+        with vault_db() as db:
+            return bool(db.list_ssh_keys_for_scope(scope))
+    except (NoPassphraseError, WrongPassphraseError):
+        return False
 
 
 if TYPE_CHECKING:

--- a/src/terok/lib/domain/vault.py
+++ b/src/terok/lib/domain/vault.py
@@ -14,13 +14,20 @@ if TYPE_CHECKING:
 
 
 @contextmanager
-def vault_db() -> Iterator[CredentialDB]:
-    """Open the shared vault `CredentialDB` and close it on exit."""
-    from terok_sandbox import CredentialDB
+def vault_db(*, prompt_on_tty: bool = False) -> Iterator[CredentialDB]:
+    """Open the shared vault ``CredentialDB`` and close it on exit.
 
+    Routes through ``SandboxConfig.open_credential_db`` so the four-tier
+    passphrase resolution chain (session-unlock file → keyring → config
+    fallback → optional prompt) runs.  Daemons and background workers
+    leave ``prompt_on_tty=False`` so a locked vault fails fast with a
+    clear ``NoPassphraseError`` instead of stalling on stdin; CLI
+    front-ends pass ``True`` to unlock the interactive last-resort
+    prompt.
+    """
     from ..core.config import make_sandbox_config
 
-    db = CredentialDB(make_sandbox_config().db_path)
+    db = make_sandbox_config().open_credential_db(prompt_on_tty=prompt_on_tty)
     try:
         yield db
     finally:

--- a/src/terok/lib/domain/vault.py
+++ b/src/terok/lib/domain/vault.py
@@ -34,4 +34,25 @@ def vault_db(*, prompt_on_tty: bool = False) -> Iterator[CredentialDB]:
         db.close()
 
 
-__all__ = ["vault_db"]
+@contextmanager
+def maybe_vault_db(*, prompt_on_tty: bool = False) -> Iterator[CredentialDB | None]:
+    """Open the vault DB, yielding ``None`` if the vault is locked.
+
+    Wraps ``vault_db`` for read-only callers that don't need to
+    distinguish "no entries" from "vault locked" at their level —
+    e.g. project-state tiles that render across the full host.  The
+    cross-package exception imports stay confined to this module so
+    ``import-linter``'s "terok_sandbox access restricted to designated
+    modules" contract holds (only ``vault.py`` reaches into
+    ``terok_sandbox``).
+    """
+    from terok_sandbox.credentials.db import NoPassphraseError, WrongPassphraseError
+
+    try:
+        with vault_db(prompt_on_tty=prompt_on_tty) as db:
+            yield db
+    except (NoPassphraseError, WrongPassphraseError):
+        yield None
+
+
+__all__ = ["maybe_vault_db", "vault_db"]

--- a/src/terok/lib/domain/vault.py
+++ b/src/terok/lib/domain/vault.py
@@ -6,7 +6,7 @@
 from __future__ import annotations
 
 from collections.abc import Iterator
-from contextlib import contextmanager
+from contextlib import ExitStack, contextmanager
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
@@ -48,11 +48,19 @@ def maybe_vault_db(*, prompt_on_tty: bool = False) -> Iterator[CredentialDB | No
     """
     from terok_sandbox.credentials.db import NoPassphraseError, WrongPassphraseError
 
-    try:
-        with vault_db(prompt_on_tty=prompt_on_tty) as db:
-            yield db
-    except (NoPassphraseError, WrongPassphraseError):
-        yield None
+    # Catch exceptions raised on entry only — wrapping the entire
+    # ``with vault_db(): yield db`` in a try/except would also swallow
+    # any locked-vault error that escaped the consumer's block and
+    # cause a second yield, breaking the contextmanager contract.
+    # ``ExitStack`` lets us scope the catch to ``__enter__`` and still
+    # guarantee teardown of the inner context.
+    with ExitStack() as stack:
+        try:
+            db = stack.enter_context(vault_db(prompt_on_tty=prompt_on_tty))
+        except (NoPassphraseError, WrongPassphraseError):
+            yield None
+            return
+        yield db
 
 
 __all__ = ["maybe_vault_db", "vault_db"]

--- a/src/terok/tui/screens.py
+++ b/src/terok/tui/screens.py
@@ -1979,19 +1979,23 @@ class ShieldSetupScreen(screen.ModalScreen[str | None]):
 
 
 def _format_credentials_typed(status: VaultStatus) -> str:
-    """Format stored credentials as ``name (type), ...`` for status display."""
-    try:
-        from terok_sandbox import CredentialDB
+    """Format stored credentials as ``name (type), ...`` for status display.
 
-        db = CredentialDB(status.db_path)
-        try:
+    Routes through ``vault_db`` so the four-tier passphrase resolution
+    chain runs; a locked vault (or any other open failure) degrades to
+    the bare ``status.credentials_stored`` names — the operator still
+    sees *which* credentials exist, just not their type, until the
+    vault is unlocked.
+    """
+    try:
+        from ..lib.domain.vault import vault_db
+
+        with vault_db() as db:
             parts = []
             for name in status.credentials_stored:
                 cred = db.load_credential("default", name)
                 ctype = cred.get("type", "unknown") if cred else "unknown"
                 parts.append(f"{name} ({ctype})")
-        finally:
-            db.close()
         return ", ".join(parts)
     except Exception:  # noqa: BLE001
         return ", ".join(status.credentials_stored)

--- a/src/terok/tui/screens.py
+++ b/src/terok/tui/screens.py
@@ -1981,24 +1981,25 @@ class ShieldSetupScreen(screen.ModalScreen[str | None]):
 def _format_credentials_typed(status: VaultStatus) -> str:
     """Format stored credentials as ``name (type), ...`` for status display.
 
-    Routes through ``vault_db`` so the four-tier passphrase resolution
-    chain runs; a locked vault (or any other open failure) degrades to
-    the bare ``status.credentials_stored`` names — the operator still
-    sees *which* credentials exist, just not their type, until the
-    vault is unlocked.
+    Routes through ``maybe_vault_db`` so the four-tier passphrase
+    resolution chain runs and a locked vault degrades to the bare
+    ``status.credentials_stored`` names — the operator still sees
+    *which* credentials exist, just not their type, until the vault
+    is unlocked.  Unexpected failures (schema drift, I/O errors) are
+    intentionally NOT swallowed: a blanket ``except`` here would hide
+    real bugs behind an identical-looking degraded render.
     """
-    try:
-        from ..lib.domain.vault import vault_db
+    from ..lib.domain.vault import maybe_vault_db
 
-        with vault_db() as db:
-            parts = []
-            for name in status.credentials_stored:
-                cred = db.load_credential("default", name)
-                ctype = cred.get("type", "unknown") if cred else "unknown"
-                parts.append(f"{name} ({ctype})")
-        return ", ".join(parts)
-    except Exception:  # noqa: BLE001
-        return ", ".join(status.credentials_stored)
+    with maybe_vault_db() as db:
+        if db is None:
+            return ", ".join(status.credentials_stored)
+        parts = []
+        for name in status.credentials_stored:
+            cred = db.load_credential("default", name)
+            ctype = cred.get("type", "unknown") if cred else "unknown"
+            parts.append(f"{name} ({ctype})")
+    return ", ".join(parts)
 
 
 def render_vault_status(status: VaultStatus | None) -> Text:

--- a/tach.toml
+++ b/tach.toml
@@ -871,7 +871,7 @@ expose = [
 from = ["terok.lib.domain.facade"]
 
 [[interfaces]]
-expose = ["vault_db"]
+expose = ["maybe_vault_db", "vault_db"]
 from = ["terok.lib.domain.vault"]
 
 [[interfaces]]

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -373,6 +373,19 @@ def terok_env(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> TerokIntegrati
         "vault:\n  bypass_no_secret_protection: true\n",
         encoding="utf-8",
     )
+    # Sandbox reads ``credentials.passphrase`` from the user-tier
+    # config (``$XDG_CONFIG_HOME/terok/config.yml``) — system-tier
+    # paths point at ``/etc/terok`` on the real filesystem and won't
+    # see our tmp-rooted config.yml.  Seeding a deterministic
+    # passphrase makes the resolution chain hit the config tier and
+    # lets ``CredentialDB`` open the encrypted DB without a daemon,
+    # keyring, or interactive prompt — the realistic shape for
+    # subprocess-based integration tests.
+    (xdg_config_home / "terok").mkdir(parents=True, exist_ok=True)
+    (xdg_config_home / "terok" / "config.yml").write_text(
+        "credentials:\n  passphrase: integration-test-passphrase\n",
+        encoding="utf-8",
+    )
 
     env = TerokIntegrationEnv(
         base_dir=tmp_path,

--- a/tests/unit/cli/test_sickbay.py
+++ b/tests/unit/cli/test_sickbay.py
@@ -50,10 +50,15 @@ class TestCheckSshSigner:
         return p
 
     def _patch_vault(self, assigned_scopes: list[str]):
-        """Patch ``CredentialDB`` to report the given assigned scopes."""
+        """Patch ``cfg.open_credential_db`` to yield the given assigned scopes."""
         db = unittest.mock.MagicMock()
         db.list_scopes_with_ssh_keys.return_value = assigned_scopes
-        return unittest.mock.patch("terok_sandbox.CredentialDB", return_value=db)
+        return unittest.mock.patch(
+            "terok.lib.core.config.make_sandbox_config",
+            return_value=unittest.mock.MagicMock(
+                open_credential_db=unittest.mock.MagicMock(return_value=db)
+            ),
+        )
 
     def test_no_projects(self) -> None:
         """No projects configured → ok (nothing to check)."""
@@ -118,7 +123,12 @@ class TestCheckSshSigner:
                 return_value=[self._mock_project("proj")],
             ),
             unittest.mock.patch(
-                "terok_sandbox.CredentialDB", side_effect=RuntimeError("db locked")
+                "terok.lib.core.config.make_sandbox_config",
+                return_value=unittest.mock.MagicMock(
+                    open_credential_db=unittest.mock.MagicMock(
+                        side_effect=RuntimeError("db locked")
+                    )
+                ),
             ),
         ):
             sev, _, detail = _check_ssh_signer()

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -72,6 +72,35 @@ def _mock_infrastructure() -> Iterator[None]:
 
 
 @pytest.fixture(autouse=True)
+def _stub_credential_db(tmp_path_factory: pytest.TempPathFactory) -> Iterator[None]:
+    """Stub ``SandboxConfig.open_credential_db`` so tests never hit the resolution chain.
+
+    After at-rest encryption (terok-sandbox#268), opening the
+    credential DB requires a passphrase that resolves through the
+    chain (session-file → keyring → config → prompt).  Unit-test
+    runners have none of those, so every ``vault_db()`` /
+    ``maybe_vault_db()`` consumer would raise ``NoPassphraseError``
+    in CI.  Provision a real per-session ``CredentialDB`` backed by
+    a SQLCipher file with a known test passphrase — tests that mock
+    deeper (``cfg.open_credential_db.return_value = MagicMock()``)
+    override this stub.
+    """
+    from terok_sandbox import CredentialDB
+
+    db_path = tmp_path_factory.mktemp("unit-vault") / "credentials.db"
+    test_passphrase = "unit-test-passphrase"  # nosec: B105 — fixture, not a real secret
+
+    def _open(*, prompt_on_tty: bool = False) -> CredentialDB:
+        return CredentialDB(db_path, passphrase=test_passphrase)
+
+    with patch(
+        "terok_sandbox.config.SandboxConfig.open_credential_db",
+        new=lambda self, *, prompt_on_tty=False: _open(prompt_on_tty=prompt_on_tty),
+    ):
+        yield
+
+
+@pytest.fixture(autouse=True)
 def mock_runtime() -> Iterator[MagicMock]:
     """Install a fresh [`MagicMock`][unittest.mock.MagicMock] as the process-wide ``ContainerRuntime``.
 

--- a/tests/unit/lib/test_task_credentials.py
+++ b/tests/unit/lib/test_task_credentials.py
@@ -29,12 +29,15 @@ from terok.lib.domain.task_credentials import (
 # ── Shared fixtures ────────────────────────────────────────────────────
 
 
+_TEST_VAULT_PASSPHRASE = "test-vault-passphrase"  # nosec: B105 — test fixture
+
+
 @pytest.fixture
 def vault_db_path(tmp_path: Path) -> Path:
     """Spin up a real CredentialDB at a tmp path and return the file path."""
     from terok_sandbox import CredentialDB
 
-    db = CredentialDB(tmp_path / "credentials.db")
+    db = CredentialDB(tmp_path / "credentials.db", passphrase=_TEST_VAULT_PASSPHRASE)
     db.close()
     return tmp_path / "credentials.db"
 
@@ -48,11 +51,25 @@ def patched_sandbox_config(tmp_path: Path, vault_db_path: Path):
     import ``make_sandbox_config`` lazily inside the function body, so
     the patch target is the canonical definition site rather than the
     callers' module namespace.
+
+    ``open_credential_db`` is wired to re-open the on-disk file with the
+    fixture's known passphrase, so the helpers' encrypted-DB code path
+    runs end-to-end against a real SQLCipher file.
     """
     from types import SimpleNamespace
 
+    from terok_sandbox import CredentialDB
+
     audit_path = tmp_path / "credential_audit.jsonl"
-    cfg = SimpleNamespace(db_path=vault_db_path, credential_audit_log_path=audit_path)
+
+    def _open_db(*, prompt_on_tty: bool = False) -> CredentialDB:
+        return CredentialDB(vault_db_path, passphrase=_TEST_VAULT_PASSPHRASE)
+
+    cfg = SimpleNamespace(
+        db_path=vault_db_path,
+        credential_audit_log_path=audit_path,
+        open_credential_db=_open_db,
+    )
     with patch("terok.lib.core.config.make_sandbox_config", return_value=cfg):
         yield cfg
 
@@ -75,7 +92,7 @@ class TestRevokeCredentials:
         """Two minted tokens for the same task → two revoked."""
         from terok_sandbox import CredentialDB
 
-        db = CredentialDB(patched_sandbox_config.db_path)
+        db = CredentialDB(patched_sandbox_config.db_path, passphrase=_TEST_VAULT_PASSPHRASE)
         try:
             db.create_token("proj", "task-1", "default", "claude")
             db.create_token("proj", "task-1", "default", "openai")

--- a/tests/unit/lib/test_vault_helpers.py
+++ b/tests/unit/lib/test_vault_helpers.py
@@ -16,9 +16,9 @@ class TestScopeHasVaultKey:
 
         db = MagicMock()
         db.list_ssh_keys_for_scope.return_value = [MagicMock(id=1)]
-        with (
-            patch("terok_sandbox.CredentialDB", return_value=db),
-            patch("terok.lib.core.config.make_sandbox_config"),
+        with patch(
+            "terok.lib.core.config.make_sandbox_config",
+            return_value=MagicMock(open_credential_db=MagicMock(return_value=db)),
         ):
             assert _scope_has_vault_key("proj") is True
         db.list_ssh_keys_for_scope.assert_called_once_with("proj")
@@ -29,9 +29,9 @@ class TestScopeHasVaultKey:
 
         db = MagicMock()
         db.list_ssh_keys_for_scope.return_value = []
-        with (
-            patch("terok_sandbox.CredentialDB", return_value=db),
-            patch("terok.lib.core.config.make_sandbox_config"),
+        with patch(
+            "terok.lib.core.config.make_sandbox_config",
+            return_value=MagicMock(open_credential_db=MagicMock(return_value=db)),
         ):
             assert _scope_has_vault_key("proj") is False
         db.close.assert_called_once()
@@ -46,9 +46,9 @@ class TestUnassignVaultSshKeys:
         db = MagicMock()
         db.unassign_all_ssh_keys.return_value = 3
         deleted: list[str] = []
-        with (
-            patch("terok_sandbox.CredentialDB", return_value=db),
-            patch("terok.lib.core.config.make_sandbox_config"),
+        with patch(
+            "terok.lib.core.config.make_sandbox_config",
+            return_value=MagicMock(open_credential_db=MagicMock(return_value=db)),
         ):
             _unassign_vault_ssh_keys("proj", deleted)
         db.unassign_all_ssh_keys.assert_called_once_with("proj")
@@ -63,9 +63,9 @@ class TestUnassignVaultSshKeys:
         db = MagicMock()
         db.unassign_all_ssh_keys.return_value = 0
         deleted: list[str] = []
-        with (
-            patch("terok_sandbox.CredentialDB", return_value=db),
-            patch("terok.lib.core.config.make_sandbox_config"),
+        with patch(
+            "terok.lib.core.config.make_sandbox_config",
+            return_value=MagicMock(open_credential_db=MagicMock(return_value=db)),
         ):
             _unassign_vault_ssh_keys("proj", deleted)
         assert deleted == []
@@ -83,9 +83,9 @@ class TestLookupVaultPubLine:
         record.comment = "tk-main:proj"
         db = MagicMock()
         db.load_ssh_keys_for_scope.return_value = [record]
-        with (
-            patch("terok_sandbox.CredentialDB", return_value=db),
-            patch("terok.lib.core.config.make_sandbox_config"),
+        with patch(
+            "terok.lib.core.config.make_sandbox_config",
+            return_value=MagicMock(open_credential_db=MagicMock(return_value=db)),
         ):
             line = _lookup_vault_pub_line("proj")
         assert line is not None
@@ -98,9 +98,9 @@ class TestLookupVaultPubLine:
 
         db = MagicMock()
         db.load_ssh_keys_for_scope.return_value = []
-        with (
-            patch("terok_sandbox.CredentialDB", return_value=db),
-            patch("terok.lib.core.config.make_sandbox_config"),
+        with patch(
+            "terok.lib.core.config.make_sandbox_config",
+            return_value=MagicMock(open_credential_db=MagicMock(return_value=db)),
         ):
             assert _lookup_vault_pub_line("ghost") is None
 
@@ -113,9 +113,9 @@ class TestLookupVaultPubLine:
         record.comment = ""
         db = MagicMock()
         db.load_ssh_keys_for_scope.return_value = [record]
-        with (
-            patch("terok_sandbox.CredentialDB", return_value=db),
-            patch("terok.lib.core.config.make_sandbox_config"),
+        with patch(
+            "terok.lib.core.config.make_sandbox_config",
+            return_value=MagicMock(open_credential_db=MagicMock(return_value=db)),
         ):
             line = _lookup_vault_pub_line("proj")
         assert line is not None

--- a/tests/unit/lib/test_vault_helpers.py
+++ b/tests/unit/lib/test_vault_helpers.py
@@ -38,7 +38,12 @@ class TestScopeHasVaultKey:
 
 
 class TestUnassignVaultSshKeys:
-    """``project._unassign_vault_ssh_keys`` drains assignments and records the count."""
+    """``project._unassign_vault_ssh_keys`` drains assignments and routes the receipt.
+
+    Real deletions land in ``deleted``; advisories (locked vault, nothing
+    to do) land in ``skipped`` so callers of ``DeleteProjectResult`` can
+    treat the two lists with the semantics their names imply.
+    """
 
     def test_records_removed_count(self) -> None:
         from terok.lib.domain.project import _unassign_vault_ssh_keys
@@ -46,16 +51,18 @@ class TestUnassignVaultSshKeys:
         db = MagicMock()
         db.unassign_all_ssh_keys.return_value = 3
         deleted: list[str] = []
+        skipped: list[str] = []
         with patch(
             "terok.lib.core.config.make_sandbox_config",
             return_value=MagicMock(open_credential_db=MagicMock(return_value=db)),
         ):
-            _unassign_vault_ssh_keys("proj", deleted)
+            _unassign_vault_ssh_keys("proj", deleted, skipped)
         db.unassign_all_ssh_keys.assert_called_once_with("proj")
         db.close.assert_called_once()
         assert len(deleted) == 1
         assert "3 SSH key assignment" in deleted[0]
         assert "'proj'" in deleted[0]
+        assert skipped == []
 
     def test_zero_keys_writes_nothing(self) -> None:
         from terok.lib.domain.project import _unassign_vault_ssh_keys
@@ -63,12 +70,70 @@ class TestUnassignVaultSshKeys:
         db = MagicMock()
         db.unassign_all_ssh_keys.return_value = 0
         deleted: list[str] = []
+        skipped: list[str] = []
         with patch(
             "terok.lib.core.config.make_sandbox_config",
             return_value=MagicMock(open_credential_db=MagicMock(return_value=db)),
         ):
-            _unassign_vault_ssh_keys("proj", deleted)
+            _unassign_vault_ssh_keys("proj", deleted, skipped)
         assert deleted == []
+        assert skipped == []
+
+    def test_locked_vault_routes_notice_to_skipped(self) -> None:
+        """A locked vault parks the notice in ``skipped`` — not ``deleted``."""
+        from terok_sandbox.credentials.db import NoPassphraseError
+
+        from terok.lib.domain.project import _unassign_vault_ssh_keys
+
+        deleted: list[str] = []
+        skipped: list[str] = []
+        with patch(
+            "terok.lib.core.config.make_sandbox_config",
+            return_value=MagicMock(
+                open_credential_db=MagicMock(side_effect=NoPassphraseError("locked"))
+            ),
+        ):
+            _unassign_vault_ssh_keys("proj", deleted, skipped)
+        assert deleted == []
+        assert len(skipped) == 1
+        assert "vault locked" in skipped[0]
+        assert "'proj'" in skipped[0]
+
+
+class TestScopeHasVaultKeyLockedVault:
+    """``_scope_has_vault_key`` degrades to ``False`` when the vault is locked.
+
+    Pins the locked-vault contract: the SSH tile in the project
+    overview must keep rendering even when the resolution chain
+    yields nothing.  Pre-fix this raised ``NoPassphraseError`` and
+    blanked the whole panel.
+    """
+
+    def test_returns_false_on_locked_vault(self) -> None:
+        from terok_sandbox.credentials.db import NoPassphraseError
+
+        from terok.lib.domain.project_state import _scope_has_vault_key
+
+        with patch(
+            "terok.lib.core.config.make_sandbox_config",
+            return_value=MagicMock(
+                open_credential_db=MagicMock(side_effect=NoPassphraseError("locked"))
+            ),
+        ):
+            assert _scope_has_vault_key("proj") is False
+
+    def test_returns_false_on_wrong_passphrase(self) -> None:
+        from terok_sandbox.credentials.db import WrongPassphraseError
+
+        from terok.lib.domain.project_state import _scope_has_vault_key
+
+        with patch(
+            "terok.lib.core.config.make_sandbox_config",
+            return_value=MagicMock(
+                open_credential_db=MagicMock(side_effect=WrongPassphraseError("wrong"))
+            ),
+        ):
+            assert _scope_has_vault_key("proj") is False
 
 
 class TestLookupVaultPubLine:


### PR DESCRIPTION
## Summary

After **terok-sandbox#268** lands, the credentials DB is SQLCipher-encrypted and `CredentialDB.__init__(*, passphrase)` is mandatory.  Two call sites in terok constructed `CredentialDB(db_path)` directly without a passphrase, surfacing in the TUI as:

```
Project state error: CredentialDB.__init__() missing 1 required keyword-only argument: 'passphrase'
```

every time a project tile loaded, and as a hard failure on the `ProjectVaultStatus` panel.

This PR routes both call sites through `SandboxConfig.open_credential_db` (and its `SSHManager.open_for_config` sibling for the SSH path) so the four-tier passphrase resolution chain runs.  Locked-vault state degrades gracefully:

- `_scope_has_vault_key` catches `NoPassphraseError` / `WrongPassphraseError` and reports the SSH tile as empty — every other tile still renders.
- `_format_credentials_typed` falls back to the bare credential names (no per-credential type lookup) when the vault won't open.

The dedicated vault-locked **surface + unlock modal** (status bar pill, `Ctrl+L` re-probe, three-way unlock dialog) is tracked separately in **#877**; this PR keeps the TUI usable in the meantime so we're not blocked on the full UX before depending on the encrypted DB.

## Dependencies

- **Requires terok-sandbox#268 merged and released.**  That PR introduces:
  - `SandboxConfig.open_credential_db` (the seam this PR calls)
  - `SSHManager.open_for_config` (the SSH-manager equivalent)
  - `NoPassphraseError` / `WrongPassphraseError` exception types

  The `pyproject.toml` pin stays at `terok-sandbox 0.0.116` for now — bumping to the new release is the merge gate for this PR.  Local testing is via `pipx inject terok 'git+https://github.com/sliwowitz/terok-sandbox.git@feat/credentials-encryption'`.

## Test plan

- [ ] Wait for terok-sandbox#268 to release, bump the pin, run `poetry lock` + `make check`.
- [x] Manual: project tile loads cleanly on a host where the vault is locked (no SSH tile shown, all other tiles intact).
- [x] Manual: `ProjectVaultStatus` panel renders credential names without crashing when the vault is locked.
- [ ] Add a unit test that mocks `vault_db()` to raise `NoPassphraseError` and asserts `_scope_has_vault_key` returns False.

## Out of scope

- The full vault-locked UX (modal, status-bar pill, `Ctrl+L`) — see **#877**.
- New `systemd-creds` resolution tier for headless Linux — see **terok-sandbox#243**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Vault-unlock failures no longer cause errors: credential displays degrade gracefully and project deletion records residual SSH-key assignments instead of failing.
* **Refactor**
  * SSH and credential access unified under the sandbox config with consistent passphrase resolution and interactive prompt support.
* **Tests**
  * Unit and integration tests updated to exercise encrypted credential DB and vault-open failure paths.
* **Chores**
  * Package dependency pins updated.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/terok-ai/terok/pull/927)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->