### PR TITLE
chore(sickbay): drop kernel keyring warning from runtime output

### DIFF
--- a/src/terok/cli/commands/sickbay.py
+++ b/src/terok/cli/commands/sickbay.py
@@ -20,9 +20,7 @@ Exit codes:
 from __future__ import annotations
 
 import argparse
-import os
 import sys
-import tomllib
 from pathlib import Path
 
 from terok_clearance import (
@@ -420,53 +418,6 @@ def _check_ssh_signer() -> _CheckResult:
     return ("ok", label, f"{total}/{total} project(s) have SSH keys")
 
 
-_KEYRING_DOC_URL = "https://terok-ai.github.io/terok/kernel-keyring/"
-
-# Podman containers.conf lookup order (rootless).  The first existing file wins.
-_CONTAINERS_CONF_PATHS = (
-    Path.home() / ".config" / "containers" / "containers.conf",
-    Path("/etc/containers/containers.conf"),
-)
-
-
-def _find_containers_conf() -> Path | None:
-    """Return the effective containers.conf path, respecting ``$CONTAINERS_CONF``."""
-    env = os.environ.get("CONTAINERS_CONF")
-    if env:
-        p = Path(env)
-        if p.is_file():
-            return p
-        # Invalid env var — fall through to standard paths
-    return next((p for p in _CONTAINERS_CONF_PATHS if p.is_file()), None)
-
-
-def _check_keyring() -> _CheckResult:
-    """Check that the kernel keyring is disabled in containers.conf."""
-    label = "Keyring"
-    conf = _find_containers_conf()
-    if conf is None:
-        return (
-            "warn",
-            label,
-            f"no containers.conf found — add keyring = false, see {_KEYRING_DOC_URL}",
-        )
-    try:
-        data = tomllib.loads(conf.read_text(encoding="utf-8"))
-    except (OSError, tomllib.TOMLDecodeError) as exc:
-        return ("warn", label, f"cannot parse {conf} — {exc}")
-    containers_section = data.get("containers")
-    keyring = (
-        containers_section.get("keyring", True) if isinstance(containers_section, dict) else True
-    )
-    if keyring is False:
-        return ("ok", label, f"disabled in {conf}")
-    return (
-        "warn",
-        label,
-        f"not disabled — add [containers] keyring = false to {conf}, see {_KEYRING_DOC_URL}",
-    )
-
-
 def _stream_containers(
     project_id: str | None,
     task_id: str | None,
@@ -603,7 +554,6 @@ _GLOBAL_CHECKS = [
     ("Vault", _check_vault),
     ("Vault migration", _check_vault_migration),
     ("SSH signer", _check_ssh_signer),
-    ("Keyring", _check_keyring),
     ("SELinux policy", _check_selinux_policy),
     ("Clearance stack", _check_clearance_stack),
 ]

--- a/tests/unit/cli/test_cli_sickbay.py
+++ b/tests/unit/cli/test_cli_sickbay.py
@@ -13,11 +13,9 @@ from terok_sandbox import GateServerStatus
 
 from terok.cli.commands import sickbay as _sickbay_module
 from terok.cli.commands.sickbay import (
-    _check_keyring,
     _check_shield,
     _check_vault,
     _cmd_sickbay,
-    _find_containers_conf,
 )
 from tests.testfs import MOCK_BASE
 from tests.testgate import OUTDATED_UNITS_MESSAGE, make_gate_server_status
@@ -106,10 +104,6 @@ def test_cmd_sickbay_reports_health(
         json.dumps({"p": {"private_key": str(dummy_key), "public_key": str(tmp_path / "id.pub")}})
     )
 
-    # Keyring check needs a containers.conf with keyring = false
-    keyring_conf = tmp_path / "containers.conf"
-    keyring_conf.write_text("[containers]\nkeyring = false\n")
-
     mock_ec = MagicMock(health="ok", hooks="per-container", dns_tier="dnsmasq")
     mock_cfg = MagicMock()
     mock_cfg.return_value.ssh_keys_json_path = ssh_keys
@@ -144,7 +138,6 @@ def test_cmd_sickbay_reports_health(
         patch("terok.cli.commands.sickbay.is_vault_systemd_available", return_value=False),
         patch("terok.cli.commands.sickbay.get_services_mode", return_value="tcp"),
         patch("terok.cli.commands.sickbay.make_sandbox_config", mock_cfg),
-        patch("terok.cli.commands.sickbay._find_containers_conf", return_value=keyring_conf),
     ):
         if exit_code is None:
             _cmd_sickbay()
@@ -335,91 +328,3 @@ def test_check_vault_states(
     assert status == expected_status
     assert label == "Vault"
     assert expected_detail in detail
-
-
-class TestCheckKeyring:
-    """Verify _check_keyring diagnostics."""
-
-    def test_disabled(self, tmp_path: Path) -> None:
-        """keyring = false → ok."""
-        conf = tmp_path / "containers.conf"
-        conf.write_text("[containers]\nkeyring = false\n")
-        with patch("terok.cli.commands.sickbay._find_containers_conf", return_value=conf):
-            sev, label, detail = _check_keyring()
-        assert sev == "ok"
-        assert label == "Keyring"
-        assert "disabled" in detail
-
-    def test_enabled_explicitly(self, tmp_path: Path) -> None:
-        """keyring = true → warn with docs link."""
-        conf = tmp_path / "containers.conf"
-        conf.write_text("[containers]\nkeyring = true\n")
-        with patch("terok.cli.commands.sickbay._find_containers_conf", return_value=conf):
-            sev, label, detail = _check_keyring()
-        assert sev == "warn"
-        assert "kernel-keyring" in detail
-
-    def test_absent_defaults_to_warn(self, tmp_path: Path) -> None:
-        """No [containers] section → warn (default is true)."""
-        conf = tmp_path / "containers.conf"
-        conf.write_text("[engine]\nevents_logger = 'file'\n")
-        with patch("terok.cli.commands.sickbay._find_containers_conf", return_value=conf):
-            sev, _, detail = _check_keyring()
-        assert sev == "warn"
-        assert "not disabled" in detail
-
-    def test_no_conf_file(self) -> None:
-        """No containers.conf found → warn."""
-        with patch("terok.cli.commands.sickbay._find_containers_conf", return_value=None):
-            sev, _, detail = _check_keyring()
-        assert sev == "warn"
-        assert "no containers.conf" in detail
-
-    def test_corrupt_toml(self, tmp_path: Path) -> None:
-        """Corrupt TOML → warn with parse error."""
-        conf = tmp_path / "containers.conf"
-        conf.write_text("[bad toml\n")
-        with patch("terok.cli.commands.sickbay._find_containers_conf", return_value=conf):
-            sev, _, detail = _check_keyring()
-        assert sev == "warn"
-        assert "cannot parse" in detail
-
-    def test_non_dict_containers_section(self, tmp_path: Path) -> None:
-        """Non-table [containers] value → warn (treated as keyring enabled)."""
-        conf = tmp_path / "containers.conf"
-        conf.write_text('containers = "not a table"\n')
-        with patch("terok.cli.commands.sickbay._find_containers_conf", return_value=conf):
-            sev, _, detail = _check_keyring()
-        assert sev == "warn"
-        assert "not disabled" in detail
-
-
-class TestFindContainersConf:
-    """Verify _find_containers_conf lookup logic."""
-
-    def test_env_var_valid(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-        """$CONTAINERS_CONF pointing to a real file → returns that path."""
-        conf = tmp_path / "custom.conf"
-        conf.write_text("[containers]\n")
-        monkeypatch.setenv("CONTAINERS_CONF", str(conf))
-        assert _find_containers_conf() == conf
-
-    def test_env_var_missing_falls_back(
-        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
-        """$CONTAINERS_CONF pointing to non-existent file → falls back to standard paths."""
-        monkeypatch.setenv("CONTAINERS_CONF", str(tmp_path / "ghost.conf"))
-        fallback = tmp_path / "containers.conf"
-        fallback.write_text("[containers]\nkeyring = false\n")
-        with patch("terok.cli.commands.sickbay._CONTAINERS_CONF_PATHS", (fallback,)):
-            result = _find_containers_conf()
-        assert result == fallback
-
-    def test_no_env_no_files(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
-        """No env var, no standard files → None."""
-        monkeypatch.delenv("CONTAINERS_CONF", raising=False)
-        with patch(
-            "terok.cli.commands.sickbay._CONTAINERS_CONF_PATHS",
-            (tmp_path / "missing1.conf", tmp_path / "missing2.conf"),
-        ):
-            assert _find_containers_conf() is None


### PR DESCRIPTION
## Summary

- The kernel-keyring exhaustion warning surfaces in `terok sickbay` even though, in practice, the failure mode it warns about only shows up on integration-test matrix runners — many short-lived containers exhausting the per-UID 200-key quota. Normal `terok` usage has not hit this.
- Remove `_check_keyring` and its `containers.conf` lookup helpers from `src/terok/cli/commands/sickbay.py`, plus the matching unit tests in `tests/unit/cli/test_cli_sickbay.py`.
- **Kept on purpose**: the `warn_keyring` block in `tests/containers/run-matrix.sh` (where it actually fires) and `docs/kernel-keyring.md` (for users who do hit the quota and want mitigation).

If real reports trickle in from users running a lot of containers over the next few weeks/months, we can reintroduce a more targeted check — but the current always-on warning was mostly noise.

## Test plan

- [ ] `make lint` clean
- [ ] `make test` passes (the only sickbay-related touch is the deletion of two test classes + a fixture cleanup in `test_cmd_sickbay_reports_health`)
- [ ] Manual: `terok sickbay` no longer prints a `Keyring` row
- [ ] Manual: `bash tests/containers/run-matrix.sh` still prints the keyring warning when `containers.conf` does not set `keyring = false`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed Keyring health check from sickbay command.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/terok-ai/terok/pull/937)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->