### PR TITLE
feat(tui): interactive SELinux fix buttons on setup exit 5

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -3587,13 +3587,14 @@ url = "https://github.com/terok-ai/terok-clearance/releases/download/v0.6.13/ter
 
 [[package]]
 name = "terok-executor"
-version = "0.0.147"
+version = "0.0.148"
 description = "Single-agent task runner for hardened Podman containers"
 optional = false
 python-versions = ">=3.12,<3.15"
 groups = ["main"]
-files = []
-develop = false
+files = [
+    {file = "terok_executor-0.0.148-py3-none-any.whl", hash = "sha256:3dd2efc605571bcd6bafd1a3a232cf01a21b4752937691d4b37d9ac4165f0337"},
+]
 
 [package.dependencies]
 agent-client-protocol = ">=0.7"
@@ -3602,24 +3603,23 @@ prompt-toolkit = ">=3.0"
 pydantic = ">=2.9"
 rich = ">=13.0"
 "ruamel.yaml" = ">=0.18"
-terok-sandbox = {git = "https://github.com/sliwowitz/terok-sandbox.git", branch = "feat/selinux-setup-surfacing"}
+terok_sandbox = {url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.0.123/terok_sandbox-0.0.123-py3-none-any.whl"}
 tomli-w = ">=1.0"
 
 [package.source]
-type = "git"
-url = "https://github.com/sliwowitz/terok-executor.git"
-reference = "chore/sandbox-selinux-pin"
-resolved_reference = "3377b15c64af5f26417140b480121e615b807b51"
+type = "url"
+url = "https://github.com/terok-ai/terok-executor/releases/download/v0.0.148/terok_executor-0.0.148-py3-none-any.whl"
 
 [[package]]
 name = "terok-sandbox"
-version = "0.0.122"
+version = "0.0.123"
 description = "Hardened Podman container runner with gate server and shield integration"
 optional = false
 python-versions = ">=3.12,<4.0"
 groups = ["main"]
-files = []
-develop = false
+files = [
+    {file = "terok_sandbox-0.0.123-py3-none-any.whl", hash = "sha256:0e2a8bd3eda875a0707cd1832d05708fbe3b59575df0cc71e7d7da761bf81766"},
+]
 
 [package.dependencies]
 aiohttp = ">=3.9"
@@ -3631,14 +3631,12 @@ prompt-toolkit = ">=3.0"
 pydantic = ">=2.9"
 "ruamel.yaml" = ">=0.18"
 sqlcipher3 = ">=0.6.2"
-terok-clearance = {url = "https://github.com/terok-ai/terok-clearance/releases/download/v0.6.13/terok_clearance-0.6.13-py3-none-any.whl"}
-terok-shield = {url = "https://github.com/terok-ai/terok-shield/releases/download/v0.6.41/terok_shield-0.6.41-py3-none-any.whl"}
+terok_clearance = {url = "https://github.com/terok-ai/terok-clearance/releases/download/v0.6.13/terok_clearance-0.6.13-py3-none-any.whl"}
+terok_shield = {url = "https://github.com/terok-ai/terok-shield/releases/download/v0.6.41/terok_shield-0.6.41-py3-none-any.whl"}
 
 [package.source]
-type = "git"
-url = "https://github.com/sliwowitz/terok-sandbox.git"
-reference = "feat/selinux-setup-surfacing"
-resolved_reference = "0cb0cc58baa45d3c9053a3583dfc0507d8b4b972"
+type = "url"
+url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.0.123/terok_sandbox-0.0.123-py3-none-any.whl"
 
 [[package]]
 name = "terok-shield"
@@ -4537,4 +4535,4 @@ propcache = ">=0.2.1"
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.12,<3.15"
-content-hash = "501760a7b93c3ccc3331146a4a8d69ddf574eb1b4bb72f17a72326bf35ebda83"
+content-hash = "6024569f7a1d503f94bd25c6e845f5326fffd5ace080c14d836a82e90f03512f"

--- a/poetry.lock
+++ b/poetry.lock
@@ -3587,14 +3587,13 @@ url = "https://github.com/terok-ai/terok-clearance/releases/download/v0.6.13/ter
 
 [[package]]
 name = "terok-executor"
-version = "0.0.147"
+version = "0.0.146"
 description = "Single-agent task runner for hardened Podman containers"
 optional = false
 python-versions = ">=3.12,<3.15"
 groups = ["main"]
-files = [
-    {file = "terok_executor-0.0.147-py3-none-any.whl", hash = "sha256:bf179920fc62a84e11fb34176efe2897f602ea7e8282f8d341233b1d701d8054"},
-]
+files = []
+develop = false
 
 [package.dependencies]
 agent-client-protocol = ">=0.7"
@@ -3603,12 +3602,14 @@ prompt-toolkit = ">=3.0"
 pydantic = ">=2.9"
 rich = ">=13.0"
 "ruamel.yaml" = ">=0.18"
-terok_sandbox = {url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.0.122/terok_sandbox-0.0.122-py3-none-any.whl"}
+terok-sandbox = {git = "https://github.com/sliwowitz/terok-sandbox.git", branch = "feat/selinux-setup-surfacing"}
 tomli-w = ">=1.0"
 
 [package.source]
-type = "url"
-url = "https://github.com/terok-ai/terok-executor/releases/download/v0.0.147/terok_executor-0.0.147-py3-none-any.whl"
+type = "git"
+url = "https://github.com/sliwowitz/terok-executor.git"
+reference = "chore/sandbox-selinux-pin"
+resolved_reference = "a505853e5c07269f7f341ca153ff6657b3255d30"
 
 [[package]]
 name = "terok-sandbox"
@@ -3617,9 +3618,8 @@ description = "Hardened Podman container runner with gate server and shield inte
 optional = false
 python-versions = ">=3.12,<4.0"
 groups = ["main"]
-files = [
-    {file = "terok_sandbox-0.0.122-py3-none-any.whl", hash = "sha256:9610ccf55491de1cf17941a8d29757919614241c687547fb539f489fa4874df7"},
-]
+files = []
+develop = false
 
 [package.dependencies]
 aiohttp = ">=3.9"
@@ -3631,12 +3631,14 @@ prompt-toolkit = ">=3.0"
 pydantic = ">=2.9"
 "ruamel.yaml" = ">=0.18"
 sqlcipher3 = ">=0.6.2"
-terok_clearance = {url = "https://github.com/terok-ai/terok-clearance/releases/download/v0.6.13/terok_clearance-0.6.13-py3-none-any.whl"}
-terok_shield = {url = "https://github.com/terok-ai/terok-shield/releases/download/v0.6.41/terok_shield-0.6.41-py3-none-any.whl"}
+terok-clearance = {url = "https://github.com/terok-ai/terok-clearance/releases/download/v0.6.13/terok_clearance-0.6.13-py3-none-any.whl"}
+terok-shield = {url = "https://github.com/terok-ai/terok-shield/releases/download/v0.6.41/terok_shield-0.6.41-py3-none-any.whl"}
 
 [package.source]
-type = "url"
-url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.0.122/terok_sandbox-0.0.122-py3-none-any.whl"
+type = "git"
+url = "https://github.com/sliwowitz/terok-sandbox.git"
+reference = "feat/selinux-setup-surfacing"
+resolved_reference = "0cb0cc58baa45d3c9053a3583dfc0507d8b4b972"
 
 [[package]]
 name = "terok-shield"
@@ -4535,4 +4537,4 @@ propcache = ">=0.2.1"
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.12,<3.15"
-content-hash = "c1a1a8bd35cb84793440d92e388e36a0f6b660c6082776782dceca8d052fdab6"
+content-hash = "501760a7b93c3ccc3331146a4a8d69ddf574eb1b4bb72f17a72326bf35ebda83"

--- a/poetry.lock
+++ b/poetry.lock
@@ -3587,7 +3587,7 @@ url = "https://github.com/terok-ai/terok-clearance/releases/download/v0.6.13/ter
 
 [[package]]
 name = "terok-executor"
-version = "0.0.146"
+version = "0.0.147"
 description = "Single-agent task runner for hardened Podman containers"
 optional = false
 python-versions = ">=3.12,<3.15"
@@ -3609,7 +3609,7 @@ tomli-w = ">=1.0"
 type = "git"
 url = "https://github.com/sliwowitz/terok-executor.git"
 reference = "chore/sandbox-selinux-pin"
-resolved_reference = "a505853e5c07269f7f341ca153ff6657b3255d30"
+resolved_reference = "3377b15c64af5f26417140b480121e615b807b51"
 
 [[package]]
 name = "terok-sandbox"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,8 +58,8 @@ platformdirs = ">=4.5.1"
 unique-namer = ">=1.3"
 textual-serve = ">=1.1.0"
 jinja2 = "^3.1"
-terok-executor = {url = "https://github.com/terok-ai/terok-executor/releases/download/v0.0.147/terok_executor-0.0.147-py3-none-any.whl"}
-terok-sandbox = {url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.0.122/terok_sandbox-0.0.122-py3-none-any.whl"}
+terok-executor = {git = "https://github.com/sliwowitz/terok-executor.git", branch = "chore/sandbox-selinux-pin"}
+terok-sandbox = {git = "https://github.com/sliwowitz/terok-sandbox.git", branch = "feat/selinux-setup-surfacing"}
 terok-shield = {url = "https://github.com/terok-ai/terok-shield/releases/download/v0.6.41/terok_shield-0.6.41-py3-none-any.whl"}
 terok-clearance = {url = "https://github.com/terok-ai/terok-clearance/releases/download/v0.6.13/terok_clearance-0.6.13-py3-none-any.whl"}
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,8 +58,8 @@ platformdirs = ">=4.5.1"
 unique-namer = ">=1.3"
 textual-serve = ">=1.1.0"
 jinja2 = "^3.1"
-terok-executor = {git = "https://github.com/sliwowitz/terok-executor.git", branch = "chore/sandbox-selinux-pin"}
-terok-sandbox = {git = "https://github.com/sliwowitz/terok-sandbox.git", branch = "feat/selinux-setup-surfacing"}
+terok-executor = {url = "https://github.com/terok-ai/terok-executor/releases/download/v0.0.148/terok_executor-0.0.148-py3-none-any.whl"}
+terok-sandbox = {url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.0.123/terok_sandbox-0.0.123-py3-none-any.whl"}
 terok-shield = {url = "https://github.com/terok-ai/terok-shield/releases/download/v0.6.41/terok_shield-0.6.41-py3-none-any.whl"}
 terok-clearance = {url = "https://github.com/terok-ai/terok-clearance/releases/download/v0.6.13/terok_clearance-0.6.13-py3-none-any.whl"}
 

--- a/src/terok/lib/integrations/sandbox.py
+++ b/src/terok/lib/integrations/sandbox.py
@@ -25,6 +25,7 @@ narrow allowed-importer rule.
 from typing import Any
 
 from terok_sandbox import (  # noqa: F401 — re-exported public API
+    EXIT_MANUAL_STEP_NEEDED,
     GATE_COMMANDS,
     SERVICES_TCP_OPTOUT_YAML,
     SSH_COMMANDS,
@@ -106,6 +107,7 @@ from terok_sandbox import (  # noqa: F401 — re-exported public API
     up,
     yellow,
 )
+from terok_sandbox._yaml import update_section as yaml_update_section  # noqa: F401
 from terok_sandbox.commands import (  # noqa: F401 — re-exported public API
     CommandTree,
     _handle_vault_seal,
@@ -153,6 +155,7 @@ __all__ = [
     "ContainerRuntime",
     "CredentialDB",
     "DoctorCheck",
+    "EXIT_MANUAL_STEP_NEEDED",
     "EnvironmentCheck",
     "ExecResult",
     "GATE_COMMANDS",
@@ -234,5 +237,6 @@ __all__ = [
     "stop_vault",
     "up",
     "vault_token_broker_main",  # noqa: F822 — PEP 562 lazy re-export via __getattr__
+    "yaml_update_section",
     "yellow",
 ]

--- a/src/terok/tui/app.py
+++ b/src/terok/tui/app.py
@@ -526,12 +526,23 @@ if _HAS_TEXTUAL:
             screen — is awaited: hiding the log to the background must
             not stop the first-run flow from chaining into the wizard
             once setup actually finishes.
+
+            Exit code 5 (``EXIT_MANUAL_STEP_NEEDED`` — every install
+            phase succeeded but the SELinux policy is still missing on
+            a socket-mode host) routes through
+            [`_offer_selinux_fix`][terok.tui.app.TerokApp._offer_selinux_fix]
+            so the user can pick Install / Switch-to-TCP from a modal
+            instead of having to drop to a shell.
             """
+            from terok.lib.integrations.sandbox import EXIT_MANUAL_STEP_NEEDED
+
             entry = self.dispatch_console_command(["terok", "setup"], title="Running terok setup")
             await self.push_screen(WorkerLogScreen(entry))
             await entry.wait()
             if entry.ok:
                 return True
+            if entry.exit_code == EXIT_MANUAL_STEP_NEEDED:
+                return await self._offer_selinux_fix()
             self.notify(
                 "terok setup reported errors.  Re-run from the command palette "
                 "once the underlying issue is fixed.",
@@ -539,6 +550,58 @@ if _HAS_TEXTUAL:
                 timeout=15,
             )
             return False
+
+        async def _offer_selinux_fix(self) -> bool:
+            """Push the SELinux-fix modal; on a chosen remediation, re-run setup.
+
+            Both remediations (install policy / switch to TCP mode)
+            dispatch through the standard console-log pipeline so the
+            operator sees the streaming output, then a fresh setup run
+            picks up the now-resolvable state.  The recursion is
+            bounded — a second exit-5 just re-opens the same modal.
+            """
+            from .selinux_fix_screen import SelinuxFixOutcome, SelinuxFixScreen
+
+            outcome = await self.push_screen_wait(SelinuxFixScreen())
+            if outcome is SelinuxFixOutcome.SKIPPED:
+                self.notify(
+                    "SELinux policy is still missing.  Run setup again "
+                    "from the command palette once it's installed, or "
+                    "switch services.mode to tcp manually.",
+                    severity="warning",
+                    timeout=12,
+                )
+                return False
+            if outcome is SelinuxFixOutcome.INSTALL_POLICY:
+                entry = self.dispatch_console_command(
+                    [
+                        "python",
+                        "-c",
+                        "from terok.tui.worker_actions import selinux_install_policy; "
+                        "selinux_install_policy()",
+                    ],
+                    title="Installing SELinux policy (sudo bash …)",
+                )
+            else:  # SWITCH_TO_TCP
+                entry = self.dispatch_console_command(
+                    [
+                        "python",
+                        "-c",
+                        "from terok.tui.worker_actions import selinux_switch_to_tcp; "
+                        "selinux_switch_to_tcp()",
+                    ],
+                    title="Switching services.mode to tcp",
+                )
+            await self.push_screen(WorkerLogScreen(entry))
+            await entry.wait()
+            if not entry.ok:
+                self.notify(
+                    "The remediation step failed — see the log view for details.",
+                    severity="error",
+                    timeout=15,
+                )
+                return False
+            return await self._run_setup_subprocess()
 
         @work(exclusive=True, group="first-run-flow", exit_on_error=False)
         async def action_run_setup(self) -> None:

--- a/src/terok/tui/selinux_fix_screen.py
+++ b/src/terok/tui/selinux_fix_screen.py
@@ -1,0 +1,147 @@
+# SPDX-FileCopyrightText: 2026 Jiri Vyskocil
+# SPDX-License-Identifier: Apache-2.0
+
+"""Modal that offers the two SELinux-policy fixes after a setup exit 5.
+
+[`terok_sandbox._handle_sandbox_setup`][terok_sandbox.commands._handle_sandbox_setup]
+exits with code 5 when all install phases succeed but the host's
+SELinux policy is missing — see [terok-ai/terok-sandbox#298](https://github.com/terok-ai/terok-sandbox/pull/298).
+The TUI catches that exit code and pushes this screen.
+
+Two paths forward:
+
+- **Install the policy (sudo bash …)** — dispatches the bundled
+  installer script as a console action; the user authenticates to
+  sudo in the captured-log view.  After a successful install, the
+  caller re-runs setup.
+- **Switch to TCP mode** — flips ``services.mode`` to ``tcp`` in the
+  user-scope ``config.yml``; no SELinux policy is required after the
+  flip.  The caller re-runs setup.
+
+A *Skip* button bails out without changing anything (the operator
+can re-open the same modal from the command palette by re-running
+setup).
+"""
+
+from __future__ import annotations
+
+import enum
+from collections.abc import Iterator
+
+from textual.app import ComposeResult
+from textual.binding import Binding
+from textual.containers import Horizontal, Vertical
+from textual.screen import ModalScreen
+from textual.widgets import Button, Label, Static
+
+
+class SelinuxFixOutcome(enum.Enum):
+    """User's pick from [`SelinuxFixScreen`][terok.tui.selinux_fix_screen.SelinuxFixScreen]."""
+
+    INSTALL_POLICY = "install_policy"
+    """Run ``sudo bash <install_script>`` to load ``terok_socket_t``."""
+
+    SWITCH_TO_TCP = "switch_to_tcp"
+    """Write ``services.mode: tcp`` to the user config and re-run setup."""
+
+    SKIPPED = "skipped"
+    """Dismiss without changing anything."""
+
+
+class SelinuxFixScreen(ModalScreen[SelinuxFixOutcome]):
+    """Modal that surfaces the two remediations for a setup exit-5 finish."""
+
+    BINDINGS = [
+        Binding("escape", "close", "Close"),
+        Binding("i", "install_policy", "Install policy"),
+        Binding("t", "switch_to_tcp", "Switch to TCP"),
+        Binding("s", "skip", "Skip"),
+    ]
+
+    CSS = """
+    SelinuxFixScreen {
+        align: center middle;
+    }
+
+    #selinux-fix-dialog {
+        width: 80;
+        max-width: 100%;
+        height: auto;
+        max-height: 80%;
+        border: heavy $primary;
+        border-title-align: right;
+        background: $surface;
+        padding: 1 2;
+    }
+
+    #selinux-fix-headline {
+        height: auto;
+        margin-bottom: 1;
+    }
+
+    #selinux-fix-blurb {
+        color: $text-muted;
+        height: auto;
+        margin-bottom: 1;
+    }
+
+    #selinux-fix-buttons {
+        height: auto;
+        align-horizontal: right;
+    }
+
+    #selinux-fix-buttons Button {
+        margin-left: 1;
+    }
+    """
+
+    def compose(self) -> ComposeResult:
+        """Build the modal: headline, explanation, three buttons."""
+        dialog = Vertical(id="selinux-fix-dialog")
+        dialog.border_title = "SELinux policy required"
+        with dialog:
+            yield Static(
+                "Sandbox setup finished, but the terok_socket_t SELinux policy "
+                "isn't loaded — containers can't reach the host sockets without it.",
+                id="selinux-fix-headline",
+            )
+            yield Label(
+                "Pick one of the two remediations below.  Both run setup again "
+                "afterwards so the install can complete cleanly.",
+                id="selinux-fix-blurb",
+            )
+            with Horizontal(id="selinux-fix-buttons"):
+                yield from self._buttons()
+
+    @staticmethod
+    def _buttons() -> Iterator[Button]:
+        """Three buttons: Skip, Switch-to-TCP, Install-policy (primary)."""
+        yield Button("[s]kip", id="selinux-fix-skip", variant="default")
+        yield Button("Switch to [t]CP mode", id="selinux-fix-tcp", variant="default")
+        yield Button("[i]nstall policy (sudo)", id="selinux-fix-install", variant="primary")
+
+    def action_close(self) -> None:
+        """Esc dismisses with [`SelinuxFixOutcome.SKIPPED`][terok.tui.selinux_fix_screen.SelinuxFixOutcome.SKIPPED]."""
+        self.dismiss(SelinuxFixOutcome.SKIPPED)
+
+    def action_install_policy(self) -> None:
+        """Key binding for Install policy."""
+        self.dismiss(SelinuxFixOutcome.INSTALL_POLICY)
+
+    def action_switch_to_tcp(self) -> None:
+        """Key binding for Switch to TCP."""
+        self.dismiss(SelinuxFixOutcome.SWITCH_TO_TCP)
+
+    def action_skip(self) -> None:
+        """Key binding for Skip."""
+        self.dismiss(SelinuxFixOutcome.SKIPPED)
+
+    def on_button_pressed(self, event: Button.Pressed) -> None:
+        """Route the three button IDs to their dismissal outcomes."""
+        match event.button.id:
+            case "selinux-fix-install":
+                self.dismiss(SelinuxFixOutcome.INSTALL_POLICY)
+            case "selinux-fix-tcp":
+                self.dismiss(SelinuxFixOutcome.SWITCH_TO_TCP)
+            case "selinux-fix-skip":
+                self.dismiss(SelinuxFixOutcome.SKIPPED)

--- a/src/terok/tui/worker_actions.py
+++ b/src/terok/tui/worker_actions.py
@@ -255,15 +255,30 @@ def selinux_install_policy() -> None:
     in its resources — same one ``terok setup`` prints when the policy
     is missing.  Output (including any sudo prompt) lands in the
     captured-log view so the operator can authenticate inline.
+
+    ``sudo`` and ``bash`` are looked up via [`shutil.which`][shutil.which]
+    so the subprocess gets an absolute executable path — keeps
+    bandit (B607 partial-path), SonarCloud, and a hostile ``PATH``
+    all out of the picture.  Failing either lookup turns into a clear
+    [`SystemExit`][SystemExit] rather than a confusing ``FileNotFoundError``.
     """
-    import subprocess
+    import shutil
+    import subprocess  # noqa: S404 — running sudo to load a bundled SELinux policy is the whole point of this verb  # nosec B404
 
     from terok.lib.integrations.sandbox import selinux_install_script
 
+    sudo = shutil.which("sudo")
+    bash = shutil.which("bash")
+    if sudo is None or bash is None:
+        missing = "sudo" if sudo is None else "bash"
+        raise SystemExit(
+            f"selinux_install_policy: {missing} not on PATH — install it or run "
+            "the bundled script manually."
+        )
     # Stream stdout/stderr to the parent process so ConsoleLog captures
     # them line-by-line — same shape as every other dispatched action.
-    subprocess.run(  # noqa: S603 — argv built from a bundled script path  # nosec B603
-        ["sudo", "bash", str(selinux_install_script())],
+    subprocess.run(  # noqa: S603 — argv built from absolute paths + a bundled script  # nosec B603
+        [sudo, bash, str(selinux_install_script())],
         check=True,
     )
 

--- a/src/terok/tui/worker_actions.py
+++ b/src/terok/tui/worker_actions.py
@@ -248,6 +248,43 @@ def vault_to_keyring() -> None:
     _handle_vault_to_keyring(cfg=make_sandbox_config())
 
 
+def selinux_install_policy() -> None:
+    """Run the bundled SELinux installer with ``sudo bash`` and stream the output.
+
+    Delegates to the ``install_policy.sh`` script terok-sandbox ships
+    in its resources — same one ``terok setup`` prints when the policy
+    is missing.  Output (including any sudo prompt) lands in the
+    captured-log view so the operator can authenticate inline.
+    """
+    import subprocess
+
+    from terok.lib.integrations.sandbox import selinux_install_script
+
+    # Stream stdout/stderr to the parent process so ConsoleLog captures
+    # them line-by-line — same shape as every other dispatched action.
+    subprocess.run(  # noqa: S603 — argv built from a bundled script path  # nosec B603
+        ["sudo", "bash", str(selinux_install_script())],
+        check=True,
+    )
+
+
+def selinux_switch_to_tcp() -> None:
+    """Flip ``services.mode`` to ``tcp`` in the user-scope config.yml.
+
+    Writes only the ``services.mode`` field; preserves any other
+    user-supplied config via terok-sandbox's round-trip YAML writer.
+    The new value takes effect on the next setup run — which the
+    caller launches immediately after this returns.
+    """
+    from terok.lib.core.config import global_config_path
+    from terok.lib.integrations.sandbox import yaml_update_section
+
+    user_config = global_config_path()
+    user_config.parent.mkdir(parents=True, exist_ok=True)
+    yaml_update_section(user_config, "services", {"mode": "tcp"})
+    print(f"→ wrote services.mode=tcp to {user_config}")
+
+
 # ── Task lifecycle ────────────────────────────────────────────────────
 
 

--- a/tests/unit/tui/test_detail_screens.py
+++ b/tests/unit/tui/test_detail_screens.py
@@ -1814,6 +1814,114 @@ class TestVaultActionImplementations:
         )
 
 
+class TestSelinuxFixDispatch:
+    """``_run_setup_subprocess`` branches on exit code 5; ``_offer_selinux_fix`` routes outcomes."""
+
+    def _entry(self, *, exit_code: int) -> mock.Mock:
+        entry = mock.Mock()
+        entry.ok = exit_code == 0
+        entry.exit_code = exit_code
+        entry.wait = mock.AsyncMock()
+        return entry
+
+    def test_exit_5_invokes_offer_selinux_fix(self) -> None:
+        """``_run_setup_subprocess`` routes exit code 5 into ``_offer_selinux_fix``."""
+        _, app_class = import_app()
+        # Plain Mock (no spec) — the methods we exercise touch
+        # ``self.notify`` and ``self.push_screen`` from Textual's App
+        # base, which a spec'd mock doesn't auto-include.
+        instance = mock.Mock()
+        instance.dispatch_console_command.return_value = self._entry(exit_code=5)
+        instance.push_screen = mock.AsyncMock()
+        instance._offer_selinux_fix = mock.AsyncMock(return_value=True)
+        result = run(app_class._run_setup_subprocess(instance))
+        assert result is True
+        instance._offer_selinux_fix.assert_awaited_once()
+
+    def test_exit_nonzero_non_5_skips_selinux_fix(self) -> None:
+        """A generic phase failure (exit 1) notifies + returns False — no SELinux modal."""
+        _, app_class = import_app()
+        instance = mock.Mock()
+        instance.dispatch_console_command.return_value = self._entry(exit_code=1)
+        instance.push_screen = mock.AsyncMock()
+        instance._offer_selinux_fix = mock.AsyncMock()
+        result = run(app_class._run_setup_subprocess(instance))
+        assert result is False
+        instance.notify.assert_called_once()
+        instance._offer_selinux_fix.assert_not_awaited()
+
+    def test_exit_0_returns_true_without_selinux_fix(self) -> None:
+        """Happy path: exit 0 returns True, never opens the modal."""
+        _, app_class = import_app()
+        instance = mock.Mock()
+        instance.dispatch_console_command.return_value = self._entry(exit_code=0)
+        instance.push_screen = mock.AsyncMock()
+        instance._offer_selinux_fix = mock.AsyncMock()
+        result = run(app_class._run_setup_subprocess(instance))
+        assert result is True
+        instance._offer_selinux_fix.assert_not_awaited()
+
+    def test_offer_selinux_fix_install_dispatches_then_reruns_setup(self) -> None:
+        """Install button → dispatches selinux_install_policy worker + re-runs setup."""
+        from terok.tui.selinux_fix_screen import SelinuxFixOutcome
+
+        _, app_class = import_app()
+        instance = mock.Mock()
+        instance.push_screen_wait = mock.AsyncMock(return_value=SelinuxFixOutcome.INSTALL_POLICY)
+        instance.push_screen = mock.AsyncMock()
+        instance.dispatch_console_command.return_value = self._entry(exit_code=0)
+        instance._run_setup_subprocess = mock.AsyncMock(return_value=True)
+        result = run(app_class._offer_selinux_fix(instance))
+        assert result is True
+        # The install worker was dispatched (title gives away the branch).
+        title = instance.dispatch_console_command.call_args.kwargs["title"]
+        assert "Installing SELinux policy" in title
+        instance._run_setup_subprocess.assert_awaited_once()
+
+    def test_offer_selinux_fix_tcp_dispatches_then_reruns_setup(self) -> None:
+        """TCP-mode button → dispatches selinux_switch_to_tcp worker + re-runs setup."""
+        from terok.tui.selinux_fix_screen import SelinuxFixOutcome
+
+        _, app_class = import_app()
+        instance = mock.Mock()
+        instance.push_screen_wait = mock.AsyncMock(return_value=SelinuxFixOutcome.SWITCH_TO_TCP)
+        instance.push_screen = mock.AsyncMock()
+        instance.dispatch_console_command.return_value = self._entry(exit_code=0)
+        instance._run_setup_subprocess = mock.AsyncMock(return_value=True)
+        result = run(app_class._offer_selinux_fix(instance))
+        assert result is True
+        title = instance.dispatch_console_command.call_args.kwargs["title"]
+        assert "Switching services.mode" in title
+
+    def test_offer_selinux_fix_skipped_returns_false_no_dispatch(self) -> None:
+        """Skip → notifies + returns False; no worker dispatched, no setup re-run."""
+        from terok.tui.selinux_fix_screen import SelinuxFixOutcome
+
+        _, app_class = import_app()
+        instance = mock.Mock()
+        instance.push_screen_wait = mock.AsyncMock(return_value=SelinuxFixOutcome.SKIPPED)
+        instance._run_setup_subprocess = mock.AsyncMock()
+        result = run(app_class._offer_selinux_fix(instance))
+        assert result is False
+        instance.notify.assert_called_once()
+        instance.dispatch_console_command.assert_not_called()
+        instance._run_setup_subprocess.assert_not_awaited()
+
+    def test_offer_selinux_fix_remediation_failure_returns_false(self) -> None:
+        """If the remediation worker fails (exit != 0), setup is not re-run."""
+        from terok.tui.selinux_fix_screen import SelinuxFixOutcome
+
+        _, app_class = import_app()
+        instance = mock.Mock()
+        instance.push_screen_wait = mock.AsyncMock(return_value=SelinuxFixOutcome.INSTALL_POLICY)
+        instance.push_screen = mock.AsyncMock()
+        instance.dispatch_console_command.return_value = self._entry(exit_code=1)
+        instance._run_setup_subprocess = mock.AsyncMock()
+        result = run(app_class._offer_selinux_fix(instance))
+        assert result is False
+        instance._run_setup_subprocess.assert_not_awaited()
+
+
 class TestVaultStatusPill:
     """Bottom-of-app StatusBar pill driven by [`_render_status_pill`][terok.tui.app.TerokTUI._render_status_pill]."""
 

--- a/tests/unit/tui/test_selinux_fix_screen.py
+++ b/tests/unit/tui/test_selinux_fix_screen.py
@@ -1,0 +1,66 @@
+# SPDX-FileCopyrightText: 2026 Jiri Vyskocil
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the SELinux-policy-missing remediation modal."""
+
+from __future__ import annotations
+
+import importlib
+import sys
+from unittest import mock
+
+import pytest
+
+
+def _import_screen() -> tuple[type, type]:
+    """Import the screen under the same textual-stubbed env as the other TUI tests.
+
+    Mirrors the import_screens helper from test_detail_screens — Textual
+    is stubbed so we don't need the runtime app harness to assert on
+    the screen's pure state transitions.
+    """
+    if "textual" not in sys.modules:
+        from . import test_detail_screens as _ds  # noqa: F401 — loads the textual stubs
+
+    module = importlib.reload(importlib.import_module("terok.tui.selinux_fix_screen"))
+    return module.SelinuxFixScreen, module.SelinuxFixOutcome
+
+
+class TestSelinuxFixScreenActions:
+    """Each binding + button dismisses with the expected outcome."""
+
+    @pytest.mark.parametrize(
+        ("method", "expected_enum_name"),
+        [
+            ("action_install_policy", "INSTALL_POLICY"),
+            ("action_switch_to_tcp", "SWITCH_TO_TCP"),
+            ("action_skip", "SKIPPED"),
+            ("action_close", "SKIPPED"),
+        ],
+    )
+    def test_actions_dismiss_with_outcome(self, method: str, expected_enum_name: str) -> None:
+        screen_cls, outcome_cls = _import_screen()
+        screen = screen_cls()
+        screen.dismiss = mock.Mock()
+        getattr(screen, method)()
+        screen.dismiss.assert_called_once_with(getattr(outcome_cls, expected_enum_name))
+
+    @pytest.mark.parametrize(
+        ("button_id", "expected_enum_name"),
+        [
+            ("selinux-fix-install", "INSTALL_POLICY"),
+            ("selinux-fix-tcp", "SWITCH_TO_TCP"),
+            ("selinux-fix-skip", "SKIPPED"),
+        ],
+    )
+    def test_button_pressed_routes_to_outcome(
+        self, button_id: str, expected_enum_name: str
+    ) -> None:
+        screen_cls, outcome_cls = _import_screen()
+        screen = screen_cls()
+        screen.dismiss = mock.Mock()
+
+        event = mock.Mock()
+        event.button.id = button_id
+        screen.on_button_pressed(event)
+        screen.dismiss.assert_called_once_with(getattr(outcome_cls, expected_enum_name))

--- a/tests/unit/tui/test_selinux_fix_screen.py
+++ b/tests/unit/tui/test_selinux_fix_screen.py
@@ -26,6 +26,25 @@ def _import_screen() -> tuple[type, type]:
     return module.SelinuxFixScreen, module.SelinuxFixOutcome
 
 
+class TestSelinuxFixScreenLayout:
+    """The pure-yield helpers can be exercised without a full Textual app."""
+
+    def test_buttons_yield_three_with_known_ids(self) -> None:
+        """``_buttons`` produces exactly three buttons with the dispatch IDs the handler reads."""
+        screen_cls, _ = _import_screen()
+        # ``_buttons`` is a staticmethod yielding Textual ``Button`` instances;
+        # the test imports it via the class to verify ID + variant.
+        buttons = list(screen_cls._buttons())
+        assert [b.id for b in buttons] == [
+            "selinux-fix-skip",
+            "selinux-fix-tcp",
+            "selinux-fix-install",
+        ]
+        # The Install path is the primary variant (Textual's accent style)
+        # because it's the recommended remediation — Skip / TCP stay default.
+        assert buttons[-1].variant == "primary"
+
+
 class TestSelinuxFixScreenActions:
     """Each binding + button dismisses with the expected outcome."""
 

--- a/tests/unit/tui/test_worker_actions.py
+++ b/tests/unit/tui/test_worker_actions.py
@@ -183,18 +183,47 @@ def test_vault_to_keyring_calls_handle_with_cfg() -> None:
 
 
 def test_selinux_install_policy_runs_sudo_bash() -> None:
-    """``selinux_install_policy`` shells out to ``sudo bash <install_script>``."""
+    """``selinux_install_policy`` resolves sudo + bash via PATH and runs the bundled script."""
     from pathlib import Path
+
+    def _which(name: str) -> str:
+        return {"sudo": "/usr/bin/sudo", "bash": "/usr/bin/bash"}[name]
 
     with (
         mock.patch(
             "terok.lib.integrations.sandbox.selinux_install_script",
             return_value=Path("/bundled/install_policy.sh"),
         ),
+        mock.patch("shutil.which", side_effect=_which),
         mock.patch("subprocess.run") as m_run,
     ):
         worker_actions.selinux_install_policy()
-    m_run.assert_called_once_with(["sudo", "bash", "/bundled/install_policy.sh"], check=True)
+    # Absolute paths from ``shutil.which`` — no partial-path lookup at
+    # exec time (bandit B607 / Sonar partial-path).
+    m_run.assert_called_once_with(
+        ["/usr/bin/sudo", "/usr/bin/bash", "/bundled/install_policy.sh"], check=True
+    )
+
+
+def test_selinux_install_policy_aborts_when_sudo_missing() -> None:
+    """A missing ``sudo`` surfaces as SystemExit with the binary name."""
+    import pytest as _pytest
+
+    with mock.patch("shutil.which", return_value=None):
+        with _pytest.raises(SystemExit, match="sudo not on PATH"):
+            worker_actions.selinux_install_policy()
+
+
+def test_selinux_install_policy_aborts_when_bash_missing() -> None:
+    """A missing ``bash`` surfaces as SystemExit with the binary name."""
+    import pytest as _pytest
+
+    def _which(name: str) -> str | None:
+        return "/usr/bin/sudo" if name == "sudo" else None
+
+    with mock.patch("shutil.which", side_effect=_which):
+        with _pytest.raises(SystemExit, match="bash not on PATH"):
+            worker_actions.selinux_install_policy()
 
 
 def test_selinux_switch_to_tcp_writes_services_mode(tmp_path) -> None:

--- a/tests/unit/tui/test_worker_actions.py
+++ b/tests/unit/tui/test_worker_actions.py
@@ -182,6 +182,32 @@ def test_vault_to_keyring_calls_handle_with_cfg() -> None:
     m_to_keyring.assert_called_once_with(cfg=cfg)
 
 
+def test_selinux_install_policy_runs_sudo_bash() -> None:
+    """``selinux_install_policy`` shells out to ``sudo bash <install_script>``."""
+    from pathlib import Path
+
+    with (
+        mock.patch(
+            "terok.lib.integrations.sandbox.selinux_install_script",
+            return_value=Path("/bundled/install_policy.sh"),
+        ),
+        mock.patch("subprocess.run") as m_run,
+    ):
+        worker_actions.selinux_install_policy()
+    m_run.assert_called_once_with(["sudo", "bash", "/bundled/install_policy.sh"], check=True)
+
+
+def test_selinux_switch_to_tcp_writes_services_mode(tmp_path) -> None:
+    """``selinux_switch_to_tcp`` writes ``services.mode: tcp`` to the user config.yml."""
+    user_config = tmp_path / "config.yml"
+    with (
+        mock.patch("terok.lib.core.config.global_config_path", return_value=user_config),
+        mock.patch("terok.lib.integrations.sandbox.yaml_update_section") as m_update,
+    ):
+        worker_actions.selinux_switch_to_tcp()
+    m_update.assert_called_once_with(user_config, "services", {"mode": "tcp"})
+
+
 # ── Task lifecycle ────────────────────────────────────────────────────
 
 


### PR DESCRIPTION
## Summary

Closes the TUI tail of [#854](https://github.com/terok-ai/terok/issues/854). When \`terok setup\` exits with code 5 (sandbox#298 — every install phase succeeded but the SELinux policy is still missing on a socket-mode host), the TUI now pushes a modal offering the two remediations:

| Button | Action |
|---|---|
| **[i]nstall policy (sudo)** | Dispatches \`sudo bash <bundled install_policy.sh>\` through the console-log pipeline; sudo prompts inline. |
| **Switch to [t]CP mode** | Writes \`services.mode: tcp\` to the user-scope \`config.yml\` via sandbox's round-trip YAML writer. |
| **[s]kip** | Closes without changes; the user can re-trigger from the command palette. |

Either remediation re-runs setup afterwards so the install completes cleanly without an extra trip through the command palette.

## Surface

| Path | Change |
|---|---|
| \`tui/selinux_fix_screen.py\` | New \`SelinuxFixScreen\` modal + \`SelinuxFixOutcome\` enum |
| \`tui/app.py\` | \`_run_setup_subprocess\` checks for exit 5; new \`_offer_selinux_fix\` dispatches the chosen remediation and recursively re-runs setup |
| \`tui/worker_actions.py\` | \`selinux_install_policy\` (sudo bash) + \`selinux_switch_to_tcp\` (yaml_update_section) |
| \`lib/integrations/sandbox.py\` | Re-export \`EXIT_MANUAL_STEP_NEEDED\` and \`yaml_update_section\` through the integration adapter |

## Depends on

- [terok-ai/terok-sandbox#298](https://github.com/terok-ai/terok-sandbox/pull/298) — sets up exit code 5 + \`EXIT_MANUAL_STEP_NEEDED\`
- [terok-ai/terok-executor#313](https://github.com/terok-ai/terok-executor/pull/313) — pin-sync companion

Pins currently:

\`\`\`toml
terok-executor = {git = \"https://github.com/sliwowitz/terok-executor.git\", branch = \"chore/sandbox-selinux-pin\"}
terok-sandbox  = {git = \"https://github.com/sliwowitz/terok-sandbox.git\",  branch = \"feat/selinux-setup-surfacing\"}
\`\`\`

Release script flips both to released wheel URLs after each upstream PR merges, in dependency order (sandbox → executor → terok).

## Test plan

- [x] \`make check\` — lint, tests (2385), tach, security, import-linter, docstrings, reuse — all green
- [x] 9 new tests cover all three layers (worker actions, screen actions, screen button dispatch)
- [ ] Manual: on a Fedora host with SELinux enforcing and the policy uninstalled, run \`terok\`, hit setup → modal appears → both buttons exercised end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added SELinux policy remediation modal during setup: when sandbox setup detects a missing SELinux policy, users can now choose to install the policy, switch services to TCP mode, or skip. Setup automatically retries after remediation completes.

* **Tests**
  * Added unit tests for the SELinux remediation modal and related worker actions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/terok-ai/terok/pull/951)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->