### PR TITLE
docs: state __init__.py + __all__ as the public API contract

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -93,6 +93,7 @@ make spdx NAME="Real Human Name" FILES="src/terok/new_file.py"  # Add SPDX heade
   When modifying an existing file, always run `make spdx` with the contributor's name to add their copyright line. NAME must be a real person's name (ASCII-only), not a project name. Use a single year (year of first contribution), not a range. Ask the user for their name if unknown. Files covered by `REUSE.toml` glob patterns (`.md`, `.yml`, `.toml`, `.json`, etc.) do not need inline headers. `make reuse` checks compliance but does not generate headers.
 - **Emojis**: Must be natively wide (`East_Asian_Width=W`) — no VS16 (U+FE0F) sequences. Use `draw_emoji()` from `terok.lib.util.emoji` for aligned output. See `docs/developer.md` → "Emoji width constraints" for details
 - **No magic literals**: Never use literal IPs, URLs, ports, or filesystem paths directly in code. Define them as named constants and import from there — `tests/constants.py` for test code, appropriate module-level constants for production code. This centralises magic values and makes future changes trivial. In tests, mock filesystem paths must use a subdirectory under `MOCK_BASE` (e.g. `/tmp/terok-testing/...`) — never `/tmp` directly
+- **Public API surface**: `__init__.py` + `__all__` is the contract. Symbols listed in `__all__` are stable across minor releases; anything underscore-prefixed or absent from `__all__` is internal and may change without notice. Review the list before each release — stable APIs stay small because growing them costs.
 
 ## Development Workflow
 


### PR DESCRIPTION
## Summary

- Add one-line bullet to `AGENTS.md` (Coding Standards) documenting the established Python convention: `__init__.py` + `__all__` is the contract; symbols outside `__all__` (or underscore-prefixed) are internal.
- The repo already follows this convention. No code changes — this just writes down the rule so future contributors can spot when the surface drifts.
- Matching docs PRs filed for `terok-sandbox`, `terok-executor`, `terok-clearance`, `terok-shield`.

## Why

Periodic public-API review is the cheap check that keeps inter-package coupling small. A written one-liner gives that review a citation, and explicitly names the signal ("surface growing → think before adding").

## Test plan
- [x] No code touched — docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)