### PR TITLE
ci: split SonarQube into its own workflow; simplify docs wait

### DIFF
--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -16,6 +16,8 @@ jobs:
   # On pull requests they also capture a tiny PR metadata artifact so the
   # privileged workflow_run-based Sonar scan can analyze fork PRs safely.
   unit-tests:
+    # NOTE: display name "Unit tests" is referenced by docs.yml's master-gate
+    # fail-fast poll. Keep them in sync if renaming.
     name: Unit tests
     if: github.repository == 'terok-ai/terok'
     runs-on: ubuntu-latest

--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -16,8 +16,6 @@ jobs:
   # On pull requests they also capture a tiny PR metadata artifact so the
   # privileged workflow_run-based Sonar scan can analyze fork PRs safely.
   unit-tests:
-    # NOTE: display name "Unit tests" is referenced by docs.yml's master-gate
-    # fail-fast poll. Keep them in sync if renaming.
     name: Unit tests
     if: github.repository == 'terok-ai/terok'
     runs-on: ubuntu-latest
@@ -153,36 +151,8 @@ jobs:
           path: reports/bandit-report.json
           retention-days: 1
 
-  # Same-repo pushes and pull requests can scan directly here because the run has access
-  # to SONAR_TOKEN. Fork PRs are handled by sonar_pr.yml via workflow_run, using the
-  # artifacts uploaded above, because GitHub does not expose secrets to fork PR runs.
-  sonar:
-    name: SonarQube Cloud
-    if: github.repository == 'terok-ai/terok' && (github.event_name == 'push' || (github.actor != 'dependabot[bot]' && github.event.pull_request.head.repo.full_name == github.repository))
-    needs: [unit-tests, ruff, bandit]
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-        with:
-          fetch-depth: 0
-
-      - uses: actions/download-artifact@v8
-        with:
-          name: coverage
-          path: reports
-
-      - uses: actions/download-artifact@v8
-        with:
-          name: ruff
-          path: reports
-
-      - uses: actions/download-artifact@v8
-        with:
-          name: bandit
-          path: reports
-
-      - name: SonarQube Cloud scan
-        uses: SonarSource/sonarqube-scan-action@59db25f34e16620e48ab4bb9e4a5dce155cb5432 # v8.0.0
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
-          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+  # The SonarQube Cloud scan runs in sonar.yml (same-repo) and sonar_pr.yml
+  # (fork PRs) — both consume the coverage/ruff/bandit artifacts uploaded
+  # above. Splitting Sonar out keeps this workflow free of third-party wait
+  # time, so downstream consumers (docs.yml, sonar.yml) unblock as soon as
+  # the local jobs finish.

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -73,42 +73,57 @@ jobs:
           echo "6c31f4d0cf3b7a8c5ca910fa4e451949434798f6541ec5dea4b83f4973e13772  scc_Linux_x86_64.tar.gz" | sha256sum -c
           sudo tar xzf scc_Linux_x86_64.tar.gz -C /usr/local/bin scc
 
-      # On master we strictly require the Tests & Analysis run for *this* commit
-      # to have finished successfully — published docs must agree with published
-      # code. We poll the runs API instead of using workflow_run as the docs
-      # trigger so this build still surfaces as its own PR check elsewhere.
-      - name: Wait for Tests & Analysis on this commit (master)
+      # On master we strictly require the Unit tests job for *this* commit to
+      # have produced its coverage artifact — published docs must agree with
+      # published code. We poll for the artifact itself (not the workflow's
+      # overall completion) so the docs build can proceed as soon as the
+      # artifact appears, without waiting for slow parallel jobs like the
+      # SonarQube Cloud scan to finish. If Unit tests has already completed
+      # without producing an artifact, we fail fast instead of polling out
+      # the full timeout.
+      - name: Wait for coverage artifact on this commit (master)
         if: github.ref == 'refs/heads/master'
         uses: actions/github-script@v7
         with:
           script: |
             const deadline = Date.now() + 20 * 60 * 1000;
             const sleep = ms => new Promise(r => setTimeout(r, ms));
+            const { owner, repo } = context.repo;
+            const sha = context.sha;
             while (Date.now() < deadline) {
-              const { data } = await github.rest.actions.listWorkflowRuns({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
+              const { data: runs } = await github.rest.actions.listWorkflowRuns({
+                owner, repo,
                 workflow_id: 'analysis.yml',
-                head_sha: context.sha,
+                head_sha: sha,
                 per_page: 5,
               });
-              const run = data.workflow_runs[0];
-              if (run?.status === 'completed') {
-                if (run.conclusion === 'success') {
-                  core.info(`Tests & Analysis succeeded for ${context.sha}`);
-                  return;
-                }
+              const run = runs.workflow_runs[0];
+              if (!run) {
+                core.info(`Tests & Analysis for ${sha}: not yet started — waiting`);
+                await sleep(20_000);
+                continue;
+              }
+              const { data: arts } = await github.rest.actions.listWorkflowRunArtifacts({
+                owner, repo, run_id: run.id,
+              });
+              if (arts.artifacts.some(a => a.name === 'coverage' && !a.expired)) {
+                core.info(`Coverage artifact ready for ${sha}`);
+                return;
+              }
+              const { data: jobs } = await github.rest.actions.listJobsForWorkflowRun({
+                owner, repo, run_id: run.id,
+              });
+              const unitTests = jobs.jobs.find(j => j.name === 'Unit tests');
+              if (unitTests?.status === 'completed') {
                 core.setFailed(
-                  `Tests & Analysis ${run.conclusion} for ${context.sha} — refusing to publish docs with a mismatched treemap`
+                  `Unit tests ${unitTests.conclusion} for ${sha} and no coverage artifact — refusing to publish docs with a mismatched treemap`
                 );
                 return;
               }
-              core.info(
-                `Tests & Analysis for ${context.sha}: ${run?.status ?? 'not yet started'} — waiting`
-              );
+              core.info(`Unit tests for ${sha}: ${unitTests?.status ?? 'not yet visible'} — waiting`);
               await sleep(20_000);
             }
-            core.setFailed('Timed out after 20m waiting for Tests & Analysis');
+            core.setFailed('Timed out after 20m waiting for coverage artifact');
 
       - name: Coverage artifact (master — same SHA, required)
         if: github.ref == 'refs/heads/master'

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -73,57 +73,43 @@ jobs:
           echo "6c31f4d0cf3b7a8c5ca910fa4e451949434798f6541ec5dea4b83f4973e13772  scc_Linux_x86_64.tar.gz" | sha256sum -c
           sudo tar xzf scc_Linux_x86_64.tar.gz -C /usr/local/bin scc
 
-      # On master we strictly require the Unit tests job for *this* commit to
-      # have produced its coverage artifact — published docs must agree with
-      # published code. We poll for the artifact itself (not the workflow's
-      # overall completion) so the docs build can proceed as soon as the
-      # artifact appears, without waiting for slow parallel jobs like the
-      # SonarQube Cloud scan to finish. If Unit tests has already completed
-      # without producing an artifact, we fail fast instead of polling out
-      # the full timeout.
-      - name: Wait for coverage artifact on this commit (master)
+      # On master we strictly require the Tests & Analysis run for *this* commit
+      # to have finished successfully — published docs must agree with published
+      # code. Tests & Analysis only contains the fast in-repo jobs (unit-tests,
+      # ruff, bandit); the third-party SonarQube scan lives in sonar.yml, so
+      # waiting on workflow completion here no longer drags in Sonar wait time.
+      # Polling rather than `workflow_run` keeps this build visible as its own
+      # PR check.
+      - name: Wait for Tests & Analysis on this commit (master)
         if: github.ref == 'refs/heads/master'
         uses: actions/github-script@v7
         with:
           script: |
             const deadline = Date.now() + 20 * 60 * 1000;
             const sleep = ms => new Promise(r => setTimeout(r, ms));
-            const { owner, repo } = context.repo;
-            const sha = context.sha;
             while (Date.now() < deadline) {
-              const { data: runs } = await github.rest.actions.listWorkflowRuns({
-                owner, repo,
+              const { data } = await github.rest.actions.listWorkflowRuns({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
                 workflow_id: 'analysis.yml',
-                head_sha: sha,
+                head_sha: context.sha,
                 per_page: 5,
               });
-              const run = runs.workflow_runs[0];
-              if (!run) {
-                core.info(`Tests & Analysis for ${sha}: not yet started — waiting`);
-                await sleep(20_000);
-                continue;
-              }
-              const { data: arts } = await github.rest.actions.listWorkflowRunArtifacts({
-                owner, repo, run_id: run.id,
-              });
-              if (arts.artifacts.some(a => a.name === 'coverage' && !a.expired)) {
-                core.info(`Coverage artifact ready for ${sha}`);
-                return;
-              }
-              const { data: jobs } = await github.rest.actions.listJobsForWorkflowRun({
-                owner, repo, run_id: run.id,
-              });
-              const unitTests = jobs.jobs.find(j => j.name === 'Unit tests');
-              if (unitTests?.status === 'completed') {
+              const run = data.workflow_runs[0];
+              if (run?.status === 'completed') {
+                if (run.conclusion === 'success') {
+                  core.info(`Tests & Analysis succeeded for ${context.sha}`);
+                  return;
+                }
                 core.setFailed(
-                  `Unit tests ${unitTests.conclusion} for ${sha} and no coverage artifact — refusing to publish docs with a mismatched treemap`
+                  `Tests & Analysis ${run.conclusion} for ${context.sha} — refusing to publish docs with a mismatched treemap`
                 );
                 return;
               }
-              core.info(`Unit tests for ${sha}: ${unitTests?.status ?? 'not yet visible'} — waiting`);
+              core.info(`Tests & Analysis for ${context.sha}: ${run?.status ?? 'not yet started'} — waiting`);
               await sleep(20_000);
             }
-            core.setFailed('Timed out after 20m waiting for coverage artifact');
+            core.setFailed('Timed out after 20m waiting for Tests & Analysis');
 
       - name: Coverage artifact (master — same SHA, required)
         if: github.ref == 'refs/heads/master'

--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -32,7 +32,12 @@ permissions:
 jobs:
   sonar:
     name: SonarQube Cloud
-    if: github.repository == 'terok-ai/terok' && (github.event_name == 'push' || (github.actor != 'dependabot[bot]' && github.event.pull_request.head.repo.full_name == github.repository))
+    if: >-
+      github.repository == 'terok-ai/terok' &&
+      (github.event_name == 'push'
+       || github.event_name == 'workflow_dispatch'
+       || (github.actor != 'dependabot[bot]'
+           && github.event.pull_request.head.repo.full_name == github.repository))
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -1,0 +1,102 @@
+name: SonarQube Cloud
+
+# Pin third-party actions to full commit SHAs for supply-chain security.
+# GitHub-owned actions (actions/*) may use version tags.
+#
+# Same-repo SonarQube scan. Split out of analysis.yml so its third-party
+# wait time doesn't block the Tests & Analysis workflow's conclusion (which
+# docs.yml waits on, and which gates the master Pages deploy).
+#
+# Triggering contexts (must match the inline sonar job this replaces):
+#   - push to master in terok-ai/terok
+#   - same-repo pull request against master (excluding dependabot)
+# Fork PRs continue to be handled by sonar_pr.yml via workflow_run in the
+# trusted base-repo context, because GitHub does not expose SONAR_TOKEN to
+# runs originating from forks.
+#
+# Wait/handoff: poll analysis.yml's run for this commit to complete, then
+# download its coverage/ruff/bandit artifacts via dawidd6 — same shape as
+# docs.yml's master gate.
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+  workflow_dispatch:
+
+permissions:
+  actions: read
+  contents: read
+
+jobs:
+  sonar:
+    name: SonarQube Cloud
+    if: github.repository == 'terok-ai/terok' && (github.event_name == 'push' || (github.actor != 'dependabot[bot]' && github.event.pull_request.head.repo.full_name == github.repository))
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Wait for Tests & Analysis on this commit
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const deadline = Date.now() + 20 * 60 * 1000;
+            const sleep = ms => new Promise(r => setTimeout(r, ms));
+            const sha = context.payload.pull_request?.head.sha || context.sha;
+            while (Date.now() < deadline) {
+              const { data } = await github.rest.actions.listWorkflowRuns({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                workflow_id: 'analysis.yml',
+                head_sha: sha,
+                per_page: 5,
+              });
+              const run = data.workflow_runs[0];
+              if (run?.status === 'completed') {
+                if (run.conclusion === 'success') {
+                  core.info(`Tests & Analysis succeeded for ${sha}`);
+                  return;
+                }
+                core.setFailed(`Tests & Analysis ${run.conclusion} for ${sha}`);
+                return;
+              }
+              core.info(`Tests & Analysis for ${sha}: ${run?.status ?? 'not yet started'} — waiting`);
+              await sleep(20_000);
+            }
+            core.setFailed('Timed out after 20m waiting for Tests & Analysis')
+
+      - name: Coverage artifact
+        uses: dawidd6/action-download-artifact@b6e2e70617bc3265edd6dab6c906732b2f1ae151 # v21
+        with:
+          workflow: analysis.yml
+          workflow_conclusion: success
+          commit: ${{ github.event.pull_request.head.sha || github.sha }}
+          name: coverage
+          path: reports
+
+      - name: Ruff artifact
+        uses: dawidd6/action-download-artifact@b6e2e70617bc3265edd6dab6c906732b2f1ae151 # v21
+        with:
+          workflow: analysis.yml
+          workflow_conclusion: success
+          commit: ${{ github.event.pull_request.head.sha || github.sha }}
+          name: ruff
+          path: reports
+
+      - name: Bandit artifact
+        uses: dawidd6/action-download-artifact@b6e2e70617bc3265edd6dab6c906732b2f1ae151 # v21
+        with:
+          workflow: analysis.yml
+          workflow_conclusion: success
+          commit: ${{ github.event.pull_request.head.sha || github.sha }}
+          name: bandit
+          path: reports
+
+      - name: SonarQube Cloud scan
+        uses: SonarSource/sonarqube-scan-action@59db25f34e16620e48ab4bb9e4a5dce155cb5432 # v8.0.0
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}


### PR DESCRIPTION
## Summary

Master-branch follow-up to #929. After that PR landed, the master `Documentation` build was observed sitting idle for the duration of the SonarQube Cloud scan even though the coverage artifact it actually consumes was ready much earlier. Root cause: docs.yml waited on `workflow_run.status == 'completed'`, which only flips after **every** job in `Tests & Analysis` finishes — unit-tests, ruff, bandit, **and** the slow third-party sonar scan.

Rather than make `docs.yml` reach inside `analysis.yml` to track a specific job, this PR splits SonarQube out into its own workflow file. Now `analysis.yml` only contains the fast in-repo jobs (unit-tests, ruff, bandit), and any downstream consumer can wait on its conclusion idiomatically.

## File changes

| File | Change |
|---|---|
| `analysis.yml` | Remove the inline `sonar` job. Replace with a comment pointing at sonar.yml / sonar_pr.yml. |
| `sonar.yml` | **New.** Triggers on push to master + same-repo PR + workflow_dispatch. Polls analysis.yml's run for this commit to complete, then downloads the `coverage`/`ruff`/`bandit` artifacts via dawidd6 and runs the SonarSource scan. |
| `docs.yml` | Master gate reverts to polling workflow-run conclusion (the artifact-list + Unit-tests-job-name fail-fast workaround from earlier in this branch is no longer needed). |
| `sonar_pr.yml` | Unchanged — still handles fork PRs via workflow_run because GitHub does not expose `SONAR_TOKEN` to runs originating from forks. |

## Contexts preserved

| Context | Before | After |
|---|---|---|
| same-repo push to master | `analysis.yml`'s inline `sonar` job | `sonar.yml` |
| same-repo PR against master | inline `sonar` job (skip if dependabot) | `sonar.yml` (skip if dependabot) |
| fork PR against master | `sonar_pr.yml` | `sonar_pr.yml` (unchanged) |

Both `sonar.yml` and `docs.yml` trigger on `push`/`pull_request` directly so they appear as their own PR checks — matching the prior UX where SonarQube showed up as `Tests & Analysis / SonarQube Cloud`.

## Test plan

- [ ] PR check column shows `Tests & Analysis`, `Documentation`, and `SonarQube Cloud` as three separate checks.
- [ ] `Tests & Analysis` completes within a few minutes (no longer waits on sonar).
- [ ] `Documentation` PR build still falls back to latest-master coverage on the first build, then picks up same-SHA after Tests & Analysis goes green and the workflow is re-run.
- [ ] `SonarQube Cloud` on a same-repo PR waits for `Tests & Analysis` to succeed, downloads artifacts, runs the scan, and reports back to the SonarCloud UI.
- [ ] After merge to master: master `Documentation` proceeds as soon as `Tests & Analysis` succeeds (no sonar wait); `SonarQube Cloud` runs on the master commit in parallel and reports to SonarCloud master.
- [ ] Fork PR: `sonar_pr.yml` still fires on `Tests & Analysis` completion via `workflow_run` and reports to SonarCloud (unchanged).
- [ ] Dependabot PR: `sonar.yml` is skipped via its `if:` condition (unchanged behaviour).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a standalone SonarQube Cloud scan that runs independently and consumes test/analysis artifacts.
  * Clarified workflow documentation to indicate where Sonar scans run and how artifacts are consumed.
  * Implemented polling to wait for required analysis artifacts with a 20-minute timeout and immediate failure on missing/failed results.
  * Simplified status logging during wait loops to single-line messages for clearer output.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/terok-ai/terok/pull/930)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->