### PR TITLE
test(containers): use executor's stage_scripts so sandbox bridges are staged

### DIFF
--- a/tests/integration/containers/conftest.py
+++ b/tests/integration/containers/conftest.py
@@ -104,13 +104,20 @@ def shell_test_image(tmp_path_factory: pytest.TempPathFactory) -> Iterator[str]:
     # Reading the raw template and writing it verbatim leaves `{{ BASE_IMAGE }}`
     # and `{% if family ... %}` placeholders un-substituted, so podman build
     # dies at `FROM {{` with "invalid reference format".
+    from terok_executor import stage_scripts, stage_tmux_config
     from terok_executor.container.build import render_l0
 
     (build_dir / "L0.Dockerfile").write_text(render_l0())
 
-    # Stage scripts and tmux config into the build context.
-    _copy_resource_tree("terok_executor", "resources/scripts", build_dir / "scripts")
-    _copy_resource_tree("terok_executor", "resources/tmux", build_dir / "tmux")
+    # Stage scripts (executor's own + sandbox bridge overlays) and tmux
+    # config into the build context.  Using executor's `stage_scripts()`
+    # rather than a bare resources-tree copy is what gets the
+    # ssh-agent-bridge.sh / ensure-bridges.sh scripts in — those live in
+    # terok_sandbox, and the L0 Dockerfile's COPY lines expect them under
+    # scripts/.  Without the overlay, STEP 8 (COPY ssh-agent-bridge.sh)
+    # fails with "no such file or directory".
+    stage_scripts(build_dir / "scripts")
+    stage_tmux_config(build_dir / "tmux")
 
     # Build L0 from the real template.
     _podman_build(build_dir / "L0.Dockerfile", ITEST_L0_IMAGE, build_dir)


### PR DESCRIPTION
## Summary

Follow-up to #933.  My previous fix made the L0 Dockerfile render through Jinja so it no longer dies at `FROM {{`, but the build still failed at **STEP 8** (`COPY scripts/ssh-agent-bridge.sh /usr/local/bin/ssh-agent-bridge.sh`) on every distro — `no such file or directory`.

Root cause: the L0 template's `COPY scripts/…` lines expect three scripts in `scripts/`:
- `init-ssh-and-repo.sh` — lives in `terok_executor/resources/scripts/` ✓
- `ssh-agent-bridge.sh` — lives in **`terok_sandbox/resources/bridges/`**
- `ensure-bridges.sh` — also in **`terok_sandbox/resources/bridges/`**

The previous conftest only copied executor's scripts, so the two sandbox bridges were missing.  Production already solves this — `terok_executor.container.build.stage_scripts()` copies executor's scripts and overlays sandbox's bridges into the same directory, and it's part of the public API (`from terok_executor import stage_scripts, stage_tmux_config`).

This PR replaces the bare `_copy_resource_tree(…)` calls in `tests/integration/containers/conftest.py` with `stage_scripts()` + `stage_tmux_config()`.  Verified locally: `scripts/` now contains both `ssh-agent-bridge.sh` and `ensure-bridges.sh` after staging.

## Test plan

- [ ] `make test-matrix` clears the 11 container-test errors on every distro
- [ ] Local `pytest tests/integration/containers/ --collect-only` still finds 11 tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal test infrastructure to use standardized staging helpers for build context preparation. No user-facing changes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/terok-ai/terok/pull/934)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->