### PR TITLE
refactor: adopt canonical vault.{store,ssh,daemon}.* paths

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -3587,13 +3587,14 @@ url = "https://github.com/terok-ai/terok-clearance/releases/download/v0.6.11/ter
 
 [[package]]
 name = "terok-executor"
-version = "0.0.144"
+version = "0.0.145"
 description = "Single-agent task runner for hardened Podman containers"
 optional = false
 python-versions = ">=3.12,<3.15"
 groups = ["main"]
-files = []
-develop = false
+files = [
+    {file = "terok_executor-0.0.145-py3-none-any.whl", hash = "sha256:648350f7af787f69dd49f33a49e504bc500a76ff4c344660fcc98e06d9776524"},
+]
 
 [package.dependencies]
 agent-client-protocol = ">=0.7"
@@ -3602,24 +3603,23 @@ prompt-toolkit = ">=3.0"
 pydantic = ">=2.9"
 rich = ">=13.0"
 "ruamel.yaml" = ">=0.18"
-terok-sandbox = {git = "https://github.com/sliwowitz/terok-sandbox.git", branch = "refactor/drop-back-compat-shims"}
+terok_sandbox = {url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.0.120/terok_sandbox-0.0.120-py3-none-any.whl"}
 tomli-w = ">=1.0"
 
 [package.source]
-type = "git"
-url = "https://github.com/sliwowitz/terok-executor.git"
-reference = "refactor/canonical-vault-paths"
-resolved_reference = "6f6b759c8f5d2275b87d67614b5c67e52f3631f8"
+type = "url"
+url = "https://github.com/terok-ai/terok-executor/releases/download/v0.0.145/terok_executor-0.0.145-py3-none-any.whl"
 
 [[package]]
 name = "terok-sandbox"
-version = "0.0.119"
+version = "0.0.120"
 description = "Hardened Podman container runner with gate server and shield integration"
 optional = false
 python-versions = ">=3.12,<4.0"
 groups = ["main"]
-files = []
-develop = false
+files = [
+    {file = "terok_sandbox-0.0.120-py3-none-any.whl", hash = "sha256:d0e247573ff522577290817580f0fc7c09991b3538242c4d1f79053abd814a7d"},
+]
 
 [package.dependencies]
 aiohttp = ">=3.9"
@@ -3631,14 +3631,12 @@ prompt-toolkit = ">=3.0"
 pydantic = ">=2.9"
 "ruamel.yaml" = ">=0.18"
 sqlcipher3 = ">=0.6.2"
-terok-clearance = {url = "https://github.com/terok-ai/terok-clearance/releases/download/v0.6.11/terok_clearance-0.6.11-py3-none-any.whl"}
-terok-shield = {url = "https://github.com/terok-ai/terok-shield/releases/download/v0.6.39/terok_shield-0.6.39-py3-none-any.whl"}
+terok_clearance = {url = "https://github.com/terok-ai/terok-clearance/releases/download/v0.6.11/terok_clearance-0.6.11-py3-none-any.whl"}
+terok_shield = {url = "https://github.com/terok-ai/terok-shield/releases/download/v0.6.39/terok_shield-0.6.39-py3-none-any.whl"}
 
 [package.source]
-type = "git"
-url = "https://github.com/sliwowitz/terok-sandbox.git"
-reference = "refactor/drop-back-compat-shims"
-resolved_reference = "13b0c13c99570dfe5f2f14ee995f716eaeb048b4"
+type = "url"
+url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.0.120/terok_sandbox-0.0.120-py3-none-any.whl"
 
 [[package]]
 name = "terok-shield"
@@ -4537,4 +4535,4 @@ propcache = ">=0.2.1"
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.12,<3.15"
-content-hash = "2e29d1e2d03924a99470df49fe4edc1ed860a07a2e6680510a142584b4ffeba8"
+content-hash = "a8878cb2d39ace594b246ab018fa2e5bf95eecae917e58a178d0b747fb1b1f78"

--- a/poetry.lock
+++ b/poetry.lock
@@ -3592,9 +3592,8 @@ description = "Single-agent task runner for hardened Podman containers"
 optional = false
 python-versions = ">=3.12,<3.15"
 groups = ["main"]
-files = [
-    {file = "terok_executor-0.0.144-py3-none-any.whl", hash = "sha256:979f24a5e7ddfd8bfee0613a7e78e5ec7c8bbcdf8561d4fbd02a2dc25ae438cc"},
-]
+files = []
+develop = false
 
 [package.dependencies]
 agent-client-protocol = ">=0.7"
@@ -3603,12 +3602,14 @@ prompt-toolkit = ">=3.0"
 pydantic = ">=2.9"
 rich = ">=13.0"
 "ruamel.yaml" = ">=0.18"
-terok_sandbox = {url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.0.119/terok_sandbox-0.0.119-py3-none-any.whl"}
+terok-sandbox = {git = "https://github.com/sliwowitz/terok-sandbox.git", branch = "refactor/drop-back-compat-shims"}
 tomli-w = ">=1.0"
 
 [package.source]
-type = "url"
-url = "https://github.com/terok-ai/terok-executor/releases/download/v0.0.144/terok_executor-0.0.144-py3-none-any.whl"
+type = "git"
+url = "https://github.com/sliwowitz/terok-executor.git"
+reference = "refactor/canonical-vault-paths"
+resolved_reference = "6f6b759c8f5d2275b87d67614b5c67e52f3631f8"
 
 [[package]]
 name = "terok-sandbox"
@@ -3617,9 +3618,8 @@ description = "Hardened Podman container runner with gate server and shield inte
 optional = false
 python-versions = ">=3.12,<4.0"
 groups = ["main"]
-files = [
-    {file = "terok_sandbox-0.0.119-py3-none-any.whl", hash = "sha256:bd24b7bf51398f752833bf3e2e9dc1ed2550c1be396013f83970321ee0f1de76"},
-]
+files = []
+develop = false
 
 [package.dependencies]
 aiohttp = ">=3.9"
@@ -3631,12 +3631,14 @@ prompt-toolkit = ">=3.0"
 pydantic = ">=2.9"
 "ruamel.yaml" = ">=0.18"
 sqlcipher3 = ">=0.6.2"
-terok_clearance = {url = "https://github.com/terok-ai/terok-clearance/releases/download/v0.6.11/terok_clearance-0.6.11-py3-none-any.whl"}
-terok_shield = {url = "https://github.com/terok-ai/terok-shield/releases/download/v0.6.39/terok_shield-0.6.39-py3-none-any.whl"}
+terok-clearance = {url = "https://github.com/terok-ai/terok-clearance/releases/download/v0.6.11/terok_clearance-0.6.11-py3-none-any.whl"}
+terok-shield = {url = "https://github.com/terok-ai/terok-shield/releases/download/v0.6.39/terok_shield-0.6.39-py3-none-any.whl"}
 
 [package.source]
-type = "url"
-url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.0.119/terok_sandbox-0.0.119-py3-none-any.whl"
+type = "git"
+url = "https://github.com/sliwowitz/terok-sandbox.git"
+reference = "refactor/drop-back-compat-shims"
+resolved_reference = "13b0c13c99570dfe5f2f14ee995f716eaeb048b4"
 
 [[package]]
 name = "terok-shield"
@@ -4535,4 +4537,4 @@ propcache = ">=0.2.1"
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.12,<3.15"
-content-hash = "fdf2188565c59ce03ef38e9fdf1d2a51805aa99b3d2b1379d56014ada0d49134"
+content-hash = "2e29d1e2d03924a99470df49fe4edc1ed860a07a2e6680510a142584b4ffeba8"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,8 +58,8 @@ platformdirs = ">=4.5.1"
 unique-namer = ">=1.3"
 textual-serve = ">=1.1.0"
 jinja2 = "^3.1"
-terok-executor = {git = "https://github.com/sliwowitz/terok-executor.git", branch = "refactor/canonical-vault-paths"}
-terok-sandbox = {git = "https://github.com/sliwowitz/terok-sandbox.git", branch = "refactor/drop-back-compat-shims"}
+terok-executor = {url = "https://github.com/terok-ai/terok-executor/releases/download/v0.0.145/terok_executor-0.0.145-py3-none-any.whl"}
+terok-sandbox = {url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.0.120/terok_sandbox-0.0.120-py3-none-any.whl"}
 terok-shield = {url = "https://github.com/terok-ai/terok-shield/releases/download/v0.6.39/terok_shield-0.6.39-py3-none-any.whl"}
 terok-clearance = {url = "https://github.com/terok-ai/terok-clearance/releases/download/v0.6.11/terok_clearance-0.6.11-py3-none-any.whl"}
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,8 +58,8 @@ platformdirs = ">=4.5.1"
 unique-namer = ">=1.3"
 textual-serve = ">=1.1.0"
 jinja2 = "^3.1"
-terok-executor = {url = "https://github.com/terok-ai/terok-executor/releases/download/v0.0.144/terok_executor-0.0.144-py3-none-any.whl"}
-terok-sandbox = {url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.0.119/terok_sandbox-0.0.119-py3-none-any.whl"}
+terok-executor = {git = "https://github.com/sliwowitz/terok-executor.git", branch = "refactor/canonical-vault-paths"}
+terok-sandbox = {git = "https://github.com/sliwowitz/terok-sandbox.git", branch = "refactor/drop-back-compat-shims"}
 terok-shield = {url = "https://github.com/terok-ai/terok-shield/releases/download/v0.6.39/terok_shield-0.6.39-py3-none-any.whl"}
 terok-clearance = {url = "https://github.com/terok-ai/terok-clearance/releases/download/v0.6.11/terok_clearance-0.6.11-py3-none-any.whl"}
 

--- a/src/terok/cli/commands/task.py
+++ b/src/terok/cli/commands/task.py
@@ -590,7 +590,7 @@ def _cmd_task_revoke_credentials(project_id: str, task_id: str) -> None:
     deciding the agent has misbehaved.  The next request the agent
     issues from inside the container gets a 401; in-flight proxy
     calls already past
-    [`lookup_token`][terok_sandbox.credentials.db.CredentialDB.lookup_token]
+    [`lookup_token`][terok_sandbox.vault.store.db.CredentialDB.lookup_token]
     complete on their real credential, which is the intended
     semantics.
     """

--- a/src/terok/lib/domain/task_credentials.py
+++ b/src/terok/lib/domain/task_credentials.py
@@ -41,7 +41,7 @@ def revoke_credentials(project_id: str, task_id: str) -> int:
     The DB-side delete takes effect on the next request the agent
     issues — the broker has no in-memory token cache, so an in-flight
     proxy call already past
-    [`lookup_token`][terok_sandbox.credentials.db.CredentialDB.lookup_token]
+    [`lookup_token`][terok_sandbox.vault.store.db.CredentialDB.lookup_token]
     completes on its real credential.  That's the intended semantics:
     block further use, don't kill in-flight TCP.
 

--- a/src/terok/lib/integrations/sandbox.py
+++ b/src/terok/lib/integrations/sandbox.py
@@ -108,10 +108,6 @@ from terok_sandbox import (  # noqa: F401 — re-exported public API
 from terok_sandbox.commands import (  # noqa: F401 — re-exported public API
     _handle_vault_seal,
 )
-from terok_sandbox.credentials.db import (  # noqa: F401 — re-exported public API
-    NoPassphraseError,
-    WrongPassphraseError,
-)
 from terok_sandbox.doctor import (  # noqa: F401 — re-exported public API
     CheckVerdict,
     DoctorCheck,
@@ -121,12 +117,16 @@ from terok_sandbox.setup_stamp import (  # noqa: F401 — re-exported public API
     _installed_versions,
     _read_stamp,
 )
+from terok_sandbox.vault.store.db import (  # noqa: F401 — re-exported public API
+    NoPassphraseError,
+    WrongPassphraseError,
+)
 
 
 def __getattr__(name: str) -> Any:
     """Lazily resolve heavyweight re-exports kept off the import hot path.
 
-    ``terok_sandbox.vault.token_broker`` drags the whole ``aiohttp``
+    ``terok_sandbox.vault.daemon.token_broker`` drags the whole ``aiohttp``
     dependency tree in with it, and its only consumer (``terok vault
     serve``) imports it from inside a dispatch function anyway.  Routing
     it through ``__getattr__`` keeps ``import terok.lib.integrations.sandbox``
@@ -134,7 +134,7 @@ def __getattr__(name: str) -> Any:
     from paying that cost.
     """
     if name == "vault_token_broker_main":
-        from terok_sandbox.vault.token_broker import main
+        from terok_sandbox.vault.daemon.token_broker import main
 
         return main
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -446,12 +446,14 @@ def _bypass_vault(request: pytest.FixtureRequest) -> Iterator[None]:
         # bypass reachability probes (socket + TCP health).
         with (
             patch.object(
-                __import__("terok_sandbox.vault.lifecycle", fromlist=["VaultManager"]).VaultManager,
+                __import__(
+                    "terok_sandbox.vault.daemon.lifecycle", fromlist=["VaultManager"]
+                ).VaultManager,
                 "_wait_for_unix_socket",
                 return_value=True,
             ),
             patch(
-                "terok_sandbox.vault.lifecycle.VaultManager._wait_for_ready",
+                "terok_sandbox.vault.daemon.lifecycle.VaultManager._wait_for_ready",
                 return_value=True,
             ),
         ):

--- a/tests/integration/stories/conftest.py
+++ b/tests/integration/stories/conftest.py
@@ -166,7 +166,7 @@ async def running_token_broker(
     vault_routes: Path,
     mock_upstream_api: MockUpstreamState,
 ) -> AsyncIterator[VaultEnv]:
-    """Run a real ``terok_sandbox.vault.token_broker`` on a random port.
+    """Run a real ``terok_sandbox.vault.daemon.token_broker`` on a random port.
 
     The broker app is built via the same ``_build_app`` factory that
     production uses — same auth header parsing, same upstream-forwarding
@@ -178,7 +178,7 @@ async def running_token_broker(
     # _build_app is the broker's internal factory; we lean on it directly
     # because there is no public "construct an in-process broker for
     # testing" entrypoint — adding one is a separate refactor.
-    from terok_sandbox.vault.token_broker import _build_app
+    from terok_sandbox.vault.daemon.token_broker import _build_app
 
     db_path, phantom_token, real_credential = populated_vault_db
     app = _build_app(str(db_path), str(vault_routes))

--- a/tests/unit/cli/test_cli_main.py
+++ b/tests/unit/cli/test_cli_main.py
@@ -254,7 +254,7 @@ class TestLockedVaultRendering:
 
     def test_no_passphrase_error_routes_to_actionable_hint(self, capsys) -> None:
         """A raised ``NoPassphraseError`` exits non-zero with the unlock hint."""
-        from terok_sandbox.credentials.encryption import NoPassphraseError
+        from terok_sandbox.vault.store.encryption import NoPassphraseError
 
         # ``terok.cli.__init__`` re-exports ``main`` and so shadows the
         # submodule attribute — reach for the symbols directly.

--- a/tests/unit/lib/test_gate_server.py
+++ b/tests/unit/lib/test_gate_server.py
@@ -152,21 +152,30 @@ class TestSystemdDetection:
 
     @pytest.mark.parametrize(
         ("returncode", "expected"),
-        [(0, True), (1, True), (2, False)],
-        ids=["ok", "acceptable-nonzero", "unavailable"],
+        [
+            (0, True),  # "running" — fully operational
+            (1, True),  # generic non-zero — could be degraded / starting / …
+            (2, True),  # also a real systemctl exit code; systemd is still present
+            (3, True),  # ditto
+        ],
+        ids=["running", "non-zero-1", "non-zero-2", "non-zero-3"],
     )
     @unittest.mock.patch("subprocess.run")
-    def test_systemd_availability_from_return_code(
+    def test_systemd_present_for_any_real_returncode(
         self,
         mock_run: unittest.mock.Mock,
         returncode: int,
         expected: bool,
     ) -> None:
+        """``is-system-running`` returncode 0 means ``running``; any other
+        real exit code means systemd is still *present* (degraded,
+        starting, maintenance, …)."""
         mock_run.return_value = make_run_result(returncode=returncode)
         assert is_systemd_available() is expected
 
     @unittest.mock.patch("subprocess.run", side_effect=FileNotFoundError)
     def test_systemd_not_available_when_missing(self, _mock: unittest.mock.Mock) -> None:
+        """A missing ``systemctl`` binary is the only "absent" signal that matters."""
         assert not is_systemd_available()
 
 

--- a/tests/unit/lib/test_vault_helpers.py
+++ b/tests/unit/lib/test_vault_helpers.py
@@ -81,7 +81,7 @@ class TestUnassignVaultSshKeys:
 
     def test_locked_vault_routes_notice_to_skipped(self) -> None:
         """A locked vault parks the notice in ``skipped`` — not ``deleted``."""
-        from terok_sandbox.credentials.db import NoPassphraseError
+        from terok_sandbox.vault.store.db import NoPassphraseError
 
         from terok.lib.domain.project import _unassign_vault_ssh_keys
 
@@ -110,7 +110,7 @@ class TestScopeHasVaultKeyLockedVault:
     """
 
     def test_returns_false_on_locked_vault(self) -> None:
-        from terok_sandbox.credentials.db import NoPassphraseError
+        from terok_sandbox.vault.store.db import NoPassphraseError
 
         from terok.lib.domain.project_state import _scope_has_vault_key
 
@@ -123,7 +123,7 @@ class TestScopeHasVaultKeyLockedVault:
             assert _scope_has_vault_key("proj") is False
 
     def test_returns_false_on_wrong_passphrase(self) -> None:
-        from terok_sandbox.credentials.db import WrongPassphraseError
+        from terok_sandbox.vault.store.db import WrongPassphraseError
 
         from terok.lib.domain.project_state import _scope_has_vault_key
 


### PR DESCRIPTION
## Summary

terok-sandbox merged the vault/credentials directory unification
(sandbox#292) and the back-compat shims are coming out via
[\`sliwowitz/terok-sandbox:refactor/drop-back-compat-shims\`](https://github.com/terok-ai/terok-sandbox/pull/293).
Update terok to import via the canonical paths before the shims
disappear.

## Changes

- \`pyproject.toml\`: re-pin both sandbox and executor at their
  matching PR branches.  Re-pinned to released wheels once the chain
  merges.
- 7 files updated to canonical paths (3 source, 4 tests):
  - \`terok_sandbox.credentials.db\`         → \`terok_sandbox.vault.store.db\`
  - \`terok_sandbox.credentials.encryption\` → \`terok_sandbox.vault.store.encryption\`
  - \`terok_sandbox.credentials.ssh\`        → \`terok_sandbox.vault.ssh.manager\`
  - \`terok_sandbox.vault.lifecycle\`        → \`terok_sandbox.vault.daemon.lifecycle\`
  - \`terok_sandbox.vault.token_broker\`     → \`terok_sandbox.vault.daemon.token_broker\`
- \`tests/unit/lib/test_gate_server.py\`: \`is_systemd_available()\`
  parametrisation widened to cover the corrected semantic — any
  non-zero \`systemctl --user is-system-running\` exit means systemd
  is *present* (\`degraded\` / \`starting\` / \`maintenance\` all return
  non-zero per the systemd man page); only the synthetic \`127\` /
  \`124\` from \`_systemctl.query\` mean "absent".

## Coordination

Final link of a three-PR chain:

1. [\`sliwowitz/terok-sandbox:refactor/drop-back-compat-shims\`](https://github.com/terok-ai/terok-sandbox/pull/293) (foundation)
2. [\`sliwowitz/terok-executor:refactor/canonical-vault-paths\`](https://github.com/terok-ai/terok-executor/pull/310) (middle)
3. **this PR** (orchestrator)

Merge order: sandbox → executor → terok.

## Test plan

- [x] \`make check\` green (lint, **2325 unit tests**, tach, docstrings,
      reuse, security)
- [x] \`properdocs build --strict\` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated dependency versions for sandbox and executor components.

* **Refactor**
  * Reorganized internal vault and credential module paths and updated related doc references.

* **Tests**
  * Adjusted test imports and fixtures to match new module layout; updated a systemd availability test to cover additional return codes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/terok-ai/terok/pull/943)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->