### PR TITLE
feat(tui): vault passphrase to-keyring action on the Vault screen

### DIFF
--- a/src/terok/lib/integrations/sandbox.py
+++ b/src/terok/lib/integrations/sandbox.py
@@ -109,6 +109,7 @@ from terok_sandbox import (  # noqa: F401 — re-exported public API
 from terok_sandbox.commands import (  # noqa: F401 — re-exported public API
     CommandTree,
     _handle_vault_seal,
+    _handle_vault_to_keyring,
 )
 from terok_sandbox.doctor import (  # noqa: F401 — re-exported public API
     CheckVerdict,
@@ -182,6 +183,7 @@ __all__ = [
     "VolumeSpec",
     "WrongPassphraseError",
     "_handle_vault_seal",
+    "_handle_vault_to_keyring",
     "_installed_versions",
     "_read_stamp",
     "block",

--- a/src/terok/tui/app.py
+++ b/src/terok/tui/app.py
@@ -184,6 +184,7 @@ if _HAS_TEXTUAL:
         "vault_unlock": "_action_vault_unlock",
         "vault_lock": "_action_vault_lock",
         "vault_seal": "_action_vault_seal",
+        "vault_to_keyring": "_action_vault_to_keyring",
     }
 
     TASK_ACTION_HANDLERS: dict[str, str] = {

--- a/src/terok/tui/project_actions.py
+++ b/src/terok/tui/project_actions.py
@@ -756,3 +756,19 @@ class ProjectActionsMixin(_MixinBase):
             title="Sealing vault passphrase into systemd-creds",
             refresh="vault_status",
         )
+
+    async def _action_vault_to_keyring(self) -> None:
+        """Move the currently resolved passphrase into the OS keyring.
+
+        Defers to sandbox's ``_handle_vault_to_keyring``: resolves the
+        passphrase from whichever tier currently holds it, writes to
+        the keyring, flips ``credentials.use_keyring: true``, drops
+        any plaintext fallbacks, removes the session/sealed copies,
+        and restarts the daemon.  The shell-side equivalent of
+        ``terok vault passphrase to-keyring``.
+        """
+        self._run_console_action(
+            "terok.tui.worker_actions:vault_to_keyring",
+            title="Moving vault passphrase to OS keyring",
+            refresh="vault_status",
+        )

--- a/src/terok/tui/screens.py
+++ b/src/terok/tui/screens.py
@@ -2220,6 +2220,7 @@ class VaultScreen(screen.Screen[str | None]):
         _modal_binding("n", "vault_unlock", "Unlock (session-file tier)"),
         _modal_binding("l", "vault_lock", "Lock (clear session-file)"),
         _modal_binding("e", "vault_seal", "Seal into systemd-creds"),
+        _modal_binding("k", "vault_to_keyring", "Move passphrase to keyring"),
         _modal_binding("r", "vault_refresh", "Refresh status"),
     ]
 
@@ -2255,6 +2256,7 @@ class VaultScreen(screen.Screen[str | None]):
             Option("u\\[n]lock (write to session-file tier)", id="vault_unlock"),
             Option("\\[l]ock (clear session-file, stop daemon)", id="vault_lock"),
             Option("s\\[e]al current passphrase into systemd-creds", id="vault_seal"),
+            Option("move passphrase to \\[k]eyring", id="vault_to_keyring"),
             None,
             Option("\\[r]efresh status", id="vault_refresh"),
             id="actions-list",
@@ -2327,6 +2329,10 @@ class VaultScreen(screen.Screen[str | None]):
     def action_vault_seal(self) -> None:
         """Seal the currently resolved passphrase into a systemd-creds credential."""
         self.dismiss("vault_seal")
+
+    def action_vault_to_keyring(self) -> None:
+        """Trigger the to-keyring relocation flow."""
+        self.dismiss("vault_to_keyring")
 
     def action_vault_refresh(self) -> None:
         """Refresh the status display."""

--- a/src/terok/tui/worker_actions.py
+++ b/src/terok/tui/worker_actions.py
@@ -240,6 +240,14 @@ def vault_seal() -> None:
     _handle_vault_seal(cfg=make_sandbox_config(), key="auto")
 
 
+def vault_to_keyring() -> None:
+    """Move the resolved passphrase from its current tier into the OS keyring."""
+    from terok.lib.api import make_sandbox_config
+    from terok.lib.integrations.sandbox import _handle_vault_to_keyring
+
+    _handle_vault_to_keyring(cfg=make_sandbox_config())
+
+
 # ── Task lifecycle ────────────────────────────────────────────────────
 
 

--- a/tests/unit/tui/test_detail_screens.py
+++ b/tests/unit/tui/test_detail_screens.py
@@ -1452,6 +1452,7 @@ class TestVaultScreen:
             pytest.param("action_vault_unlock", "vault_unlock", id="unlock"),
             pytest.param("action_vault_lock", "vault_lock", id="lock"),
             pytest.param("action_vault_seal", "vault_seal", id="seal"),
+            pytest.param("action_vault_to_keyring", "vault_to_keyring", id="to-keyring"),
         ],
     )
     def test_vault_screen_actions(self, method_name: str, expected: str) -> None:
@@ -1726,6 +1727,7 @@ class TestVaultActionDispatch:
             ("vault_unlock", "_action_vault_unlock"),
             ("vault_lock", "_action_vault_lock"),
             ("vault_seal", "_action_vault_seal"),
+            ("vault_to_keyring", "_action_vault_to_keyring"),
         ],
     )
     def test_vault_action_dispatch_all(self, action: str, handler: str) -> None:
@@ -1797,6 +1799,17 @@ class TestVaultActionImplementations:
         instance._run_console_action.assert_called_once_with(
             "terok.tui.worker_actions:vault_seal",
             title="Sealing vault passphrase into systemd-creds",
+            refresh="vault_status",
+        )
+
+    def test_to_keyring_dispatches_vault_to_keyring(self) -> None:
+        """``_action_vault_to_keyring`` dispatches the worker action + refreshes status."""
+        mixin = self._get_mixin()
+        instance = mock.Mock(spec=mixin)
+        run(mixin._action_vault_to_keyring(instance))
+        instance._run_console_action.assert_called_once_with(
+            "terok.tui.worker_actions:vault_to_keyring",
+            title="Moving vault passphrase to OS keyring",
             refresh="vault_status",
         )
 

--- a/tests/unit/tui/test_worker_actions.py
+++ b/tests/unit/tui/test_worker_actions.py
@@ -171,6 +171,17 @@ def test_vault_seal_calls_handle_with_key_auto() -> None:
     m_seal.assert_called_once_with(cfg=cfg, key="auto")
 
 
+def test_vault_to_keyring_calls_handle_with_cfg() -> None:
+    """``vault_to_keyring`` defers to the sandbox helper with terok's cfg."""
+    cfg = mock.Mock()
+    with (
+        mock.patch("terok.lib.api.make_sandbox_config", return_value=cfg),
+        mock.patch("terok.lib.integrations.sandbox._handle_vault_to_keyring") as m_to_keyring,
+    ):
+        worker_actions.vault_to_keyring()
+    m_to_keyring.assert_called_once_with(cfg=cfg)
+
+
 # ── Task lifecycle ────────────────────────────────────────────────────
 
 


### PR DESCRIPTION
## Summary

Adds a \`[k]eyring\` option to the Vault detail screen, next to the existing \`[e]al\` action. Closes the UX tail of [#294](https://github.com/terok-ai/terok/pull/294) — the CLI verb (\`terok vault passphrase to-keyring\`) already existed; the TUI now matches.

| Path | Change |
|---|---|
| \`tui/screens.py\` | Add option + key binding \`k\` + \`action_vault_to_keyring\` |
| \`tui/project_actions.py\` | \`_action_vault_to_keyring\` dispatches to worker, refreshes \`vault_status\` afterward |
| \`tui/worker_actions.py\` | \`vault_to_keyring()\` calls sandbox's handler with the terok-flavored \`SandboxConfig\` |
| \`tui/app.py\` | Map \`vault_to_keyring\` action ID to the handler |
| \`lib/integrations/sandbox.py\` | Re-export \`_handle_vault_to_keyring\` through the integration adapter |

Same plumbing pattern as the existing \`vault_seal\` action — minimal new surface, maximum parity with the CLI.

## Test plan

- [x] \`make check\` — lint, tests (2372), tach, security, import-linter, docstrings, reuse — all green
- [ ] Manual: open the TUI, navigate to the Vault screen, press \`k\` — verify the worker runs and the status pane updates to show the new \`Passphrase: resolved via keyring\` line

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added "Move passphrase to keyring" action to the vault interface with keyboard shortcut (k).
  * Enables storing resolved vault passphrases in the operating system keyring for improved security and convenience.

* **Tests**
  * Added and updated unit tests to cover the new vault action, its routing, and the worker-side invocation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/terok-ai/terok/pull/949)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->