### PR TITLE
test(matrix): Nix slot + two regression tests for #717

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -3566,34 +3566,34 @@ tomli-w = ">=1.0,<2.0"
 
 [[package]]
 name = "terok-clearance"
-version = "0.6.13"
+version = "0.6.14a1"
 description = "Shield clearance and desktop notifications for terok"
 optional = false
 python-versions = ">=3.12,<4.0"
 groups = ["main"]
-files = []
-develop = false
+files = [
+    {file = "terok_clearance-0.6.14a1-py3-none-any.whl", hash = "sha256:ddfceaa29dd23dfaea77804960a578fd97dbe8313a63af1e309cd8ee79d2f07b"},
+]
 
 [package.dependencies]
-asyncvarlink = "^0.3.1"
+asyncvarlink = ">=0.3.1,<0.4.0"
 dbus-fast = ">=2.0,<5.0"
-pyyaml = "^6.0"
+pyyaml = ">=6.0,<7.0"
 
 [package.source]
-type = "git"
-url = "https://github.com/sliwowitz/terok-clearance.git"
-reference = "feat/uniform-command-registry"
-resolved_reference = "c417b56e4a91c7bfd9b7d65f3d3ebf915c69c26e"
+type = "url"
+url = "https://github.com/terok-ai/terok-clearance/releases/download/v0.6.14a1/terok_clearance-0.6.14a1-py3-none-any.whl"
 
 [[package]]
 name = "terok-executor"
-version = "0.0.148"
+version = "0.0.149a1"
 description = "Single-agent task runner for hardened Podman containers"
 optional = false
 python-versions = ">=3.12,<3.15"
 groups = ["main"]
-files = []
-develop = false
+files = [
+    {file = "terok_executor-0.0.149a1-py3-none-any.whl", hash = "sha256:4ee37d47a6719d3913b8d196016e15901353ef3361c53eeb3e82cc52a7f1b797"},
+]
 
 [package.dependencies]
 agent-client-protocol = ">=0.7"
@@ -3602,24 +3602,23 @@ prompt-toolkit = ">=3.0"
 pydantic = ">=2.9"
 rich = ">=13.0"
 "ruamel.yaml" = ">=0.18"
-terok-sandbox = {git = "https://github.com/sliwowitz/terok-sandbox.git", branch = "feat/uniform-command-registry"}
+terok_sandbox = {url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.0.124a1/terok_sandbox-0.0.124a1-py3-none-any.whl"}
 tomli-w = ">=1.0"
 
 [package.source]
-type = "git"
-url = "https://github.com/sliwowitz/terok-executor.git"
-reference = "feat/uniform-command-registry"
-resolved_reference = "761e803b2e5e41b6bf73c5265ebf92b9dbe3f7e6"
+type = "url"
+url = "https://github.com/terok-ai/terok-executor/releases/download/v0.0.149a1/terok_executor-0.0.149a1-py3-none-any.whl"
 
 [[package]]
 name = "terok-sandbox"
-version = "0.0.123"
+version = "0.0.124a1"
 description = "Hardened Podman container runner with gate server and shield integration"
 optional = false
 python-versions = ">=3.12,<4.0"
 groups = ["main"]
-files = []
-develop = false
+files = [
+    {file = "terok_sandbox-0.0.124a1-py3-none-any.whl", hash = "sha256:42a2a77c657816887a30f4af1ba07a96b11999f9e875562518a83a4a5db6946e"},
+]
 
 [package.dependencies]
 aiohttp = ">=3.9"
@@ -3631,34 +3630,31 @@ prompt-toolkit = ">=3.0"
 pydantic = ">=2.9"
 "ruamel.yaml" = ">=0.18"
 sqlcipher3 = ">=0.6.2"
-terok-clearance = {git = "https://github.com/sliwowitz/terok-clearance.git", branch = "feat/uniform-command-registry"}
-terok-shield = {git = "https://github.com/sliwowitz/terok-shield.git", branch = "feat/uniform-command-registry"}
+terok_clearance = {url = "https://github.com/terok-ai/terok-clearance/releases/download/v0.6.14a1/terok_clearance-0.6.14a1-py3-none-any.whl"}
+terok_shield = {url = "https://github.com/terok-ai/terok-shield/releases/download/v0.6.42a1/terok_shield-0.6.42a1-py3-none-any.whl"}
 
 [package.source]
-type = "git"
-url = "https://github.com/sliwowitz/terok-sandbox.git"
-reference = "feat/uniform-command-registry"
-resolved_reference = "668b3fd7aa728db322d7425624554447c3d5b4c1"
+type = "url"
+url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.0.124a1/terok_sandbox-0.0.124a1-py3-none-any.whl"
 
 [[package]]
 name = "terok-shield"
-version = "0.6.41"
+version = "0.6.42a1"
 description = "nftables-based egress firewalling for Podman containers"
 optional = false
 python-versions = ">=3.12,<4.0"
 groups = ["main"]
-files = []
-develop = false
+files = [
+    {file = "terok_shield-0.6.42a1-py3-none-any.whl", hash = "sha256:c1178b8d80eab860e74d0c141ba749bfc83a18c5e0276425829030cf05c17418"},
+]
 
 [package.dependencies]
 pydantic = ">=2.0"
 PyYAML = ">=6.0"
 
 [package.source]
-type = "git"
-url = "https://github.com/sliwowitz/terok-shield.git"
-reference = "feat/uniform-command-registry"
-resolved_reference = "3a0535ff473090bdf78e9c095c6c30e4a845b003"
+type = "url"
+url = "https://github.com/terok-ai/terok-shield/releases/download/v0.6.42a1/terok_shield-0.6.42a1-py3-none-any.whl"
 
 [[package]]
 name = "textual"
@@ -4538,4 +4534,4 @@ propcache = ">=0.2.1"
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.12,<3.15"
-content-hash = "2ce416a11aece396cce542b411427b46e9175cdc9b12a79dda32a9b36f5641be"
+content-hash = "c8a2adac4b4581b7699df7157be6c408a67eafbc2fa90d2bc7a936a64ea6857c"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,10 +58,10 @@ platformdirs = ">=4.5.1"
 unique-namer = ">=1.3"
 textual-serve = ">=1.1.0"
 jinja2 = "^3.1"
-terok-executor = {git = "https://github.com/sliwowitz/terok-executor.git", branch = "feat/uniform-command-registry"}
-terok-sandbox = {git = "https://github.com/sliwowitz/terok-sandbox.git", branch = "feat/uniform-command-registry"}
-terok-shield = {git = "https://github.com/sliwowitz/terok-shield.git", branch = "feat/uniform-command-registry"}
-terok-clearance = {git = "https://github.com/sliwowitz/terok-clearance.git", branch = "feat/uniform-command-registry"}
+terok-executor = {url = "https://github.com/terok-ai/terok-executor/releases/download/v0.0.149a1/terok_executor-0.0.149a1-py3-none-any.whl"}
+terok-sandbox = {url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.0.124a1/terok_sandbox-0.0.124a1-py3-none-any.whl"}
+terok-shield = {url = "https://github.com/terok-ai/terok-shield/releases/download/v0.6.42a1/terok_shield-0.6.42a1-py3-none-any.whl"}
+terok-clearance = {url = "https://github.com/terok-ai/terok-clearance/releases/download/v0.6.14a1/terok_clearance-0.6.14a1-py3-none-any.whl"}
 
 [tool.poetry.group.dev.dependencies]
 pydevd-pycharm = "262.4852.46"

--- a/src/terok/cli/commands/acp.py
+++ b/src/terok/cli/commands/acp.py
@@ -43,6 +43,7 @@ from terok.lib.integrations.executor import acp_socket_is_live
 from ...lib.api import list_projects
 from ...lib.core.config import is_experimental
 from ...lib.core.paths import acp_log_path, acp_socket_path
+from ...lib.util.subprocess_env import child_process_env
 from ._completers import add_project_id, add_task_id
 
 if TYPE_CHECKING:
@@ -213,6 +214,7 @@ def _spawn_daemon(
     try:
         proc = subprocess.Popen(  # nosec B603 — argv = [interpreter, -m, module, container, sock]
             [sys.executable, "-m", "terok_executor.acp.daemon", cname, str(sock_path)],
+            env=child_process_env(),
             stdin=subprocess.DEVNULL,
             stdout=subprocess.DEVNULL,
             stderr=log_fd,

--- a/src/terok/lib/util/subprocess_env.py
+++ b/src/terok/lib/util/subprocess_env.py
@@ -1,0 +1,33 @@
+# SPDX-FileCopyrightText: 2026 Jiri Vyskocil
+# SPDX-License-Identifier: Apache-2.0
+
+"""Environment-construction helpers for spawned ``terok`` child processes.
+
+Centralises the ``PYTHONPATH`` shim that every ``subprocess.run`` /
+``Popen`` of ``sys.executable`` must use, so adding a new spawn site
+doesn't silently regress Franz Pöschel's Nix-wrapped-Python fix
+(terok-ai/terok#717).
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+
+def child_process_env(overrides: dict[str, str] | None = None) -> dict[str, str]:
+    """Build the environment for a spawned ``terok`` child process.
+
+    Threads the parent's ``sys.path`` through as ``PYTHONPATH`` so the
+    child can import ``terok`` regardless of how the parent was
+    launched.  Under Nix, ``sys.executable`` is a wrapper script that
+    rewrites the env on startup — but spawning it directly via
+    ``subprocess`` / ``create_subprocess_exec`` bypasses that wrapper,
+    leaving the child unable to find the ``terok`` package.  This shim
+    restores it (Franz Pöschel's fix in #717).
+
+    *overrides* are applied on top of the parent env; ``PYTHONPATH``
+    always wins so a stray ambient value can't shadow the parent's
+    real import path.
+    """
+    return {**os.environ, **(overrides or {}), "PYTHONPATH": os.pathsep.join(sys.path)}

--- a/src/terok/tui/console_log.py
+++ b/src/terok/tui/console_log.py
@@ -250,7 +250,7 @@ class ConsoleLogMixin(_MixinBase):
         *env*, if given, layers extra environment variables onto the
         child's env (e.g. the askpass wiring a personal-SSH gate-sync
         needs); ``PYTHONPATH`` is still forced last (see
-        [`child_process_env`][terok.tui.console_log.child_process_env]).
+        [`child_process_env`][terok.lib.util.subprocess_env.child_process_env]).
         """
         command = " ".join([ref, *(str(arg) for arg in args)])
         return self._dispatch_console(worker_argv(ref, args), command, title, on_complete, env)
@@ -295,7 +295,7 @@ class ConsoleLogMixin(_MixinBase):
         ``start_new_session=True`` + ``stdin=DEVNULL`` detach the child
         from the controlling terminal so nothing below it can reach
         ``/dev/tty`` and draw over the Textual frame.  *env* layers
-        extra variables onto [`child_process_env`][terok.tui.console_log.child_process_env].
+        extra variables onto [`child_process_env`][terok.lib.util.subprocess_env.child_process_env].
         """
         try:
             proc = await asyncio.create_subprocess_exec(

--- a/src/terok/tui/console_log.py
+++ b/src/terok/tui/console_log.py
@@ -33,7 +33,6 @@ import asyncio
 import enum
 import itertools
 import json
-import os
 import shlex
 import sys
 import time
@@ -42,6 +41,8 @@ from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
 
 from textual import work
+
+from ..lib.util.subprocess_env import child_process_env
 
 if TYPE_CHECKING:
     from textual.app import App
@@ -52,25 +53,6 @@ else:
 
 #: Module path of the child-process entrypoint (the `_worker_entry` module).
 _WORKER_ENTRY_MODULE = "terok.tui._worker_entry"
-
-
-def child_process_env(overrides: dict[str, str] | None = None) -> dict[str, str]:
-    """Build the environment for a spawned ``terok`` child process.
-
-    Threads the parent's ``sys.path`` through as ``PYTHONPATH`` so the
-    child can import ``terok`` regardless of how the parent was
-    launched.  Under Nix, ``sys.executable`` is a wrapper script that
-    rewrites the env on startup — but spawning it directly via
-    ``subprocess`` / ``create_subprocess_exec`` bypasses that wrapper,
-    leaving the child unable to find the ``terok`` package.  This shim
-    restores it (Franz Pöschel's fix in #717, which was lost when #797
-    replaced the function it lived in).
-
-    *overrides* are applied on top of the parent env; ``PYTHONPATH``
-    always wins so a stray ambient value can't shadow the parent's
-    real import path.
-    """
-    return {**os.environ, **(overrides or {}), "PYTHONPATH": os.pathsep.join(sys.path)}
 
 
 class LogStatus(enum.Enum):

--- a/tests/containers/Containerfile.nix
+++ b/tests/containers/Containerfile.nix
@@ -3,8 +3,7 @@
 
 # Nix matrix slot.  Not a "distro" — the only goal is to reproduce a
 # wrapped-Python setup so we can assert that ``[sys.executable, '-m',
-# 'terok.cli.main', ...]`` re-entry still works (terok-ai/terok#717,
-# Franz Pöschel's fix).
+# 'terok.cli.main', ...]`` re-entry still works (terok-ai/terok#717).
 #
 # We don't package terok as a Nix derivation; we just install it with
 # pip inside a ``nix profile``-installed Python, which is enough to
@@ -15,21 +14,15 @@
 FROM docker.io/nixos/nix:latest
 
 # Pre-populate the system profile with what the tests need at runtime:
-# wrapped python + pip, awk, shadow (newuidmap / newgidmap for the
-# rootless-podman follow-up), and util-linux (provides ``su``, which
-# the outer ``bash -c`` uses to drop to the testrunner uid).
-#
-# Bash and git-minimal already ship in the base image's profile;
-# adding ``nixpkgs#bash`` or ``nixpkgs#git`` here conflicts on shared
-# files (``bash/printenv``, ``bin/git-shell``).
+# wrapped python + pip and awk.  Bash and git-minimal already ship in
+# the base image's profile; adding ``nixpkgs#bash`` or ``nixpkgs#git``
+# here conflicts on shared files (``bash/printenv``, ``bin/git-shell``).
 #
 # ``--extra-experimental-features`` turns on flakes (off by default in
 # nix 2.18-).
 RUN nix --extra-experimental-features 'nix-command flakes' \
         profile add \
-        nixpkgs#gawk \
-        nixpkgs#shadow \
-        nixpkgs#util-linux
+        nixpkgs#gawk
 
 # ``python312`` and ``python312Packages.pip`` are *separate* derivations
 # that don't share a site-packages; installing them side-by-side leaves
@@ -44,27 +37,14 @@ RUN nix --extra-experimental-features 'nix-command flakes' \
         profile add --impure --expr \
         '(builtins.getFlake "nixpkgs").legacyPackages.${builtins.currentSystem}.python312.withPackages (ps: [ ps.pip ])'
 
-# /bin/bash → the bash the base image already has, so shebangs and
-# shadow's shell checks resolve.
+# /bin/bash → the bash the base image already has, so shebangs resolve.
 RUN ln -s /nix/var/nix/profiles/default/bin/bash /bin/bash
 
-# Non-root user (uid 1000) — parity with the other matrix slots, and
-# the prerequisite for rootless podman if/when this image starts
-# exercising it.  Skipping ``useradd``: nixos/nix ships none of the
-# files shadow's userdb wants (``/etc/passwd``, ``/etc/login.defs``,
-# the lastlog skeleton on the bind-mounted ``/nix/store``), and a
-# direct ``/etc/passwd`` line is the same outcome with less ceremony.
-RUN install -d /etc \
-    && echo 'testrunner:x:1000:1000::/home/testrunner:/bin/bash' >> /etc/passwd \
-    && echo 'testrunner:x:1000:' >> /etc/group \
-    && install -d -o 1000 -g 1000 /home/testrunner /home/testrunner/.local/bin
-
-# Each user gets their own per-user nix profile; pip --user etc. write
-# under it.
-RUN install -d -o 1000 -g 1000 /nix/var/nix/profiles/per-user/testrunner
-
-# No USER / WORKDIR: ``run_nix_tests`` follows the same pattern as
-# ``run_tests`` — outer ``bash -c`` runs as root to do the
-# ``cp -a /src /workspace`` + ``chown`` + per-user nix-profile init,
-# then ``su - testrunner`` runs the actual install/test as uid 1000.
+# Run as root.  The wrapped-Python failure mode this slot exercises is
+# uid-independent (the Nix wrapper rewrites sys.path the same way for
+# any uid).  When podman gets added to this slot later, that's when a
+# proper non-root user setup is needed for rootless operation —
+# bringing in ``shadow``/``util-linux`` for ``newuidmap``/``su`` and
+# the per-user nix profile dance.  Until then, root-only keeps the
+# image lean and avoids the user-switching plumbing entirely.
 ENV PATH=/nix/var/nix/profiles/default/bin:$PATH

--- a/tests/containers/Containerfile.nix
+++ b/tests/containers/Containerfile.nix
@@ -14,15 +14,27 @@
 FROM docker.io/nixos/nix:latest
 
 # Pre-populate the system profile with what the tests need at runtime:
-# wrapped python + pip and awk.  Bash and git-minimal already ship in
-# the base image's profile; adding ``nixpkgs#bash`` or ``nixpkgs#git``
-# here conflicts on shared files (``bash/printenv``, ``bin/git-shell``).
+# wrapped python + pip, awk, util-linux (for ``su`` — the outer
+# ``bash -c`` drops to the testrunner uid; modern Linux moved ``su``
+# from ``shadow`` to ``util-linux``), and shadow (for the
+# ``newuidmap``/``newgidmap`` rootless-podman follow-up).
+#
+# Bash and git-minimal already ship in the base image's profile;
+# adding ``nixpkgs#bash`` or ``nixpkgs#git`` here conflicts on shared
+# files (``bash/printenv``, ``bin/git-shell``).
 #
 # ``--extra-experimental-features`` turns on flakes (off by default in
 # nix 2.18-).
 RUN nix --extra-experimental-features 'nix-command flakes' \
         profile add \
-        nixpkgs#gawk
+        nixpkgs#gawk \
+        nixpkgs#util-linux \
+        nixpkgs#shadow
+
+# Visibility for the next iteration if su still isn't there: dumps
+# every binary the system profile exposes.  Cheap; runs once at
+# build time.
+RUN ls /nix/var/nix/profiles/default/bin/ | sort
 
 # ``python312`` and ``python312Packages.pip`` are *separate* derivations
 # that don't share a site-packages; installing them side-by-side leaves
@@ -37,14 +49,24 @@ RUN nix --extra-experimental-features 'nix-command flakes' \
         profile add --impure --expr \
         '(builtins.getFlake "nixpkgs").legacyPackages.${builtins.currentSystem}.python312.withPackages (ps: [ ps.pip ])'
 
-# /bin/bash → the bash the base image already has, so shebangs resolve.
+# /bin/bash → the bash the base image already has, so shebangs and
+# the testrunner login shell resolve.
 RUN ln -s /nix/var/nix/profiles/default/bin/bash /bin/bash
 
-# Run as root.  The wrapped-Python failure mode this slot exercises is
-# uid-independent (the Nix wrapper rewrites sys.path the same way for
-# any uid).  When podman gets added to this slot later, that's when a
-# proper non-root user setup is needed for rootless operation —
-# bringing in ``shadow``/``util-linux`` for ``newuidmap``/``su`` and
-# the per-user nix profile dance.  Until then, root-only keeps the
-# image lean and avoids the user-switching plumbing entirely.
+# Non-root user (uid 1000) so terok-sandbox's ``systemd_user_unit_dir``
+# guard doesn't refuse on us — that path bails when running as root,
+# and several unit tests touch it.  Direct ``/etc/passwd`` write
+# instead of useradd: nixos/nix ships none of the files shadow's
+# userdb wants (``/etc/passwd``, ``/etc/login.defs``, the lastlog
+# skeleton on the bind-mounted ``/nix/store``), and an echo into
+# ``/etc/passwd`` is the same outcome with less ceremony.
+RUN install -d /etc \
+    && echo 'testrunner:x:1000:1000::/home/testrunner:/bin/bash' >> /etc/passwd \
+    && echo 'testrunner:x:1000:' >> /etc/group \
+    && install -d -o 1000 -g 1000 /home/testrunner /home/testrunner/.local/bin \
+    && install -d -o 1000 -g 1000 /nix/var/nix/profiles/per-user/testrunner
+
+# No USER directive — outer ``bash -c`` in run_nix_tests runs as root
+# to do the workspace prep, then ``su - testrunner`` for the venv +
+# tests.  See the dispatch in run-matrix.sh.
 ENV PATH=/nix/var/nix/profiles/default/bin:$PATH

--- a/tests/containers/Containerfile.nix
+++ b/tests/containers/Containerfile.nix
@@ -14,40 +14,39 @@
 
 FROM docker.io/nixos/nix:latest
 
-# Pre-populate the wrapped python + pip + shadow utilities in the
-# system profile so the test container has them ready without a
-# network round-trip per matrix run.  The base image already ships
-# ``bash`` and ``git-minimal`` — adding ``nixpkgs#git`` here conflicts
-# on ``bin/git-shell``, and we don't need git anyway (source tree
-# arrives via bind-mount, not a clone).
-#
-# ``shadow`` provides ``useradd`` / ``groupadd``: the slot itself
-# doesn't strictly need a non-root user (the wrapped-Python failure
-# mode is uid-independent), but rootless podman *does*, and we want
-# this image ready for that follow-up without a second image change.
+# Pre-populate the system profile with everything the tests need at
+# runtime: wrapped python + pip, awk, shadow (for rootless podman's
+# newuidmap/newgidmap if/when this slot starts exercising podman),
+# and bash (the base image only has bash via /nix/store, not at
+# /bin/bash, which trips most ``#!/bin/bash`` shebangs).
 #
 # ``--extra-experimental-features`` turns on flakes (off by default in
 # nix 2.18-).
 RUN nix --extra-experimental-features 'nix-command flakes' \
         profile install \
+        nixpkgs#bash \
+        nixpkgs#gawk \
         nixpkgs#python312 \
         nixpkgs#python312Packages.pip \
-        nixpkgs#shadow \
-        nixpkgs#gawk
+        nixpkgs#shadow
+
+# /bin/bash → wrapped bash so shebangs and shadow's shell checks find it.
+RUN ln -s /nix/var/nix/profiles/default/bin/bash /bin/bash
 
 # Non-root user (uid 1000) — parity with the other matrix slots, and
 # the prerequisite for rootless podman if/when this image starts
-# exercising it.  ``--no-log-init`` is mandatory: the default tries to
-# allocate the entire 32-bit lastlog file via ``ftruncate``, which
-# fails on the bind-mounted /nix/store mountpoint with EINVAL.
-RUN useradd --no-log-init -m -u 1000 -s /bin/bash testrunner \
-    && mkdir -p /home/testrunner/.local/bin \
-    && chown -R testrunner:testrunner /home/testrunner
+# exercising it.  Skipping ``useradd``: nixos/nix ships none of the
+# files shadow's userdb wants (``/etc/passwd``, ``/etc/login.defs``,
+# the lastlog skeleton on the bind-mounted ``/nix/store``), and a
+# direct ``/etc/passwd`` line is the same outcome with less ceremony.
+RUN install -d /etc \
+    && echo 'testrunner:x:1000:1000::/home/testrunner:/bin/bash' >> /etc/passwd \
+    && echo 'testrunner:x:1000:' >> /etc/group \
+    && install -d -o 1000 -g 1000 /home/testrunner /home/testrunner/.local/bin
 
 # Each user gets their own per-user nix profile; pip --user etc. write
 # under it.
-RUN mkdir -p /nix/var/nix/profiles/per-user/testrunner \
-    && chown testrunner:testrunner /nix/var/nix/profiles/per-user/testrunner
+RUN install -d -o 1000 -g 1000 /nix/var/nix/profiles/per-user/testrunner
 
 USER testrunner
 ENV USER=testrunner HOME=/home/testrunner

--- a/tests/containers/Containerfile.nix
+++ b/tests/containers/Containerfile.nix
@@ -1,0 +1,47 @@
+# SPDX-FileCopyrightText: 2026 Jiri Vyskocil
+# SPDX-License-Identifier: Apache-2.0
+
+# Nix matrix slot.  Not a "distro" — the only goal is to reproduce a
+# wrapped-Python setup so we can assert that ``[sys.executable, '-m',
+# 'terok.cli.main', ...]`` re-entry still works (terok-ai/terok#717,
+# Franz Pöschel's fix).
+#
+# We don't package terok as a Nix derivation; we just install it with
+# pip inside a ``nix profile``-installed Python, which is enough to
+# get the Nix wrapping behaviour on the interpreter.  Building a full
+# nixpkgs derivation for terok-* siblings is a separate, much larger
+# project.
+
+FROM docker.io/nixos/nix:latest
+
+# Single-user nix install in the base image runs as root.  Enable
+# unprivileged user namespaces and pre-populate ``python3`` (with pip)
+# + ``git`` in the system profile so the test container has them ready
+# without a network round-trip per matrix run.
+#
+# ``--accept-flake-config`` keeps the build hermetic; ``--extra-experimental-features``
+# turns on flakes (off by default in nix 2.18-).
+RUN nix --extra-experimental-features 'nix-command flakes' \
+        profile install \
+        nixpkgs#python312 \
+        nixpkgs#python312Packages.pip \
+        nixpkgs#git \
+        nixpkgs#bash
+
+# Non-root user (uid 1000) so the container exercises the same "regular
+# user shell" path Franz hit, not the root path.  Nix needs the user's
+# home to exist for ~/.local writes from pip --user.
+RUN useradd -m -u 1000 -s /bin/bash testrunner \
+    && mkdir -p /home/testrunner/.local/bin \
+    && chown -R testrunner:testrunner /home/testrunner
+
+# Each user needs their own nix profile to install user-local packages
+# without root.  Initialise the per-user profile dir.
+RUN mkdir -p /nix/var/nix/profiles/per-user/testrunner \
+    && chown testrunner:testrunner /nix/var/nix/profiles/per-user/testrunner
+
+USER testrunner
+ENV USER=testrunner HOME=/home/testrunner
+ENV PATH=/home/testrunner/.local/bin:/nix/var/nix/profiles/default/bin:$PATH
+
+WORKDIR /workspace

--- a/tests/containers/Containerfile.nix
+++ b/tests/containers/Containerfile.nix
@@ -24,11 +24,15 @@ FROM docker.io/nixos/nix:latest
 #
 # ``--extra-experimental-features`` turns on flakes (off by default in
 # nix 2.18-).
+# ``python312`` and ``python312Packages.pip`` are *separate*
+# derivations that don't share a site-packages; installing them
+# side-by-side leaves ``python3.12 -m pip`` unable to find pip.
+# ``python312.withPackages(ps: [ ps.pip ])`` builds a wrapped python
+# whose sys.path includes the listed packages — what we actually want.
 RUN nix --extra-experimental-features 'nix-command flakes' \
         profile install \
         nixpkgs#gawk \
-        nixpkgs#python312 \
-        nixpkgs#python312Packages.pip \
+        'nixpkgs#python312.withPackages(ps: [ ps.pip ])' \
         nixpkgs#shadow
 
 # /bin/bash → the bash the base image already has, so shebangs and

--- a/tests/containers/Containerfile.nix
+++ b/tests/containers/Containerfile.nix
@@ -14,9 +14,10 @@
 
 FROM docker.io/nixos/nix:latest
 
-# Pre-populate the system profile with what the tests need at
-# runtime: wrapped python + pip, awk, shadow (for rootless podman's
-# newuidmap/newgidmap if/when this slot starts exercising podman).
+# Pre-populate the system profile with what the tests need at runtime:
+# wrapped python + pip, awk, shadow (newuidmap / newgidmap for the
+# rootless-podman follow-up), and util-linux (provides ``su``, which
+# the outer ``bash -c`` uses to drop to the testrunner uid).
 #
 # Bash and git-minimal already ship in the base image's profile;
 # adding ``nixpkgs#bash`` or ``nixpkgs#git`` here conflicts on shared
@@ -27,7 +28,8 @@ FROM docker.io/nixos/nix:latest
 RUN nix --extra-experimental-features 'nix-command flakes' \
         profile add \
         nixpkgs#gawk \
-        nixpkgs#shadow
+        nixpkgs#shadow \
+        nixpkgs#util-linux
 
 # ``python312`` and ``python312Packages.pip`` are *separate* derivations
 # that don't share a site-packages; installing them side-by-side leaves

--- a/tests/containers/Containerfile.nix
+++ b/tests/containers/Containerfile.nix
@@ -57,7 +57,8 @@ RUN ln -s /nix/var/nix/profiles/default/bin/bash /bin/bash
 RUN install -d /etc \
     && echo 'testrunner:x:1000:1000::/home/testrunner:/bin/bash' >> /etc/passwd \
     && echo 'testrunner:x:1000:' >> /etc/group \
-    && install -d -o 1000 -g 1000 /home/testrunner /home/testrunner/.local/bin \
+    && mkdir -p /home/testrunner/.local/bin /home/testrunner/.local/share \
+    && chown -R 1000:1000 /home/testrunner \
     && install -d -o 1000 -g 1000 /nix/var/nix/profiles/per-user/testrunner
 
 # No USER directive — outer ``bash -c`` in run_nix_tests runs as root

--- a/tests/containers/Containerfile.nix
+++ b/tests/containers/Containerfile.nix
@@ -65,4 +65,7 @@ USER testrunner
 ENV USER=testrunner HOME=/home/testrunner
 ENV PATH=/home/testrunner/.local/bin:/nix/var/nix/profiles/default/bin:$PATH
 
-WORKDIR /workspace
+# No WORKDIR: ``run_nix_tests`` does ``cp -a /src /workspace`` and then
+# ``cd /workspace``.  ``cp`` only lands /src's contents at /workspace/
+# when /workspace doesn't already exist; pre-creating it via WORKDIR
+# would land them at /workspace/src/ instead and break the cd.

--- a/tests/containers/Containerfile.nix
+++ b/tests/containers/Containerfile.nix
@@ -61,11 +61,8 @@ RUN install -d /etc \
 # under it.
 RUN install -d -o 1000 -g 1000 /nix/var/nix/profiles/per-user/testrunner
 
-USER testrunner
-ENV USER=testrunner HOME=/home/testrunner
-ENV PATH=/home/testrunner/.local/bin:/nix/var/nix/profiles/default/bin:$PATH
-
-# No WORKDIR: ``run_nix_tests`` does ``cp -a /src /workspace`` and then
-# ``cd /workspace``.  ``cp`` only lands /src's contents at /workspace/
-# when /workspace doesn't already exist; pre-creating it via WORKDIR
-# would land them at /workspace/src/ instead and break the cd.
+# No USER / WORKDIR: ``run_nix_tests`` follows the same pattern as
+# ``run_tests`` — outer ``bash -c`` runs as root to do the
+# ``cp -a /src /workspace`` + ``chown`` + per-user nix-profile init,
+# then ``su - testrunner`` runs the actual install/test as uid 1000.
+ENV PATH=/nix/var/nix/profiles/default/bin:$PATH

--- a/tests/containers/Containerfile.nix
+++ b/tests/containers/Containerfile.nix
@@ -24,16 +24,23 @@ FROM docker.io/nixos/nix:latest
 #
 # ``--extra-experimental-features`` turns on flakes (off by default in
 # nix 2.18-).
-# ``python312`` and ``python312Packages.pip`` are *separate*
-# derivations that don't share a site-packages; installing them
-# side-by-side leaves ``python3.12 -m pip`` unable to find pip.
+RUN nix --extra-experimental-features 'nix-command flakes' \
+        profile add \
+        nixpkgs#gawk \
+        nixpkgs#shadow
+
+# ``python312`` and ``python312Packages.pip`` are *separate* derivations
+# that don't share a site-packages; installing them side-by-side leaves
+# ``python3.12 -m pip`` unable to find pip.
 # ``python312.withPackages(ps: [ ps.pip ])`` builds a wrapped python
 # whose sys.path includes the listed packages — what we actually want.
+#
+# That expression isn't a valid flakeref attrpath (``profile add`` only
+# parses dot-separated names there), so feed it via ``--expr``.
+# ``--impure`` is required by ``builtins.getFlake``.
 RUN nix --extra-experimental-features 'nix-command flakes' \
-        profile install \
-        nixpkgs#gawk \
-        'nixpkgs#python312.withPackages(ps: [ ps.pip ])' \
-        nixpkgs#shadow
+        profile add --impure --expr \
+        '(builtins.getFlake "nixpkgs").legacyPackages.x86_64-linux.python312.withPackages (ps: [ ps.pip ])'
 
 # /bin/bash → the bash the base image already has, so shebangs and
 # shadow's shell checks resolve.

--- a/tests/containers/Containerfile.nix
+++ b/tests/containers/Containerfile.nix
@@ -14,27 +14,21 @@
 FROM docker.io/nixos/nix:latest
 
 # Pre-populate the system profile with what the tests need at runtime:
-# wrapped python + pip, awk, util-linux (for ``su`` — the outer
-# ``bash -c`` drops to the testrunner uid; modern Linux moved ``su``
-# from ``shadow`` to ``util-linux``), and shadow (for the
-# ``newuidmap``/``newgidmap`` rootless-podman follow-up).
+# wrapped python + pip and awk.  Bash and git-minimal already ship in
+# the base image's profile; adding ``nixpkgs#bash`` or ``nixpkgs#git``
+# here conflicts on shared files (``bash/printenv``, ``bin/git-shell``).
 #
-# Bash and git-minimal already ship in the base image's profile;
-# adding ``nixpkgs#bash`` or ``nixpkgs#git`` here conflicts on shared
-# files (``bash/printenv``, ``bin/git-shell``).
+# No ``util-linux`` / ``shadow``: their ``su`` / ``runuser`` need SUID
+# (configured via NixOS security-wrappers, which the bare ``nixos/nix``
+# image doesn't ship).  ``run_nix_tests`` switches users via Python's
+# ``os.setuid`` instead.  When the rootless-podman follow-up lands
+# we'll add ``shadow`` for ``newuidmap``/``newgidmap``.
 #
 # ``--extra-experimental-features`` turns on flakes (off by default in
 # nix 2.18-).
 RUN nix --extra-experimental-features 'nix-command flakes' \
         profile add \
-        nixpkgs#gawk \
-        nixpkgs#util-linux \
-        nixpkgs#shadow
-
-# Visibility for the next iteration if su still isn't there: dumps
-# every binary the system profile exposes.  Cheap; runs once at
-# build time.
-RUN ls /nix/var/nix/profiles/default/bin/ | sort
+        nixpkgs#gawk
 
 # ``python312`` and ``python312Packages.pip`` are *separate* derivations
 # that don't share a site-packages; installing them side-by-side leaves

--- a/tests/containers/Containerfile.nix
+++ b/tests/containers/Containerfile.nix
@@ -32,7 +32,8 @@ RUN nix --extra-experimental-features 'nix-command flakes' \
         profile install \
         nixpkgs#python312 \
         nixpkgs#python312Packages.pip \
-        nixpkgs#shadow
+        nixpkgs#shadow \
+        nixpkgs#gawk
 
 # Non-root user (uid 1000) — parity with the other matrix slots, and
 # the prerequisite for rootless podman if/when this image starts

--- a/tests/containers/Containerfile.nix
+++ b/tests/containers/Containerfile.nix
@@ -28,20 +28,11 @@ RUN nix --extra-experimental-features 'nix-command flakes' \
         nixpkgs#python312 \
         nixpkgs#python312Packages.pip
 
-# Non-root user (uid 1000) so the container exercises the same "regular
-# user shell" path Franz hit, not the root path.  Nix needs the user's
-# home to exist for ~/.local writes from pip --user.
-RUN useradd -m -u 1000 -s /bin/bash testrunner \
-    && mkdir -p /home/testrunner/.local/bin \
-    && chown -R testrunner:testrunner /home/testrunner
-
-# Each user needs their own nix profile to install user-local packages
-# without root.  Initialise the per-user profile dir.
-RUN mkdir -p /nix/var/nix/profiles/per-user/testrunner \
-    && chown testrunner:testrunner /nix/var/nix/profiles/per-user/testrunner
-
-USER testrunner
-ENV USER=testrunner HOME=/home/testrunner
-ENV PATH=/home/testrunner/.local/bin:/nix/var/nix/profiles/default/bin:$PATH
+# Run as root.  ``nixos/nix`` is minimal — no ``shadow`` / ``useradd`` —
+# and the wrapped-Python failure mode this slot exists to catch is uid-
+# independent (the wrapper rewrites sys.path the same way for any uid).
+# Pulling in ``nixpkgs#shadow`` just to drop privileges would add ~30 MB
+# of nix-store paths for no test-shape gain.
+ENV PATH=/root/.local/bin:/nix/var/nix/profiles/default/bin:$PATH
 
 WORKDIR /workspace

--- a/tests/containers/Containerfile.nix
+++ b/tests/containers/Containerfile.nix
@@ -14,19 +14,19 @@
 
 FROM docker.io/nixos/nix:latest
 
-# Single-user nix install in the base image runs as root.  Enable
-# unprivileged user namespaces and pre-populate ``python3`` (with pip)
-# + ``git`` in the system profile so the test container has them ready
-# without a network round-trip per matrix run.
+# Pre-populate the wrapped python + pip in the system profile so the
+# test container has them ready without a network round-trip per matrix
+# run.  The base image already ships ``bash`` and ``git-minimal`` —
+# adding ``nixpkgs#git`` here conflicts on ``bin/git-shell``, and we
+# don't need git anyway (the source tree arrives via bind-mount, not a
+# clone).
 #
-# ``--accept-flake-config`` keeps the build hermetic; ``--extra-experimental-features``
-# turns on flakes (off by default in nix 2.18-).
+# ``--extra-experimental-features`` turns on flakes (off by default in
+# nix 2.18-).
 RUN nix --extra-experimental-features 'nix-command flakes' \
         profile install \
         nixpkgs#python312 \
-        nixpkgs#python312Packages.pip \
-        nixpkgs#git \
-        nixpkgs#bash
+        nixpkgs#python312Packages.pip
 
 # Non-root user (uid 1000) so the container exercises the same "regular
 # user shell" path Franz hit, not the root path.  Nix needs the user's

--- a/tests/containers/Containerfile.nix
+++ b/tests/containers/Containerfile.nix
@@ -14,25 +14,42 @@
 
 FROM docker.io/nixos/nix:latest
 
-# Pre-populate the wrapped python + pip in the system profile so the
-# test container has them ready without a network round-trip per matrix
-# run.  The base image already ships ``bash`` and ``git-minimal`` —
-# adding ``nixpkgs#git`` here conflicts on ``bin/git-shell``, and we
-# don't need git anyway (the source tree arrives via bind-mount, not a
-# clone).
+# Pre-populate the wrapped python + pip + shadow utilities in the
+# system profile so the test container has them ready without a
+# network round-trip per matrix run.  The base image already ships
+# ``bash`` and ``git-minimal`` — adding ``nixpkgs#git`` here conflicts
+# on ``bin/git-shell``, and we don't need git anyway (source tree
+# arrives via bind-mount, not a clone).
+#
+# ``shadow`` provides ``useradd`` / ``groupadd``: the slot itself
+# doesn't strictly need a non-root user (the wrapped-Python failure
+# mode is uid-independent), but rootless podman *does*, and we want
+# this image ready for that follow-up without a second image change.
 #
 # ``--extra-experimental-features`` turns on flakes (off by default in
 # nix 2.18-).
 RUN nix --extra-experimental-features 'nix-command flakes' \
         profile install \
         nixpkgs#python312 \
-        nixpkgs#python312Packages.pip
+        nixpkgs#python312Packages.pip \
+        nixpkgs#shadow
 
-# Run as root.  ``nixos/nix`` is minimal — no ``shadow`` / ``useradd`` —
-# and the wrapped-Python failure mode this slot exists to catch is uid-
-# independent (the wrapper rewrites sys.path the same way for any uid).
-# Pulling in ``nixpkgs#shadow`` just to drop privileges would add ~30 MB
-# of nix-store paths for no test-shape gain.
-ENV PATH=/root/.local/bin:/nix/var/nix/profiles/default/bin:$PATH
+# Non-root user (uid 1000) — parity with the other matrix slots, and
+# the prerequisite for rootless podman if/when this image starts
+# exercising it.  ``--no-log-init`` is mandatory: the default tries to
+# allocate the entire 32-bit lastlog file via ``ftruncate``, which
+# fails on the bind-mounted /nix/store mountpoint with EINVAL.
+RUN useradd --no-log-init -m -u 1000 -s /bin/bash testrunner \
+    && mkdir -p /home/testrunner/.local/bin \
+    && chown -R testrunner:testrunner /home/testrunner
+
+# Each user gets their own per-user nix profile; pip --user etc. write
+# under it.
+RUN mkdir -p /nix/var/nix/profiles/per-user/testrunner \
+    && chown testrunner:testrunner /nix/var/nix/profiles/per-user/testrunner
+
+USER testrunner
+ENV USER=testrunner HOME=/home/testrunner
+ENV PATH=/home/testrunner/.local/bin:/nix/var/nix/profiles/default/bin:$PATH
 
 WORKDIR /workspace

--- a/tests/containers/Containerfile.nix
+++ b/tests/containers/Containerfile.nix
@@ -14,23 +14,25 @@
 
 FROM docker.io/nixos/nix:latest
 
-# Pre-populate the system profile with everything the tests need at
+# Pre-populate the system profile with what the tests need at
 # runtime: wrapped python + pip, awk, shadow (for rootless podman's
-# newuidmap/newgidmap if/when this slot starts exercising podman),
-# and bash (the base image only has bash via /nix/store, not at
-# /bin/bash, which trips most ``#!/bin/bash`` shebangs).
+# newuidmap/newgidmap if/when this slot starts exercising podman).
+#
+# Bash and git-minimal already ship in the base image's profile;
+# adding ``nixpkgs#bash`` or ``nixpkgs#git`` here conflicts on shared
+# files (``bash/printenv``, ``bin/git-shell``).
 #
 # ``--extra-experimental-features`` turns on flakes (off by default in
 # nix 2.18-).
 RUN nix --extra-experimental-features 'nix-command flakes' \
         profile install \
-        nixpkgs#bash \
         nixpkgs#gawk \
         nixpkgs#python312 \
         nixpkgs#python312Packages.pip \
         nixpkgs#shadow
 
-# /bin/bash → wrapped bash so shebangs and shadow's shell checks find it.
+# /bin/bash → the bash the base image already has, so shebangs and
+# shadow's shell checks resolve.
 RUN ln -s /nix/var/nix/profiles/default/bin/bash /bin/bash
 
 # Non-root user (uid 1000) — parity with the other matrix slots, and

--- a/tests/containers/Containerfile.nix
+++ b/tests/containers/Containerfile.nix
@@ -40,7 +40,7 @@ RUN nix --extra-experimental-features 'nix-command flakes' \
 # ``--impure`` is required by ``builtins.getFlake``.
 RUN nix --extra-experimental-features 'nix-command flakes' \
         profile add --impure --expr \
-        '(builtins.getFlake "nixpkgs").legacyPackages.x86_64-linux.python312.withPackages (ps: [ ps.pip ])'
+        '(builtins.getFlake "nixpkgs").legacyPackages.${builtins.currentSystem}.python312.withPackages (ps: [ ps.pip ])'
 
 # /bin/bash → the bash the base image already has, so shebangs and
 # shadow's shell checks resolve.

--- a/tests/containers/run-matrix.sh
+++ b/tests/containers/run-matrix.sh
@@ -378,7 +378,10 @@ run_nix_tests() {
             python3.12 -m venv .venv
             . .venv/bin/activate
             pip install --quiet --upgrade pip
-            pip install --quiet . pytest pytest-asyncio pytest-cov pytest-tach
+            # ``tach`` (not ``pytest-tach``) is the package that
+            # registers the pytest plugin; pyproject.toml's pytest
+            # config doesn't load it conditionally.
+            pip install --quiet . pytest pytest-asyncio pytest-cov tach
 
             echo ''
             echo '--- unit tests ---'

--- a/tests/containers/run-matrix.sh
+++ b/tests/containers/run-matrix.sh
@@ -378,21 +378,24 @@ run_nix_tests() {
             python3.12 -m venv .venv
             . .venv/bin/activate
             pip install --quiet --upgrade pip
-            # ``tach`` (not ``pytest-tach``) is the package that
-            # registers the pytest plugin; pyproject.toml's pytest
-            # config doesn't load it conditionally.
-            pip install --quiet . pytest pytest-asyncio pytest-cov tach
+            pip install --quiet poetry
+
+            # Poetry knows the full dev/test/docs/stories matrix from
+            # pyproject.toml — saves us from enumerating test deps by
+            # hand (``mkdocs_terok``, ``tach`` plugin, etc.).  Same
+            # group set the matrix's ``run_tests`` uses.
+            poetry install --with test --with stories --with docs --no-interaction
 
             echo ''
             echo '--- unit tests ---'
-            pytest tests/unit -v --tb=short
+            poetry run pytest tests/unit -v --tb=short
 
             echo ''
             echo '--- host-only integration tests ---'
             # Same marker filter ``make test-integration-host`` uses on
             # GitHub-Actions: skip everything that wants podman or the
             # internet.  Nix container has neither.
-            pytest tests/integration -v --tb=short \
+            poetry run pytest tests/integration -v --tb=short \
                 -m 'needs_host_features and not needs_internet and not needs_podman'
         "
 

--- a/tests/containers/run-matrix.sh
+++ b/tests/containers/run-matrix.sh
@@ -365,7 +365,11 @@ run_nix_tests() {
             echo '--- nix-wrapped python ---'
             which python3.12
             python3.12 --version
-            python3.12 --version | awk '{print \$2}' > /results/$name.python-version
+            # Capture the version into the shared results dir.  No awk
+            # in the nixos/nix base image; bash parameter expansion is
+            # all we need.  Same pattern run_tests uses for podman.
+            python_ver_line=\$(python3.12 --version 2>&1)
+            echo \"\${python_ver_line##* }\" > /results/$name.python-version
 
             # Install terok with all runtime + sibling deps (URL pins
             # in pyproject.toml resolve to released wheels), plus the

--- a/tests/containers/run-matrix.sh
+++ b/tests/containers/run-matrix.sh
@@ -359,35 +359,47 @@ run_nix_tests() {
         "$image" \
         bash -c "
             set -e
+
+            # ── Prepare workspace (as root) ──
             cp -a $SOURCE_MOUNT $WORKSPACE_DIR
-            cd $WORKSPACE_DIR
+            chown -R testrunner:testrunner $WORKSPACE_DIR
 
-            echo '--- nix-wrapped python ---'
-            which python3.12
-            python3.12 --version
-            python3.12 --version | awk '{print \$2}' > /results/$name.python-version
+            # ── Run everything as the rootless test user ──
+            # Single-quoted su -c body: ``\$`` defers expansion to the
+            # inner shell; bare ``\$name`` etc. expand here in the
+            # outer double-quoted bash -c.
+            su - testrunner -c '
+                set -e
+                cd $WORKSPACE_DIR
 
-            # Nix disables user site-packages (PYTHONNOUSERSITE), so
-            # ``pip install --user`` is rejected.  Install into a venv
-            # instead — same shape the other matrix slots use.  The
-            # venv inherits the wrapper's sys.path scrubbing, which is
-            # the wrapped-Python failure mode we want to exercise.
-            python3.12 -m venv .venv
-            . .venv/bin/activate
-            pip install --quiet --upgrade pip
-            pip install --quiet . pytest pytest-asyncio pytest-cov pytest-tach
+                echo \"--- nix-wrapped python ---\"
+                which python3.12
+                python3.12 --version
+                python3.12 --version | awk \"{print \\\$2}\" > /results/$name.python-version
 
-            echo ''
-            echo '--- unit tests ---'
-            python3.12 -m pytest tests/unit -v --tb=short
+                # Nix disables user site-packages (PYTHONNOUSERSITE),
+                # so ``pip install --user`` is rejected.  Install into
+                # a venv instead — same shape the other matrix slots
+                # use.  The venv inherits the wrapper's sys.path
+                # scrubbing, which is the wrapped-Python failure mode
+                # we want to exercise.
+                python3.12 -m venv .venv
+                . .venv/bin/activate
+                pip install --quiet --upgrade pip
+                pip install --quiet . pytest pytest-asyncio pytest-cov pytest-tach
 
-            echo ''
-            echo '--- host-only integration tests ---'
-            # Same marker filter ``make test-integration-host`` uses on
-            # GitHub-Actions: skip everything that wants podman or the
-            # internet.  Nix container has neither.
-            python3.12 -m pytest tests/integration -v --tb=short \
-                -m 'needs_host_features and not needs_internet and not needs_podman'
+                echo \"\"
+                echo \"--- unit tests ---\"
+                pytest tests/unit -v --tb=short
+
+                echo \"\"
+                echo \"--- host-only integration tests ---\"
+                # Same marker filter ``make test-integration-host`` uses
+                # on GitHub-Actions: skip everything that wants podman
+                # or the internet.  Nix container has neither.
+                pytest tests/integration -v --tb=short \
+                    -m \"needs_host_features and not needs_internet and not needs_podman\"
+            '
         "
 
     local status=$?

--- a/tests/containers/run-matrix.sh
+++ b/tests/containers/run-matrix.sh
@@ -352,9 +352,6 @@ run_nix_tests() {
     echo -e "${C_CYAN}==> Testing ${C_BOLD}$name${C_CYAN} ($(version_expectation "$name"))${C_RESET}"
     echo ""
 
-    # Runs as root inside the Nix container — see Containerfile.nix
-    # for why (the wrapped-Python failure mode is uid-independent and
-    # ``su``/``newuidmap`` plumbing is deferred until podman lands).
     podman run --rm --name "$ctr_name" \
         --security-opt label=disable \
         -v "$REPO_ROOT:$SOURCE_MOUNT:ro,Z" \
@@ -362,49 +359,65 @@ run_nix_tests() {
         "$image" \
         bash -c "
             set -e
+
+            # ── Prep workspace as root ──
             cp -a $SOURCE_MOUNT $WORKSPACE_DIR
-            cd $WORKSPACE_DIR
+            chown -R testrunner:testrunner $WORKSPACE_DIR
 
-            echo '--- nix-wrapped python ---'
-            which python3.12
-            python3.12 --version
-            python3.12 --version | awk '{print \$2}' > /results/$name.python-version
+            # ── Tests as testrunner ──
+            # Running as a non-root user keeps terok-sandbox's
+            # ``systemd_user_unit_dir`` guard happy (it refuses on
+            # root because user units belong under \$XDG_RUNTIME_DIR).
+            # Single-quoted su -c body: ``\$`` defers expansion to the
+            # inner shell; bare ``\$name`` etc. expand here in the
+            # outer double-quoted bash -c.
+            su - testrunner -c '
+                set -e
+                cd $WORKSPACE_DIR
 
-            # Nix disables user site-packages (PYTHONNOUSERSITE), so
-            # ``pip install --user`` is rejected.  Install into a venv
-            # instead — same shape the other matrix slots use.  The
-            # venv inherits the wrapper's sys.path scrubbing, which is
-            # the wrapped-Python failure mode we want to exercise.
-            python3.12 -m venv .venv
-            . .venv/bin/activate
-            pip install --quiet --upgrade pip
-            pip install --quiet poetry
+                echo \"--- nix-wrapped python ---\"
+                which python3.12
+                python3.12 --version
+                python3.12 --version | awk \"{print \\\$2}\" > /results/$name.python-version
 
-            # ``test`` + ``docs`` is the minimum that makes the unit
-            # suite collect: ``test`` for pytest, ``docs`` for the
-            # ``mkdocs_terok`` module that two unit tests import.
-            #
-            # Skipped on purpose:
-            #   - ``stories`` pulls python-dbusmock → dbus-python,
-            #     which has no wheel and needs system libdbus headers
-            #     + ninja + meson to compile — would balloon the Nix
-            #     image for tests we filter out anyway.
-            #   - ``dev`` carries pydevd-pycharm, ruff, mypy, tach …
-            #     none load-bearing for running tests; ``-p no:tach``
-            #     below keeps pytest happy without the plugin.
-            poetry install --with test --with docs --no-interaction
+                # Nix disables user site-packages (PYTHONNOUSERSITE),
+                # so install into a venv — same shape the other
+                # matrix slots use.  The venv inherits the wrapper's
+                # sys.path scrubbing, which is the wrapped-Python
+                # failure mode (#717 family) we want to exercise.
+                python3.12 -m venv .venv
+                . .venv/bin/activate
+                pip install --quiet --upgrade pip
+                pip install --quiet poetry
 
-            echo ''
-            echo '--- unit tests ---'
-            poetry run pytest tests/unit -v --tb=short -p no:tach
+                # ``test`` + ``docs`` is the minimum that makes the
+                # unit suite collect: ``test`` for pytest, ``docs``
+                # for the ``mkdocs_terok`` module that two unit tests
+                # import.
+                #
+                # Skipped on purpose:
+                #   - ``stories`` pulls python-dbusmock → dbus-python,
+                #     no wheel + needs ninja/meson/libdbus headers
+                #     to compile, for tests our marker filter excludes
+                #     anyway.
+                #   - ``dev`` carries pydevd-pycharm, ruff, mypy, tach
+                #     — none load-bearing for running tests;
+                #     ``-p no:tach`` below keeps pytest happy without
+                #     the plugin.
+                poetry install --with test --with docs --no-interaction
 
-            echo ''
-            echo '--- host-only integration tests ---'
-            # Same marker filter ``make test-integration-host`` uses on
-            # GitHub-Actions: skip everything that wants podman or the
-            # internet.  Nix container has neither.
-            poetry run pytest tests/integration -v --tb=short -p no:tach \
-                -m 'needs_host_features and not needs_internet and not needs_podman'
+                echo \"\"
+                echo \"--- unit tests ---\"
+                poetry run pytest tests/unit -v --tb=short -p no:tach
+
+                echo \"\"
+                echo \"--- host-only integration tests ---\"
+                # Same marker filter ``make test-integration-host``
+                # uses on GitHub-Actions: skip everything that wants
+                # podman or the internet.  Nix container has neither.
+                poetry run pytest tests/integration -v --tb=short -p no:tach \
+                    -m \"needs_host_features and not needs_internet and not needs_podman\"
+            '
         "
 
     local status=$?

--- a/tests/containers/run-matrix.sh
+++ b/tests/containers/run-matrix.sh
@@ -62,10 +62,14 @@ declare -A DISTROS=(
     [nix]="nix"
 )
 
-# The ``nix`` slot is a focused regression target — wrapped-Python
-# import behaviour, not the full nested-podman integration suite.
-# Skipping the multi-phase ``run_tests`` flow keeps it tens of seconds
-# instead of minutes, since the nix image carries no podman / nftables.
+# The ``nix`` slot runs the same flavour the GitHub-Actions host CI
+# does — full unit suite plus host-only integration tests — but under
+# Nix-wrapped Python.  No podman / nftables, so the multi-phase
+# ``run_tests`` flow doesn't apply; we route through ``run_nix_tests``
+# instead.  Use of nix isn't an officially-supported install mode;
+# the slot exists so wrapped-Python regressions (#717 family) can't
+# slip past unit + host-only coverage on a different conceptual
+# install setup.
 declare -A SLOT_KIND=(
     [debian12]="podman"
     [ubuntu2404]="podman"
@@ -102,7 +106,7 @@ version_expectation() {
     local expected="${EXPECTED_VERSIONS[$name]:-}"
     case "$expected" in
         latest) printf 'podman latest, version pinned by upstream' ;;
-        n/a) printf 'nix-wrapped Python regression check (no podman)' ;;
+        n/a) printf 'nix-wrapped Python (unit + host-only integration, no podman)' ;;
         *) printf 'expected podman %s' "$expected" ;;
     esac
 }
@@ -329,19 +333,17 @@ print(\\\"Shield hooks verified.\\\")
     return "$status"
 }
 
-run_nix_check() {
-    # Focused regression check for the Nix-wrapped-Python failure mode
-    # (terok-ai/terok#717, Franz Pöschel): under Nix, ``sys.executable``
-    # is a wrapper script whose sys.path setup isn't reflected in the
-    # ``PYTHONPATH`` env var.  A subprocess started directly from that
-    # parent can't ``import terok`` unless every spawn site threads
-    # PYTHONPATH=os.pathsep.join(sys.path) through.
+run_nix_tests() {
+    # Run the same suite GitHub Actions runs (unit + host-only
+    # integration) but under Nix-wrapped Python.  Catches the
+    # wrapped-Python regressions (#717 family — every spawn of
+    # ``[sys.executable, "-m", "terok…"]`` must thread PYTHONPATH)
+    # and any other behaviour that quietly only works on the
+    # GitHub-Actions interpreter shape.
     #
-    # The check: install terok inside the nix-wrapped Python and run
-    # the two regression tests
-    # (``test_subprocess_pythonpath_call_sites`` AST scan +
-    # ``test_subprocess_env`` behavioural test).  No podman, no nested
-    # containers, no hook phases — by design.
+    # No podman, no nft, no hooks — the Nix container is intentionally
+    # leaner than the multi-distro slots.  Marker-filtered integration
+    # mirrors ``make test-integration-host``.
     local name="$1"
     local image="$IMAGE_PREFIX:$name"
     local ctr_name="$IMAGE_PREFIX-$name"
@@ -365,23 +367,26 @@ run_nix_check() {
             python3.12 --version
             python3.12 --version | awk '{print \$2}' > /results/$name.python-version
 
-            # Install terok itself + pytest into the user-site of the
-            # nix-wrapped interpreter.  ``--break-system-packages`` is a
-            # no-op on nix's per-user profile but pip 23+ requires it
-            # when site-packages lives outside the venv.
-            python3.12 -m pip install --user --quiet --break-system-packages . pytest
+            # Install terok with all runtime + sibling deps (URL pins
+            # in pyproject.toml resolve to released wheels), plus the
+            # pytest stack needed by the conftest auto-fixtures.
+            # ``--break-system-packages`` is a no-op on nix's per-user
+            # profile but pip 23+ requires it when site-packages lives
+            # outside a venv.
+            python3.12 -m pip install --user --quiet --break-system-packages \
+                . pytest pytest-asyncio pytest-cov pytest-tach
 
-            # Skip the heavy unit-suite conftest (it pulls
-            # terok_sandbox.paths etc. — siblings we don't install in
-            # this focused slot).  Disable tach/asyncio plugins the two
-            # tests don't need.  ``--override-ini=addopts=`` strips the
-            # pyproject's ``-v --tb=short`` so the inner command-line
-            # wins.
-            python3.12 -m pytest -v --tb=short \
-                --noconftest --override-ini='addopts=' \
-                -p no:tach -p no:asyncio \
-                tests/unit/test_subprocess_pythonpath_call_sites.py \
-                tests/unit/lib/util/test_subprocess_env.py
+            echo ''
+            echo '--- unit tests ---'
+            python3.12 -m pytest tests/unit -v --tb=short
+
+            echo ''
+            echo '--- host-only integration tests ---'
+            # Same marker filter ``make test-integration-host`` uses on
+            # GitHub-Actions: skip everything that wants podman or the
+            # internet.  Nix container has neither.
+            python3.12 -m pytest tests/integration -v --tb=short \
+                -m 'needs_host_features and not needs_internet and not needs_podman'
         "
 
     local status=$?
@@ -449,7 +454,7 @@ FAILED=()
 
 for target in "${TARGETS[@]}"; do
     case "${SLOT_KIND[$target]}" in
-        nix) runner=run_nix_check ;;
+        nix) runner=run_nix_tests ;;
         *) runner=run_tests ;;
     esac
     if "$runner" "$target"; then

--- a/tests/containers/run-matrix.sh
+++ b/tests/containers/run-matrix.sh
@@ -364,60 +364,70 @@ run_nix_tests() {
             cp -a $SOURCE_MOUNT $WORKSPACE_DIR
             chown -R testrunner:testrunner $WORKSPACE_DIR
 
-            # ── Tests as testrunner ──
-            # Running as a non-root user keeps terok-sandbox's
-            # ``systemd_user_unit_dir`` guard happy (it refuses on
-            # root because user units belong under \$XDG_RUNTIME_DIR).
-            # Single-quoted su -c body: ``\$`` defers expansion to the
-            # inner shell; bare ``\$name`` etc. expand here in the
-            # outer double-quoted bash -c.
-            su - testrunner -c '
-                set -e
-                cd $WORKSPACE_DIR
+            # Inner test script is self-contained and runs as
+            # testrunner.  Heredoc with a quoted delimiter keeps
+            # ``\$2``, etc. literal; ``$name`` (the slot name from
+            # the outer shell) is interpolated before write.
+            cat > /tmp/run-nix-tests.sh <<TESTSCRIPT
+#!/bin/bash
+set -e
+cd $WORKSPACE_DIR
 
-                echo \"--- nix-wrapped python ---\"
-                which python3.12
-                python3.12 --version
-                python3.12 --version | awk \"{print \\\$2}\" > /results/$name.python-version
+echo '--- nix-wrapped python ---'
+which python3.12
+python3.12 --version
+python3.12 --version | awk '{print \\\$2}' > /results/$name.python-version
 
-                # Nix disables user site-packages (PYTHONNOUSERSITE),
-                # so install into a venv — same shape the other
-                # matrix slots use.  The venv inherits the wrapper's
-                # sys.path scrubbing, which is the wrapped-Python
-                # failure mode (#717 family) we want to exercise.
-                python3.12 -m venv .venv
-                . .venv/bin/activate
-                pip install --quiet --upgrade pip
-                pip install --quiet poetry
+# Nix disables user site-packages (PYTHONNOUSERSITE), so install into
+# a venv — same shape the other matrix slots use.  The venv inherits
+# the wrapper's sys.path scrubbing, which is the wrapped-Python
+# failure mode (#717 family) we want to exercise.
+python3.12 -m venv .venv
+. .venv/bin/activate
+pip install --quiet --upgrade pip
+pip install --quiet poetry
 
-                # ``test`` + ``docs`` is the minimum that makes the
-                # unit suite collect: ``test`` for pytest, ``docs``
-                # for the ``mkdocs_terok`` module that two unit tests
-                # import.
-                #
-                # Skipped on purpose:
-                #   - ``stories`` pulls python-dbusmock → dbus-python,
-                #     no wheel + needs ninja/meson/libdbus headers
-                #     to compile, for tests our marker filter excludes
-                #     anyway.
-                #   - ``dev`` carries pydevd-pycharm, ruff, mypy, tach
-                #     — none load-bearing for running tests;
-                #     ``-p no:tach`` below keeps pytest happy without
-                #     the plugin.
-                poetry install --with test --with docs --no-interaction
+# ``test`` + ``docs`` is the minimum that makes the unit suite
+# collect: ``test`` for pytest, ``docs`` for the ``mkdocs_terok``
+# module that two unit tests import.
+#
+# Skipped on purpose:
+#   - ``stories`` pulls python-dbusmock → dbus-python, no wheel +
+#     needs ninja/meson/libdbus headers, for tests our marker filter
+#     excludes anyway.
+#   - ``dev`` carries pydevd-pycharm, ruff, mypy, tach — none load-
+#     bearing for running tests; ``-p no:tach`` below keeps pytest
+#     happy without the plugin.
+poetry install --with test --with docs --no-interaction
 
-                echo \"\"
-                echo \"--- unit tests ---\"
-                poetry run pytest tests/unit -v --tb=short -p no:tach
+echo ''
+echo '--- unit tests ---'
+poetry run pytest tests/unit -v --tb=short -p no:tach
 
-                echo \"\"
-                echo \"--- host-only integration tests ---\"
-                # Same marker filter ``make test-integration-host``
-                # uses on GitHub-Actions: skip everything that wants
-                # podman or the internet.  Nix container has neither.
-                poetry run pytest tests/integration -v --tb=short -p no:tach \
-                    -m \"needs_host_features and not needs_internet and not needs_podman\"
-            '
+echo ''
+echo '--- host-only integration tests ---'
+# Same marker filter ``make test-integration-host`` uses on
+# GitHub-Actions: skip everything that wants podman or the internet.
+poetry run pytest tests/integration -v --tb=short -p no:tach \\
+    -m 'needs_host_features and not needs_internet and not needs_podman'
+TESTSCRIPT
+            chmod +x /tmp/run-nix-tests.sh
+
+            # Switch to testrunner via Python's setuid + execvp.
+            # nixos/nix's ``util-linux``/``shadow`` packages don't
+            # expose ``su`` on the profile bin (su needs SUID, which
+            # is a NixOS security-wrappers concern, not a profile
+            # one).  ``runuser`` has the same problem.  Python's
+            # ``os.setuid`` doesn't need any of that infrastructure
+            # and is portable across whatever the base image happens
+            # to ship.
+            exec python3.12 -c \"
+import os
+os.setgid(1000)
+os.setuid(1000)
+os.environ.update(HOME='/home/testrunner', USER='testrunner', LOGNAME='testrunner')
+os.execvp('/tmp/run-nix-tests.sh', ['/tmp/run-nix-tests.sh'])
+\"
         "
 
     local status=$?

--- a/tests/containers/run-matrix.sh
+++ b/tests/containers/run-matrix.sh
@@ -365,11 +365,7 @@ run_nix_tests() {
             echo '--- nix-wrapped python ---'
             which python3.12
             python3.12 --version
-            # Capture the version into the shared results dir.  No awk
-            # in the nixos/nix base image; bash parameter expansion is
-            # all we need.  Same pattern run_tests uses for podman.
-            python_ver_line=\$(python3.12 --version 2>&1)
-            echo \"\${python_ver_line##* }\" > /results/$name.python-version
+            python3.12 --version | awk '{print \$2}' > /results/$name.python-version
 
             # Install terok with all runtime + sibling deps (URL pins
             # in pyproject.toml resolve to released wheels), plus the

--- a/tests/containers/run-matrix.sh
+++ b/tests/containers/run-matrix.sh
@@ -59,6 +59,22 @@ declare -A DISTROS=(
     [fedora43]="fedora43"
     [fedora44]="fedora44"
     [podman]="podman"
+    [nix]="nix"
+)
+
+# The ``nix`` slot is a focused regression target — wrapped-Python
+# import behaviour, not the full nested-podman integration suite.
+# Skipping the multi-phase ``run_tests`` flow keeps it tens of seconds
+# instead of minutes, since the nix image carries no podman / nftables.
+declare -A SLOT_KIND=(
+    [debian12]="podman"
+    [ubuntu2404]="podman"
+    [ubuntu2604]="podman"
+    [debian13]="podman"
+    [fedora43]="podman"
+    [fedora44]="podman"
+    [podman]="podman"
+    [nix]="nix"
 )
 
 # Expected podman versions — pinned to the exact distro-shipped point
@@ -74,6 +90,7 @@ declare -A EXPECTED_VERSIONS=(
     [fedora43]="5.8.2"
     [fedora44]="5.8.2"
     [podman]="latest"
+    [nix]="n/a"
 )
 
 # Print "expected podman X.Y.Z" for distros with a version pin, or
@@ -83,11 +100,11 @@ declare -A EXPECTED_VERSIONS=(
 version_expectation() {
     local name="$1"
     local expected="${EXPECTED_VERSIONS[$name]:-}"
-    if [[ "$expected" == "latest" ]]; then
-        printf 'podman latest, version pinned by upstream'
-    else
-        printf 'expected podman %s' "$expected"
-    fi
+    case "$expected" in
+        latest) printf 'podman latest, version pinned by upstream' ;;
+        n/a) printf 'nix-wrapped Python regression check (no podman)' ;;
+        *) printf 'expected podman %s' "$expected" ;;
+    esac
 }
 
 # Print the parenthesised version summary for ``$name`` after a run.
@@ -99,7 +116,9 @@ version_summary() {
     local name="$1"
     local expected="${EXPECTED_VERSIONS[$name]:-}"
     local actual="${ACTUAL_VERSIONS[$name]:-?}"
-    if [[ "$expected" == "latest" || "$expected" == "$actual" ]]; then
+    if [[ "$expected" == "n/a" ]]; then
+        printf '%s(nix-wrapped Python %s)%s' "$C_DIM" "$actual" "$C_RESET"
+    elif [[ "$expected" == "latest" || "$expected" == "$actual" ]]; then
         printf '%s(podman %s)%s' "$C_DIM" "$actual" "$C_RESET"
     else
         printf '%s(WARNING: expected podman %s, got podman %s)%s' \
@@ -117,6 +136,7 @@ declare -A TEST_USERS=(
     [fedora43]="testrunner"
     [fedora44]="testrunner"
     [podman]="podman"
+    [nix]="testrunner"
 )
 
 usage() {
@@ -309,6 +329,76 @@ print(\\\"Shield hooks verified.\\\")
     return "$status"
 }
 
+run_nix_check() {
+    # Focused regression check for the Nix-wrapped-Python failure mode
+    # (terok-ai/terok#717, Franz Pöschel): under Nix, ``sys.executable``
+    # is a wrapper script whose sys.path setup isn't reflected in the
+    # ``PYTHONPATH`` env var.  A subprocess started directly from that
+    # parent can't ``import terok`` unless every spawn site threads
+    # PYTHONPATH=os.pathsep.join(sys.path) through.
+    #
+    # The check: install terok inside the nix-wrapped Python and run
+    # the two regression tests
+    # (``test_subprocess_pythonpath_call_sites`` AST scan +
+    # ``test_subprocess_env`` behavioural test).  No podman, no nested
+    # containers, no hook phases — by design.
+    local name="$1"
+    local image="$IMAGE_PREFIX:$name"
+    local ctr_name="$IMAGE_PREFIX-$name"
+
+    echo ""
+    echo -e "${C_CYAN}==> Testing ${C_BOLD}$name${C_CYAN} ($(version_expectation "$name"))${C_RESET}"
+    echo ""
+
+    podman run --rm --name "$ctr_name" \
+        --security-opt label=disable \
+        -v "$REPO_ROOT:$SOURCE_MOUNT:ro,Z" \
+        -v "$RESULTS_DIR:/results:rw,Z" \
+        "$image" \
+        bash -c "
+            set -e
+            cp -a $SOURCE_MOUNT $WORKSPACE_DIR
+            cd $WORKSPACE_DIR
+
+            echo '--- nix-wrapped python ---'
+            which python3.12
+            python3.12 --version
+            python3.12 --version | awk '{print \$2}' > /results/$name.python-version
+
+            # Install terok itself + pytest into the user-site of the
+            # nix-wrapped interpreter.  ``--break-system-packages`` is a
+            # no-op on nix's per-user profile but pip 23+ requires it
+            # when site-packages lives outside the venv.
+            python3.12 -m pip install --user --quiet --break-system-packages . pytest
+
+            # Skip the heavy unit-suite conftest (it pulls
+            # terok_sandbox.paths etc. — siblings we don't install in
+            # this focused slot).  Disable tach/asyncio plugins the two
+            # tests don't need.  ``--override-ini=addopts=`` strips the
+            # pyproject's ``-v --tb=short`` so the inner command-line
+            # wins.
+            python3.12 -m pytest -v --tb=short \
+                --noconftest --override-ini='addopts=' \
+                -p no:tach -p no:asyncio \
+                tests/unit/test_subprocess_pythonpath_call_sites.py \
+                tests/unit/lib/util/test_subprocess_env.py
+        "
+
+    local status=$?
+    local actual
+    actual=$(cat "$RESULTS_DIR/$name.python-version" 2>/dev/null || true)
+    ACTUAL_VERSIONS[$name]="${actual:-?}"
+
+    local vsummary
+    vsummary=$(version_summary "$name")
+    if [[ $status -eq 0 ]]; then
+        echo -e "${C_GREEN}==> $name: PASS${C_RESET} $vsummary"
+    else
+        echo -e "${C_RED}==> $name: FAIL${C_RESET} $vsummary" >&2
+    fi
+    return "$status"
+}
+
 BUILD_ONLY=false
 LIST_ONLY=false
 NO_CACHE=false
@@ -358,7 +448,11 @@ PASSED=()
 FAILED=()
 
 for target in "${TARGETS[@]}"; do
-    if run_tests "$target"; then
+    case "${SLOT_KIND[$target]}" in
+        nix) runner=run_nix_check ;;
+        *) runner=run_tests ;;
+    esac
+    if "$runner" "$target"; then
         PASSED+=("$target")
     else
         FAILED+=("$target")

--- a/tests/containers/run-matrix.sh
+++ b/tests/containers/run-matrix.sh
@@ -367,14 +367,15 @@ run_nix_tests() {
             python3.12 --version
             python3.12 --version | awk '{print \$2}' > /results/$name.python-version
 
-            # Install terok with all runtime + sibling deps (URL pins
-            # in pyproject.toml resolve to released wheels), plus the
-            # pytest stack needed by the conftest auto-fixtures.
-            # ``--break-system-packages`` is a no-op on nix's per-user
-            # profile but pip 23+ requires it when site-packages lives
-            # outside a venv.
-            python3.12 -m pip install --user --quiet --break-system-packages \
-                . pytest pytest-asyncio pytest-cov pytest-tach
+            # Nix disables user site-packages (PYTHONNOUSERSITE), so
+            # ``pip install --user`` is rejected.  Install into a venv
+            # instead — same shape the other matrix slots use.  The
+            # venv inherits the wrapper's sys.path scrubbing, which is
+            # the wrapped-Python failure mode we want to exercise.
+            python3.12 -m venv .venv
+            . .venv/bin/activate
+            pip install --quiet --upgrade pip
+            pip install --quiet . pytest pytest-asyncio pytest-cov pytest-tach
 
             echo ''
             echo '--- unit tests ---'

--- a/tests/containers/run-matrix.sh
+++ b/tests/containers/run-matrix.sh
@@ -380,22 +380,30 @@ run_nix_tests() {
             pip install --quiet --upgrade pip
             pip install --quiet poetry
 
-            # Poetry knows the full dev/test/docs/stories matrix from
-            # pyproject.toml — saves us from enumerating test deps by
-            # hand (``mkdocs_terok``, ``tach`` plugin, etc.).  Same
-            # group set the matrix's ``run_tests`` uses.
-            poetry install --with test --with stories --with docs --no-interaction
+            # ``test`` + ``docs`` is the minimum that makes the unit
+            # suite collect: ``test`` for pytest, ``docs`` for the
+            # ``mkdocs_terok`` module that two unit tests import.
+            #
+            # Skipped on purpose:
+            #   - ``stories`` pulls python-dbusmock → dbus-python,
+            #     which has no wheel and needs system libdbus headers
+            #     + ninja + meson to compile — would balloon the Nix
+            #     image for tests we filter out anyway.
+            #   - ``dev`` carries pydevd-pycharm, ruff, mypy, tach …
+            #     none load-bearing for running tests; ``-p no:tach``
+            #     below keeps pytest happy without the plugin.
+            poetry install --with test --with docs --no-interaction
 
             echo ''
             echo '--- unit tests ---'
-            poetry run pytest tests/unit -v --tb=short
+            poetry run pytest tests/unit -v --tb=short -p no:tach
 
             echo ''
             echo '--- host-only integration tests ---'
             # Same marker filter ``make test-integration-host`` uses on
             # GitHub-Actions: skip everything that wants podman or the
             # internet.  Nix container has neither.
-            poetry run pytest tests/integration -v --tb=short \
+            poetry run pytest tests/integration -v --tb=short -p no:tach \
                 -m 'needs_host_features and not needs_internet and not needs_podman'
         "
 

--- a/tests/containers/run-matrix.sh
+++ b/tests/containers/run-matrix.sh
@@ -352,6 +352,9 @@ run_nix_tests() {
     echo -e "${C_CYAN}==> Testing ${C_BOLD}$name${C_CYAN} ($(version_expectation "$name"))${C_RESET}"
     echo ""
 
+    # Runs as root inside the Nix container — see Containerfile.nix
+    # for why (the wrapped-Python failure mode is uid-independent and
+    # ``su``/``newuidmap`` plumbing is deferred until podman lands).
     podman run --rm --name "$ctr_name" \
         --security-opt label=disable \
         -v "$REPO_ROOT:$SOURCE_MOUNT:ro,Z" \
@@ -359,47 +362,35 @@ run_nix_tests() {
         "$image" \
         bash -c "
             set -e
-
-            # ── Prepare workspace (as root) ──
             cp -a $SOURCE_MOUNT $WORKSPACE_DIR
-            chown -R testrunner:testrunner $WORKSPACE_DIR
+            cd $WORKSPACE_DIR
 
-            # ── Run everything as the rootless test user ──
-            # Single-quoted su -c body: ``\$`` defers expansion to the
-            # inner shell; bare ``\$name`` etc. expand here in the
-            # outer double-quoted bash -c.
-            su - testrunner -c '
-                set -e
-                cd $WORKSPACE_DIR
+            echo '--- nix-wrapped python ---'
+            which python3.12
+            python3.12 --version
+            python3.12 --version | awk '{print \$2}' > /results/$name.python-version
 
-                echo \"--- nix-wrapped python ---\"
-                which python3.12
-                python3.12 --version
-                python3.12 --version | awk \"{print \\\$2}\" > /results/$name.python-version
+            # Nix disables user site-packages (PYTHONNOUSERSITE), so
+            # ``pip install --user`` is rejected.  Install into a venv
+            # instead — same shape the other matrix slots use.  The
+            # venv inherits the wrapper's sys.path scrubbing, which is
+            # the wrapped-Python failure mode we want to exercise.
+            python3.12 -m venv .venv
+            . .venv/bin/activate
+            pip install --quiet --upgrade pip
+            pip install --quiet . pytest pytest-asyncio pytest-cov pytest-tach
 
-                # Nix disables user site-packages (PYTHONNOUSERSITE),
-                # so ``pip install --user`` is rejected.  Install into
-                # a venv instead — same shape the other matrix slots
-                # use.  The venv inherits the wrapper's sys.path
-                # scrubbing, which is the wrapped-Python failure mode
-                # we want to exercise.
-                python3.12 -m venv .venv
-                . .venv/bin/activate
-                pip install --quiet --upgrade pip
-                pip install --quiet . pytest pytest-asyncio pytest-cov pytest-tach
+            echo ''
+            echo '--- unit tests ---'
+            pytest tests/unit -v --tb=short
 
-                echo \"\"
-                echo \"--- unit tests ---\"
-                pytest tests/unit -v --tb=short
-
-                echo \"\"
-                echo \"--- host-only integration tests ---\"
-                # Same marker filter ``make test-integration-host`` uses
-                # on GitHub-Actions: skip everything that wants podman
-                # or the internet.  Nix container has neither.
-                pytest tests/integration -v --tb=short \
-                    -m \"needs_host_features and not needs_internet and not needs_podman\"
-            '
+            echo ''
+            echo '--- host-only integration tests ---'
+            # Same marker filter ``make test-integration-host`` uses on
+            # GitHub-Actions: skip everything that wants podman or the
+            # internet.  Nix container has neither.
+            pytest tests/integration -v --tb=short \
+                -m 'needs_host_features and not needs_internet and not needs_podman'
         "
 
     local status=$?

--- a/tests/unit/lib/util/test_subprocess_env.py
+++ b/tests/unit/lib/util/test_subprocess_env.py
@@ -1,0 +1,104 @@
+# SPDX-FileCopyrightText: 2026 Jiri Vyskocil
+# SPDX-License-Identifier: Apache-2.0
+
+"""Behavioural tests for the ``child_process_env`` Nix-wrapped-Python shim.
+
+The wrapped-Python failure mode (Nix, some Conda envs):
+
+* The parent process has its ``sys.path`` augmented at import time by a
+  wrapper script or ``.pth`` file — terok lives at a path the bare
+  interpreter doesn't auto-discover.
+* That augmentation is *not* reflected in ``os.environ['PYTHONPATH']``.
+* A subprocess started directly via ``[sys.executable, '-m', 'terok', …]``
+  inherits the empty/wrong ``PYTHONPATH`` and can't ``import terok``.
+
+These tests prove
+[`child_process_env`][terok.lib.util.subprocess_env.child_process_env]
+actually fixes that path without needing real Nix.  They drop a stub
+module into a tmpdir, add the dir to the *parent's* ``sys.path`` only,
+then exercise both the broken (naive) and fixed (via the helper)
+subprocess patterns and assert the expected outcomes.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from terok.lib.util.subprocess_env import child_process_env
+
+_STUB_MODULE_NAME = "_terok_nix_regression_stub"
+
+
+@pytest.fixture
+def parent_only_sys_path_module(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Drop a stub package into *tmp_path* and add it to the parent's sys.path only.
+
+    Simulates the Nix-wrapped-Python setup where a directory is added to
+    the parent's ``sys.path`` via wrapper magic (not via ``PYTHONPATH``),
+    so a naive subprocess can't see it.
+    """
+    stub = tmp_path / f"{_STUB_MODULE_NAME}.py"
+    stub.write_text(f"VALUE = 'imported-from-{tmp_path.name}'\n")
+    monkeypatch.syspath_prepend(str(tmp_path))
+    # PYTHONPATH must *not* contain tmp_path — that's the whole point.
+    # ``monkeypatch.syspath_prepend`` only touches the in-process
+    # ``sys.path``, never the env var, so this invariant is automatic.
+    return stub
+
+
+def _subprocess_can_import(env: dict[str, str]) -> tuple[int, str]:
+    """Return ``(returncode, stdout)`` of a subprocess trying to import the stub."""
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            f"import {_STUB_MODULE_NAME}; print({_STUB_MODULE_NAME}.VALUE)",
+        ],
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=10,
+        check=False,
+    )
+    return result.returncode, result.stdout.strip()
+
+
+def test_naive_subprocess_cannot_import_parent_only_module(
+    parent_only_sys_path_module: Path,
+) -> None:
+    """Without the helper, the child can't see the parent's wrapped sys.path.
+
+    This *is* the bug Franz Pöschel hit (terok-ai/terok#717): a fresh
+    Python subprocess started from a Nix-wrapped parent doesn't inherit
+    the wrapper's sys.path adjustments.
+    """
+    # Naive: inherit os.environ (no PYTHONPATH override).  Strip any
+    # ambient PYTHONPATH so the test is hermetic regardless of how
+    # CI launched it.
+    rc, _stdout = _subprocess_can_import({"PATH": "/usr/bin:/bin"})
+    assert rc != 0, (
+        "Test fixture is broken: the child found the stub module without "
+        "PYTHONPATH forwarding.  Check that the parent's sys.path "
+        "augmentation isn't leaking into PYTHONPATH."
+    )
+
+
+def test_child_process_env_fixes_wrapped_python_import(
+    parent_only_sys_path_module: Path,
+) -> None:
+    """With ``child_process_env``, the child finds the parent-only module.
+
+    The other half of the regression test: prove that the same subprocess
+    invocation that failed above succeeds once ``env=child_process_env()``
+    threads the parent's ``sys.path`` through ``PYTHONPATH``.
+    """
+    rc, stdout = _subprocess_can_import(child_process_env())
+    assert rc == 0, "child_process_env() failed to forward parent sys.path"
+    assert stdout.startswith("imported-from-"), (
+        f"unexpected child stdout: {stdout!r} — the stub module rendered "
+        "differently than expected; check the fixture."
+    )

--- a/tests/unit/test_subprocess_pythonpath_call_sites.py
+++ b/tests/unit/test_subprocess_pythonpath_call_sites.py
@@ -1,0 +1,110 @@
+# SPDX-FileCopyrightText: 2026 Jiri Vyskocil
+# SPDX-License-Identifier: Apache-2.0
+
+"""Static check: every ``[sys.executable, ...]`` spawn must thread ``PYTHONPATH``.
+
+Walks ``src/terok/`` looking for ``subprocess.run`` / ``subprocess.Popen``
+/ ``asyncio.create_subprocess_exec`` calls whose argv starts with
+``sys.executable``.  Each such site must pass ``env=child_process_env(...)``
+— otherwise terok crashes under wrapped-Python setups (Nix, some Conda
+environments) where the parent's ``sys.path`` is hidden from the child's
+default import-path discovery (terok-ai/terok#717).
+
+Failing this test means someone added a new spawn site without going
+through the helper.  Fix it by importing
+``from terok.lib.util.subprocess_env import child_process_env`` and
+passing ``env=child_process_env()`` on the call.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+_SRC_ROOT = Path(__file__).resolve().parents[2] / "src" / "terok"
+_SPAWN_CALLABLES = {
+    ("subprocess", "run"),
+    ("subprocess", "Popen"),
+    ("subprocess", "check_call"),
+    ("subprocess", "check_output"),
+    ("asyncio", "create_subprocess_exec"),
+}
+
+
+def _argv_starts_with_sys_executable(call: ast.Call) -> bool:
+    """Return True when *call*'s first positional arg is ``[sys.executable, ...]``."""
+    if not call.args:
+        return False
+    argv = call.args[0]
+    if not isinstance(argv, ast.List) or not argv.elts:
+        return False
+    first = argv.elts[0]
+    return (
+        isinstance(first, ast.Attribute)
+        and isinstance(first.value, ast.Name)
+        and first.value.id == "sys"
+        and first.attr == "executable"
+    )
+
+
+def _is_spawn_call(call: ast.Call) -> bool:
+    """Return True when *call* invokes a known subprocess-spawning function."""
+    func = call.func
+    if isinstance(func, ast.Attribute) and isinstance(func.value, ast.Name):
+        return (func.value.id, func.attr) in _SPAWN_CALLABLES
+    return False
+
+
+def _env_kwarg_uses_helper(call: ast.Call) -> bool:
+    """Return True when *call* has ``env=child_process_env(...)``."""
+    for kw in call.keywords:
+        if kw.arg != "env":
+            continue
+        value = kw.value
+        # env=child_process_env() / child_process_env({...})
+        if isinstance(value, ast.Call):
+            func = value.func
+            if isinstance(func, ast.Name) and func.id == "child_process_env":
+                return True
+            if isinstance(func, ast.Attribute) and func.attr == "child_process_env":
+                return True
+    return False
+
+
+def _iter_python_files(root: Path):
+    """Yield every ``.py`` file under *root*, excluding ``__pycache__`` etc."""
+    for path in root.rglob("*.py"):
+        if "__pycache__" in path.parts:
+            continue
+        yield path
+
+
+def test_every_sys_executable_spawn_uses_child_process_env() -> None:
+    """Every ``[sys.executable, ...]`` spawn must pass ``env=child_process_env(...)``.
+
+    Regression guard for terok-ai/terok#717 (Nix-wrapped Python: a
+    subprocess that doesn't inherit the parent's ``sys.path`` via
+    ``PYTHONPATH`` can't ``import terok``).
+    """
+    offenders: list[str] = []
+    for path in _iter_python_files(_SRC_ROOT):
+        tree = ast.parse(path.read_text())
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Call):
+                continue
+            if not _is_spawn_call(node):
+                continue
+            if not _argv_starts_with_sys_executable(node):
+                continue
+            if _env_kwarg_uses_helper(node):
+                continue
+            offenders.append(
+                f"  {path.relative_to(_SRC_ROOT.parents[1])}:{node.lineno} — "
+                "missing env=child_process_env(...)"
+            )
+
+    assert not offenders, (
+        "Found subprocess spawns of ``sys.executable`` that don't go through "
+        "``child_process_env`` — these will fail to import terok under "
+        "wrapped-Python setups (Nix, terok-ai/terok#717):\n" + "\n".join(offenders)
+    )

--- a/tests/unit/test_subprocess_pythonpath_call_sites.py
+++ b/tests/unit/test_subprocess_pythonpath_call_sites.py
@@ -31,20 +31,29 @@ _SPAWN_CALLABLES = {
 }
 
 
-def _argv_starts_with_sys_executable(call: ast.Call) -> bool:
-    """Return True when *call*'s first positional arg is ``[sys.executable, ...]``."""
+def _is_module_run(call: ast.Call) -> bool:
+    """Return True when *call*'s argv looks like ``[sys.executable, "-m", "<mod>", ...]``.
+
+    Only ``python -m module`` invocations need the ``PYTHONPATH`` shim —
+    they import the module and so depend on ``sys.path``.  Script-path
+    invocations (``python /path/to/script.py``) get their script dir
+    on ``sys.path[0]`` automatically, so they don't need the helper
+    (and stdlib-only scripts shouldn't pretend to).
+    """
     if not call.args:
         return False
     argv = call.args[0]
-    if not isinstance(argv, ast.List) or not argv.elts:
+    if not isinstance(argv, ast.List) or len(argv.elts) < 3:
         return False
-    first = argv.elts[0]
-    return (
+    first, second = argv.elts[0], argv.elts[1]
+    is_sys_executable = (
         isinstance(first, ast.Attribute)
         and isinstance(first.value, ast.Name)
         and first.value.id == "sys"
         and first.attr == "executable"
     )
+    is_dash_m = isinstance(second, ast.Constant) and second.value == "-m"
+    return is_sys_executable and is_dash_m
 
 
 def _is_spawn_call(call: ast.Call) -> bool:
@@ -94,7 +103,7 @@ def test_every_sys_executable_spawn_uses_child_process_env() -> None:
                 continue
             if not _is_spawn_call(node):
                 continue
-            if not _argv_starts_with_sys_executable(node):
+            if not _is_module_run(node):
                 continue
             if _env_kwarg_uses_helper(node):
                 continue

--- a/tests/unit/tui/test_console_log.py
+++ b/tests/unit/tui/test_console_log.py
@@ -19,13 +19,13 @@ import sys
 import pytest
 from textual.app import App
 
+from terok.lib.util.subprocess_env import child_process_env
 from terok.tui import _worker_entry
 from terok.tui.console_log import (
     ConsoleLogEntry,
     ConsoleLogMixin,
     ConsoleLogRegistry,
     LogStatus,
-    child_process_env,
     worker_argv,
 )
 


### PR DESCRIPTION
Captures the Nix-wrapped-Python regression (#717) flagged by *franzpoeschel* as automation so it can't silently come back.

## What's regressing if this PR is reverted

A new `[sys.executable, "-m", "terok.…"]` spawn site without `env=child_process_env(...)` would silently break terok for every Nix user. #717 fixed one such site (the project-wizard); today's master has a *second* unfixed site at `src/terok/cli/commands/acp.py:215` (the ACP daemon spawn) — fixed in this PR as a drive-by.

## Three layers of coverage

1. **`tests/unit/test_subprocess_pythonpath_call_sites.py`** — AST scan over `src/terok/`. Asserts every `subprocess.run` / `Popen` / `asyncio.create_subprocess_exec` of `sys.executable` passes `env=child_process_env(...)`. Runs on **every PR**. Catches "someone added a new spawn site without the helper".

2. **`tests/unit/lib/util/test_subprocess_env.py`** — behavioural test. Synthesises the wrapped-Python failure mode (parent's `sys.path` augmented in-process; `PYTHONPATH` deliberately empty), then exercises both the broken-naive subprocess pattern (asserts failure) and the fixed one (asserts success). Runs on **every PR**. Catches "the helper itself regressed".

3. **`tests/containers/Containerfile.nix` + `run_nix_check` in `run-matrix.sh`** — real Nix slot. Builds from `nixos/nix:latest`, installs terok into `~/.local/` (realistic operator setup), runs the two regression tests under the nix-wrapped interpreter. Truth check on real Nix; runs less often (matrix is operator-triggered, not on every PR).

## Refactor along the way

- `child_process_env` moved from `terok.tui.console_log` to `terok.lib.util.subprocess_env` — needed for `cli/commands/acp.py` to import without crossing tach layers.
- `cli/commands/acp.py` (`_spawn_daemon`) now passes `env=child_process_env()` — was missing the PYTHONPATH forwarding entirely. Layer-1 AST scan would have flagged it.

## Test plan

- [x] `poetry run pytest tests/unit` — 2379 pass (2376 prior + 3 new)
- [x] `poetry run tach check` — clean
- [x] `poetry run ruff check && ruff format --check` — clean
- [x] `poetry run reuse lint` — clean
- [x] `poetry run properdocs build --strict` — clean
- [ ] `./tests/containers/run-matrix.sh nix` on a dev host with podman (the Nix slot itself)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Spawned child processes now inherit the correct Python import path when the parent uses a wrapped Python launcher.

* **Tests**
  * Added unit tests validating environment propagation and a static check ensuring all python -m spawns use the helper.
  * Added a Nix-based test container and a nix test runner to exercise these scenarios.

* **Chores**
  * Consolidated subprocess environment construction into a shared utility.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/terok-ai/terok/pull/955)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->