### PR TITLE
refactor: cut orchestration complexity, drop dead pre-split meta layout

### DIFF
--- a/src/terok/lib/orchestration/container_doctor.py
+++ b/src/terok/lib/orchestration/container_doctor.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 
 import subprocess
 from pathlib import Path
-from urllib.parse import urlparse, urlunparse
+from urllib.parse import ParseResult, urlparse, urlunparse
 
 from terok.lib.integrations.executor import agent_doctor_checks, get_roster
 from terok.lib.integrations.sandbox import (
@@ -120,6 +120,28 @@ _PORT_DRIFT_HINT = (
 )
 
 
+def _gatekeeping_remote_verdict(
+    parsed: ParseResult, port: int | None, safe_url: str, gate_port: int | None
+) -> CheckVerdict:
+    """Verdict for a gatekeeping-class git origin — it must route through the gate.
+
+    Gate URL shape: ``http://<token>@host.containers.internal:<port>/<name>``.
+    """
+    if parsed.hostname != "host.containers.internal":
+        return CheckVerdict(
+            "error",
+            f"git origin: {safe_url!r} bypasses gate — should use host.containers.internal",
+            fixable=False,
+        )
+    if gate_port is not None and port != gate_port:
+        return CheckVerdict(
+            "error",
+            f"git origin: port {port} does not match gate port {gate_port}" + _PORT_DRIFT_HINT,
+            fixable=False,
+        )
+    return CheckVerdict("ok", "git origin: routed through gate")
+
+
 def _git_remote_check(security_class: str, gate_port: int | None) -> DoctorCheck:
     """Check that git origin remote matches the expected pattern for the security class."""
 
@@ -140,21 +162,7 @@ def _git_remote_check(security_class: str, gate_port: int | None) -> DoctorCheck
         safe_url = urlunparse(parsed._replace(netloc=netloc))
 
         if security_class == "gatekeeping":
-            # Gate URL: http://<token>@host.containers.internal:<port>/<name>
-            if parsed.hostname != "host.containers.internal":
-                return CheckVerdict(
-                    "error",
-                    f"git origin: {safe_url!r} bypasses gate — should use host.containers.internal",
-                    fixable=False,
-                )
-            if gate_port is not None and port != gate_port:
-                return CheckVerdict(
-                    "error",
-                    f"git origin: port {port} does not match gate port {gate_port}"
-                    + _PORT_DRIFT_HINT,
-                    fixable=False,
-                )
-            return CheckVerdict("ok", "git origin: routed through gate")
+            return _gatekeeping_remote_verdict(parsed, port, safe_url, gate_port)
         # Online mode: any URL is acceptable
         return CheckVerdict("ok", f"git origin: {safe_url}")
 

--- a/src/terok/lib/orchestration/environment.py
+++ b/src/terok/lib/orchestration/environment.py
@@ -89,6 +89,103 @@ def _gate_url(
     return f"http://{token}@{host}/{gate_repo.name}"
 
 
+def _resolve_gate_port(cfg: SandboxConfig, *, use_socket: bool) -> int:
+    """Resolve the port the container reaches the gate on.
+
+    Socket mode uses the fixed in-container socat-bridge port (see
+    ensure-bridges.sh); TCP mode uses the host gate server's port —
+    required, so a missing one is fatal.
+    """
+    if use_socket:
+        return _CONTAINER_GATE_PORT
+    host_port = get_gate_server_port(cfg)
+    if host_port is None:
+        raise SystemExit(
+            "Gate server port not configured — required in TCP mode. "
+            "Check sandbox config or switch to socket mode."
+        )
+    return host_port
+
+
+def _gatekeeping_repo_env(
+    project: ProjectConfig,
+    task_id: str,
+    cfg: SandboxConfig,
+    gate_base: Path,
+    gate_port: int,
+    *,
+    use_socket: bool,
+) -> dict[str, str]:
+    """Repo-access env for a gatekeeping-class task — the gate *is* origin.
+
+    The container clones and pushes through the gate, so a missing gate
+    mirror is fatal.
+    """
+    gate_repo = project.gate_path
+    if not gate_repo.exists():
+        raise SystemExit(
+            f"Git gate missing for project '{project.id}'.\n"
+            f"Expected at: {gate_repo}\n"
+            f"Run 'terok project gate-sync {project.id}' to create/update the local mirror."
+        )
+    ensure_server_reachable(cfg)
+    token = create_token(project.id, task_id, cfg)
+    gate_url = _gate_url(gate_repo, gate_base, gate_port, token, use_socket=use_socket)
+    env: dict[str, str] = {"CODE_REPO": gate_url}
+    if project.default_branch:
+        env["GIT_BRANCH"] = project.default_branch
+    if project.expose_external_remote and project.upstream_url:
+        env["EXTERNAL_REMOTE_URL"] = project.upstream_url
+    return env
+
+
+def _online_repo_env(
+    project: ProjectConfig,
+    task_id: str,
+    cfg: SandboxConfig,
+    gate_base: Path,
+    gate_port: int,
+    *,
+    use_socket: bool,
+) -> dict[str, str]:
+    """Repo-access env for an online-class task — clones from upstream directly.
+
+    The gate is used only as an opt-in clone accelerator
+    (``gate.enabled``) when its mirror exists and the server is
+    reachable; ``gate.enabled: false`` is the escape hatch for hosts
+    that cannot reach the gate.
+    """
+    env: dict[str, str] = {}
+    gate_repo = project.gate_path
+    if project.gate_enabled and gate_repo.exists():
+        try:
+            ensure_server_reachable(cfg)
+        except SystemExit:
+            from ..util.logging_utils import warn_user
+
+            warn_user(
+                "gate",
+                "Gate server unreachable; cloning directly from upstream. "
+                "This is safe — online mode does not require the gate.",
+            )
+        else:
+            token = create_token(project.id, task_id, cfg)
+            gate_url = _gate_url(gate_repo, gate_base, gate_port, token, use_socket=use_socket)
+            env["CLONE_FROM"] = gate_url
+            # Surface the gate as a named "gate" remote alongside origin
+            # (which points at upstream).  The agent can push WIP branches
+            # host-locally without going to upstream — a free checkpoint
+            # that makes the gate's role coherent across both modes.  In
+            # gatekeeping mode the gate is already origin, so this env var
+            # is online-mode-only.  Consumed by init-ssh-and-repo.sh.
+            env["GATE_REMOTE_URL"] = gate_url
+    if project.upstream_url:
+        env["CODE_REPO"] = project.upstream_url
+        if project.default_branch:
+            env["GIT_BRANCH"] = project.default_branch
+    return env
+
+
 def _security_mode_env_and_volumes(
     project: ProjectConfig,
     task_id: str,
@@ -97,71 +194,17 @@ def _security_mode_env_and_volumes(
     use_socket: bool = False,
 ) -> tuple[dict[str, str], list[str]]:
     """Return env vars and volumes for the project's security mode."""
-    env: dict[str, str] = {}
     volumes: list[str] = []
-
     gate_repo = project.gate_path
     gate_base = get_gate_base_path(cfg)
-    # In socket mode the container reaches the gate via an in-container
-    # socat bridge that listens on a fixed port (see ensure-bridges.sh);
-    # in TCP mode the container reaches the host's gate server directly.
-    if use_socket:
-        gate_port = _CONTAINER_GATE_PORT
-    else:
-        host_port = get_gate_server_port(cfg)
-        if host_port is None:
-            raise SystemExit(
-                "Gate server port not configured — required in TCP mode. "
-                "Check sandbox config or switch to socket mode."
-            )
-        gate_port = host_port
+    gate_port = _resolve_gate_port(cfg, use_socket=use_socket)
 
     if project.security_class == "gatekeeping":
-        if not gate_repo.exists():
-            raise SystemExit(
-                f"Git gate missing for project '{project.id}'.\n"
-                f"Expected at: {gate_repo}\n"
-                f"Run 'terok project gate-sync {project.id}' to create/update the local mirror."
-            )
-        ensure_server_reachable(cfg)
-        token = create_token(project.id, task_id, cfg)
-        gate_url = _gate_url(gate_repo, gate_base, gate_port, token, use_socket=use_socket)
-        env["CODE_REPO"] = gate_url
-        if project.default_branch:
-            env["GIT_BRANCH"] = project.default_branch
-        if project.expose_external_remote and project.upstream_url:
-            env["EXTERNAL_REMOTE_URL"] = project.upstream_url
+        env = _gatekeeping_repo_env(
+            project, task_id, cfg, gate_base, gate_port, use_socket=use_socket
+        )
     else:
-        # Online mode: use the gate as a clone accelerator when it exists
-        # *and* the project opted in.  ``gate.enabled: false`` is the
-        # explicit escape hatch for hosts that cannot reach the remote
-        # (container clones directly from upstream instead).
-        if project.gate_enabled and gate_repo.exists():
-            try:
-                ensure_server_reachable(cfg)
-            except SystemExit:
-                from ..util.logging_utils import warn_user
-
-                warn_user(
-                    "gate",
-                    "Gate server unreachable; cloning directly from upstream. "
-                    "This is safe — online mode does not require the gate.",
-                )
-            else:
-                token = create_token(project.id, task_id, cfg)
-                gate_url = _gate_url(gate_repo, gate_base, gate_port, token, use_socket=use_socket)
-                env["CLONE_FROM"] = gate_url
-                # Surface the gate as a named "gate" remote alongside origin
-                # (which points at upstream).  The agent can push WIP branches
-                # host-locally without going to upstream — a free checkpoint
-                # that makes the gate's role coherent across both modes.  In
-                # gatekeeping mode the gate is already origin, so this env var
-                # is online-mode-only.  Consumed by init-ssh-and-repo.sh.
-                env["GATE_REMOTE_URL"] = gate_url
-        if project.upstream_url:
-            env["CODE_REPO"] = project.upstream_url
-            if project.default_branch:
-                env["GIT_BRANCH"] = project.default_branch
+        env = _online_repo_env(project, task_id, cfg, gate_base, gate_port, use_socket=use_socket)
 
     # Gate socket path for the container-side socat bridge (set once for both modes).
     if use_socket and ("CODE_REPO" in env or "CLONE_FROM" in env) and gate_repo.exists():

--- a/src/terok/lib/orchestration/task_runners/headless.py
+++ b/src/terok/lib/orchestration/task_runners/headless.py
@@ -34,6 +34,7 @@ from ...util.ansi import (
     red as _red,
     supports_color as _supports_color,
 )
+from ...util.host_cmd import WORKSPACE_DANGEROUS_DIRNAME
 from ...util.yaml import load as _yaml_load
 from ..agent_config import resolve_agent_config
 from ..container_exec import container_git_diff
@@ -50,6 +51,12 @@ from ..tasks import (
 from .config import _apply_unrestricted_env, _str_to_bool
 from .container import _assert_running, _podman_start, _run_container
 from .shield import _apply_shield_policy
+
+#: Agent-config volume filename holding the current follow-up prompt.
+_PROMPT_FILENAME = "prompt.txt"
+
+#: Agent-config volume filename the prior prompt is archived to on follow-up.
+_PROMPT_HISTORY_FILENAME = "prompt-history.txt"
 
 
 @dataclass(frozen=True)
@@ -143,7 +150,7 @@ def _report_headless_result(
     color_enabled = _supports_color()
     if follow:
         exit_code = _rt.get_runtime().container(cname).wait()
-        _print_run_summary(project_id, task_id, "run", task_dir / "workspace-dangerous")
+        _print_run_summary(project_id, task_id, "run", task_dir / WORKSPACE_DANGEROUS_DIRNAME)
         update_task_exit_code(project_id, task_id, exit_code)
         if exit_code != 0:
             print(f"\n{label} exited with code {_red(str(exit_code), color_enabled)}")
@@ -343,8 +350,8 @@ def _inject_followup_prompt(
         inject_prompt(cname, prompt)
         return
 
-    prompt_path = agent_config_dir / "prompt.txt"
-    history_path = agent_config_dir / "prompt-history.txt"
+    prompt_path = agent_config_dir / _PROMPT_FILENAME
+    history_path = agent_config_dir / _PROMPT_HISTORY_FILENAME
     existing = prompt_path.read_text(encoding="utf-8") if prompt_path.is_file() else ""
     if existing:
         with history_path.open("a", encoding="utf-8") as hf:

--- a/src/terok/lib/orchestration/task_runners/headless.py
+++ b/src/terok/lib/orchestration/task_runners/headless.py
@@ -111,6 +111,55 @@ def _print_run_summary(project_id: str, task_id: str, mode: str, workspace: Path
     print(f"  Workspace: {workspace}")
 
 
+def _build_cli_overrides(config_path: str | None) -> dict:
+    """Load the optional ``--config`` agent-config file into an overrides dict.
+
+    Returns ``{}`` when no config file was given; raises ``SystemExit``
+    when the named file does not exist.
+    """
+    if not config_path:
+        return {}
+    config_src = Path(config_path)
+    if not config_src.is_file():
+        raise SystemExit(f"Agent config file not found: {config_path}")
+    return _yaml_load(config_src.read_text(encoding="utf-8")) or {}
+
+
+def _report_headless_result(
+    *,
+    project_id: str,
+    task_id: str,
+    cname: str,
+    task_dir: Path,
+    follow: bool,
+    label: str,
+    detached_label: str,
+) -> None:
+    """Print the shared tail of the headless run + follow-up runners.
+
+    When *follow* is set, wait for the container, print the run summary,
+    and record the exit code; otherwise print the detached-task block.
+    """
+    color_enabled = _supports_color()
+    if follow:
+        exit_code = _rt.get_runtime().container(cname).wait()
+        _print_run_summary(project_id, task_id, "run", task_dir / "workspace-dangerous")
+        update_task_exit_code(project_id, task_id, exit_code)
+        if exit_code != 0:
+            print(f"\n{label} exited with code {_red(str(exit_code), color_enabled)}")
+    else:
+        _print_detached_summary(
+            DetachedSummary(
+                label=detached_label,
+                task_id=task_id,
+                cname=cname,
+                color=color_enabled,
+                log_cmd=f"podman logs -f {cname}",
+                stop_cmd=f"podman stop {cname}",
+            )
+        )
+
+
 def task_run_headless(request: HeadlessRunRequest) -> str:
     """Run an agent headlessly (autopilot mode) in a new task container.
 
@@ -134,22 +183,14 @@ def task_run_headless(request: HeadlessRunRequest) -> str:
     resolved = get_provider(request.provider, default_agent=project.default_agent)
     require_agent_installed(project, resolved.name)
 
-    # Build CLI overrides from --config file and explicit flags
-    cli_overrides: dict = {}
-    if request.config_path:
-        config_src = Path(request.config_path)
-        if not config_src.is_file():
-            raise SystemExit(f"Agent config file not found: {request.config_path}")
-        cli_config = _yaml_load(config_src.read_text(encoding="utf-8")) or {}
-        cli_overrides = cli_config
-
     # Resolve layered agent config (global → project → preset → CLI overrides)
+    cli_overrides = _build_cli_overrides(request.config_path)
     effective = resolve_agent_config(
         request.project_id,
         agent_config=project.agent_config,
         project_root=project.root,
         preset=request.preset,
-        cli_overrides=cli_overrides if cli_overrides else None,
+        cli_overrides=cli_overrides or None,
     )
 
     # Resolve instructions: CLI --instructions overrides config stack
@@ -273,29 +314,42 @@ def task_run_headless(request: HeadlessRunRequest) -> str:
         meta["preset"] = request.preset
     write_task_meta(meta_path, meta)
 
-    color_enabled = _supports_color()
-
-    if request.follow:
-        exit_code = _rt.get_runtime().container(cname).wait()
-        _print_run_summary(project.id, task_id, "run", task_dir / "workspace-dangerous")
-
-        update_task_exit_code(project.id, task_id, exit_code)
-
-        if exit_code != 0:
-            print(f"\n{resolved.label} exited with code {_red(str(exit_code), color_enabled)}")
-    else:
-        _print_detached_summary(
-            DetachedSummary(
-                label=f"Headless {resolved.label} task started (detached).",
-                task_id=task_id,
-                cname=cname,
-                color=color_enabled,
-                log_cmd=f"podman logs -f {cname}",
-                stop_cmd=f"podman stop {cname}",
-            )
-        )
+    _report_headless_result(
+        project_id=project.id,
+        task_id=task_id,
+        cname=cname,
+        task_dir=task_dir,
+        follow=request.follow,
+        label=resolved.label,
+        detached_label=f"Headless {resolved.label} task started (detached).",
+    )
 
     return task_id
+
+
+def _inject_followup_prompt(
+    *, is_sealed: bool, cname: str, agent_config_dir: Path, prompt: str
+) -> None:
+    """Hand the follow-up *prompt* to the (stopped) task container.
+
+    Sealed projects get it copied straight in via ``podman cp``; unsealed
+    ones replace ``prompt.txt`` on the agent-config volume, archiving the
+    prior prompt to ``prompt-history.txt`` so the agent only ever sees
+    the current instruction.
+    """
+    if is_sealed:
+        from terok.lib.integrations.executor import inject_prompt
+
+        inject_prompt(cname, prompt)
+        return
+
+    prompt_path = agent_config_dir / "prompt.txt"
+    history_path = agent_config_dir / "prompt-history.txt"
+    existing = prompt_path.read_text(encoding="utf-8") if prompt_path.is_file() else ""
+    if existing:
+        with history_path.open("a", encoding="utf-8") as hf:
+            hf.write(f"{existing}\n\n---\n\n")
+    prompt_path.write_text(prompt, encoding="utf-8")
 
 
 def task_followup_headless(
@@ -368,25 +422,13 @@ def task_followup_headless(
             f"Follow-up will start a fresh session with the new prompt."
         )
 
-    # Write follow-up prompt to prompt.txt (replaces previous content so the
-    # agent only sees the current instruction).  Prior prompts are archived to
-    # prompt-history.txt for logging/debugging.
     task_dir = project.tasks_root / str(task_id)
-    agent_config_dir = task_dir / "agent-config"
-
-    if project.is_sealed:
-        # Sealed: inject prompt via podman cp into stopped container
-        from terok.lib.integrations.executor import inject_prompt
-
-        inject_prompt(cname, prompt)
-    else:
-        prompt_path = agent_config_dir / "prompt.txt"
-        history_path = agent_config_dir / "prompt-history.txt"
-        existing = prompt_path.read_text(encoding="utf-8") if prompt_path.is_file() else ""
-        if existing:
-            with history_path.open("a", encoding="utf-8") as hf:
-                hf.write(f"{existing}\n\n---\n\n")
-        prompt_path.write_text(prompt, encoding="utf-8")
+    _inject_followup_prompt(
+        is_sealed=project.is_sealed,
+        cname=cname,
+        agent_config_dir=task_dir / "agent-config",
+        prompt=prompt,
+    )
 
     # Ensure the vault is reachable before restarting — after a
     # host reboot the systemd socket may be active but the service idle.
@@ -412,27 +454,15 @@ def task_followup_headless(
     meta["exit_code"] = None
     write_task_meta(meta_path, meta)
 
-    color_enabled = _supports_color()
-
-    if follow:
-        exit_code = _rt.get_runtime().container(cname).wait()
-        _print_run_summary(project.id, task_id, "run", task_dir / "workspace-dangerous")
-
-        update_task_exit_code(project.id, task_id, exit_code)
-
-        if exit_code != 0:
-            print(f"\n{label} exited with code {_red(str(exit_code), color_enabled)}")
-    else:
-        _print_detached_summary(
-            DetachedSummary(
-                label="Follow-up started (detached).",
-                task_id=task_id,
-                cname=cname,
-                color=color_enabled,
-                log_cmd=f"podman logs -f {cname}",
-                stop_cmd=f"podman stop {cname}",
-            )
-        )
+    _report_headless_result(
+        project_id=project.id,
+        task_id=task_id,
+        cname=cname,
+        task_dir=task_dir,
+        follow=follow,
+        label=label,
+        detached_label="Follow-up started (detached).",
+    )
 
 
 __all__ = [

--- a/src/terok/lib/orchestration/task_runners/restart.py
+++ b/src/terok/lib/orchestration/task_runners/restart.py
@@ -10,6 +10,8 @@ than re-creating it; that's ``task run``'s job.
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 from ...core import runtime as _rt
 from ...core.config import get_public_host
 from ...core.projects import load_project
@@ -26,6 +28,86 @@ from ..tasks import container_name, load_task_meta
 from .container import _assert_running, _podman_start, _print_login_instructions
 from .shield import _apply_shield_policy
 from .toad import _rehydrate_toad_token, _toad_browser_url
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+    from ...core.project_model import ProjectConfig
+
+
+def _validate_restart_preconditions(
+    project: ProjectConfig, task_id: str, mode: str, meta: dict, cname: str
+) -> None:
+    """Validate what would fail the restart *before* the container is stopped.
+
+    Taking down a working service only to then error out is worse than
+    refusing to stop: re-claim the saved web port and rehydrate the toad
+    token here, raising ``SystemExit`` if either is no longer viable.
+    """
+    web_port = meta.get("web_port")
+    if isinstance(web_port, int):
+        actual = assign_web_port(project.id, task_id, preferred=web_port)
+        if actual != web_port:
+            release_web_port(project.id, task_id)
+            raise SystemExit(
+                f"Port {web_port} for {project.id}/{task_id} is no longer available "
+                f"(got {actual}).  Re-create the task to use the new port."
+            )
+    if mode == "toad":
+        _rehydrate_toad_token(project, task_id, meta, cname)
+
+
+def _stop_running_container(
+    project: ProjectConfig, task_id: str, mode: str, cname: str, meta_path: Path
+) -> None:
+    """Stop the running task container, then fire its ``post_stop`` hook."""
+    try:
+        _rt.get_runtime().container(cname).stop(timeout=project.shutdown_timeout)
+    except FileNotFoundError:
+        raise SystemExit("podman not found; please install podman")
+    except RuntimeError as exc:
+        raise SystemExit(f"Failed to stop container: {exc}")
+    run_hook(
+        "post_stop",
+        project.hook_post_stop,
+        project_id=project.id,
+        task_id=task_id,
+        mode=mode,
+        cname=cname,
+        task_dir=project.tasks_root / str(task_id),
+        meta_path=meta_path,
+    )
+
+
+def _start_and_report_restart(
+    project: ProjectConfig, task_id: str, mode: str, cname: str, meta: dict, meta_path: Path
+) -> None:
+    """Start the (stopped) container, apply shield policy, print how to reach it."""
+    task_dir = project.tasks_root / str(task_id)
+    _podman_start(cname)
+    _assert_running(cname)
+    run_hook(
+        "post_start",
+        project.hook_post_start,
+        project_id=project.id,
+        task_id=task_id,
+        mode=mode,
+        cname=cname,
+        task_dir=task_dir,
+        meta_path=meta_path,
+    )
+    _apply_shield_policy(project, cname, task_dir, is_restart=True)
+
+    color_enabled = _supports_color()
+    print(f"Restarted task {task_id}: {_green(cname, color_enabled)}")
+    if mode == "cli":
+        _print_login_instructions(project.id, task_id, cname, color_enabled)
+    elif mode == "toad":
+        port = meta.get("web_port")
+        token = meta.get("web_token")
+        if isinstance(port, int) and isinstance(token, str):
+            url = _toad_browser_url(get_public_host(), port, token)
+            print(f"Toad: {_hyperlink(_blue(url, color_enabled), url, enabled=color_enabled)}")
 
 
 def task_restart(project_id: str, task_id: str) -> None:
@@ -49,68 +131,7 @@ def task_restart(project_id: str, task_id: str) -> None:
     print(f"Restarting task {project_id}/{task_id} ({mode})...")
     ensure_vault()
 
-    # Validate the preconditions that would fail the restart *before*
-    # stopping a healthy container — taking down a working service only
-    # to then error out is a worse outcome than refusing to stop.
-    if container_state is not None:
-        web_port = meta.get("web_port")
-        if isinstance(web_port, int):
-            actual = assign_web_port(project.id, task_id, preferred=web_port)
-            if actual != web_port:
-                release_web_port(project.id, task_id)
-                raise SystemExit(
-                    f"Port {web_port} for {project.id}/{task_id} is no longer available "
-                    f"(got {actual}).  Re-create the task to use the new port."
-                )
-        if mode == "toad":
-            _rehydrate_toad_token(project, task_id, meta, cname)
-
-    if container_state == "running":
-        # Container is running - stop it first, then start it again
-        try:
-            _rt.get_runtime().container(cname).stop(timeout=project.shutdown_timeout)
-        except FileNotFoundError:
-            raise SystemExit("podman not found; please install podman")
-        except RuntimeError as exc:
-            raise SystemExit(f"Failed to stop container: {exc}")
-        run_hook(
-            "post_stop",
-            project.hook_post_stop,
-            project_id=project_id,
-            task_id=task_id,
-            mode=mode,
-            cname=cname,
-            task_dir=project.tasks_root / str(task_id),
-            meta_path=meta_path,
-        )
-
-    if container_state is not None:
-        task_dir = project.tasks_root / str(task_id)
-        _podman_start(cname)
-        _assert_running(cname)
-        run_hook(
-            "post_start",
-            project.hook_post_start,
-            project_id=project_id,
-            task_id=task_id,
-            mode=mode,
-            cname=cname,
-            task_dir=task_dir,
-            meta_path=meta_path,
-        )
-        _apply_shield_policy(project, cname, task_dir, is_restart=True)
-
-        color_enabled = _supports_color()
-        print(f"Restarted task {task_id}: {_green(cname, color_enabled)}")
-        if mode == "cli":
-            _print_login_instructions(project_id, task_id, cname, color_enabled)
-        elif mode == "toad":
-            port = meta.get("web_port")
-            token = meta.get("web_token")
-            if isinstance(port, int) and isinstance(token, str):
-                url = _toad_browser_url(get_public_host(), port, token)
-                print(f"Toad: {_hyperlink(_blue(url, color_enabled), url, enabled=color_enabled)}")
-    else:
+    if container_state is None:
         # Container is gone — restart can't recreate it.  User must start
         # a fresh task with ``task run``.
         raise SystemExit(
@@ -119,6 +140,11 @@ def task_restart(project_id: str, task_id: str) -> None:
             f"  terok task run {project_id}"
             + (' "<prompt>" --mode headless' if mode == "run" else "")
         )
+
+    _validate_restart_preconditions(project, task_id, mode, meta, cname)
+    if container_state == "running":
+        _stop_running_container(project, task_id, mode, cname, meta_path)
+    _start_and_report_restart(project, task_id, mode, cname, meta, meta_path)
 
 
 __all__ = [

--- a/src/terok/lib/orchestration/tasks/lifecycle.py
+++ b/src/terok/lib/orchestration/tasks/lifecycle.py
@@ -315,19 +315,22 @@ def _remove_workspace(workspace: Path, warnings: list[str]) -> None:
 def _remove_meta_files(paths: tuple[Path, ...], warnings: list[str]) -> None:
     """Unlink the on-disk meta-file pair plus any legacy single-file remnants.
 
-    Each ``unlink(missing_ok=True)`` is independent so a half-installed
-    bundle still cleans up everything that was there.
+    Each path is unlinked independently so a failure on one (e.g. a
+    permission error) still lets the rest be cleaned up.
     """
     if not any(p.is_file() for p in paths):
         return
     _log_debug("task_delete: removing metadata files")
-    try:
-        for p in paths:
+    all_removed = True
+    for p in paths:
+        try:
             p.unlink(missing_ok=True)
+        except Exception as exc:
+            _log_debug(f"task_delete: metadata removal failed for {p}: {exc}")
+            warnings.append(f"Metadata removal failed for {p}: {exc}")
+            all_removed = False
+    if all_removed:
         _log_debug("task_delete: metadata files removed")
-    except Exception as exc:
-        _log_debug(f"task_delete: metadata removal failed: {exc}")
-        warnings.append(f"Metadata removal failed: {exc}")
 
 
 def _release_task_web_port(
@@ -344,6 +347,7 @@ def _release_task_web_port(
         release_web_port(project_id, task_id)
     except Exception as exc:  # noqa: BLE001 — best-effort cleanup
         _log_debug(f"task_delete: web port release failed: {exc}")
+        warnings.append(f"Web port release failed: {exc}")
 
 
 def _task_delete(project: ProjectConfig, task_id: str) -> TaskDeleteResult:

--- a/src/terok/lib/orchestration/tasks/lifecycle.py
+++ b/src/terok/lib/orchestration/tasks/lifecycle.py
@@ -265,8 +265,94 @@ class TaskDeleteResult:
     warnings: list[str]
 
 
+def _revoke_task_token(project_id: str, task_id: str, warnings: list[str]) -> None:
+    """Revoke the task's gate token; record a warning on failure."""
+    from terok.lib.integrations.sandbox import revoke_token_for_task
+
+    try:
+        revoke_token_for_task(project_id, task_id)
+    except Exception as exc:
+        _log_debug(f"task_delete: token revoke failed: {exc}")
+        warnings.append(f"Token revoke failed: {exc}")
+
+
+def _remove_task_containers(project_id: str, task_id: str, warnings: list[str]) -> bool:
+    """Force-remove every mode's container for the task.
+
+    Returns ``True`` only when every container was removed cleanly;
+    a raised error or per-container failure is collected into *warnings*
+    and yields ``False``.
+    """
+    names = [container_name(project_id, mode, str(task_id)) for mode in CONTAINER_MODES]
+    try:
+        rm_results = _rt.get_runtime().force_remove([_rt.get_runtime().container(n) for n in names])
+    except Exception as exc:
+        _log_debug(f"task_delete: stop_task_containers raised: {exc}")
+        warnings.append(f"Container removal failed: {exc}")
+        return False
+    removed = True
+    for r in rm_results:
+        if not r.removed:
+            _log_debug(f"task_delete: container {r.name} not removed: {r.error}")
+            warnings.append(f"Container {r.name}: {r.error}")
+            removed = False
+    return removed
+
+
+def _remove_workspace(workspace: Path, warnings: list[str]) -> None:
+    """Remove the task workspace directory; record a warning on failure."""
+    if not workspace.is_dir():
+        return
+    _log_debug("task_delete: removing workspace directory")
+    try:
+        shutil.rmtree(workspace)
+        _log_debug("task_delete: workspace directory removed")
+    except Exception as exc:
+        _log_debug(f"task_delete: workspace removal failed: {exc}")
+        warnings.append(f"Workspace removal failed: {exc}")
+
+
+def _remove_meta_files(paths: tuple[Path, ...], warnings: list[str]) -> None:
+    """Unlink the on-disk meta-file pair plus any legacy single-file remnants.
+
+    Each ``unlink(missing_ok=True)`` is independent so a half-installed
+    bundle still cleans up everything that was there.
+    """
+    if not any(p.is_file() for p in paths):
+        return
+    _log_debug("task_delete: removing metadata files")
+    try:
+        for p in paths:
+            p.unlink(missing_ok=True)
+        _log_debug("task_delete: metadata files removed")
+    except Exception as exc:
+        _log_debug(f"task_delete: metadata removal failed: {exc}")
+        warnings.append(f"Metadata removal failed: {exc}")
+
+
+def _release_task_web_port(
+    project_id: str, task_id: str, containers_removed: bool, warnings: list[str]
+) -> None:
+    """Release the task's claimed web port — only safe once its containers are gone."""
+    if not containers_removed:
+        warnings.append("Web port kept claimed — containers may still be running")
+        return
+    _log_debug("task_delete: releasing web port")
+    try:
+        from ..ports import release_web_port
+
+        release_web_port(project_id, task_id)
+    except Exception as exc:  # noqa: BLE001 — best-effort cleanup
+        _log_debug(f"task_delete: web port release failed: {exc}")
+
+
 def _task_delete(project: ProjectConfig, task_id: str) -> TaskDeleteResult:
-    """Delete a task's workspace, metadata, and associated containers."""
+    """Delete a task's workspace, metadata, and associated containers.
+
+    Always completes — each cleanup step is independent and best-effort,
+    collecting any failure into the returned warnings rather than
+    aborting the rest of the teardown.
+    """
     _log_debug(f"task_delete: start project_id={project.id} task_id={task_id}")
     warnings: list[str] = []
 
@@ -284,41 +370,20 @@ def _task_delete(project: ProjectConfig, task_id: str) -> TaskDeleteResult:
     )
 
     meta = read_task_meta(meta_dir, task_id) or {}
-
     mode = meta.get("mode")
+
     if mode:
         _log_debug("task_delete: capturing container logs")
         capture_task_logs(project, task_id, mode)
-
     if meta:
         _log_debug("task_delete: archiving task")
         _archive_task(project, task_id, meta)
 
-    _log_debug("task_delete: revoking gate tokens")
-    from terok.lib.integrations.sandbox import revoke_token_for_task
+    _log_debug("task_delete: revoking gate token")
+    _revoke_task_token(project.id, task_id, warnings)
 
-    try:
-        revoke_token_for_task(project.id, task_id)
-    except Exception as exc:
-        _log_debug(f"task_delete: token revoke failed: {exc}")
-        warnings.append(f"Token revoke failed: {exc}")
-
-    _log_debug("task_delete: calling stop_task_containers")
-    names = [container_name(project.id, mode, str(task_id)) for mode in CONTAINER_MODES]
-    containers_removed = True
-    try:
-        rm_results = _rt.get_runtime().force_remove([_rt.get_runtime().container(n) for n in names])
-    except Exception as exc:
-        _log_debug(f"task_delete: stop_task_containers raised: {exc}")
-        warnings.append(f"Container removal failed: {exc}")
-        rm_results = []
-        containers_removed = False
-    for r in rm_results:
-        if not r.removed:
-            _log_debug(f"task_delete: container {r.name} not removed: {r.error}")
-            warnings.append(f"Container {r.name}: {r.error}")
-            containers_removed = False
-    _log_debug("task_delete: stop_task_containers returned")
+    _log_debug("task_delete: removing task containers")
+    containers_removed = _remove_task_containers(project.id, task_id, warnings)
 
     if mode:
         from ..hooks import run_hook
@@ -334,39 +399,9 @@ def _task_delete(project: ProjectConfig, task_id: str) -> TaskDeleteResult:
             meta_path=meta_file,
         )
 
-    if workspace.is_dir():
-        _log_debug("task_delete: removing workspace directory")
-        try:
-            shutil.rmtree(workspace)
-            _log_debug("task_delete: workspace directory removed")
-        except Exception as exc:
-            _log_debug(f"task_delete: workspace removal failed: {exc}")
-            warnings.append(f"Workspace removal failed: {exc}")
-
-    # Drop both halves of the on-disk pair plus any legacy single-file
-    # remnants.  Each ``unlink(missing_ok=True)`` is independent so a
-    # half-installed bundle still cleans up everything that was there.
-    paths_to_remove = (dossier_file, meta_file, legacy_json, legacy_yml)
-    if any(p.is_file() for p in paths_to_remove):
-        _log_debug("task_delete: removing metadata files")
-        try:
-            for p in paths_to_remove:
-                p.unlink(missing_ok=True)
-            _log_debug("task_delete: metadata files removed")
-        except Exception as exc:
-            _log_debug(f"task_delete: metadata removal failed: {exc}")
-            warnings.append(f"Metadata removal failed: {exc}")
-
-    if containers_removed:
-        _log_debug("task_delete: releasing web port")
-        try:
-            from ..ports import release_web_port
-
-            release_web_port(project.id, task_id)
-        except Exception as exc:  # noqa: BLE001 — best-effort cleanup
-            _log_debug(f"task_delete: web port release failed: {exc}")
-    else:
-        warnings.append("Web port kept claimed — containers may still be running")
+    _remove_workspace(workspace, warnings)
+    _remove_meta_files((dossier_file, meta_file, legacy_json, legacy_yml), warnings)
+    _release_task_web_port(project.id, task_id, containers_removed, warnings)
 
     _log_debug("task_delete: finished")
     return TaskDeleteResult(task_id=task_id, warnings=warnings)

--- a/src/terok/lib/orchestration/tasks/meta.py
+++ b/src/terok/lib/orchestration/tasks/meta.py
@@ -97,9 +97,7 @@ def read_task_meta(meta_dir: Path, task_id: str) -> dict | None:
 
     A pre-self-describing layout (``<task_id>.json`` / ``<task_id>.yml``)
     is migrated to the new names in place before the read so callers
-    never see the legacy paths.  Likewise a layout from before the
-    dossier/bookkeeping split — a single JSON file mixing wire-dossier
-    keys with bookkeeping — is detected and re-split here.
+    never see the legacy paths.
     """
     _migrate_legacy_filenames(meta_dir, task_id)
     json_path = dossier_path(meta_dir, task_id)
@@ -108,22 +106,9 @@ def read_task_meta(meta_dir: Path, task_id: str) -> dict | None:
     if not (json_path.is_file() or yml_path.is_file()):
         return None
 
-    # Pre-split single-JSON layout: one file mixed wire dossier with
-    # bookkeeping.  Detect, split, normalise.
-    dossier_data, spillover = _split_dossier_spillover(_read_json_meta(json_path))
-    yml_data = _read_yml_meta(yml_path)
-
-    # Spillover came from a caller writing the pre-split layout — treat
-    # it as more authoritative than any YAML on disk, since that YAML
-    # was written before the latest mutation and may be stale.
-    if spillover:
-        yml_data = {**yml_data, **spillover}
-
-    merged = _merge_dossier_into(yml_data, dossier_data)
-    backfilled = _backfill_project_id(merged, meta_dir)
-
-    if spillover or backfilled:
-        # Normalise on disk so the next read takes the fast path.
+    merged = _merge_dossier_into(_read_yml_meta(yml_path), _read_json_meta(json_path))
+    if _backfill_project_id(merged, meta_dir):
+        # Normalise on disk so the backfilled project_id persists.
         write_task_meta(dossier_path(meta_dir, task_id), merged)
 
     return merged
@@ -144,22 +129,18 @@ def _read_yml_meta(yml_path: Path) -> dict:
     return _to_plain(_yaml_load(yml_path.read_text(encoding="utf-8")) or {})
 
 
-def _split_dossier_spillover(json_data: dict) -> tuple[dict, dict]:
-    """Split a JSON-meta dict into ``(wire-dossier keys, bookkeeping spillover)``.
-
-    A current-format dossier file holds only wire keys; a pre-split file
-    mixed bookkeeping in — that mixed-in half is the *spillover*.
-    """
-    dossier = {k: v for k, v in json_data.items() if k in _DOSSIER_FROM_WIRE}
-    spillover = {k: v for k, v in json_data.items() if k not in _DOSSIER_FROM_WIRE}
-    return dossier, spillover
-
-
 def _merge_dossier_into(yml_data: dict, dossier_data: dict) -> dict:
-    """Return *yml_data* merged with the wire-key-translated *dossier_data*."""
+    """Return *yml_data* merged with the wire-key-translated *dossier_data*.
+
+    Only recognised wire keys (``project`` / ``task`` / ``name``) are
+    translated and merged; any other key in the dossier file is ignored
+    rather than crashing this persistence boundary on an unexpected shape.
+    """
     merged = dict(yml_data)
     for wire_key, value in dossier_data.items():
-        merged[_DOSSIER_FROM_WIRE[wire_key]] = value
+        internal_key = _DOSSIER_FROM_WIRE.get(wire_key)
+        if internal_key is not None:
+            merged[internal_key] = value
     return merged
 
 

--- a/src/terok/lib/orchestration/tasks/meta.py
+++ b/src/terok/lib/orchestration/tasks/meta.py
@@ -108,20 +108,10 @@ def read_task_meta(meta_dir: Path, task_id: str) -> dict | None:
     if not (json_path.is_file() or yml_path.is_file()):
         return None
 
-    json_data: dict = {}
-    if json_path.is_file():
-        text = json_path.read_text(encoding="utf-8")
-        json_data = json.loads(text) if text.strip() else {}
-
     # Pre-split single-JSON layout: one file mixed wire dossier with
     # bookkeeping.  Detect, split, normalise.
-    spillover = {k: v for k, v in json_data.items() if k not in _DOSSIER_FROM_WIRE}
-    if spillover:
-        json_data = {k: v for k, v in json_data.items() if k in _DOSSIER_FROM_WIRE}
-
-    yml_data: dict = {}
-    if yml_path.is_file():
-        yml_data = _to_plain(_yaml_load(yml_path.read_text(encoding="utf-8")) or {})
+    dossier_data, spillover = _split_dossier_spillover(_read_json_meta(json_path))
+    yml_data = _read_yml_meta(yml_path)
 
     # Spillover came from a caller writing the pre-split layout — treat
     # it as more authoritative than any YAML on disk, since that YAML
@@ -129,25 +119,66 @@ def read_task_meta(meta_dir: Path, task_id: str) -> dict | None:
     if spillover:
         yml_data = {**yml_data, **spillover}
 
-    merged: dict = dict(yml_data)
-    for wire_key, value in json_data.items():
-        if wire_key in _DOSSIER_FROM_WIRE:
-            merged[_DOSSIER_FROM_WIRE[wire_key]] = value
+    merged = _merge_dossier_into(yml_data, dossier_data)
+    backfilled = _backfill_project_id(merged, meta_dir)
 
-    # Backfill ``project_id`` from the meta-dir path for legacy records
-    # that predate the field landing in TaskMeta.  Without this, a
-    # task-rename on a legacy task lands a half-populated dossier (no
-    # ``project``) on the wire until some other code path happens to
-    # set it.  Path layout is ``<state>/projects/<project_id>/tasks``.
-    backfill_needed = not merged.get("project_id")
-    if backfill_needed and meta_dir.parent.parent.name == "projects":
-        merged["project_id"] = meta_dir.parent.name
-
-    if spillover or backfill_needed:
+    if spillover or backfilled:
         # Normalise on disk so the next read takes the fast path.
         write_task_meta(dossier_path(meta_dir, task_id), merged)
 
     return merged
+
+
+def _read_json_meta(json_path: Path) -> dict:
+    """Read the wire-dossier JSON file — ``{}`` when absent or empty."""
+    if not json_path.is_file():
+        return {}
+    text = json_path.read_text(encoding="utf-8")
+    return json.loads(text) if text.strip() else {}
+
+
+def _read_yml_meta(yml_path: Path) -> dict:
+    """Read the bookkeeping YAML file as a plain dict — ``{}`` when absent."""
+    if not yml_path.is_file():
+        return {}
+    return _to_plain(_yaml_load(yml_path.read_text(encoding="utf-8")) or {})
+
+
+def _split_dossier_spillover(json_data: dict) -> tuple[dict, dict]:
+    """Split a JSON-meta dict into ``(wire-dossier keys, bookkeeping spillover)``.
+
+    A current-format dossier file holds only wire keys; a pre-split file
+    mixed bookkeeping in — that mixed-in half is the *spillover*.
+    """
+    dossier = {k: v for k, v in json_data.items() if k in _DOSSIER_FROM_WIRE}
+    spillover = {k: v for k, v in json_data.items() if k not in _DOSSIER_FROM_WIRE}
+    return dossier, spillover
+
+
+def _merge_dossier_into(yml_data: dict, dossier_data: dict) -> dict:
+    """Return *yml_data* merged with the wire-key-translated *dossier_data*."""
+    merged = dict(yml_data)
+    for wire_key, value in dossier_data.items():
+        merged[_DOSSIER_FROM_WIRE[wire_key]] = value
+    return merged
+
+
+def _backfill_project_id(merged: dict, meta_dir: Path) -> bool:
+    """Backfill ``project_id`` from the meta-dir path for legacy records.
+
+    Records that predate the field landing in TaskMeta carry no
+    ``project_id``; without it a task-rename lands a half-populated
+    dossier (no ``project``) on the wire.  Path layout is
+    ``<state>/projects/<project_id>/tasks``.  Returns ``True`` when a
+    value was filled in, so the caller knows the record needs
+    re-normalising on disk.
+    """
+    if merged.get("project_id"):
+        return False
+    if meta_dir.parent.parent.name != "projects":
+        return False
+    merged["project_id"] = meta_dir.parent.name
+    return True
 
 
 def write_task_meta(dossier_handle: Path, meta: dict) -> None:

--- a/tests/unit/lib/test_autopilot.py
+++ b/tests/unit/lib/test_autopilot.py
@@ -592,17 +592,17 @@ class TestTaskFollowupHeadless:
 
             config_file = write_runner_project(base, "proj_mode")
 
-            from terok.lib.orchestration.tasks import task_new
+            from terok.lib.orchestration.tasks import task_new, write_task_meta
 
             with unittest.mock.patch.dict(
                 os.environ, runner_env_vars(base, config_file), clear=True
             ):
                 with mock_git_config():
                     task_id = task_new("proj_mode")
-                    _agent_cfg, meta_path = task_paths(base, "proj_mode", task_id)
-                    meta = json.loads(meta_path.read_text() or "{}")
+                    _agent_cfg, dossier_handle = task_paths(base, "proj_mode", task_id)
+                    meta = read_task_meta(base, "proj_mode", task_id)
                     meta["mode"] = "cli"
-                    meta_path.write_text(json.dumps(meta, indent=2))
+                    write_task_meta(dossier_handle, meta)
 
                     with pytest.raises(SystemExit) as ctx:
                         task_followup_headless("proj_mode", task_id, "test")
@@ -615,17 +615,17 @@ class TestTaskFollowupHeadless:
 
             config_file = write_runner_project(base, "proj_run")
 
-            from terok.lib.orchestration.tasks import task_new
+            from terok.lib.orchestration.tasks import task_new, write_task_meta
 
             with unittest.mock.patch.dict(
                 os.environ, runner_env_vars(base, config_file), clear=True
             ):
                 with mock_git_config():
                     task_id = task_new("proj_run")
-                    _agent_cfg, meta_path = task_paths(base, "proj_run", task_id)
-                    meta = json.loads(meta_path.read_text() or "{}")
+                    _agent_cfg, dossier_handle = task_paths(base, "proj_run", task_id)
+                    meta = read_task_meta(base, "proj_run", task_id)
                     meta["mode"] = "run"
-                    meta_path.write_text(json.dumps(meta, indent=2))
+                    write_task_meta(dossier_handle, meta)
 
                     mock_runtime.container.return_value.state = "running"
                     with pytest.raises(SystemExit) as ctx:

--- a/tests/unit/lib/test_container_lifecycle.py
+++ b/tests/unit/lib/test_container_lifecycle.py
@@ -5,7 +5,6 @@
 
 from __future__ import annotations
 
-import json
 import subprocess
 from collections.abc import Callable
 from contextlib import redirect_stdout
@@ -18,7 +17,14 @@ import pytest
 from terok_sandbox import PodmanRuntime
 
 from terok.lib.orchestration.task_runners import task_restart
-from terok.lib.orchestration.tasks import get_task_container_state, task_new, task_status, task_stop
+from terok.lib.orchestration.tasks import (
+    get_task_container_state,
+    read_task_meta,
+    task_new,
+    task_status,
+    task_stop,
+    write_task_meta,
+)
 from tests.test_utils import mock_git_config, project_env
 
 
@@ -39,10 +45,10 @@ def update_task_meta(
     ctx: SimpleNamespace, project_id: str, task_id: str, **changes: object
 ) -> None:
     """Patch selected metadata keys for a generated task."""
-    meta_path = task_meta_path(ctx, project_id, task_id)
-    meta = json.loads(meta_path.read_text() or "{}") or {}
+    dossier_handle = task_meta_path(ctx, project_id, task_id)
+    meta = read_task_meta(dossier_handle.parent, task_id) or {}
     meta.update(changes)
-    meta_path.write_text(json.dumps(meta, indent=2), encoding="utf-8")
+    write_task_meta(dossier_handle, meta)
 
 
 def create_task_with_mode(ctx: SimpleNamespace, project_id: str, *, mode: str = "cli") -> str:

--- a/tests/unit/lib/test_login.py
+++ b/tests/unit/lib/test_login.py
@@ -5,13 +5,19 @@
 
 from __future__ import annotations
 
-import json
 import types
 import unittest.mock
 
 import pytest
 
-from terok.lib.orchestration.tasks import get_login_command, task_login, task_new
+from terok.lib.orchestration.tasks import (
+    dossier_path,
+    get_login_command,
+    read_task_meta,
+    task_login,
+    task_new,
+    write_task_meta,
+)
 from tests.test_utils import mock_git_config, project_env
 
 
@@ -32,10 +38,10 @@ def setup_task_with_mode(
     """
     task_id = task_new(project_id)
     if mode:
-        meta_path = ctx.state_dir / "projects" / project_id / "tasks" / f"{task_id}_dossier.json"
-        meta = json.loads(meta_path.read_text() or "{}")
+        meta_dir = ctx.state_dir / "projects" / project_id / "tasks"
+        meta = read_task_meta(meta_dir, task_id) or {}
         meta["mode"] = mode
-        meta_path.write_text(json.dumps(meta, indent=2), encoding="utf-8")
+        write_task_meta(dossier_path(meta_dir, task_id), meta)
     return task_id
 
 

--- a/tests/unit/lib/test_task_ids.py
+++ b/tests/unit/lib/test_task_ids.py
@@ -5,16 +5,17 @@
 
 from __future__ import annotations
 
-import json
 import unittest.mock
 
 import pytest
 
 from terok.lib.core.task_state import CONTAINER_MODES, container_name
 from terok.lib.orchestration.tasks import (
+    dossier_path,
     normalize_task_id_input,
     resolve_task_id,
     tasks_meta_dir,
+    write_task_meta,
 )
 from terok.lib.orchestration.tasks.identity import (
     _TASK_ID_BODY_CHARS,
@@ -111,10 +112,8 @@ class TestResolveTaskId:
 
     def _write_meta(self, project_id: str, task_id: str) -> None:
         """Write a minimal task metadata file."""
-        meta_dir = tasks_meta_dir(project_id)
-        meta_dir.mkdir(parents=True, exist_ok=True)
         meta = {"task_id": task_id, "name": "test-task", "mode": None, "workspace": "/tmp/ws"}
-        (meta_dir / f"{task_id}_dossier.json").write_text(json.dumps(meta, indent=2))
+        write_task_meta(dossier_path(tasks_meta_dir(project_id), task_id), meta)
 
     def test_exact_match(self) -> None:
         """Full task ID should resolve immediately."""
@@ -211,10 +210,8 @@ class TestLegacyHexCompat:
 
     def _write_meta(self, project_id: str, task_id: str) -> None:
         """Write a minimal task metadata file."""
-        meta_dir = tasks_meta_dir(project_id)
-        meta_dir.mkdir(parents=True, exist_ok=True)
         meta = {"task_id": task_id, "name": "legacy", "mode": None, "workspace": "/tmp/ws"}
-        (meta_dir / f"{task_id}_dossier.json").write_text(json.dumps(meta, indent=2))
+        write_task_meta(dossier_path(tasks_meta_dir(project_id), task_id), meta)
 
     def test_legacy_hex_resolves_with_deprecation(self) -> None:
         """A legacy 8-char hex task on disk should still resolve, with a DeprecationWarning."""
@@ -235,13 +232,8 @@ class TestLegacyHexCompat:
         import warnings
 
         with project_env(MINIMAL_PROJECT) as _ctx:
-            meta_dir = tasks_meta_dir("test-proj")
-            meta_dir.mkdir(parents=True, exist_ok=True)
-            (meta_dir / f"{ID_A}.json").write_text(
-                json.dumps(
-                    {"task_id": ID_A, "name": "n", "mode": None, "workspace": "/tmp/ws"}, indent=2
-                )
-            )
+            meta = {"task_id": ID_A, "name": "n", "mode": None, "workspace": "/tmp/ws"}
+            write_task_meta(dossier_path(tasks_meta_dir("test-proj"), ID_A), meta)
             with warnings.catch_warnings():
                 warnings.simplefilter("error", DeprecationWarning)
                 assert resolve_task_id("test-proj", ID_A) == ID_A

--- a/tests/unit/lib/test_tasks.py
+++ b/tests/unit/lib/test_tasks.py
@@ -26,12 +26,16 @@ from terok.lib.orchestration.task_runners.toad import (
 )
 from terok.lib.orchestration.tasks import (
     TaskDeleteResult,
+    dossier_path,
     get_tasks,
     get_workspace_git_diff,
+    load_task_meta,
     read_task_meta,
     task_delete,
     task_list,
     task_new,
+    tasks_meta_dir,
+    write_task_meta,
 )
 from terok.lib.util.net import url_host
 from terok.tui.clipboard import (
@@ -227,15 +231,14 @@ class TestTask:
 
     @staticmethod
     def _patch_task_meta(ctx, project_id: str, tid: str, **updates) -> None:
-        """Load a task's YAML metadata, apply updates, and write it back."""
+        """Load a task's metadata, apply updates, and write it back."""
         meta_dir = ctx.state_dir / "projects" / project_id / "tasks"
-        meta_path = meta_dir / f"{tid}_dossier.json"
-        meta = json.loads(meta_path.read_text() or "{}")
+        meta = read_task_meta(meta_dir, tid) or {}
         meta.update(updates)
         # Setting mode implies the task reached readiness (ready_at marker).
         if "mode" in updates and updates["mode"] is not None and "ready_at" not in updates:
             meta.setdefault("ready_at", "2025-01-01T00:00:00+00:00")
-        meta_path.write_text(json.dumps(meta, indent=2))
+        write_task_meta(dossier_path(meta_dir, tid), meta)
 
     @staticmethod
     def _task_list_output(project_id: str, states: dict[str, str | None], **filters: str) -> str:
@@ -659,12 +662,11 @@ class TestTask:
         ) as ctx:
             tid = task_new(project_id)
             meta_dir = ctx.state_dir / "projects" / project_id / "tasks"
-            meta_path = meta_dir / f"{tid}_dossier.json"
 
             # Simulate task was previously run
-            meta = json.loads(meta_path.read_text() or "{}")
+            meta = read_task_meta(meta_dir, tid) or {}
             meta["mode"] = "cli"
-            meta_path.write_text(json.dumps(meta, indent=2))
+            write_task_meta(dossier_path(meta_dir, tid), meta)
 
             cname = f"{project_id}-cli-{tid}"
             with (
@@ -713,12 +715,10 @@ class TestTask:
             project_id=project_id,
         ):
             tid = task_new(project_id)
-            from terok.lib.orchestration.tasks import tasks_meta_dir
-
-            meta_path = tasks_meta_dir(project_id) / f"{tid}_dossier.json"
-            meta = json.loads(meta_path.read_text() or "{}")
+            meta_dir = tasks_meta_dir(project_id)
+            meta = read_task_meta(meta_dir, tid) or {}
             meta["mode"] = "cli"
-            meta_path.write_text(json.dumps(meta, indent=2))
+            write_task_meta(dossier_path(meta_dir, tid), meta)
 
             expected = "diff --git a/f.txt b/f.txt\n+line\n"
             with unittest.mock.patch(
@@ -737,12 +737,10 @@ class TestTask:
             project_id=project_id,
         ):
             tid = task_new(project_id)
-            from terok.lib.orchestration.tasks import tasks_meta_dir
-
-            meta_path = tasks_meta_dir(project_id) / f"{tid}_dossier.json"
-            meta = json.loads(meta_path.read_text() or "{}")
+            meta_dir = tasks_meta_dir(project_id)
+            meta = read_task_meta(meta_dir, tid) or {}
             meta["mode"] = "run"
-            meta_path.write_text(json.dumps(meta, indent=2))
+            write_task_meta(dossier_path(meta_dir, tid), meta)
 
             expected = "diff --git a/f.txt b/f.txt\n+prev\n"
             with unittest.mock.patch(
@@ -761,12 +759,10 @@ class TestTask:
             project_id=project_id,
         ):
             tid = task_new(project_id)
-            from terok.lib.orchestration.tasks import tasks_meta_dir
-
-            meta_path = tasks_meta_dir(project_id) / f"{tid}_dossier.json"
-            meta = json.loads(meta_path.read_text() or "{}")
+            meta_dir = tasks_meta_dir(project_id)
+            meta = read_task_meta(meta_dir, tid) or {}
             meta["mode"] = "cli"
-            meta_path.write_text(json.dumps(meta, indent=2))
+            write_task_meta(dossier_path(meta_dir, tid), meta)
 
             with unittest.mock.patch(
                 "terok.lib.orchestration.tasks.query.container_git_diff",
@@ -1161,12 +1157,9 @@ class TestResumeToadContainer:
     def _seed_toad_meta(project_id: str, task_id: str, *, port: int, token: str) -> None:
         """Preload task metadata as if a toad launch had already succeeded."""
         project = load_project(project_id)
-        from terok.lib.orchestration.tasks import load_task_meta
-
-        _, meta_path = load_task_meta(project.id, task_id, "toad")
-        meta = json.loads(meta_path.read_text(encoding="utf-8") or "{}")
+        meta, dossier_handle = load_task_meta(project.id, task_id, "toad")
         meta.update({"mode": "toad", "web_port": port, "web_token": token})
-        meta_path.write_text(json.dumps(meta, indent=2))
+        write_task_meta(dossier_handle, meta)
         (project.tasks_root / str(task_id) / "agent-config").mkdir(parents=True, exist_ok=True)
 
     def test_resume_running_container_prints_tokenized_url(self, mock_runtime) -> None:
@@ -1271,13 +1264,10 @@ class TestTaskLogs:
         """Create a task and set its mode in metadata."""
         task_id = task_new(project_id)
         # Manually update metadata to set mode (normally done by task runners)
-        from terok.lib.core.paths import core_state_dir
-
-        meta_dir = core_state_dir() / "projects" / project_id / "tasks"
-        meta_path = meta_dir / f"{task_id}_dossier.json"
-        meta = json.loads(meta_path.read_text() or "{}") or {}
+        meta_dir = tasks_meta_dir(project_id)
+        meta = read_task_meta(meta_dir, task_id) or {}
         meta["mode"] = mode
-        meta_path.write_text(json.dumps(meta, indent=2))
+        write_task_meta(dossier_path(meta_dir, task_id), meta)
         return task_id
 
     def test_unknown_task_raises(self) -> None:
@@ -1546,14 +1536,13 @@ class TestTaskArchive:
             with mock_git_config():
                 task_id = task_new(project_id)
                 meta_dir = ctx.state_dir / "projects" / project_id / "tasks"
-                meta_path = meta_dir / f"{task_id}_dossier.json"
 
                 # Set mode in metadata (simulating a task that ran)
-                meta = json.loads(meta_path.read_text() or "{}") or {}
+                meta = read_task_meta(meta_dir, task_id) or {}
                 meta["mode"] = "run"
                 meta["name"] = "test-task"
                 meta["exit_code"] = 0
-                meta_path.write_text(json.dumps(meta, indent=2))
+                write_task_meta(dossier_path(meta_dir, task_id), meta)
 
                 # Create logs dir to simulate persisted logs
                 task_dir = ctx.state_dir / "tasks" / project_id / task_id
@@ -1574,7 +1563,7 @@ class TestTaskArchive:
                     task_delete(project_id, task_id)
 
                 # Task should be deleted
-                assert not meta_path.exists()
+                assert not dossier_path(meta_dir, task_id).exists()
 
                 # Archive should exist under namespace archive tree
                 from terok.lib.orchestration.tasks import tasks_archive_dir
@@ -2018,12 +2007,7 @@ class TestGetTaskMeta:
 
     def test_hydrates_live_container_state(self, mock_runtime) -> None:
         """A task that has run gets its container_state filled from the runtime."""
-        from terok.lib.orchestration.tasks import (
-            dossier_path,
-            get_task_meta,
-            tasks_meta_dir,
-            write_task_meta,
-        )
+        from terok.lib.orchestration.tasks import get_task_meta
 
         pid = "proj_gtm_live"
         with project_env(f"project:\n  id: {pid}\n", project_id=pid), mock_git_config():


### PR DESCRIPTION
## Summary

Follow-up to #941. The orchestration-core carve split the god *modules*; this PR makes the worst *functions* in those modules clean too. Every function `complexipy` flagged over the cognitive-complexity threshold (15) in `src/terok/lib/orchestration/` is now under it:

| Function | Before | After |
|---|---|---|
| `tasks/meta.py::read_task_meta` | 16 | **3** |
| `task_runners/headless.py::task_run_headless` | 17 | **9** |
| `task_runners/headless.py::task_followup_headless` | 17 | **7** |
| `tasks/lifecycle.py::_task_delete` | 19 | **4** |
| `task_runners/restart.py::task_restart` | 21 | **3** |
| `container_doctor.py::_git_remote_check` | 17 | **10** |
| `environment.py::_security_mode_env_and_volumes` | 25 | **5** |

Each complexity reduction is **pure extraction / restructuring with no behaviour change** — the functions all have test coverage (existing + the ones added in #941), and the extracted helpers are cohesive sub-steps, not arbitrary line-splits.

## Per-commit

1. **`read_task_meta`** — extract `_read_json_meta` / `_read_yml_meta` / `_split_dossier_spillover` / `_merge_dossier_into` / `_backfill_project_id`.
2. **headless runners** — `task_run_headless` and `task_followup_headless` shared the same follow/detached tail -> extract `_report_headless_result` (also removes a copy-paste-with-variation block). Plus `_build_cli_overrides` and `_inject_followup_prompt`.
3. **`_task_delete`** — one helper per step of the 8-step delete choreography (`_revoke_task_token`, `_remove_task_containers`, `_remove_workspace`, `_remove_meta_files`, `_release_task_web_port`).
4. **`task_restart`** — flip the trailing `if not None: ... else: raise` into an early `if None: raise`, which un-nests the body; the three phases then extract cleanly.
5. **`_git_remote_check` / `_security_mode_env_and_volumes`** — the two functions #941's audit flagged but commits 1-4 didn't touch. `_git_remote_check` 17->10 (extract `_gatekeeping_remote_verdict`); `_security_mode_env_and_volumes` 25->5 (extract `_resolve_gate_port` plus per-security-class `_gatekeeping_repo_env` / `_online_repo_env`).
6. **remove pre-split single-JSON meta layout** — `read_task_meta` carried a re-split path for a long-dead on-disk format (one JSON file mixing the wire dossier with bookkeeping). No production code writes it — every write goes through `write_task_meta`, which always splits — but ~14 test sites hand-rolled it via `json.dumps`. Migrate those to the real `write_task_meta` API, then drop `_split_dossier_spillover` and the spillover detect/merge/re-normalise (`read_task_meta` 16->5->**3**).
7. **task-delete cleanup fixes** (review feedback) — `_remove_meta_files` unlinks each path independently so one failure no longer aborts the rest; `_release_task_web_port` surfaces release failures in the returned warnings like every other cleanup step.
8. **path-literal constants** (review feedback) — route `headless.py` through the existing `WORKSPACE_DANGEROUS_DIRNAME` plus new `_PROMPT_FILENAME` / `_PROMPT_HISTORY_FILENAME`.

## Test plan

`make check` fully green:
- [x] `make lint` — ruff clean
- [x] `make test` — full unit suite passes
- [x] `make tach` / `make lint-imports` — clean
- [x] `make typecheck` — mypy clean
- [x] `make security` — bandit: 0 medium/high
- [x] `make docstrings` — 97.4%
- [x] `make reuse` — compliant
- [x] `complexipy src/terok/lib/orchestration/` — every function under 15

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Consistent headless CLI behavior: unified follow vs detached output and clearer run/follow reporting.
  * Improved restart flow reporting with clearer restart/connect instructions.
  * Task deletion now performs more robust cleanup and surfaces consolidated warnings.
  * Metadata handling is more resilient: missing project IDs can be inferred and on-disk metadata is normalized when needed.
  * No changes to public APIs or user-facing commands.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/terok-ai/terok/pull/942)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
