### PR TITLE
chore(image): bump default Fedora L0 base from fedora:43 to fedora:44

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ terok agents                            # list available AI coding agents
 ```
 
 Officially-tested base images for `image.base_image`: `ubuntu:24.04`,
-`fedora:43`, `quay.io/podman/stable`, `nvcr.io/nvidia/nvhpc`.  Other
+`fedora:44`, `quay.io/podman/stable`, `nvcr.io/nvidia/nvhpc`.  Other
 images in the same family (`ubuntu:*`, `debian:*`, `fedora:*`,
 `nvcr.io/nvidia/*`, `quay.io/podman/*`) work via auto-detection;
 anything else needs an explicit `image.family: deb|rpm` override.

--- a/docs/container-layers.md
+++ b/docs/container-layers.md
@@ -17,7 +17,7 @@ terok builds project containers in three logical layers. L0 (dev) and L1 (agent)
 
 #### Base image families
 
-Officially tested base images: `ubuntu:24.04`, `fedora:43`, `quay.io/podman/stable`, `nvcr.io/nvidia/nvhpc`. The package-manager branch (`apt`/`dnf`) is auto-detected from the image name. For images outside the allowlist, set `image.family: deb` or `image.family: rpm` explicitly:
+Officially tested base images: `ubuntu:24.04`, `fedora:44`, `quay.io/podman/stable`, `nvcr.io/nvidia/nvhpc`. The package-manager branch (`apt`/`dnf`) is auto-detected from the image name. For images outside the allowlist, set `image.family: deb` or `image.family: rpm` explicitly:
 
 ```yaml
 image:

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -1195,7 +1195,7 @@ If the image doesn't have podman preinstalled, `nested_containers: true` still s
 
 ```yaml
 image:
-  base_image: fedora:43
+  base_image: fedora:44
   user_snippet_inline: RUN dnf install -y podman fuse-overlayfs
 run:
   nested_containers: true

--- a/src/terok/cli/commands/setup.py
+++ b/src/terok/cli/commands/setup.py
@@ -83,7 +83,7 @@ def register(subparsers: argparse._SubParsersAction[argparse.ArgumentParser]) ->
         default=None,
         help=(
             "Pre-build L0/L1 for BASE_IMAGE (e.g. ``ubuntu:24.04``, "
-            "``fedora:43``, ``nvidia/cuda:12.6.0-runtime-ubuntu24.04``).  "
+            "``fedora:44``, ``nvidia/cuda:12.6.0-runtime-ubuntu24.04``).  "
             "Normally images build lazily on first ``terok task run`` or "
             "``terok project init``, keyed by each project's declared "
             "base — so this flag is only useful when you *know* your "

--- a/src/terok/lib/core/config.py
+++ b/src/terok/lib/core/config.py
@@ -445,9 +445,9 @@ def get_global_image_base_image() -> str:
     """Return ``image.base_image`` from the global config.
 
     Defaults to [`DEFAULT_BASE_IMAGE`][terok_executor.DEFAULT_BASE_IMAGE]
-    (currently ``ubuntu:24.04``) when unset.  Used by host-wide flows
-    (e.g. ``terok auth``) so users on Fedora/NVIDIA/Podman bases don't
-    end up with a parallel Ubuntu L1 just for auth.
+    when unset.  Used by host-wide flows (e.g. ``terok auth``) so users
+    on Fedora/NVIDIA/Podman bases don't end up with a parallel default
+    L1 just for auth.
     """
     from terok.lib.integrations.executor import DEFAULT_BASE_IMAGE
 

--- a/src/terok/lib/domain/wizards/new_project.py
+++ b/src/terok/lib/domain/wizards/new_project.py
@@ -50,7 +50,7 @@ SECURITY_CLASSES: list[tuple[str, str]] = [
 BASES: list[tuple[str, str]] = sorted(
     [
         ("ubuntu", "Ubuntu 24.04"),
-        ("fedora", "Fedora 43"),
+        ("fedora", "Fedora 44"),
         ("podman", "Podman (Fedora-based)"),
         ("nvidia", "NVIDIA CUDA (GPU)"),
     ],
@@ -58,7 +58,7 @@ BASES: list[tuple[str, str]] = sorted(
 )
 BASE_IMAGES: dict[str, str] = {
     "ubuntu": "ubuntu:24.04",
-    "fedora": "fedora:43",
+    "fedora": "fedora:44",
     "podman": "quay.io/podman/stable:latest",
     "nvidia": "nvcr.io/nvidia/nvhpc:25.9-devel-cuda13.0-ubuntu24.04",
 }

--- a/tests/unit/lib/test_wizard.py
+++ b/tests/unit/lib/test_wizard.py
@@ -240,7 +240,7 @@ def generate_into_tmp(values: dict[str, object]) -> tuple[str, str, str]:
                 project_id="fedora-proj",
                 upstream_url="https://example.com/r.git",
             ),
-            ['base_image: "fedora:43"', 'security_class: "online"'],
+            ['base_image: "fedora:44"', 'security_class: "online"'],
             id="online-fedora",
         ),
         pytest.param(


### PR DESCRIPTION
## Summary

Bump the default Fedora L0 base from \`fedora:43\` to \`fedora:44\`.  Six lines across five files (wizard default, docs, help text, README) + one test that pins the wizard's fedora preset.

## Out of scope intentionally

- \`tests/containers/run-matrix.sh\` and \`Containerfile.fedora43\` — the matrix already covers both \`fedora43\` and \`fedora44\` and exercising both is its job
- Test fixtures elsewhere that happen to use \`"fedora:43"\` as a generic image-string for parser / loader behaviour — those aren't pinning the recommended version

## Note

terok-executor's own \`container/build.py\` comment and a few of its tests still name \`fedora:43\` as the officially-tested example.  Filed separately if/when it makes sense — terok's user-facing default is what matters to operators picking a new project's base.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated all user-facing docs, examples, and CLI help text to reference Fedora base image version 44 instead of 43.

* **Chores**
  * Default base image updated to Fedora 44 across templates and configuration defaults.

* **Tests**
  * Adjusted unit tests and expected outputs to reflect Fedora 44 as the standard base image.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/terok-ai/terok/pull/975?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->