### PR TITLE
chore: bump build-system minimum to poetry-core>=2.0 for PEP 639 metadata

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["poetry-core>=1.9.0", "poetry-dynamic-versioning>=1.0.0,<2.0.0"]
+requires = ["poetry-core>=2.0.0", "poetry-dynamic-versioning>=1.0.0,<2.0.0"]
 build-backend = "poetry_dynamic_versioning.backend"
 
 [project]


### PR DESCRIPTION
## Summary

Bump build-system minimum from \`poetry-core>=1.9.0\` to \`poetry-core>=2.0.0\` so that PEP 639 license metadata is emitted correctly.

## Why

The PEP 621 migration (just merged) declares \`license = "Apache-2.0"\` as a PEP 639 SPDX expression.  poetry-core 1.9.x doesn't fully support PEP 639 — a build with 1.9 would emit the legacy \`License:\` field instead of the modern \`License-Expression:\`, and may auto-enrich the deprecated \`License :: OSI Approved\` classifier that PyPI now rejects.

poetry-core 2.0+ handles this correctly.  Verified locally with 2.4.0:

\`\`\`
Metadata-Version: 2.4
License-Expression: Apache-2.0
License-File: LICENSE
\`\`\`

No \`License ::\` classifier in the wheel.

In practice, modern build environments (pip's PEP 517 isolation, recent Poetry releases) already pull a 2.x poetry-core, so this is mostly hygiene.  But declaring it explicitly removes the only way a build could fall back to legacy metadata.

## Test plan

- [x] \`poetry build\` produces a wheel with \`Metadata-Version: 2.4\`, \`License-Expression: Apache-2.0\`, no \`License ::\` classifier
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)