### PR TITLE
fix(security): defense-in-depth ID validation in tasks/meta.py

### DIFF
--- a/src/terok/lib/orchestration/tasks/meta.py
+++ b/src/terok/lib/orchestration/tasks/meta.py
@@ -52,12 +52,45 @@ CONTAINER_TEROK_CONFIG = "/home/dev/.terok"
 """In-container mount point for the per-task agent-config dir."""
 
 
+def _is_safe_id_segment(value: str) -> bool:
+    """Return True if *value* is safe to use as a single path component.
+
+    Rejects empty, ``.``, ``..``, anything containing ``/`` or ``\\``,
+    and anything starting with ``..``.  The path-builders in this
+    module compose values via ``Path / value``, which treats embedded
+    separators as nested components and ``..`` as a parent reference;
+    this predicate is the defense-in-depth guard at that composition
+    point.
+    """
+    return (
+        bool(value)
+        and value not in (".", "..")
+        and "/" not in value
+        and "\\" not in value
+        and not value.startswith("..")
+    )
+
+
+def _reject_unsafe_id(value: str, what: str) -> None:
+    """Raise ``SystemExit`` if *value* would escape the task store.
+
+    Used at every path-builder boundary in this module so any caller
+    — internal or otherwise — that hands an unvetted identifier in
+    gets a loud error instead of a silent traversal.  The CLI entry
+    points (``_normalize_pt`` slash branch, ``lookup_container_by_pt``)
+    catch the obvious cases earlier; this layer catches the rest.
+    """
+    if not _is_safe_id_segment(value):
+        raise SystemExit(f"Refusing path-unsafe {what}: {value!r}")
+
+
 def dossier_path(meta_dir: Path, task_id: str) -> Path:
     """Path to the wire-dossier JSON file — what shield consumers read.
 
     The OCI ``dossier.meta_path`` annotation points operators at *this*
     file.  Companion bookkeeping lives at the ``_meta.yml`` sibling.
     """
+    _reject_unsafe_id(task_id, "task_id")
     return meta_dir / f"{task_id}{_DOSSIER_SUFFIX}"
 
 
@@ -67,6 +100,7 @@ def meta_path(meta_dir: Path, task_id: str) -> Path:
     Holds everything except the wire-dossier triple.  Single consumer
     (terok itself), so ruamel round-tripping is fine.
     """
+    _reject_unsafe_id(task_id, "task_id")
     return meta_dir / f"{task_id}{_META_SUFFIX}"
 
 
@@ -278,11 +312,14 @@ def task_exists(project_id: str, task_id: str) -> bool:
 
 def tasks_meta_dir(project_id: str) -> Path:
     """Return the directory containing task metadata files for *project_id*."""
+    _reject_unsafe_id(project_id, "project_id")
     return core_state_dir() / "projects" / project_id / "tasks"
 
 
 def agent_config_dir(project_id: str, task_id: str) -> Path:
     """Host path of the agent-config dir bind-mounted at `CONTAINER_TEROK_CONFIG`."""
+    _reject_unsafe_id(project_id, "project_id")
+    _reject_unsafe_id(task_id, "task_id")
     return load_project(project_id).tasks_root / str(task_id) / "agent-config"
 
 
@@ -294,6 +331,7 @@ def tasks_archive_dir(project_id: str) -> Path:
     deletion the entire ``archive/<pid>/`` subtree is bundled into the
     project snapshot and removed.
     """
+    _reject_unsafe_id(project_id, "project_id")
     return archive_dir() / project_id / "tasks"
 
 

--- a/src/terok/lib/orchestration/tasks/query.py
+++ b/src/terok/lib/orchestration/tasks/query.py
@@ -14,26 +14,7 @@ from ...core.task_state import TaskState, container_name, effective_status
 from ...core.work_status import read_work_status
 from ..container_exec import container_git_diff
 from .identity import is_task_id
-from .meta import iter_task_ids, read_task_meta, tasks_meta_dir
-
-
-def _is_safe_id_segment(value: str) -> bool:
-    """Return True if *value* is safe to use as a path component.
-
-    Refuses empty strings, ``.``, ``..``, anything containing a path
-    separator, and anything starting with ``..``.  Used as the
-    defense-in-depth guard on identifier inputs that flow into
-    filesystem paths via [`tasks_meta_dir`][terok.lib.orchestration.tasks.meta.tasks_meta_dir]
-    / [`meta_path`][terok.lib.orchestration.tasks.meta.meta_path] /
-    [`dossier_path`][terok.lib.orchestration.tasks.meta.dossier_path].
-    """
-    return (
-        bool(value)
-        and value not in (".", "..")
-        and "/" not in value
-        and "\\" not in value
-        and not value.startswith("..")
-    )
+from .meta import _is_safe_id_segment, iter_task_ids, read_task_meta, tasks_meta_dir
 
 
 def get_task_container_state(project_id: str, task_id: str, mode: str | None) -> str | None:

--- a/tests/unit/test_unified_layering_contracts.py
+++ b/tests/unit/test_unified_layering_contracts.py
@@ -328,6 +328,56 @@ def test_lookup_container_by_pt_rejects_unsafe_ids(project_id: str, task_id: str
     assert lookup_container_by_pt(project_id, task_id) is None
 
 
+@pytest.mark.parametrize("bad", ["", ".", "..", "../escape", "..hidden", "a/b", "a\\b"])
+def test_meta_path_builders_reject_unsafe_project_id(bad: str) -> None:
+    """The five ``tasks/meta.py`` path-builders raise on a path-unsafe project_id.
+
+    Defense-in-depth: even if a caller smuggles past the CLI / resolver
+    guards (``_normalize_pt``, ``lookup_container_by_pt``), the
+    path-building layer itself refuses the construction with a loud
+    ``SystemExit``.  Covers
+    [`tasks_meta_dir`][terok.lib.orchestration.tasks.meta.tasks_meta_dir],
+    [`tasks_archive_dir`][terok.lib.orchestration.tasks.meta.tasks_archive_dir],
+    and [`agent_config_dir`][terok.lib.orchestration.tasks.meta.agent_config_dir]
+    (the project_id-consuming builders).
+    """
+    from terok.lib.orchestration.tasks.meta import (
+        agent_config_dir,
+        tasks_archive_dir,
+        tasks_meta_dir,
+    )
+
+    for builder in (tasks_meta_dir, tasks_archive_dir):
+        with pytest.raises(SystemExit, match="project_id"):
+            builder(bad)
+    with pytest.raises(SystemExit, match="project_id"):
+        agent_config_dir(bad, "a1b2c")
+
+
+@pytest.mark.parametrize("bad", ["", ".", "..", "../escape", "..hidden", "a/b", "a\\b"])
+def test_meta_path_builders_reject_unsafe_task_id(bad: str, tmp_path: Path) -> None:
+    """The three ``tasks/meta.py`` builders that take task_id refuse path-unsafe values.
+
+    Covers [`dossier_path`][terok.lib.orchestration.tasks.meta.dossier_path],
+    [`meta_path`][terok.lib.orchestration.tasks.meta.meta_path], and
+    [`agent_config_dir`][terok.lib.orchestration.tasks.meta.agent_config_dir]
+    (the task_id-consuming builders).  ``dossier_path`` / ``meta_path``
+    are given a real ``meta_dir`` so the failure is the id check, not
+    a missing-arg shape.
+    """
+    from terok.lib.orchestration.tasks.meta import (
+        agent_config_dir,
+        dossier_path,
+        meta_path,
+    )
+
+    for builder in (dossier_path, meta_path):
+        with pytest.raises(SystemExit, match="task_id"):
+            builder(tmp_path, bad)
+    with pytest.raises(SystemExit, match="task_id"):
+        agent_config_dir("myproj", bad)
+
+
 def test_terok_gate_ownership() -> None:
     """`terok-gate` console script is provided by terok-sandbox, not terok.
 


### PR DESCRIPTION
## Summary

Validate \`project_id\` / \`task_id\` at the path-builder layer itself, not just at the CLI entry points hardened in the prior chain (\`_normalize_pt\`, \`lookup_container_by_pt\`).  Closes the explicitly-deferred follow-up from #961's path-traversal fix:

> Defense-in-depth in \`tasks/meta.py\` was also in the recommendation; left as a follow-up — the helpers are also reached through legitimate code paths that already validate at their own boundaries, so wider changes need separate review.

## Approach

Promoted \`_is_safe_id_segment\` from \`query.py\` to \`meta.py\` (where the path-builders live), added a raising-helper \`_reject_unsafe_id(value, what)\` next to it, and called that helper at the top of every path-builder:

| Builder | Validates |
|---|---|
| \`dossier_path(meta_dir, task_id)\` | \`task_id\` |
| \`meta_path(meta_dir, task_id)\` | \`task_id\` |
| \`tasks_meta_dir(project_id)\` | \`project_id\` |
| \`agent_config_dir(project_id, task_id)\` | both |
| \`tasks_archive_dir(project_id)\` | \`project_id\` |

\`query.py\` now imports \`_is_safe_id_segment\` from \`meta.py\` instead of redefining it — single source for the predicate.

## Tests

14 new parametrized contract cases in \`test_unified_layering_contracts.py\` covering \`\"\"\`, \`\".\"\`, \`\"..\"\`, \`\"../escape\"\`, \`\"..hidden\"\`, \`\"a/b\"\`, \`\"a\\\\b\"\` for project_id and task_id at every builder.  Existing 20 contract tests still pass.

## Test plan

- [x] \`make lint\` — passes
- [x] \`make tach\` — passes
- [x] \`make test\` — 2437 unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)