### PR TITLE
ci(docs): reuse coverage artifact from Tests & Analysis

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -2,6 +2,23 @@ name: Documentation
 
 # Pin third-party actions to full commit SHAs for supply-chain security.
 # GitHub-owned actions (actions/*) may use version tags.
+#
+# Coverage handoff contract (well-known address):
+#   workflow=analysis.yml  job=unit-tests  artifact=coverage  contains reports/coverage.{json,xml}
+#
+# reports/coverage.json drives mkdocs-terok's code-coverage treemap. The unit
+# tests workflow already produces it (and ships it to SonarQube), so the docs
+# build downloads that artifact instead of paying for a second `make test-unit`.
+# The coverage JSON itself is throwaway: only the rendered SVG is published.
+#
+# Freshness policy:
+#   master ref  -> require the same-SHA Tests & Analysis run to complete
+#                  successfully (with a 20m wait). The published treemap must
+#                  match the published code.
+#   other refs  -> try same-SHA opportunistically, fall back immediately to
+#                  the latest successful master run. PR builds are not
+#                  published, so a one-merge-stale treemap is acceptable in
+#                  exchange for never-pending PR feedback.
 
 on:
   push:
@@ -15,12 +32,14 @@ concurrency:
   group: "pages"
   cancel-in-progress: false
 
+permissions:
+  contents: read
+  actions: read
+
 jobs:
   build:
     if: github.repository == 'terok-ai/terok'
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
     steps:
       - uses: actions/checkout@v6
 
@@ -54,12 +73,79 @@ jobs:
           echo "6c31f4d0cf3b7a8c5ca910fa4e451949434798f6541ec5dea4b83f4973e13772  scc_Linux_x86_64.tar.gz" | sha256sum -c
           sudo tar xzf scc_Linux_x86_64.tar.gz -C /usr/local/bin scc
 
-      - name: Generate coverage data for treemap
-        # Unit tests produce reports/coverage.json, which mkdocs-terok's
-        # code_metrics generator turns into a local treemap SVG. Replaces
-        # the previous curl from codecov.io/.../tree.svg, which intermittently
-        # failed and required a manual workflow rerun.
-        run: make test-unit
+      # On master we strictly require the Tests & Analysis run for *this* commit
+      # to have finished successfully — published docs must agree with published
+      # code. We poll the runs API instead of using workflow_run as the docs
+      # trigger so this build still surfaces as its own PR check elsewhere.
+      - name: Wait for Tests & Analysis on this commit (master)
+        if: github.ref == 'refs/heads/master'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const deadline = Date.now() + 20 * 60 * 1000;
+            const sleep = ms => new Promise(r => setTimeout(r, ms));
+            while (Date.now() < deadline) {
+              const { data } = await github.rest.actions.listWorkflowRuns({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                workflow_id: 'analysis.yml',
+                head_sha: context.sha,
+                per_page: 5,
+              });
+              const run = data.workflow_runs[0];
+              if (run?.status === 'completed') {
+                if (run.conclusion === 'success') {
+                  core.info(`Tests & Analysis succeeded for ${context.sha}`);
+                  return;
+                }
+                core.setFailed(
+                  `Tests & Analysis ${run.conclusion} for ${context.sha} — refusing to publish docs with a mismatched treemap`
+                );
+                return;
+              }
+              core.info(
+                `Tests & Analysis for ${context.sha}: ${run?.status ?? 'not yet started'} — waiting`
+              );
+              await sleep(20_000);
+            }
+            core.setFailed('Timed out after 20m waiting for Tests & Analysis');
+
+      - name: Coverage artifact (master — same SHA, required)
+        if: github.ref == 'refs/heads/master'
+        uses: dawidd6/action-download-artifact@b6e2e70617bc3265edd6dab6c906732b2f1ae151 # v21
+        with:
+          workflow: analysis.yml
+          workflow_conclusion: success
+          commit: ${{ github.sha }}
+          name: coverage
+          path: reports
+          if_no_artifact_found: fail
+
+      # First push of a PR: Tests & Analysis and this workflow start together,
+      # so this step usually misses and we fall through to latest-master below.
+      # Re-running this workflow after Tests & Analysis goes green picks up the
+      # same-SHA artifact here instead.
+      - name: Coverage artifact (non-master — same SHA, best effort)
+        if: github.ref != 'refs/heads/master'
+        uses: dawidd6/action-download-artifact@b6e2e70617bc3265edd6dab6c906732b2f1ae151 # v21
+        with:
+          workflow: analysis.yml
+          workflow_conclusion: success
+          commit: ${{ github.event.pull_request.head.sha || github.sha }}
+          name: coverage
+          path: reports
+          if_no_artifact_found: warn
+
+      - name: Coverage artifact (non-master — fall back to latest master)
+        if: github.ref != 'refs/heads/master' && !hashFiles('reports/coverage.json')
+        uses: dawidd6/action-download-artifact@b6e2e70617bc3265edd6dab6c906732b2f1ae151 # v21
+        with:
+          workflow: analysis.yml
+          workflow_conclusion: success
+          branch: master
+          name: coverage
+          path: reports
+          if_no_artifact_found: fail
 
       - name: Build documentation
         run: poetry run properdocs build --strict
@@ -69,6 +155,7 @@ jobs:
         uses: actions/configure-pages@v6
 
       - name: Upload artifact
+        if: github.ref == 'refs/heads/master'
         uses: actions/upload-pages-artifact@v5
         with:
           path: site


### PR DESCRIPTION
## Summary

- The docs build was re-running `make test-unit` purely to regenerate `reports/coverage.json` for the mkdocs-terok coverage treemap. That duplicated CI's slowest job for an artifact the `unit-tests` job in `analysis.yml` already uploads (alongside the `coverage.xml` shipped to SonarQube).
- This PR makes `docs.yml` consume the existing `coverage` artifact from `Tests & Analysis` instead of re-running tests. Tests and docs remain in **separate workflow files** (each is its own PR check, each is independently `workflow_dispatch`-able).
- Coverage JSON stays a transient input — only the rendered SVG is published, so we keep the artifact's existing 1-day retention.

## Freshness policy

| ref | behaviour |
|---|---|
| `refs/heads/master` (push or dispatch) | `actions/github-script` polls `listWorkflowRuns` for the same-SHA `Tests & Analysis` run for up to 20 min. If it succeeds, dawidd6 downloads its `coverage` artifact. If it errors or times out, the docs build fails — published treemap must match published code. |
| PR / dispatch elsewhere | Best-effort same-SHA download (warn on miss), then immediate fallback to the latest successful master `coverage` artifact. Never blocks. Re-running the workflow after `Tests & Analysis` goes green will pick up the same-SHA artifact. |

## Third-party action

`dawidd6/action-download-artifact` is pinned to commit `b6e2e706` (v21, released 2026-04-28). Maintainer is a long-time GitHub contributor (NixOS/nixpkgs, Homebrew/homebrew-core) with multiple actively maintained actions. ~34k dependents including Microsoft and Nordic Semiconductor projects. v21 dropped its built-in `wait_for_completion`, so the master-strict wait is handled by an official `actions/github-script@v7` step instead.

## Test plan

- [ ] Open this PR: `Documentation` check should run in parallel with `Tests & Analysis` and complete fast (no `make test-unit`); on the first build it will likely fall back to latest-master coverage.
- [ ] After `Tests & Analysis` finishes on this PR commit, re-run `Documentation` from the Actions tab; the same-SHA download step should succeed and the treemap should reflect this PR's code.
- [ ] After merge: master `Documentation` run should wait briefly for the same-SHA `Tests & Analysis` to finish, then publish to Pages with a treemap matching the merged commit.
- [ ] Sanity: artifact name (`coverage`), workflow file (`analysis.yml`), and download path (`reports/`) all match the producer in `analysis.yml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved documentation build reliability through additional quality validation checks
  * Enhanced workflow stability with explicit permission management
  * Optimized coverage artifact handling with intelligent fallback behavior

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/terok-ai/terok/pull/929)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->