### PR TITLE
fix(desktop): point TryExec at the binary, not the shim

### DIFF
--- a/src/terok/cli/commands/_desktop_entry.py
+++ b/src/terok/cli/commands/_desktop_entry.py
@@ -341,9 +341,17 @@ def _render_desktop_file(bin_str: str) -> str:
     # container-tabs UI they want.
     if shutil.which("ptyxis"):
         shim = str(_resource_dir().joinpath(_PTYXIS_SHIM_NAME))
+        # ``TryExec`` points at the binary, not the shim: pipx (and any
+        # PEP 517 wheel installer) ships package data without the
+        # executable bit, and GNOME silently hides any launcher whose
+        # ``TryExec`` target isn't ``+x``.  ``Exec`` invokes the shim
+        # via ``/bin/sh``, so the shim doesn't need to be executable —
+        # and the semantic we want to gate on ("is terok-tui actually
+        # installed?") is best expressed by ``TryExec``-ing the binary
+        # anyway.
         variables = {
             "EXEC": f"/bin/sh {shim} {bin_str}",
-            "TRY_EXEC": shim,
+            "TRY_EXEC": bin_str,
             "TERMINAL": "false",
         }
     else:

--- a/tests/unit/cli/test_desktop_entry.py
+++ b/tests/unit/cli/test_desktop_entry.py
@@ -558,4 +558,6 @@ class TestPtyxisGate:
         assert "Terminal=false" in content
         assert "/terok-xdg-terminal-exec.sh /usr/local/bin/terok-tui" in content
         assert "Exec=/bin/sh " in content
-        assert "/terok-xdg-terminal-exec.sh\n" in content  # TryExec line
+        # ``TryExec`` points at the binary, not the shim, so wheel-installed
+        # (non-executable) shims don't cause GNOME to hide the launcher.
+        assert "TryExec=/usr/local/bin/terok-tui\n" in content


### PR DESCRIPTION
## Summary

Reported in-session: after the gate-fix in #926, the rendered `~/.local/share/applications/terok.desktop` looked correct (`Terminal=false`, `Exec=/bin/sh <shim> <bin>`) but **didn't appear in the GNOME applications menu** on Fedora 44.

Root cause: the rendered `TryExec=` pointed at the bundled shim — but the freedesktop spec says

> If the path is not an absolute path, the file is looked up in the \$PATH environment variable. If the file is not present or if it is not executable, **the entry may be ignored** (not be used in menus, for example).

pipx (and any PEP 517 wheel installer) ships package data with mode `0644` — the wheel format doesn't preserve the +x bit on resources — so the shim landed at `…/site-packages/terok/resources/desktop/terok-xdg-terminal-exec.sh` as `-rw-r--r--`. GNOME hid the launcher entirely.

Fix: `TryExec=` points at the terok-tui binary instead of the shim.

- pipx installs entry-point scripts as `+x`, so the freedesktop existence check passes.
- `Exec=/bin/sh <shim> <bin>` reads the shim with `sh`, so the shim doesn't need to be executable.
- The semantic that `TryExec` is meant to gate on — "is the program actually installed?" — is better expressed against the binary anyway.

Tests updated:
```diff
- assert "/terok-xdg-terminal-exec.sh\n" in content  # TryExec line
+ assert "TryExec=/usr/local/bin/terok-tui\n" in content
```

## Test plan

- [x] `pytest tests/unit/cli/test_desktop_entry.py` — 29/29 pass.
- [x] `ruff check` clean on touched files.
- [ ] Manual on F44: re-run `terok setup`, confirm Terok now shows in the applications menu and launches into Ptyxis with container tabs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced desktop launcher configuration to ensure proper system compatibility verification. The application launcher now references the actual executable binary for system compatibility checks instead of the wrapper script, while continuing to execute through the wrapper as designed. This provides improved reliability and compatibility across different desktop environments, window managers, and Linux distributions.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/terok-ai/terok/pull/928)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->