### PR TITLE
test(stories): container-launching variant of the phantom-token roundtrip

### DIFF
--- a/tests/integration/cli/test_vault_unlock_story.py
+++ b/tests/integration/cli/test_vault_unlock_story.py
@@ -85,8 +85,11 @@ class TestVaultUnlockStory:
         self._prime_locked_vault(terok_env)
         terok_env.write_project("alpha", _SOURCE_PROJECT)
 
+        # ``terok_env`` already creates this path and exports
+        # ``TEROK_SANDBOX_RUNTIME_DIR``; ``exist_ok=True`` keeps this
+        # explicit assignment idempotent.
         runtime_dir = tmp_path / "sandbox-runtime"
-        runtime_dir.mkdir()
+        runtime_dir.mkdir(exist_ok=True)
         sandbox_env = {"TEROK_SANDBOX_RUNTIME_DIR": str(runtime_dir)}
 
         # --- Act 1: locked vault → exit 2 + actionable hint ----------

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -407,10 +407,21 @@ def terok_env(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> TerokIntegrati
     monkeypatch.setenv("TEROK_EXECUTOR_STATE_DIR", str(agent_state))
     sandbox_live = tmp_path / "sandbox-live"
     sandbox_state = tmp_path / "sandbox-state"
+    sandbox_runtime = tmp_path / "sandbox-runtime"
     sandbox_live.mkdir(parents=True, exist_ok=True)
     sandbox_state.mkdir(parents=True, exist_ok=True)
+    sandbox_runtime.mkdir(parents=True, exist_ok=True)
     monkeypatch.setenv("TEROK_SANDBOX_LIVE_DIR", str(sandbox_live))
     monkeypatch.setenv("TEROK_SANDBOX_STATE_DIR", str(sandbox_state))
+    # Redirect sandbox's runtime_dir too — otherwise SandboxConfig.runtime_dir
+    # falls back to $XDG_RUNTIME_DIR/terok/sandbox and reads the operator's
+    # *real* ``vault.passphrase`` (written by ``terok-sandbox vault unlock``).
+    # The chain then prefers that over the test config's
+    # ``credentials.passphrase``, so the broker decrypts the test DB with
+    # the operator's real passphrase → ``file is not a database``.  Matrix
+    # containers have no such file so this only bites on developer hosts
+    # with an unlocked vault.
+    monkeypatch.setenv("TEROK_SANDBOX_RUNTIME_DIR", str(sandbox_runtime))
 
     # Seed a valid setup.stamp so subprocess CLIs don't exit 3 at the
     # verdict gate on ``terok task run`` / ``terok-executor run``.  Real

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -202,7 +202,10 @@ def _pull_image() -> None:
             "-",
             ".",
         ],
-        input=f"FROM {PODMAN_BASE_IMAGE}\nRUN apk add --no-cache git\n",
+        # `curl` is for the container-launching story tests
+        # (`tests/integration/stories/`); busybox's wget can't speak
+        # `--unix-socket`, which the vault-broker socket transport needs.
+        input=f"FROM {PODMAN_BASE_IMAGE}\nRUN apk add --no-cache git curl\n",
         check=True,
         text=True,
         timeout=120,

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -257,7 +257,7 @@ def start_shielded_container(
 ) -> None:
     """Start a podman container with shield args and detailed failure output."""
     result = subprocess.run(
-        ["podman", "run", "-d", "--rm", "--name", name, *extra_args, image, *PODMAN_SLEEP_COMMAND],
+        ["podman", "run", "-d", "--name", name, *extra_args, image, *PODMAN_SLEEP_COMMAND],
         capture_output=True,
         text=True,
         timeout=timeout,

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -257,7 +257,7 @@ def start_shielded_container(
 ) -> None:
     """Start a podman container with shield args and detailed failure output."""
     result = subprocess.run(
-        ["podman", "run", "-d", "--name", name, *extra_args, image, *PODMAN_SLEEP_COMMAND],
+        ["podman", "run", "-d", "--rm", "--name", name, *extra_args, image, *PODMAN_SLEEP_COMMAND],
         capture_output=True,
         text=True,
         timeout=timeout,

--- a/tests/integration/stories/conftest.py
+++ b/tests/integration/stories/conftest.py
@@ -202,6 +202,65 @@ async def running_token_broker(
         await runner.cleanup()
 
 
+@dataclass
+class VaultSocketEnv:
+    """Wired-up vault with a UNIX-socket-listening broker for container tests."""
+
+    db_path: Path
+    phantom_token: str
+    real_credential: dict[str, Any]
+    socket_path: Path
+    routes_path: Path
+
+
+@pytest.fixture
+async def running_token_broker_socket(
+    populated_vault_db: tuple[Path, str, dict[str, Any]],
+    vault_routes: Path,
+    mock_upstream_api: MockUpstreamState,
+    tmp_path: Path,
+) -> AsyncIterator[VaultSocketEnv]:
+    """Run the token broker on a UNIX domain socket instead of TCP.
+
+    This is the shape the container-launching story uses: a podman
+    container bind-mounts the socket and reaches the broker without
+    needing ``host.containers.internal`` resolution, which varies by
+    rootless network backend (pasta vs slirp4netns) and podman
+    version.  Production's "socket" vault transport is also this
+    shape — see ``terok_sandbox.config.get_vault_transport``.
+
+    The socket file is ``chmod 0666`` so a container running as a
+    different rootless UID (the in-namespace ``testrunner``) can still
+    reach the host-side broker through the bind-mount.
+    """
+    from aiohttp import web
+    from terok_sandbox.vault.daemon.token_broker import _build_app
+
+    db_path, phantom_token, real_credential = populated_vault_db
+    app = _build_app(str(db_path), str(vault_routes))
+
+    socket_path = tmp_path / "vault.sock"
+    runner = web.AppRunner(app)
+    await runner.setup()
+    site = web.UnixSite(runner, path=str(socket_path))
+    await site.start()
+    # Loosen perms so a container peer with a different mapped UID can
+    # still connect through the bind-mount — the file is in a per-test
+    # tmp dir, so the looser mode never escapes the test sandbox.
+    socket_path.chmod(0o666)
+
+    try:
+        yield VaultSocketEnv(
+            db_path=db_path,
+            phantom_token=phantom_token,
+            real_credential=real_credential,
+            socket_path=socket_path,
+            routes_path=vault_routes,
+        )
+    finally:
+        await runner.cleanup()
+
+
 # ── D-Bus mock notification daemon ──────────────────────────
 
 

--- a/tests/integration/stories/test_phantom_token_roundtrip.py
+++ b/tests/integration/stories/test_phantom_token_roundtrip.py
@@ -173,37 +173,35 @@ def test_phantom_swap_through_container_socket(
     host_socket = running_token_broker_socket.socket_path
 
     name = f"{PODMAN_CONTAINER_PREFIX}-phantom-{uuid.uuid4().hex[:8]}"
-    # podman's strict short-name policy refuses to resolve
-    # ``terok-itest:latest`` on hosts that have no
-    # ``unqualified-search-registries`` configured in
-    # ``/etc/containers/registries.conf`` (most personal dev machines).
-    # The image was built locally and stored as
-    # ``localhost/terok-itest:latest``; qualify the reference so podman
-    # doesn't go shopping for a registry.
-    qualified_image = (
-        PODMAN_TEST_IMAGE
-        if "/" in PODMAN_TEST_IMAGE
-        else f"localhost/{PODMAN_TEST_IMAGE}"
-    )
     try:
-        # ``label=disable`` mirrors what the matrix's outer-container run
-        # does, so SELinux relabeling doesn't trip nested-rootless podman
-        # bind-mounts (the prior ``:z`` flag did the wrong thing — it
-        # tried to relabel a file the outer container had marked
-        # unlabeled, and podman exited 125).  On non-SELinux hosts it is
-        # a no-op.
+        # Two podman knobs the matrix doesn't need but a personal dev
+        # host does:
+        #   --pull=never  short-circuits the pull-decision step.  Without
+        #     it, podman either trips the strict short-name policy (no
+        #     unqualified-search-registries → refuses ``terok-itest:latest``)
+        #     or treats a ``localhost/`` prefix as a registry hostname and
+        #     tries to ``https://localhost/v2/`` (the image lives in the
+        #     local store after _pull_image's ``podman build``, but
+        #     ``--pull=missing`` short-circuited the local-store lookup
+        #     before finding it).
+        #   --security-opt label=disable  mirrors the outer matrix
+        #     container's setting, so SELinux relabeling doesn't trip
+        #     nested-rootless podman bind-mounts.  On non-SELinux hosts
+        #     a no-op.
         result = subprocess.run(
             [
                 "podman",
                 "run",
                 "-d",
+                "--pull",
+                "never",
                 "--security-opt",
                 "label=disable",
                 "--name",
                 name,
                 "-v",
                 f"{host_socket}:/vault.sock",
-                qualified_image,
+                PODMAN_TEST_IMAGE,
                 "sleep",
                 "60",
             ],

--- a/tests/integration/stories/test_phantom_token_roundtrip.py
+++ b/tests/integration/stories/test_phantom_token_roundtrip.py
@@ -29,6 +29,8 @@ to drive the request from a separate process / namespace.
 
 from __future__ import annotations
 
+import os
+import pwd
 import shutil
 import subprocess
 import uuid
@@ -41,6 +43,24 @@ from tests.integration.stories.conftest import (
     VaultEnv,
     VaultSocketEnv,
 )
+
+
+def _podman_env() -> dict[str, str]:
+    """Return a subprocess env with ``HOME`` pointing at the real user home.
+
+    ``terok_env`` monkeypatches ``HOME`` to a per-test tmp dir so terok's
+    own config-resolution paths land inside the sandbox.  Podman uses
+    ``$HOME/.local/share/containers/storage`` for its rootless image
+    store, so inheriting the patched HOME makes ``podman run``
+    consult an empty store — even when ``_pull_image`` already built
+    the image in the real one.
+
+    Read the real home from ``/etc/passwd`` (immune to ``os.environ``
+    edits) and splice it back in just for podman.
+    """
+    real_home = pwd.getpwuid(os.getuid()).pw_dir
+    return {**os.environ, "HOME": real_home}
+
 
 # All stories in this file talk to a real DB + broker.
 pytestmark = pytest.mark.needs_vault
@@ -215,6 +235,7 @@ def test_phantom_swap_through_container_socket(
             capture_output=True,
             text=True,
             timeout=30,
+            env=_podman_env(),
         )
         assert result.returncode == 0, (
             f"podman run failed (exit {result.returncode}):\n"
@@ -244,6 +265,7 @@ def test_phantom_swap_through_container_socket(
             capture_output=True,
             text=True,
             timeout=15,
+            env=_podman_env(),
         )
         assert exec_result.returncode == 0, (
             f"curl from inside the container failed (exit {exec_result.returncode}):\n"
@@ -267,10 +289,16 @@ def test_phantom_swap_through_container_socket(
             capture_output=True,
             text=True,
             timeout=10,
+            env=_podman_env(),
         )
         assert real_key not in env_result.stdout, (
             "real API key leaked into container environment — vault transport "
             "should have kept it host-side"
         )
     finally:
-        subprocess.run(["podman", "rm", "-f", name], capture_output=True, timeout=30)
+        subprocess.run(
+            ["podman", "rm", "-f", name],
+            capture_output=True,
+            timeout=30,
+            env=_podman_env(),
+        )

--- a/tests/integration/stories/test_phantom_token_roundtrip.py
+++ b/tests/integration/stories/test_phantom_token_roundtrip.py
@@ -173,17 +173,23 @@ def test_phantom_swap_through_container_socket(
     host_socket = running_token_broker_socket.socket_path
 
     name = f"{PODMAN_CONTAINER_PREFIX}-phantom-{uuid.uuid4().hex[:8]}"
+    # ``podman build -t terok-itest:latest`` stores the image as
+    # ``localhost/terok-itest:latest`` — qualify the reference so
+    # podman's strict short-name policy (no
+    # ``unqualified-search-registries`` configured, typical of personal
+    # dev hosts) doesn't refuse to resolve the bare name even for a
+    # local-store lookup.
+    qualified_image = (
+        PODMAN_TEST_IMAGE if "/" in PODMAN_TEST_IMAGE else f"localhost/{PODMAN_TEST_IMAGE}"
+    )
     try:
         # Two podman knobs the matrix doesn't need but a personal dev
         # host does:
-        #   --pull=never  short-circuits the pull-decision step.  Without
-        #     it, podman either trips the strict short-name policy (no
-        #     unqualified-search-registries → refuses ``terok-itest:latest``)
-        #     or treats a ``localhost/`` prefix as a registry hostname and
-        #     tries to ``https://localhost/v2/`` (the image lives in the
-        #     local store after _pull_image's ``podman build``, but
-        #     ``--pull=missing`` short-circuited the local-store lookup
-        #     before finding it).
+        #   --pull=never  podman's default ``--pull=missing`` interprets
+        #     the ``localhost/`` prefix as a real registry hostname and
+        #     probes ``https://localhost/v2/`` before checking the local
+        #     store.  ``never`` skips that probe and goes straight to
+        #     the local store where the image already lives.
         #   --security-opt label=disable  mirrors the outer matrix
         #     container's setting, so SELinux relabeling doesn't trip
         #     nested-rootless podman bind-mounts.  On non-SELinux hosts
@@ -201,7 +207,7 @@ def test_phantom_swap_through_container_socket(
                 name,
                 "-v",
                 f"{host_socket}:/vault.sock",
-                PODMAN_TEST_IMAGE,
+                qualified_image,
                 "sleep",
                 "60",
             ],

--- a/tests/integration/stories/test_phantom_token_roundtrip.py
+++ b/tests/integration/stories/test_phantom_token_roundtrip.py
@@ -173,6 +173,18 @@ def test_phantom_swap_through_container_socket(
     host_socket = running_token_broker_socket.socket_path
 
     name = f"{PODMAN_CONTAINER_PREFIX}-phantom-{uuid.uuid4().hex[:8]}"
+    # podman's strict short-name policy refuses to resolve
+    # ``terok-itest:latest`` on hosts that have no
+    # ``unqualified-search-registries`` configured in
+    # ``/etc/containers/registries.conf`` (most personal dev machines).
+    # The image was built locally and stored as
+    # ``localhost/terok-itest:latest``; qualify the reference so podman
+    # doesn't go shopping for a registry.
+    qualified_image = (
+        PODMAN_TEST_IMAGE
+        if "/" in PODMAN_TEST_IMAGE
+        else f"localhost/{PODMAN_TEST_IMAGE}"
+    )
     try:
         # ``label=disable`` mirrors what the matrix's outer-container run
         # does, so SELinux relabeling doesn't trip nested-rootless podman
@@ -191,7 +203,7 @@ def test_phantom_swap_through_container_socket(
                 name,
                 "-v",
                 f"{host_socket}:/vault.sock",
-                PODMAN_TEST_IMAGE,
+                qualified_image,
                 "sleep",
                 "60",
             ],

--- a/tests/integration/stories/test_phantom_token_roundtrip.py
+++ b/tests/integration/stories/test_phantom_token_roundtrip.py
@@ -57,6 +57,15 @@ def _podman_env() -> dict[str, str]:
 
     Read the real home from ``/etc/passwd`` (immune to ``os.environ``
     edits) and splice it back in just for podman.
+
+    Safety boundary: this re-exposes the operator's real container
+    state to the test.  The only mutations the test performs against
+    that state are scoped to a single ``terok-itest-phantom-<uuid4>``
+    container — created, exec'd into, and removed in ``finally``.
+    No image build, no commits, no config writes; the image is
+    pulled with ``--pull=never`` so no registry traffic either.  If
+    you add subprocess calls that mutate user state more broadly,
+    re-evaluate whether they belong here at all.
     """
     real_home = pwd.getpwuid(os.getuid()).pw_dir
     return {**os.environ, "HOME": real_home}
@@ -203,8 +212,13 @@ def test_phantom_swap_through_container_socket(
         PODMAN_TEST_IMAGE if "/" in PODMAN_TEST_IMAGE else f"localhost/{PODMAN_TEST_IMAGE}"
     )
     try:
-        # Two podman knobs the matrix doesn't need but a personal dev
-        # host does:
+        # Podman knobs:
+        #   --rm  belt-and-suspenders cleanup.  ``finally`` already
+        #     runs ``podman rm -f``, but if pytest is SIGKILL'd between
+        #     ``podman run`` and the ``finally`` block, ``--rm`` ensures
+        #     the container is auto-removed once ``sleep 60`` exits.
+        #     Keeps the operator's container state pristine even on a
+        #     crashed test run.
         #   --pull=never  podman's default ``--pull=missing`` interprets
         #     the ``localhost/`` prefix as a real registry hostname and
         #     probes ``https://localhost/v2/`` before checking the local
@@ -219,6 +233,7 @@ def test_phantom_swap_through_container_socket(
                 "podman",
                 "run",
                 "-d",
+                "--rm",
                 "--pull",
                 "never",
                 "--security-opt",

--- a/tests/integration/stories/test_phantom_token_roundtrip.py
+++ b/tests/integration/stories/test_phantom_token_roundtrip.py
@@ -19,18 +19,28 @@ End-to-end, this story exercises:
   roster generates in production)
 - An aiohttp upstream that records what authorization header it sees
 
-The container layer is *not* launched here — that would require real
-podman + the host-side networking wiring (host.containers.internal,
-vault transport mode) which is the bit I cannot validate without the
-dev hardware.  Container-launching variant is tracked as a follow-up
-(see this directory's ``__init__.py``).
+In-process tests at the bottom of the file run the broker in the
+same Python process and skip the container layer; the container-
+launching test (``test_phantom_swap_through_container_socket``)
+adds the missing transport hop: a real podman container with the
+broker's UNIX socket bind-mounted, exec'ing ``curl --unix-socket``
+to drive the request from a separate process / namespace.
 """
 
 from __future__ import annotations
 
+import shutil
+import subprocess
+import uuid
+
 import pytest
 
-from tests.integration.stories.conftest import MockUpstreamState, VaultEnv
+from tests.integration.helpers import PODMAN_CONTAINER_PREFIX, PODMAN_TEST_IMAGE
+from tests.integration.stories.conftest import (
+    MockUpstreamState,
+    VaultEnv,
+    VaultSocketEnv,
+)
 
 # All stories in this file talk to a real DB + broker.
 pytestmark = pytest.mark.needs_vault
@@ -126,3 +136,115 @@ async def test_revoked_phantom_is_rejected(
     assert mock_upstream_api.requests == [], (
         "revoked phantom reached the upstream — broker did not honour revocation"
     )
+
+
+# ── Container-launching variant ──────────────────────────────
+
+
+@pytest.mark.needs_podman
+def test_phantom_swap_through_container_socket(
+    running_token_broker_socket: VaultSocketEnv,
+    mock_upstream_api: MockUpstreamState,
+    _pull_image: None,
+) -> None:
+    """Same swap, but driven by ``curl`` *inside a real podman container*.
+
+    The in-process tests above prove the broker swaps phantom for real
+    *given a same-process HTTP client*.  This test adds the transport
+    hop the agent uses in production: the container has the broker's
+    UNIX socket bind-mounted and reaches it via
+    ``curl --unix-socket``.  No more shared event loop, no more
+    same-namespace shortcut.
+
+    UNIX socket (rather than ``host.containers.internal``) keeps the
+    test reliable across rootless backends — pasta and slirp4netns
+    resolve the host gateway differently, and that's not what this
+    story is testing.  Production's "socket" vault transport is
+    exactly this shape.
+
+    Marker: ``needs_podman`` — skipped where podman is absent (CI,
+    laptops without a runtime); the matrix runners exercise it.
+    """
+    if not shutil.which("podman"):
+        pytest.skip("podman not on PATH")
+
+    real_key = running_token_broker_socket.real_credential["key"]
+    phantom = running_token_broker_socket.phantom_token
+    host_socket = running_token_broker_socket.socket_path
+
+    name = f"{PODMAN_CONTAINER_PREFIX}-phantom-{uuid.uuid4().hex[:8]}"
+    try:
+        subprocess.run(
+            [
+                "podman",
+                "run",
+                "-d",
+                "--name",
+                name,
+                # Bind the broker's UNIX socket into the container.  ``:z``
+                # relabels for SELinux on hosts where it's enforcing —
+                # noop where it isn't.
+                "-v",
+                f"{host_socket}:/vault.sock:z",
+                PODMAN_TEST_IMAGE,
+                "sleep",
+                "60",
+            ],
+            check=True,
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+
+        # 1. Container's curl drives the request through the bind-mounted
+        #    socket.  The phantom token is what the agent in production
+        #    would send; the broker sees it and substitutes the real key
+        #    before forwarding to the upstream.
+        exec_result = subprocess.run(
+            [
+                "podman",
+                "exec",
+                name,
+                "curl",
+                "-sS",
+                "--fail",
+                "--unix-socket",
+                "/vault.sock",
+                "-H",
+                f"Authorization: Bearer {phantom}",
+                "http://localhost/v1/messages",
+            ],
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=15,
+        )
+        assert exec_result.returncode == 0, (
+            f"curl from inside the container failed (exit {exec_result.returncode}):\n"
+            f"  stdout: {exec_result.stdout!r}\n"
+            f"  stderr: {exec_result.stderr!r}"
+        )
+
+        # 2. The mock upstream got exactly one request, with the *real* key.
+        assert len(mock_upstream_api.requests) == 1
+        captured = mock_upstream_api.last
+        assert captured.path == "/v1/messages"
+        assert captured.headers.get("Authorization") == f"Bearer {real_key}"
+
+        # 3. The phantom never left the host — neither in any header the
+        #    upstream saw, nor anywhere in the container's environment.
+        raw_headers = " ".join(captured.headers.values())
+        assert phantom not in raw_headers
+        env_result = subprocess.run(
+            ["podman", "exec", name, "env"],
+            check=True,
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        assert real_key not in env_result.stdout, (
+            "real API key leaked into container environment — vault transport "
+            "should have kept it host-side"
+        )
+    finally:
+        subprocess.run(["podman", "rm", "-f", name], capture_output=True, timeout=30)

--- a/tests/integration/stories/test_phantom_token_roundtrip.py
+++ b/tests/integration/stories/test_phantom_token_roundtrip.py
@@ -29,6 +29,7 @@ to drive the request from a separate process / namespace.
 
 from __future__ import annotations
 
+import asyncio
 import os
 import pwd
 import shutil
@@ -171,7 +172,7 @@ async def test_revoked_phantom_is_rejected(
 
 
 @pytest.mark.needs_podman
-def test_phantom_swap_through_container_socket(
+async def test_phantom_swap_through_container_socket(
     running_token_broker_socket: VaultSocketEnv,
     mock_upstream_api: MockUpstreamState,
     _pull_image: None,
@@ -190,6 +191,14 @@ def test_phantom_swap_through_container_socket(
     resolve the host gateway differently, and that's not what this
     story is testing.  Production's "socket" vault transport is
     exactly this shape.
+
+    The test is ``async`` so the aiohttp broker (running in the same
+    event loop as the test body, courtesy of the
+    ``running_token_broker_socket`` fixture) keeps servicing requests
+    while the blocking ``podman exec curl`` is offloaded via
+    ``asyncio.to_thread``.  A sync test would park the loop and the
+    in-container curl would hang waiting for a response the broker
+    never gets to send.
 
     Marker: ``needs_podman`` — skipped where podman is absent (CI,
     laptops without a runtime); the matrix runners exercise it.
@@ -223,7 +232,8 @@ def test_phantom_swap_through_container_socket(
         #     container's setting, so SELinux relabeling doesn't trip
         #     nested-rootless podman bind-mounts.  On non-SELinux hosts
         #     a no-op.
-        result = subprocess.run(
+        result = await asyncio.to_thread(
+            subprocess.run,
             [
                 "podman",
                 "run",
@@ -257,7 +267,8 @@ def test_phantom_swap_through_container_socket(
         #    socket.  The phantom token is what the agent in production
         #    would send; the broker sees it and substitutes the real key
         #    before forwarding to the upstream.
-        exec_result = subprocess.run(
+        exec_result = await asyncio.to_thread(
+            subprocess.run,
             [
                 "podman",
                 "exec",
@@ -293,7 +304,8 @@ def test_phantom_swap_through_container_socket(
         #    upstream saw, nor anywhere in the container's environment.
         raw_headers = " ".join(captured.headers.values())
         assert phantom not in raw_headers
-        env_result = subprocess.run(
+        env_result = await asyncio.to_thread(
+            subprocess.run,
             ["podman", "exec", name, "env"],
             check=True,
             capture_output=True,
@@ -306,7 +318,8 @@ def test_phantom_swap_through_container_socket(
             "should have kept it host-side"
         )
     finally:
-        subprocess.run(
+        await asyncio.to_thread(
+            subprocess.run,
             ["podman", "rm", "-f", name],
             capture_output=True,
             timeout=30,

--- a/tests/integration/stories/test_phantom_token_roundtrip.py
+++ b/tests/integration/stories/test_phantom_token_roundtrip.py
@@ -212,13 +212,8 @@ def test_phantom_swap_through_container_socket(
         PODMAN_TEST_IMAGE if "/" in PODMAN_TEST_IMAGE else f"localhost/{PODMAN_TEST_IMAGE}"
     )
     try:
-        # Podman knobs:
-        #   --rm  belt-and-suspenders cleanup.  ``finally`` already
-        #     runs ``podman rm -f``, but if pytest is SIGKILL'd between
-        #     ``podman run`` and the ``finally`` block, ``--rm`` ensures
-        #     the container is auto-removed once ``sleep 60`` exits.
-        #     Keeps the operator's container state pristine even on a
-        #     crashed test run.
+        # Two podman knobs the matrix doesn't need but a personal dev
+        # host does:
         #   --pull=never  podman's default ``--pull=missing`` interprets
         #     the ``localhost/`` prefix as a real registry hostname and
         #     probes ``https://localhost/v2/`` before checking the local
@@ -233,7 +228,6 @@ def test_phantom_swap_through_container_socket(
                 "podman",
                 "run",
                 "-d",
-                "--rm",
                 "--pull",
                 "never",
                 "--security-opt",

--- a/tests/integration/stories/test_phantom_token_roundtrip.py
+++ b/tests/integration/stories/test_phantom_token_roundtrip.py
@@ -228,6 +228,7 @@ def test_phantom_swap_through_container_socket(
                 "podman",
                 "run",
                 "-d",
+                "--rm",
                 "--pull",
                 "never",
                 "--security-opt",

--- a/tests/integration/stories/test_phantom_token_roundtrip.py
+++ b/tests/integration/stories/test_phantom_token_roundtrip.py
@@ -174,26 +174,36 @@ def test_phantom_swap_through_container_socket(
 
     name = f"{PODMAN_CONTAINER_PREFIX}-phantom-{uuid.uuid4().hex[:8]}"
     try:
-        subprocess.run(
+        # ``label=disable`` mirrors what the matrix's outer-container run
+        # does, so SELinux relabeling doesn't trip nested-rootless podman
+        # bind-mounts (the prior ``:z`` flag did the wrong thing — it
+        # tried to relabel a file the outer container had marked
+        # unlabeled, and podman exited 125).  On non-SELinux hosts it is
+        # a no-op.
+        result = subprocess.run(
             [
                 "podman",
                 "run",
                 "-d",
+                "--security-opt",
+                "label=disable",
                 "--name",
                 name,
-                # Bind the broker's UNIX socket into the container.  ``:z``
-                # relabels for SELinux on hosts where it's enforcing —
-                # noop where it isn't.
                 "-v",
-                f"{host_socket}:/vault.sock:z",
+                f"{host_socket}:/vault.sock",
                 PODMAN_TEST_IMAGE,
                 "sleep",
                 "60",
             ],
-            check=True,
+            check=False,
             capture_output=True,
             text=True,
             timeout=30,
+        )
+        assert result.returncode == 0, (
+            f"podman run failed (exit {result.returncode}):\n"
+            f"  stdout: {result.stdout!r}\n"
+            f"  stderr: {result.stderr!r}"
         )
 
         # 1. Container's curl drives the request through the bind-mounted


### PR DESCRIPTION
## Summary

Follow-up to the in-process Story 2 that landed in #938.  Adds the transport hop the agent uses in production: a real podman container with the vault broker's UNIX socket bind-mounted, exec'ing `curl --unix-socket` from a separate process and namespace.

The in-process tests already prove the broker swaps phantom for real *given a same-process HTTP client*.  This one closes the remaining gap — that the swap still works when the request crosses an OS process boundary plus a container namespace, exactly the way agents reach the vault in real deployment.

## Wire shape

**UNIX socket transport** (not `host.containers.internal`).  Two reasons:

1. `host.containers.internal` resolution varies by rootless backend (pasta vs slirp4netns) and podman version; that's not what this story is about and would make the test flaky on the matrix.
2. Production's `vault.transport = "socket"` mode is exactly this shape — bind-mount the broker's socket into the container, point the agent at `unix://…` (or just `localhost` with `--unix-socket`).

## What's in the PR

- `running_token_broker_socket` fixture in `tests/integration/stories/conftest.py`: same `_build_app` as the TCP variant, but listens on `aiohttp.web.UnixSite` under `tmp_path`; `chmod 0666` so a different rootless UID in the container can still connect through the bind-mount.
- `_pull_image` (the shared session-scoped test-image builder) now does `apk add --no-cache git curl` (was just `git`).  Busybox's `wget` can't speak `--unix-socket`; real `curl` can.
- New test `test_phantom_swap_through_container_socket` marked `needs_podman`.  Skips cleanly on hosts without podman (GitHub CI, local dev); the matrix runners actually exercise it.

## Test plan

- [x] Local: `pytest tests/integration/stories/` → 3 pass + 2 skip (in-process Story 2 still green; new container test skips because no podman in this dev container; verdict-loop still skips because no python-dbusmock)
- [x] Lint + format clean (`ruff check`, `ruff format --check`)
- [ ] Matrix on dev HW: the new test actually launches a container, exec's curl, and asserts the upstream got the real key — flag any flake or rootless-permission issue

I can't run podman in my dev container, so the test is shipped blind for the *runtime* path.  Structurally it follows the same shape as `test_shield_podman.py` (subprocess-based podman launch with name-prefixed cleanup in `finally`), so the bones should be sound — the variables are SELinux relabel behaviour on the bind-mount and rootless-UID-mapping of the socket file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added container-based integration coverage for the UNIX-socket broker transport.
  * Introduced a socket-based test fixture that exposes socket and routing details for tests.
  * Added an end-to-end container test validating phantom→real token swap over the socket transport.
  * Test container image now includes curl to support in-container socket requests.
  * Relaxed socket file permissions so containers can connect via bind-mount.
  * Integration tests now isolate runtime state by redirecting sandbox runtime directories.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/terok-ai/terok/pull/944)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->