### PR TITLE
fix(sickbay): don't require TCP ports in socket mode; broaden contract

### DIFF
--- a/src/terok/lib/orchestration/container_doctor.py
+++ b/src/terok/lib/orchestration/container_doctor.py
@@ -203,11 +203,17 @@ def _port_drift_check(env_var: str, label: str, expected: int) -> DoctorCheck:
 
 def _terok_doctor_checks(
     project_id: str,
-    gate_port: int,
-    token_broker_port: int,
-    ssh_signer_port: int,
+    gate_port: int | None,
+    token_broker_port: int | None,
+    ssh_signer_port: int | None,
 ) -> list[DoctorCheck]:
-    """Build terok-level health checks from project config."""
+    """Build terok-level health checks from project config.
+
+    ``None`` for any of the three port arguments selects socket mode
+    for that subsystem: the matching drift check is omitted because
+    sandbox doesn't bake a ``TEROK_*_PORT`` env into the container in
+    that mode, so there is no value to drift from.
+    """
     project = load_project(project_id)
 
     checks: list[DoctorCheck] = []
@@ -221,12 +227,16 @@ def _terok_doctor_checks(
     checks.append(_git_identity_check(human_name, human_email, "email"))
 
     checks.append(_git_remote_check(project.security_class, gate_port))
-    checks.append(
-        _port_drift_check("TEROK_TOKEN_BROKER_PORT", "Token broker port drift", token_broker_port)
-    )
-    checks.append(
-        _port_drift_check("TEROK_SSH_SIGNER_PORT", "SSH signer port drift", ssh_signer_port)
-    )
+    if token_broker_port is not None:
+        checks.append(
+            _port_drift_check(
+                "TEROK_TOKEN_BROKER_PORT", "Token broker port drift", token_broker_port
+            )
+        )
+    if ssh_signer_port is not None:
+        checks.append(
+            _port_drift_check("TEROK_SSH_SIGNER_PORT", "SSH signer port drift", ssh_signer_port)
+        )
 
     return checks
 
@@ -276,17 +286,30 @@ def _collect_all_checks(
     project_id: str,
     task_dir: Path,
 ) -> list[DoctorCheck]:
-    """Gather health checks from sandbox, agent, and terok layers."""
+    """Gather health checks from sandbox, agent, and terok layers.
+
+    In TCP mode all three port fields must resolve to an ``int`` (either
+    pinned via ``config.yml`` or auto-allocated by sandbox's port
+    registry).  In socket mode they are *supposed* to be ``None`` — no
+    TCP listener exists, comms go over Unix sockets — and every
+    downstream assembler ([`sandbox_doctor_checks`][terok_sandbox.doctor.sandbox_doctor_checks],
+    [`agent_doctor_checks`][terok_executor.doctor.agent_doctor_checks],
+    and the local [`_terok_doctor_checks`][terok.lib.orchestration.container_doctor._terok_doctor_checks])
+    already special-cases ``None`` to drop the TCP-only probes.  So the
+    "must be set" gate fires only in TCP mode.
+    """
     cfg = make_sandbox_config()
     token_broker_port = get_token_broker_port(cfg)
     ssh_signer_port = get_ssh_signer_port(cfg)
     desired_shield = _read_desired_shield_state(task_dir)
 
-    if cfg.gate_port is None or token_broker_port is None or ssh_signer_port is None:
+    if cfg.services_mode == "tcp" and (
+        cfg.gate_port is None or token_broker_port is None or ssh_signer_port is None
+    ):
         raise SystemExit(
-            "Sandbox service ports are not all configured — sickbay needs "
-            "gate.port / vault.token_broker_port / vault.ssh_signer_port in "
-            "config.yml or auto-allocation enabled."
+            "Sandbox service ports are not all configured — sickbay (TCP mode) "
+            "needs gate.port / vault.port / vault.ssh_signer_port in config.yml "
+            "or auto-allocation enabled."
         )
 
     checks: list[DoctorCheck] = []

--- a/tests/unit/lib/test_container_doctor.py
+++ b/tests/unit/lib/test_container_doctor.py
@@ -393,26 +393,28 @@ class TestRunContainerDoctor:
         assert "unknown host-side check" in results[0][2]
         mock_exec.assert_not_called()
 
-    @patch("terok.lib.orchestration.container_doctor.get_ssh_signer_port", return_value=2222)
-    @patch("terok.lib.orchestration.container_doctor.get_token_broker_port", return_value=8080)
+    @patch("terok.lib.orchestration.container_doctor.get_ssh_signer_port", return_value=None)
+    @patch("terok.lib.orchestration.container_doctor.get_token_broker_port", return_value=None)
     @patch("terok.lib.orchestration.container_doctor.make_sandbox_config")
-    def test_collect_all_checks_raises_when_gate_port_unset(
+    def test_collect_all_checks_raises_in_tcp_mode_with_unset_ports(
         self,
         mock_sandbox_cfg: MagicMock,
         _broker_port: MagicMock,
         _ssh_port: MagicMock,
         tmp_path: Path,
     ) -> None:
-        """Regression: ``_terok_doctor_checks`` requires a non-``None`` gate port.
+        """``_collect_all_checks`` refuses TCP mode without resolved ports.
 
-        Previously the call passed ``cfg.gate_port`` directly into a function
-        typed as ``int``, building checks that talked to ``host:None`` and
-        only failed deep inside the probe path with an opaque error.
+        In TCP mode the per-task probes need real port numbers — either
+        pinned in ``config.yml`` or auto-allocated by the port registry.
+        Socket mode is the opposite contract (no TCP ports expected) and
+        is covered by ``test_sickbay_collects_checks_in_socket_mode`` in
+        ``test_unified_layering_contracts``.
         """
         from terok.lib.orchestration.container_doctor import _collect_all_checks
 
-        mock_sandbox_cfg.return_value = MagicMock(gate_port=None)
-        with pytest.raises(SystemExit, match="gate server port|gate.port"):
+        mock_sandbox_cfg.return_value = MagicMock(services_mode="tcp", gate_port=None)
+        with pytest.raises(SystemExit, match="ports are not all configured"):
             _collect_all_checks("proj", tmp_path)
 
 

--- a/tests/unit/test_unified_layering_contracts.py
+++ b/tests/unit/test_unified_layering_contracts.py
@@ -48,10 +48,14 @@ import pytest
 # (``~/.config/terok/config.yml``) or a ``TEROK_CONFIG_FILE`` env
 # override can never silently disable the egress firewall — even
 # though the orchestrator-driven path through ``make_sandbox_config``
-# does read it.  Port fields (gate/token_broker/ssh_signer) flow
-# through sandbox's port-registry resolution rather than a config.yml
-# factory, so they're not pinned either.
-_TEROK_PROMISED_FIELDS: tuple[str, ...] = ("services_mode", "shield_audit")
+# does read it.
+_TEROK_PROMISED_FIELDS: tuple[str, ...] = (
+    "services_mode",
+    "shield_audit",
+    "gate_port",
+    "token_broker_port",
+    "ssh_signer_port",
+)
 
 
 def _write_user_config(tmp_path: Path, body: str) -> Path:
@@ -376,6 +380,48 @@ def test_meta_path_builders_reject_unsafe_task_id(bad: str, tmp_path: Path) -> N
             builder(tmp_path, bad)
     with pytest.raises(SystemExit, match="task_id"):
         agent_config_dir("myproj", bad)
+
+
+def test_sickbay_collects_checks_in_socket_mode(tmp_path: Path) -> None:
+    """`_collect_all_checks` must not raise on a socket-mode cfg with ``None`` ports.
+
+    Regression for the false-positive "Sandbox service ports are not all
+    configured" SystemExit that fired for every running task on hosts using
+    socket-mode services.yml (the default outside of TCP-mode setups).  In
+    socket mode the three TCP ports are *supposed* to be ``None`` — the
+    downstream assemblers already special-case it — so the early gate must
+    only fire in TCP mode.
+    """
+    from unittest.mock import MagicMock
+
+    from terok_sandbox import SandboxConfig
+
+    from terok.lib.orchestration import container_doctor
+
+    socket_cfg = SandboxConfig(
+        services_mode="socket",
+        gate_port=None,
+        token_broker_port=None,
+        ssh_signer_port=None,
+    )
+
+    with (
+        patch.object(container_doctor, "make_sandbox_config", return_value=socket_cfg),
+        patch.object(container_doctor, "get_roster", return_value=MagicMock()),
+        patch.object(container_doctor, "load_project") as load_proj,
+    ):
+        load_proj.return_value = MagicMock(
+            human_name="N",
+            human_email="n@x",
+            security_class="gatekeeping",
+        )
+        checks = container_doctor._collect_all_checks("any-project", tmp_path)
+
+    assert isinstance(checks, list)
+    # Port-drift checks are TCP-only and must be elided in socket mode.
+    labels = [c.label for c in checks]
+    assert "Token broker port drift" not in labels
+    assert "SSH signer port drift" not in labels
 
 
 def test_terok_gate_ownership() -> None:

--- a/tests/unit/test_unified_layering_contracts.py
+++ b/tests/unit/test_unified_layering_contracts.py
@@ -424,6 +424,34 @@ def test_sickbay_collects_checks_in_socket_mode(tmp_path: Path) -> None:
     assert "SSH signer port drift" not in labels
 
 
+def test_terok_doctor_checks_emits_port_drift_in_tcp_mode() -> None:
+    """Mirror of the socket-mode test: real ports → drift checks present.
+
+    Exercises the ``if … is not None: checks.append(_port_drift_check(…))``
+    branches in [`_terok_doctor_checks`][terok.lib.orchestration.container_doctor._terok_doctor_checks].
+    """
+    from unittest.mock import MagicMock
+
+    from terok.lib.orchestration import container_doctor
+
+    with patch.object(container_doctor, "load_project") as load_proj:
+        load_proj.return_value = MagicMock(
+            human_name="N",
+            human_email="n@x",
+            security_class="gatekeeping",
+        )
+        checks = container_doctor._terok_doctor_checks(
+            "any-project",
+            gate_port=18700,
+            token_broker_port=18701,
+            ssh_signer_port=18702,
+        )
+
+    labels = [c.label for c in checks]
+    assert "Token broker port drift" in labels
+    assert "SSH signer port drift" in labels
+
+
 def test_terok_gate_ownership() -> None:
     """`terok-gate` console script is provided by terok-sandbox, not terok.
 


### PR DESCRIPTION
## Summary

User-reported regression on Fedora (default socket-mode services): \`terok sickbay\` correctly streams the per-service / per-task report, then dies with

> Sandbox service ports are not all configured — sickbay needs gate.port / vault.token_broker_port / vault.ssh_signer_port in config.yml or auto-allocation enabled.

even though the user's \`config.yml\` has \`services.mode: socket\` (TCP block commented out) and every actually-running service is fine.

The SystemExit fires once per running task — the visible \"info (not running) — skipped\" lines for exited tasks pass through the early-out, but as soon as the doctor finds one running task it hits \`_collect_all_checks\` which unconditionally requires non-\`None\` TCP ports.

## Fix

Gate the requirement on \`cfg.services_mode == \"tcp\"\`.  In socket mode the three ports are *supposed* to be \`None\` — there's no TCP listener.  Every downstream assembler already special-cases \`None\` to drop TCP-only probes:

- \`sandbox_doctor_checks\` (terok-sandbox) skips the TCP probe when port is \`None\`.
- \`agent_doctor_checks\` (terok-executor) treats \`token_broker_port is None\` as socket mode.
- \`_terok_doctor_checks\` (this file) was the one piece that didn't — now widened to \`int | None\` and the \`_port_drift_check\` is appended only when the port is a real \`int\` (drift is meaningless when the container has no \`TEROK_*_PORT\` env to drift from).

## Tests

- Existing \`test_collect_all_checks_raises_when_gate_port_unset\` pinned the over-strict behavior; renamed / repurposed as \`test_collect_all_checks_raises_in_tcp_mode_with_unset_ports\` — TCP mode still rejects unset ports (the original defensive intent).
- New \`test_sickbay_collects_checks_in_socket_mode\` pins the fix: socket-mode cfg with \`None\` ports completes without \`SystemExit\`, and the port-drift checks are elided.

## Bundled with

- \`_TEROK_PROMISED_FIELDS\` in \`test_unified_layering_contracts.py\` broadens to include \`gate_port\` / \`token_broker_port\` / \`ssh_signer_port\` — sandbox's port factories landed in terok-ai/terok-sandbox#312 and now round-trip them through \`config.yml\`.

## Test plan

- [x] \`make lint\` — passes
- [x] \`make tach\` — passes
- [x] \`make test\` — 2438 unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Socket mode no longer fails when TCP service ports are unset; TCP-only ports are optional in socket deployments.
  * Error messages now clearly indicate when required TCP service ports are missing in TCP mode.
  * Port drift diagnostics run only for services configured in TCP mode.

* **Tests**
  * Added/updated tests to cover socket vs. TCP modes and port-drift behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/terok-ai/terok/pull/963?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->