### PR TITLE
feat(panic): lock the session tier as an early step

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -451,6 +451,22 @@ Run `terok sickbay <project> <task>` to see a per-task auth report.
 Missing phantom env vars show up as warnings ("not set") and flag exactly
 which providers were unauthenticated when the container was created.
 
+### Vault passphrase backend
+
+The credentials DB itself is SQLCipher-encrypted; the passphrase
+travels through a resolver chain (session-unlock file → systemd-creds
+→ keyring → `credentials.passphrase` plaintext → interactive prompt).
+`terok vault unlock` writes to the session tier, `terok vault lock`
+clears it, and `terok-sandbox setup` picks the persistent tier at
+install time.  To move the passphrase between backends —
+**retrieve → lock --forget → reseed** — see the
+["Changing tiers" recipe](https://github.com/terok-ai/terok-sandbox/blob/master/docs/credentials-encryption.md)
+in terok-sandbox.
+
+Pressing PANIC also clears the session-unlock file so the daemon
+can't auto-resume from that tier; persistent tiers stay so the panic
+is reversible.
+
 ---
 
 ## Headless Agent Runs (Autopilot)

--- a/src/terok/lib/domain/panic.py
+++ b/src/terok/lib/domain/panic.py
@@ -3,9 +3,18 @@
 
 """Emergency panic — immediately cut all resource access across all projects.
 
-Two-phase sequence: Phase 1 raises shields, stops the vault and gate
-server — all in parallel, all reversible.  Phase 2 optionally stops
-the containers themselves (slow on some platforms, so user-prompted).
+Two-phase sequence: Phase 1 raises shields, locks the vault session
+tier + stops its daemon, and stops the gate server — all in parallel,
+all reversible.  Phase 2 optionally stops the containers themselves
+(slow on some platforms, so user-prompted).
+
+The vault step deletes the session-unlock tmpfs file in addition to
+stopping the daemon so the next socket activation can't auto-resume
+from the session tier — a stopped-but-unlocked daemon defeats the
+point of pressing PANIC.  Persistent tiers (keyring, systemd-creds,
+``credentials.passphrase``) are intentionally untouched; clearing
+them is destructive and the operator can opt-in via
+``terok-sandbox vault lock --forget``.
 
 Token revocation is deliberately excluded — it is irreversible and
 shields + stopped services already cut access.
@@ -111,7 +120,7 @@ def format_panic_report(result: PanicResult) -> str:
     lines = [
         f"Containers found: {result.total_running}",
         _format_shield_status(result),
-        f"Vault: {'stopped' if result.vault_stopped else 'FAILED'}",
+        f"Vault: {'locked + stopped' if result.vault_stopped else 'FAILED'}",
         f"Gate:  {'stopped' if result.gate_stopped else 'FAILED'}",
     ]
 
@@ -238,10 +247,24 @@ def _raise_shield(target: _Target) -> tuple[str, str | None]:
 
 
 def _stop_vault() -> tuple[bool, str | None]:
-    """Stop the vault daemon."""
-    from terok_sandbox import stop_vault
+    """Lock the session tier and stop the vault daemon.
+
+    Removes the session-unlock tmpfs file *before* stopping the daemon
+    so a panic genuinely makes the vault locked rather than merely
+    stopped — without this, the daemon happily auto-restarts from the
+    session tier on next socket activation, which is not what an
+    operator hitting "PANIC" wants.
+
+    Persistent tiers (keyring, sealed systemd-creds,
+    ``credentials.passphrase``) are intentionally NOT wiped: panic
+    must stay reversible, and the operator can run
+    ``terok-sandbox vault lock --forget`` afterwards if they want
+    a destructive lockout.
+    """
+    from terok_sandbox import SandboxConfig, stop_vault
 
     try:
+        SandboxConfig().vault_passphrase_file.unlink(missing_ok=True)
         stop_vault()
         return True, None
     except Exception as exc:

--- a/tests/unit/lib/test_panic.py
+++ b/tests/unit/lib/test_panic.py
@@ -282,23 +282,62 @@ class TestRaiseShield:
 
 
 class TestStopVault:
-    """Tests for _stop_vault."""
+    """Tests for _stop_vault — the panic "lock + stop" step."""
 
     @patch("terok_sandbox.stop_vault")
-    def test_success(self, mock_stop: MagicMock) -> None:
+    @patch("terok_sandbox.SandboxConfig")
+    def test_success(self, mock_cfg: MagicMock, mock_stop: MagicMock) -> None:
         """Vault stop succeeds."""
         from terok.lib.domain.panic import _stop_vault
 
+        mock_cfg.return_value.vault_passphrase_file = MagicMock()
         ok, err = _stop_vault()
         assert ok and err is None
 
+    @patch("terok_sandbox.SandboxConfig")
     @patch("terok_sandbox.stop_vault", side_effect=Exception("no vault"))
-    def test_failure(self, mock_stop: MagicMock) -> None:
+    def test_failure(self, _stop: MagicMock, mock_cfg: MagicMock) -> None:
         """Vault stop failure returns error."""
         from terok.lib.domain.panic import _stop_vault
 
+        mock_cfg.return_value.vault_passphrase_file = MagicMock()
         ok, err = _stop_vault()
         assert not ok and "no vault" in err
+
+    def test_removes_session_unlock_file(self, tmp_path) -> None:
+        """Panic unlinks the tmpfs session-unlock file before stopping the daemon.
+
+        Without this, the daemon auto-resumes from the session tier on
+        next socket activation — a stopped-but-unlocked vault defeats
+        the point of pressing PANIC.
+        """
+        from terok.lib.domain.panic import _stop_vault
+
+        passphrase_file = tmp_path / "vault.passphrase"
+        passphrase_file.write_text("not-a-real-passphrase\n", encoding="utf-8")
+        fake_cfg = MagicMock()
+        fake_cfg.vault_passphrase_file = passphrase_file
+        with (
+            patch("terok_sandbox.SandboxConfig", return_value=fake_cfg),
+            patch("terok_sandbox.stop_vault"),
+        ):
+            ok, err = _stop_vault()
+        assert ok and err is None
+        assert not passphrase_file.exists()
+
+    def test_missing_session_file_is_not_an_error(self, tmp_path) -> None:
+        """No session file → still succeeds; missing_ok=True covers the cold-start path."""
+        from terok.lib.domain.panic import _stop_vault
+
+        missing = tmp_path / "never-created.passphrase"
+        fake_cfg = MagicMock()
+        fake_cfg.vault_passphrase_file = missing
+        with (
+            patch("terok_sandbox.SandboxConfig", return_value=fake_cfg),
+            patch("terok_sandbox.stop_vault"),
+        ):
+            ok, err = _stop_vault()
+        assert ok and err is None
 
 
 class TestStopGate:
@@ -352,7 +391,11 @@ class TestFormatReport:
         r = PanicResult(
             shields_raised=["c1"], vault_stopped=True, gate_stopped=True, total_running=1
         )
-        assert "FAILED" not in format_panic_report(r)
+        report = format_panic_report(r)
+        assert "FAILED" not in report
+        # Label reflects the lock-then-stop semantics introduced for panic so
+        # the operator can tell that the session tier is gone too.
+        assert "locked" in report
 
     def test_errors(self):
         """Failures shown."""


### PR DESCRIPTION
## Summary

``terok panic`` previously stopped the vault daemon but left the
session-unlock tmpfs file in place, so on next socket activation
the daemon auto-resumed from the session tier — a stopped-but-
unlocked vault defeats the point of pressing PANIC.

This PR unlinks ``vault_passphrase_file`` before stopping the daemon
so panic genuinely makes the vault locked.  Persistent tiers
(keyring, sealed systemd-creds, ``credentials.passphrase``) stay
intact so the panic is reversible; the operator can run
``terok-sandbox vault lock --forget`` afterwards for a destructive
lockout.

- ``_stop_vault`` docstring + the module docstring spell out the
  new semantics so a future reader doesn't reduce it back to "just
  stop the daemon".
- Status report label: ``Vault: stopped`` → ``Vault: locked + stopped``.
- New tests: ``test_removes_session_unlock_file``,
  ``test_missing_session_file_is_not_an_error``.

Plus a short ``docs/usage.md`` subsection that points operators at
the sandbox-side tier-change recipe
(terok-ai/terok-sandbox#288).

## Test plan

- [x] ``make lint`` clean
- [x] ``make tach`` clean
- [x] ``poetry run pytest tests/`` — 2342 passed, 32 skipped
- [x] New tests cover both the happy path and the "no session file
      to delete" cold-start path
- [ ] Manual: ``terok panic`` while the vault daemon is running,
      then ``terok vault status`` shows ``locked`` (no session-file
      path; daemon stopped); restart the daemon and confirm it can't
      auto-unlock from the session tier

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive vault passphrase backend guide covering credential encryption, passphrase resolver chain, and unlock/lock management workflows.

* **Bug Fixes**
  * Enhanced emergency shutdown to remove session unlock files, preventing unintended auto-resume of services.
  * Improved panic status reporting for clearer vault state visibility.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/terok-ai/terok/pull/940)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->