### PR TITLE
ci(sonar): only allow workflow_dispatch from master

### DIFF
--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -35,7 +35,7 @@ jobs:
     if: >-
       github.repository == 'terok-ai/terok' &&
       (github.event_name == 'push'
-       || github.event_name == 'workflow_dispatch'
+       || (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/master')
        || (github.actor != 'dependabot[bot]'
            && github.event.pull_request.head.repo.full_name == github.repository))
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

Follow-up to #930. Found by CodeRabbit on the freshly merged sonar split: `sonar.yml`'s job guard accepts `workflow_dispatch` as a triggering event, but doesn't restrict the ref the dispatch came from. Dispatching from a non-master ref hangs the "Wait for Tests & Analysis" poll for the full 20-minute timeout — the upstream `Tests & Analysis` workflow only fires on push to master and on pull_request, so it never produces a run keyed on a feature-branch SHA unless a PR is also open for that exact commit.

This PR scopes `workflow_dispatch` to `refs/heads/master`. The supported use case for manual sonar runs is rescanning master after a transient SonarCloud flake; dispatching from feature branches isn't useful (no artifacts to consume) and would silently waste a worker.

## Diff
```diff
-       || github.event_name == 'workflow_dispatch'
+       || (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/master')
```

## Test plan

This small PR also doubles as the first real-world exercise of the new split CI shape on master after #930. Expected behaviour on this PR:

- [ ] `Tests & Analysis` (unit-tests + ruff + bandit) runs and goes green in a few minutes.
- [ ] `Documentation` waits for Tests & Analysis on this commit, then either downloads same-SHA coverage or falls back to latest-master, builds docs.
- [ ] `SonarQube Cloud` polls Tests & Analysis, downloads coverage/ruff/bandit, runs the scan, and reports back to SonarCloud.
- [ ] All three appear as separate PR checks.

After merge, manual dispatches from feature branches are skipped instead of hanging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD workflow configuration to enhance build pipeline controls.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/terok-ai/terok/pull/931)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->