### PR TITLE
test(shield): update test_allow_then_deny to the post-#230 semantics

### DIFF
--- a/tests/integration/test_shield_podman.py
+++ b/tests/integration/test_shield_podman.py
@@ -21,6 +21,22 @@ from .helpers import assert_blocked, assert_reachable, inspect_container_json
 pytestmark = pytest.mark.needs_podman
 
 
+def _nft_set(rules: str, name: str) -> str:
+    """Return the body of the ``set <name> { ... }`` block from an ``nft list`` dump.
+
+    Useful for assertions that need to know *which* set an IP lives in
+    (e.g. ``allow_v4`` vs ``deny_v4``) rather than just whether the IP
+    appears anywhere in the rule text.  Returns an empty string when
+    the named set isn't found.
+    """
+    head = f"set {name} "
+    if head not in rules:
+        return ""
+    _, _, after = rules.partition(head)
+    body, _, _ = after.partition("set ")
+    return body
+
+
 # ── TestShieldEndToEnd ───────────────────────────────────
 
 
@@ -46,16 +62,24 @@ class TestShieldEndToEnd:
         assert "terok_shield" in output
 
     def test_allow_then_deny(self, shielded_container: str, real_shield: Shield) -> None:
-        """shield.allow adds an IP; shield.deny removes it."""
+        """``shield.allow`` puts an IP into ``allow_v4``; ``shield.deny`` moves it to ``deny_v4``.
+
+        Per terok-shield PR #230 the deny.list is enforced as an explicit
+        nftables set (``deny_v4`` / ``deny_v6``) rather than silently
+        dropping the IP from ``allow_v4`` — the IP is still present in
+        the ruleset dump, just in a different set so packets get
+        actively rejected with a logged reason.
+        """
         allowed = real_shield.allow(shielded_container, TEST_IP_RFC5737)
         assert TEST_IP_RFC5737 in allowed
         rules_after_allow = real_shield.rules(shielded_container)
-        assert TEST_IP_RFC5737 in rules_after_allow
+        assert TEST_IP_RFC5737 in _nft_set(rules_after_allow, "allow_v4")
 
         denied = real_shield.deny(shielded_container, TEST_IP_RFC5737)
         assert TEST_IP_RFC5737 in denied
         rules_after_deny = real_shield.rules(shielded_container)
-        assert TEST_IP_RFC5737 not in rules_after_deny
+        assert TEST_IP_RFC5737 not in _nft_set(rules_after_deny, "allow_v4")
+        assert TEST_IP_RFC5737 in _nft_set(rules_after_deny, "deny_v4")
 
 
 # ── TestShieldEgress ──────────────────────────────────────


### PR DESCRIPTION
## Summary

One test failing across all 7 distros: `tests/integration/test_shield_podman.py::TestShieldEndToEnd::test_allow_then_deny`.

The test asserts `IP not in rules_after_deny` — that's the **pre-#230** contract.  At the time, `shield.deny()` was just a silent removal from `allow_v4` and the IP would disappear from the rules dump.

terok-shield **PR #230 ("enforce deny.list when shield is down")** changed the model: `deny` now populates an explicit `deny_v4` / `deny_v6` nftables set so packets to the IP are actively rejected with a logged reason, rather than falling through to the default-deny rule.  The IP stays present in the ruleset — just moved from `allow_v4` to `deny_v4`.

This is the same kind of stale assertion I fixed for shield's own `test_deny_during_bypass_*` in shield #303 (rename + `assert_not_connectable`).  The terok-side counterpart was missed at the time because it didn't run in the previous matrix.

## Fix

Replace the coarse "IP not anywhere in rules" check with a check that answers the right question — *which set* is the IP in?

```python
def _nft_set(rules: str, name: str) -> str:
    """Return the body of `set <name> { ... }` from an `nft list` dump."""

# after allow:
assert TEST_IP_RFC5737 in _nft_set(rules_after_allow, "allow_v4")

# after deny: IP moved from allow_v4 to deny_v4 (per PR #230)
assert TEST_IP_RFC5737 not in _nft_set(rules_after_deny, "allow_v4")
assert TEST_IP_RFC5737 in _nft_set(rules_after_deny, "deny_v4")
```

`_nft_set()` lives at module scope, ~6 lines, no external deps.

## Test plan

- [ ] `make test-matrix` clears the last red row — every distro should report PASS
- [ ] Local pytest collection still finds the test (verified: 5 tests collected)
- [ ] Spot-check `_nft_set()` logic against a sample dump (verified locally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced integration tests to better verify allow and deny list functionality, including validation of IP transitions between states.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/terok-ai/terok/pull/935)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->