### PR TITLE
test(matrix): align runner with terok-shield; +ubuntu26.04 +fedora44

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -73,7 +73,7 @@ test-integration-podman:
 test-integration-map:
 	poetry run python docs/test_map.py
 
-# Multi-distro integration test matrix (Debian 12/13, Ubuntu 24.04, Fedora 43)
+# Multi-distro integration test matrix (Debian 12/13, Ubuntu 24.04/26.04, Fedora 43/44, podman:stable)
 #   NO_CACHE=1 make test-matrix           — force full image rebuild
 #   BUILD_ONLY=1 make test-matrix         — build images only
 #   SCOPE=host-only make test-matrix      — run only needs_host_features tests

--- a/tests/containers/Containerfile.fedora44
+++ b/tests/containers/Containerfile.fedora44
@@ -1,0 +1,29 @@
+# SPDX-FileCopyrightText: 2026 Jiri Vyskocil
+# SPDX-License-Identifier: Apache-2.0
+
+# Fedora 44 — podman 5.x line, pasta default, looking forward
+FROM registry.fedoraproject.org/fedora:44
+
+RUN dnf install -y \
+    podman passt nftables slirp4netns fuse-overlayfs crun \
+    python3 python3-pip \
+    git curl bind-utils \
+    && dnf clean all
+
+# ── Rootless podman nesting setup (mirrors quay.io/podman/stable) ────
+# Subordinate UID/GID ranges MUST stay within 0-65535 so they fit inside
+# the outer rootless-podman container's user-namespace mapping.
+RUN useradd -m testrunner \
+    && uid=$(id -u testrunner) \
+    && printf "testrunner:1:%d\ntestrunner:%d:%d\n" \
+        $((uid - 1)) $((uid + 1)) $((65535 - uid)) > /etc/subuid \
+    && cp /etc/subuid /etc/subgid \
+    && chmod 4755 /usr/bin/newuidmap /usr/bin/newgidmap \
+    && printf '[storage]\ndriver = "overlay"\n\n[storage.options.overlay]\nmount_program = "/usr/bin/fuse-overlayfs"\nmountopt = "nodev,fsync=0"\n' \
+        > /etc/containers/storage.conf \
+    && printf '[engine]\ncgroup_manager = "cgroupfs"\nevents_logger = "file"\n\n# Disable per-container kernel keyring \xe2\x80\x94 prevents keyring leak / EDQUOT\n[containers]\nkeyring = false\n' \
+        > /etc/containers/containers.conf \
+    && mkdir -p /run/user/$uid \
+    && chown testrunner:testrunner /run/user/$uid
+
+WORKDIR /src

--- a/tests/containers/Containerfile.podman
+++ b/tests/containers/Containerfile.podman
@@ -11,8 +11,12 @@ RUN dnf install -y \
     git curl bind-utils openssh-clients \
     && dnf clean all
 
-# Disable per-container kernel keyring — prevents keyring leak / EDQUOT
-RUN printf '\n[containers]\nkeyring = false\n' >> /etc/containers/containers.conf
+# Disable per-container kernel keyring — prevents keyring leak / EDQUOT.
+# Use a conf.d drop-in: the base image already defines [containers] in the
+# main file, and TOML rejects a duplicate section header.
+RUN mkdir -p /etc/containers/containers.conf.d \
+    && printf '[containers]\nkeyring = false\n' \
+        > /etc/containers/containers.conf.d/00-no-keyring.conf
 
 # Ensure runtime dir exists for the pre-existing 'podman' user
 RUN mkdir -p /run/user/$(id -u podman) && chown podman:podman /run/user/$(id -u podman)

--- a/tests/containers/Containerfile.ubuntu2604
+++ b/tests/containers/Containerfile.ubuntu2604
@@ -1,0 +1,30 @@
+# SPDX-FileCopyrightText: 2026 Jiri Vyskocil
+# SPDX-License-Identifier: Apache-2.0
+
+# Ubuntu 26.04 (Resolute) — next LTS, pulls in a newer podman than 24.04
+FROM docker.io/library/ubuntu:26.04
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    podman slirp4netns passt nftables uidmap fuse-overlayfs crun \
+    python3 python3-pip python3-venv \
+    git curl ca-certificates dnsutils \
+    && rm -rf /var/lib/apt/lists/*
+
+# ── Rootless podman nesting setup (mirrors quay.io/podman/stable) ────
+# Subordinate UID/GID ranges MUST stay within 0-65535 so they fit inside
+# the outer rootless-podman container's user-namespace mapping.
+RUN useradd -m testrunner \
+    && uid=$(id -u testrunner) \
+    && printf "testrunner:1:%d\ntestrunner:%d:%d\n" \
+        $((uid - 1)) $((uid + 1)) $((65535 - uid)) > /etc/subuid \
+    && cp /etc/subuid /etc/subgid \
+    && chmod 4755 /usr/bin/newuidmap /usr/bin/newgidmap \
+    && mkdir -p /etc/containers \
+    && printf '[storage]\ndriver = "overlay"\n\n[storage.options.overlay]\nmount_program = "/usr/bin/fuse-overlayfs"\nmountopt = "nodev,fsync=0"\n' \
+        > /etc/containers/storage.conf \
+    && printf '[engine]\ncgroup_manager = "cgroupfs"\nevents_logger = "file"\n\n# Disable per-container kernel keyring \xe2\x80\x94 prevents keyring leak / EDQUOT\n[containers]\nkeyring = false\n' \
+        > /etc/containers/containers.conf \
+    && mkdir -p /run/user/$uid \
+    && chown testrunner:testrunner /run/user/$uid
+
+WORKDIR /src

--- a/tests/containers/run-matrix.sh
+++ b/tests/containers/run-matrix.sh
@@ -27,6 +27,16 @@ WORKSPACE_DIR="/workspace"
 PYTHON_VERSION="3.12"
 TEROK_DIAGNOSTIC_COMMAND="poetry run terok config"
 
+# Host-side scratch dir each test container writes its observed podman
+# version to.  Surfaced after each distro and in the final summary so the
+# matrix report shows what was actually exercised, not just what we expected.
+RESULTS_DIR="$(mktemp -d "${TMPDIR:-/tmp}/terok-matrix-XXXXXX")"
+chmod 0777 "$RESULTS_DIR"
+trap 'rm -rf "$RESULTS_DIR"' EXIT
+
+# distro name -> observed podman version (populated by run_tests).
+declare -A ACTUAL_VERSIONS=()
+
 # ── Terminal colors (disabled when stdout is not a tty) ──
 if [[ -t 1 ]]; then
     C_BOLD='\033[1m'
@@ -44,8 +54,10 @@ fi
 declare -A DISTROS=(
     [debian12]="debian12"
     [ubuntu2404]="ubuntu2404"
+    [ubuntu2604]="ubuntu2604"
     [debian13]="debian13"
     [fedora43]="fedora43"
+    [fedora44]="fedora44"
     [podman]="podman"
 )
 
@@ -53,8 +65,10 @@ declare -A DISTROS=(
 declare -A EXPECTED_VERSIONS=(
     [debian12]="4.3.x"
     [ubuntu2404]="4.9.x"
+    [ubuntu2604]="5.7.x"
     [debian13]="5.4.x"
     [fedora43]="5.8.x"
+    [fedora44]="5.8.x"
     [podman]="latest"
 )
 
@@ -63,8 +77,10 @@ declare -A EXPECTED_VERSIONS=(
 declare -A TEST_USERS=(
     [debian12]="testrunner"
     [ubuntu2404]="testrunner"
+    [ubuntu2604]="testrunner"
     [debian13]="testrunner"
     [fedora43]="testrunner"
+    [fedora44]="testrunner"
     [podman]="podman"
 )
 
@@ -147,6 +163,7 @@ run_tests() {
         --device /dev/fuse:rw \
         -e container=podman \
         -v "$REPO_ROOT:$SOURCE_MOUNT:ro,Z" \
+        -v "$RESULTS_DIR:/results:rw,Z" \
         "$image" \
         bash -c "
             set -e
@@ -171,7 +188,19 @@ run_tests() {
                 cd $WORKSPACE_DIR
 
                 echo \"--- podman version ---\"
-                podman --version || echo \"podman not available\"
+                # Capture observed version into the shared /results dir.
+                # No single quotes anywhere in this inner block — it is
+                # wrapped in a single-quoted su -c argument, so any single
+                # quote would close it early.  Parameter expansion only.
+                if command -v podman >/dev/null 2>&1; then
+                    podman_ver_line=\$(podman --version 2>&1 | head -n1)
+                    echo \"\$podman_ver_line\"
+                    # podman version 5.8.2 -> 5.8.2
+                    echo \"\${podman_ver_line##* }\" > /results/$name.podman-version
+                else
+                    echo \"podman not available\"
+                    : > /results/$name.podman-version
+                fi
 
                 echo \"--- rootless podman preflight ---\"
                 podman info --format \"podman={{.Version.Version}} storage={{.Store.GraphDriverName}}\" \
@@ -223,10 +252,18 @@ print(\\\"Shield hooks verified.\\\")
         "
 
     local status=$?
+
+    # Pick up what the inner script observed (may be empty if podman
+    # was missing or the container died before reaching that step).
+    local actual
+    actual=$(cat "$RESULTS_DIR/$name.podman-version" 2>/dev/null || true)
+    ACTUAL_VERSIONS[$name]="${actual:-?}"
+
+    local versions="expected ${EXPECTED_VERSIONS[$name]}, got ${ACTUAL_VERSIONS[$name]}"
     if [[ $status -eq 0 ]]; then
-        echo -e "${C_GREEN}==> $name: PASS${C_RESET}"
+        echo -e "${C_GREEN}==> $name: PASS${C_RESET} ${C_DIM}($versions)${C_RESET}"
     else
-        echo -e "${C_RED}==> $name: FAIL${C_RESET}" >&2
+        echo -e "${C_RED}==> $name: FAIL${C_RESET} ${C_DIM}($versions)${C_RESET}" >&2
     fi
     return "$status"
 }
@@ -290,10 +327,10 @@ done
 echo ""
 echo -e "${C_BOLD}===== Matrix Summary =====${C_RESET}"
 for target in "${PASSED[@]}"; do
-    echo -e "  ${C_GREEN}PASS${C_RESET}: $target ${C_DIM}(podman ${EXPECTED_VERSIONS[$target]})${C_RESET}"
+    echo -e "  ${C_GREEN}PASS${C_RESET}: $target ${C_DIM}(expected ${EXPECTED_VERSIONS[$target]}, got ${ACTUAL_VERSIONS[$target]:-?})${C_RESET}"
 done
 for target in "${FAILED[@]}"; do
-    echo -e "  ${C_RED}FAIL${C_RESET}: $target ${C_DIM}(podman ${EXPECTED_VERSIONS[$target]})${C_RESET}"
+    echo -e "  ${C_RED}FAIL${C_RESET}: $target ${C_DIM}(expected ${EXPECTED_VERSIONS[$target]}, got ${ACTUAL_VERSIONS[$target]:-?})${C_RESET}"
 done
 
 if [[ ${#FAILED[@]} -gt 0 ]]; then


### PR DESCRIPTION
## Summary

Brings the matrix runner in line with what landed in **terok-shield #303**.  The three improvements are independent and all worth having in this repo too:

- **Containerfile.podman**: drops `keyring = false` into `/etc/containers/containers.conf.d/00-no-keyring.conf` rather than appending a second `[containers]` header to the main file.  The current `quay.io/podman/stable` (Fedora 44-based) already defines `[containers]`, and TOML rejects the duplicate.  Without this, the `podman` target fails before tests even start.
- **Observed-version capture**: each container writes the line-1 trailing token of `podman --version` to a host-side scratch dir bind-mounted at `/results`.  The runner reads it back after the container exits and the per-distro footer + final summary now show both expected and observed values (e.g. `PASS: fedora43 (expected 5.8.x, got 5.8.2)`).  No single quotes inside the inner `su -c '…'` block — parameter expansion only.
- **Matrix extension**: new `Containerfile.fedora44` (podman 5.8.x) and `Containerfile.ubuntu2604` (podman 5.7.x); `DISTROS` / `EXPECTED_VERSIONS` / `TEST_USERS` arrays extended; Makefile help comment updated.

terok's `poetry.lock` is **not** affected by the broken `virtualenv 21.2.4` pin that shield's lockfile had — terok's lock never resolved that combination.  No lockfile changes needed.

## Test plan

- [ ] `make test-matrix` runs cleanly across all 7 distros (`debian12`, `debian13`, `ubuntu2404`, `ubuntu2604`, `fedora43`, `fedora44`, `podman`)
- [ ] `NO_CACHE=1 make test-matrix` produces the same green result (no stale image layers hiding the fix)
- [ ] Each distro footer reports `expected X.Y.z, got A.B.c` consistent with its `EXPECTED_VERSIONS` entry
- [ ] `podman` target no longer dies at `containers.conf` parsing — confirms the conf.d drop-in fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded test coverage to additional Linux distributions: Fedora 44, Ubuntu 26.04, and Debian 13.
  * Enhanced test infrastructure with improved Podman version tracking and validation across supported platforms.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/terok-ai/terok/pull/932)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->