### PR TITLE
examples(snippets): readable colors for Vibe in Ptyxis with GNOME palette

### DIFF
--- a/examples/snippets/vibe-readable-colors.dockerinclude
+++ b/examples/snippets/vibe-readable-colors.dockerinclude
@@ -1,0 +1,6 @@
+# SPDX-FileCopyrightText: 2026 Jiri Vyskocil
+# SPDX-License-Identifier: Apache-2.0
+#
+# Better contrast for Mistral Vibe on the default GNOME / Ptyxis palette.
+RUN grep -rl 'ansi_bright_black' /opt/pipx/venvs/mistral-vibe/ \
+    | xargs sed -i 's/ansi_bright_black/#888888/g'


### PR DESCRIPTION
## Summary

Adds a single-file recipe under \`examples/snippets/\` that lifts every \`ansi_bright_black\` literal in mistral-vibe's install to a readable mid-gray. The default GNOME Ptyxis palette renders ANSI 8 as a near-black gray, so Vibe's borders, hints, secondary text and markdown comments are nearly invisible on a black background. Personal-taste tweak — drop into your project's \`user.dockerinclude\` or point \`image.user_snippet_file\` at this file.

\`\`\`dockerfile
RUN grep -rl 'ansi_bright_black' /opt/pipx/venvs/mistral-vibe/ \
    | xargs sed -i 's/ansi_bright_black/#888888/g'
\`\`\`

Hits every Textual stylesheet (\`app.tcss\`, \`onboarding.tcss\`, \`trust_folder_dialog.tcss\`) plus the Pygments code-comment theme in \`ansi_markdown.py\` — so the markdown-code-block "black-on-black" leftover from patching just \`app.tcss\` is also fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added a Docker example snippet demonstrating color value substitution and configuration within a virtual environment context.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/terok-ai/terok/pull/973?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->