### PR TITLE
fix(tui): surface silent exception handlers via _log_debug (#599)

### DIFF
--- a/src/terok/tui/screens.py
+++ b/src/terok/tui/screens.py
@@ -252,7 +252,10 @@ class GateServerScreen(screen.Screen[str | None]):
 
         try:
             self._status = get_server_status()
-        except Exception:
+        except Exception as exc:
+            from ..lib.util.logging_utils import _log_debug
+
+            _log_debug(f"Gate server status refresh failed: {exc}")
             self._status = None
         self._render_status()
 
@@ -1328,7 +1331,10 @@ class TaskLaunchScreen(screen.ModalScreen["tuple[str, str, str, str, str, str | 
         if state == "running":
             try:
                 has_mode = get_task_meta(self._project_id, self._task_id).mode is not None
-            except (SystemExit, Exception):
+            except (SystemExit, Exception) as exc:
+                from ..lib.util.logging_utils import _log_debug
+
+                _log_debug(f"Task meta fetch failed for {self._project_id}/{self._task_id}: {exc}")
                 has_mode = False
         return state, has_mode
 
@@ -1729,7 +1735,10 @@ def render_shield_status(
         from importlib.metadata import version as _meta_version
 
         shield_version = _meta_version("terok-shield")
-    except Exception:
+    except Exception as exc:
+        from terok.lib.util.logging_utils import _log_debug
+
+        _log_debug(f"importlib.metadata lookup for terok-shield failed: {exc}")
         shield_version = "unknown"
 
     podman_str = ".".join(str(v) for v in env_check.podman_version)
@@ -1830,7 +1839,10 @@ class ShieldScreen(screen.Screen[str | None]):
 
         try:
             self._shield_info = shield_status()
-        except Exception:
+        except Exception as exc:
+            from ..lib.util.logging_utils import _log_debug
+
+            _log_debug(f"Shield status load failed: {exc}")
             self._shield_info = None
 
     def _render_status(self) -> None:
@@ -1876,12 +1888,16 @@ class ShieldScreen(screen.Screen[str | None]):
         info: dict | None = None
         try:
             env = shield_check_environment()
-        except Exception:
-            pass
+        except Exception as exc:
+            from terok.lib.util.logging_utils import _log_debug
+
+            _log_debug(f"shield_check_environment failed in background fetch: {exc}")
         try:
             info = shield_status()
-        except Exception:
-            pass
+        except Exception as exc:
+            from terok.lib.util.logging_utils import _log_debug
+
+            _log_debug(f"shield status load failed in background fetch: {exc}")
         return env, info
 
     def on_worker_state_changed(self, event: Any) -> None:

--- a/src/terok/tui/task_actions.py
+++ b/src/terok/tui/task_actions.py
@@ -250,8 +250,11 @@ class TaskActionsMixin(_MixinBase):
             from ..lib.api import installed_agents_for_project
 
             installed = await asyncio.to_thread(installed_agents_for_project, project)
-        except (SystemExit, Exception):
-            pass
+        except (SystemExit, Exception) as exc:
+            self._log_debug(
+                f"_action_login: project/agents lookup failed for {pid!r}; "
+                f"falling back to bash. {exc}"
+            )
 
         await self.push_screen(
             TaskLaunchScreen(

--- a/src/terok/tui/widgets/project_state.py
+++ b/src/terok/tui/widgets/project_state.py
@@ -156,7 +156,10 @@ def render_project_details(
     yaml_instructions = project.agent_config.get("instructions")
     try:
         has_file = (project.root / "instructions.md").is_file()
-    except (TypeError, AttributeError):
+    except (TypeError, AttributeError) as exc:
+        from terok.lib.util.logging_utils import _log_debug
+
+        _log_debug(f"project_state: instructions.md existence probe failed: {exc}")
         has_file = False
     has_yaml = yaml_instructions is not None
 

--- a/src/terok/tui/widgets/task_detail.py
+++ b/src/terok/tui/widgets/task_detail.py
@@ -25,7 +25,10 @@ def _get_css_variables(widget: Static) -> dict[str, str]:
         return {}  # type: ignore[unreachable]
     try:
         return widget.app.get_css_variables()
-    except Exception:
+    except Exception as exc:
+        from terok.lib.util.logging_utils import _log_debug
+
+        _log_debug(f"task_detail: get_css_variables failed: {exc}")
         return {}
 
 
@@ -236,8 +239,10 @@ class TaskDetails(Static):
             shield_env = getattr(self.app, "_last_shield_env", None)
             if shield_env is not None:
                 hooks_ok = shield_env.health == "ok"
-        except Exception:
-            pass
+        except Exception as exc:
+            from terok.lib.util.logging_utils import _log_debug
+
+            _log_debug(f"task_detail: shield env probe failed: {exc}")
 
         rendered = render_task_details(
             self._current_task,


### PR DESCRIPTION
## Summary

Closes #599.  Of the ten silent-handler sites the issue enumerated, nine are still present in current master (one was already fixed via \`notify()\` on \`project_actions.py\`).  All nine get the same minimal treatment: \`_log_debug(...)\` before the existing fallback so user-visible behaviour is unchanged, but operators triaging a "shield status shows unknown" report can now find the cause in \`terok.log\`.

| File | Line | Handler |
|---|---|---|
| \`tui/screens.py\` | 253 | gate server status fetch |
| \`tui/screens.py\` | 1329 | task metadata fetch (\`has_mode\`) |
| \`tui/screens.py\` | 1728 | \`importlib.metadata\` shield version |
| \`tui/screens.py\` | 1831 | shield status load |
| \`tui/screens.py\` | 1877, 1881 | background-fetch shield env + status |
| \`tui/task_actions.py\` | 244 | project / installed-agents for login default |
| \`tui/widgets/task_detail.py\` | 26 | CSS theme variable extraction |
| \`tui/widgets/task_detail.py\` | 235 | cached shield env probe |
| \`tui/widgets/project_state.py\` | 157 | \`instructions.md\` is_file probe |

## Why no new tests

The change is mechanical — every handler keeps the same fallback value (return \`None\`, fall through to \`"bash"\`, render \`"unknown"\`, etc.); only the side-effect of writing a log line is new.  Existing TUI unit tests don't pin log output (correctly so), and pinning it would just test the wording.  All 602 TUI unit tests still pass.

## Style note

\`task_actions.py\` uses the mixin's existing \`self._log_debug\` to match the \`_action_login:\` line-prefix convention already established in the file.  All other sites use the module-level \`_log_debug\` from \`terok.lib.util.logging_utils\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced error logging across the application. System operations including server status checks, task readiness validation, configuration loading, and environment probes now generate debug logs when they fail, improving troubleshooting and diagnostics capabilities instead of silently swallowing errors.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/terok-ai/terok/pull/974?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->