### PR TITLE
docs(examples): add vibe-readable-colors snippet under examples/snippets/

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -276,7 +276,9 @@ Create `~/.config/terok/projects/myproj/user.dockerinclude`:
 RUN apt-get update && apt-get install -y ripgrep jq && rm -rf /var/lib/apt/lists/*
 ```
 
-This text is pasted near the end of your project image (L2) Dockerfile.
+This text is pasted near the end of your project image (L2) Dockerfile. You can also set `image.user_snippet_inline` in `project.yml` for short one-liners and keep the per-project `.dockerinclude` for longer recipes — both are concatenated.
+
+Ready-to-use snippets for personal-taste tweaks (e.g. retuning an agent's terminal colors) live in [`examples/snippets/`](../examples/snippets/) — append to your `user.dockerinclude` as-is, or use `image.user_snippet_file` to point at one directly.
 
 ### Step 4: Generate Dockerfiles
 

--- a/examples/projects/alpaka3/project.yml
+++ b/examples/projects/alpaka3/project.yml
@@ -24,6 +24,20 @@ image:
     RUN update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-14 140 \
      && update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-14 140
 
+    # Personal-taste UI tweak: lift Vibe's ansi_bright_black to a
+    # readable mid-gray so menus + hints stop disappearing on the
+    # default GNOME Ptyxis palette.  Same recipe as
+    # examples/snippets/vibe-readable-colors.dockerinclude — inlined
+    # here to demonstrate the user_snippet_inline form.
+    #
+    # terok's L1 sets PIPX_HOME=/opt/pipx, so mistral-vibe's venv is
+    # always at /opt/pipx/venvs/mistral-vibe.  Find skips the python-
+    # version subdir without us hard-coding it.
+    RUN set -eux; \
+        TCSS=$(find /opt/pipx/venvs/mistral-vibe \
+                    -path '*/vibe/cli/textual_ui/app.tcss' 2>/dev/null | head -1); \
+        [ -n "$TCSS" ] && sed -i 's/ansi_bright_black/#888888/g' "$TCSS"
+
 # Gatekeeping mode settings
 gatekeeping:
   # Expose the upstream URL as a remote named "external" inside the container.

--- a/examples/snippets/vibe-readable-colors.dockerinclude
+++ b/examples/snippets/vibe-readable-colors.dockerinclude
@@ -1,0 +1,34 @@
+# SPDX-FileCopyrightText: 2026 Jiri Vyskocil
+# SPDX-License-Identifier: Apache-2.0
+#
+# Vibe — lift `ansi_bright_black` to a readable mid-gray.
+#
+# Vibe's Textual UI uses `ansi_bright_black` in ~40 places for borders,
+# hints, and secondary text.  On terminal palettes that render that
+# slot as a near-black gray (notably GNOME's default Ptyxis scheme),
+# the affected text is almost invisible on a black background.  Upstream
+# hard-codes `self.theme = "textual-ansi"` with no override knob, so
+# the cleanest fix without changing the terminal palette is to patch
+# the installed stylesheet at image-build time.
+#
+# Tweak the replacement to taste: `#aaa` for higher contrast,
+# `#666` to stay subtle, etc.  Hex colors land verbatim in Textual CSS.
+#
+# Usage: drop this into your project's `user.dockerinclude`, or point
+# `image.user_snippet_file:` at this file from `project.yml`.  The
+# snippet runs after L1 has installed every agent CLI, so the pipx
+# venv exists when this RUN executes.
+#
+# terok's L1 template sets `PIPX_HOME=/opt/pipx`, so pipx-installed
+# agent venvs (mistral-vibe among them) land at
+# `/opt/pipx/venvs/<package>/`.  Don't try to resolve `vibe` via
+# `command -v` / `which` — terok's interactive shells source a
+# `vibe()` shell-function wrapper that shadows the binary, and PATH
+# resolution at L2 build time vs. at an interactive prompt would
+# give different answers; the venv root is the stable thing to anchor
+# on.  `find` skips the python-version subdir (`lib/python3.12/` vs
+# `python3.13/` etc.) without us hard-coding it.
+RUN set -eux; \
+    TCSS=$(find /opt/pipx/venvs/mistral-vibe \
+                -path '*/vibe/cli/textual_ui/app.tcss' 2>/dev/null | head -1); \
+    [ -n "$TCSS" ] && sed -i 's/ansi_bright_black/#888888/g' "$TCSS"


### PR DESCRIPTION
## Summary

Adds a standalone reusable Vibe color-patch snippet under \`examples/snippets/\`, inlines the same recipe into the alpaka3 example project to demonstrate the \`user_snippet_inline\` form, and updates \`docs/usage.md\` Step 3 with a one-line pointer to the snippets directory.

### Why

Vibe leans on \`ansi_bright_black\` for ~40 sites in its Textual UI (borders, hints, secondary text). On the default GNOME / Ptyxis palette that ANSI slot is near-black, so the affected text reads as nearly-invisible dark gray on a black background. Vibe hard-codes \`self.theme = "textual-ansi"\` with no override knob (verified against [mistralai/mistral-vibe](https://github.com/mistralai/mistral-vibe) source), so the cleanest fix without retuning the terminal's palette is to \`sed\` the installed stylesheet at image-build time.

This is personal taste — different terminal palettes render \`ansi_bright_black\` very differently, and some users will want a different replacement (\`#aaa\`, \`#666\`, …). The right home is the per-project \`user.dockerinclude\` / \`user_snippet_inline\`, so the recipe ships as a reusable example, not a default.

### What lands

- New file \`examples/snippets/vibe-readable-colors.dockerinclude\` — self-contained recipe with header comments explaining the why and how-to-tweak
- New \`examples/snippets/\` directory established as the home for reusable user-snippet recipes
- The alpaka3 example project (\`examples/projects/alpaka3/project.yml\`) gets the same recipe inlined into its existing \`image.user_snippet_inline\` block, demonstrating both forms side by side
- One-line addition to \`docs/usage.md\` Step 3 pointing readers at \`examples/snippets/\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced build customization documentation with clearer explanation of user snippet insertion behavior and guidance for applying personal preference tweaks.

* **Examples**
  * Added new Docker build snippet for UI theme color customization.
  * Updated project example with inline build configuration for visual customization.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/terok-ai/terok/pull/970?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->