### PR TITLE
feat(tui): reorder TaskLaunchScreen dialog with multiline prompt

### DIFF
--- a/src/terok/tui/screens.py
+++ b/src/terok/tui/screens.py
@@ -1228,6 +1228,7 @@ class TaskLaunchScreen(screen.ModalScreen["tuple[str, str, str, str, str, str | 
 
     #launch-prompt {
         margin-bottom: 1;
+        height: 10;
     }
 
     #launch-buttons {
@@ -1274,11 +1275,14 @@ class TaskLaunchScreen(screen.ModalScreen["tuple[str, str, str, str, str, str | 
         self._start_time = 0.0
 
     def compose(self) -> ComposeResult:
-        """Build status, agent selector, prompt input, and action buttons."""
+        """Build prompt input, agent selector, status, and action buttons."""
         from terok.lib.integrations.executor import AGENT_PROVIDERS
 
         with Vertical(id="launch-dialog") as dialog:
             yield Static("Status: Starting container\u2026", id="launch-status")
+
+            # Prompt input first (multiline TextArea with Ctrl+Enter for newline)
+            yield TextArea(placeholder="Initial prompt (optional)", id="launch-prompt")
 
             # bash is always offered (login shell); the rest are filtered by
             # what's installed in the project's L1 image.
@@ -1291,7 +1295,7 @@ class TaskLaunchScreen(screen.ModalScreen["tuple[str, str, str, str, str, str | 
             valid_values = {v for _, v in choices}
             login_value = self._default_login if self._default_login in valid_values else "bash"
             yield Select(choices, value=login_value, id="login-agent")
-            yield Input(placeholder="Initial prompt (optional)", id="launch-prompt")
+
             with Horizontal(id="launch-buttons"):
                 if self._console_entry is not None:
                     yield Button("Show log", id="btn-show-log", variant="default")
@@ -1304,10 +1308,38 @@ class TaskLaunchScreen(screen.ModalScreen["tuple[str, str, str, str, str, str | 
         """Start polling for container readiness and focus the prompt input."""
         import time
 
-        prompt = self.query_one("#launch-prompt", Input)
+        prompt = self.query_one("#launch-prompt", TextArea)
         prompt.focus()
         self._start_time = time.monotonic()
         self._poll_timer = self.set_interval(1.5, self._poll_status)
+
+    def on_key(self, event: events.Key) -> None:
+        """Handle special keys when prompt input has focus.
+
+        - Ctrl+Enter inserts a newline character (for multi-line prompts)
+        - Enter (without Ctrl) submits the form (presses Login)
+        - Tab moves focus between widgets (default behavior)
+        """
+        # Only handle keys when the prompt TextArea has focus
+        if not self.query_one("#launch-prompt", TextArea).has_focus:
+            return
+
+        if event.key == "ctrl+enter":
+            # Insert a newline character at cursor position
+            prompt = self.query_one("#launch-prompt", TextArea)
+            cursor_pos = prompt.cursor_position
+            current_value = prompt.text
+            # Insert newline at cursor position
+            new_value = current_value[:cursor_pos] + "\n" + current_value[cursor_pos:]
+            prompt.text = new_value
+            # Move cursor past the newline
+            prompt.cursor_position = cursor_pos + 1
+            event.stop()
+        elif event.key == "enter":
+            # Enter submits the form (presses Login) if container is ready
+            if self._container_ready:
+                self._do_login()
+                event.stop()
 
     # If no container has appeared within this many wall-clock seconds, assume
     # the launch failed and surface a hint.  Wall-clock based (not tick count)
@@ -1404,8 +1436,8 @@ class TaskLaunchScreen(screen.ModalScreen["tuple[str, str, str, str, str, str | 
         if isinstance(agent, NoSelection):
             self.app.notify("Pick an agent first.")
             return
-        prompt_input = self.query_one("#launch-prompt", Input)
-        prompt = prompt_input.value.strip() or None
+        prompt_input = self.query_one("#launch-prompt", TextArea)
+        prompt = prompt_input.text.strip() or None
         self.dismiss(
             (
                 self._project_id,

--- a/src/terok/tui/screens.py
+++ b/src/terok/tui/screens.py
@@ -1325,15 +1325,9 @@ class TaskLaunchScreen(screen.ModalScreen["tuple[str, str, str, str, str, str | 
             return
 
         if event.key == "ctrl+enter":
-            # Insert a newline character at cursor position
+            # Insert a newline at cursor position using TextArea.insert()
             prompt = self.query_one("#launch-prompt", TextArea)
-            cursor_pos = prompt.cursor_position
-            current_value = prompt.text
-            # Insert newline at cursor position
-            new_value = current_value[:cursor_pos] + "\n" + current_value[cursor_pos:]
-            prompt.text = new_value
-            # Move cursor past the newline
-            prompt.cursor_position = cursor_pos + 1
+            prompt.insert("\n")
             event.stop()
         elif event.key == "enter":
             # Enter submits the form (presses Login) if container is ready

--- a/tests/unit/tui/test_new_task_flow.py
+++ b/tests/unit/tui/test_new_task_flow.py
@@ -280,6 +280,118 @@ class TestTaskLaunchScreen:
         screen.on_input_submitted(event)
         screen._do_login.assert_called_once()
 
+    def test_on_key_ctrl_enter_inserts_newline(self) -> None:
+        """Ctrl+Enter in focused prompt TextArea inserts a newline."""
+        screens, _ = import_screens()
+        screen = screens.TaskLaunchScreen(container_name="c", project_id="p", task_id="1")
+
+        mock_textarea = mock.Mock()
+        mock_textarea.text = "line1"
+        mock_textarea.has_focus = True
+        mock_textarea.insert = mock.Mock()
+
+        mock_select = mock.Mock()
+
+        def query_one(selector, cls=None):
+            if "login-agent" in selector:
+                return mock_select
+            return mock_textarea
+
+        screen.query_one = query_one
+
+        # Simulate Ctrl+Enter
+        event = mock.Mock()
+        event.key = "ctrl+enter"
+        screen.on_key(event)
+
+        # Verify newline was inserted
+        mock_textarea.insert.assert_called_once_with("\n")
+        event.stop.assert_called_once()
+
+    def test_on_key_enter_submits_when_ready_and_focused(self) -> None:
+        """Enter (without Ctrl) submits when container ready and prompt has focus."""
+        screens, _ = import_screens()
+        screen = screens.TaskLaunchScreen(container_name="c", project_id="p", task_id="1")
+        screen._container_ready = True
+        screen._do_login = mock.Mock()
+
+        mock_textarea = mock.Mock()
+        mock_textarea.has_focus = True
+
+        mock_select = mock.Mock()
+
+        def query_one(selector, cls=None):
+            if "login-agent" in selector:
+                return mock_select
+            return mock_textarea
+
+        screen.query_one = query_one
+
+        # Simulate Enter (without Ctrl)
+        event = mock.Mock()
+        event.key = "enter"
+        event.ctrl = False
+        screen.on_key(event)
+
+        screen._do_login.assert_called_once()
+        event.stop.assert_called_once()
+
+    def test_on_key_enter_noop_when_not_ready(self) -> None:
+        """Enter does nothing when container is not ready, even with focus."""
+        screens, _ = import_screens()
+        screen = screens.TaskLaunchScreen(container_name="c", project_id="p", task_id="1")
+        screen._container_ready = False
+        screen._do_login = mock.Mock()
+
+        mock_textarea = mock.Mock()
+        mock_textarea.has_focus = True
+
+        mock_select = mock.Mock()
+
+        def query_one(selector, cls=None):
+            if "login-agent" in selector:
+                return mock_select
+            return mock_textarea
+
+        screen.query_one = query_one
+
+        # Simulate Enter (without Ctrl)
+        event = mock.Mock()
+        event.key = "enter"
+        event.ctrl = False
+        screen.on_key(event)
+
+        screen._do_login.assert_not_called()
+        event.stop.assert_not_called()
+
+    def test_on_key_enter_noop_when_not_focused(self) -> None:
+        """Enter does nothing when prompt doesn't have focus, even if ready."""
+        screens, _ = import_screens()
+        screen = screens.TaskLaunchScreen(container_name="c", project_id="p", task_id="1")
+        screen._container_ready = True
+        screen._do_login = mock.Mock()
+
+        mock_textarea = mock.Mock()
+        mock_textarea.has_focus = False  # No focus
+
+        mock_select = mock.Mock()
+
+        def query_one(selector, cls=None):
+            if "login-agent" in selector:
+                return mock_select
+            return mock_textarea
+
+        screen.query_one = query_one
+
+        # Simulate Enter (without Ctrl)
+        event = mock.Mock()
+        event.key = "enter"
+        event.ctrl = False
+        screen.on_key(event)
+
+        screen._do_login.assert_not_called()
+        event.stop.assert_not_called()
+
 
 # ---------------------------------------------------------------------------
 # Launch command shape — prompt travels via the on-disk file, not as a CLI arg

--- a/tests/unit/tui/test_new_task_flow.py
+++ b/tests/unit/tui/test_new_task_flow.py
@@ -199,13 +199,13 @@ class TestTaskLaunchScreen:
 
         mock_select = mock.Mock()
         mock_select.value = "claude"
-        mock_input = mock.Mock()
-        mock_input.value = "fix the bug"
+        mock_textarea = mock.Mock()
+        mock_textarea.text = "fix the bug"
 
         def query_one(selector, cls=None):
             if "login-agent" in selector:
                 return mock_select
-            return mock_input
+            return mock_textarea
 
         screen.query_one = query_one
 
@@ -221,13 +221,13 @@ class TestTaskLaunchScreen:
 
         mock_select = mock.Mock()
         mock_select.value = "bash"
-        mock_input = mock.Mock()
-        mock_input.value = "scribble for the agent"
+        mock_textarea = mock.Mock()
+        mock_textarea.text = "scribble for the agent"
 
         def query_one(selector, cls=None):
             if "login-agent" in selector:
                 return mock_select
-            return mock_input
+            return mock_textarea
 
         screen.query_one = query_one
 
@@ -245,13 +245,13 @@ class TestTaskLaunchScreen:
 
         mock_select = mock.Mock()
         mock_select.value = "bash"
-        mock_input = mock.Mock()
-        mock_input.value = "   "
+        mock_textarea = mock.Mock()
+        mock_textarea.text = "   "
 
         def query_one(selector, cls=None):
             if "login-agent" in selector:
                 return mock_select
-            return mock_input
+            return mock_textarea
 
         screen.query_one = query_one
 
@@ -711,10 +711,12 @@ class TestTaskLaunchScreenNamePropagation:
 
         mock_select = mock.Mock()
         mock_select.value = "vibe"
-        mock_input = mock.Mock()
-        mock_input.value = "refactor auth"
+        mock_textarea = mock.Mock()
+        mock_textarea.text = "refactor auth"
 
-        screen.query_one = lambda sel, cls=None: mock_select if "login-agent" in sel else mock_input
+        screen.query_one = lambda sel, cls=None: (
+            mock_select if "login-agent" in sel else mock_textarea
+        )
 
         screen._do_login()
         result = screen.dismiss.call_args[0][0]
@@ -729,10 +731,12 @@ class TestTaskLaunchScreenNamePropagation:
 
         mock_select = mock.Mock()
         mock_select.value = "bash"
-        mock_input = mock.Mock()
-        mock_input.value = ""
+        mock_textarea = mock.Mock()
+        mock_textarea.text = ""
 
-        screen.query_one = lambda sel, cls=None: mock_select if "login-agent" in sel else mock_input
+        screen.query_one = lambda sel, cls=None: (
+            mock_select if "login-agent" in sel else mock_textarea
+        )
 
         screen._do_login()
         result = screen.dismiss.call_args[0][0]


### PR DESCRIPTION
- Put prompt TextArea first, then agent dropdown, then buttons
- Ctrl+Enter inserts newline in prompt
- Enter submits form (presses Login) when container ready
- Tab moves focus between widgets (default behavior)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Task launch prompt now supports multiline input, autofocuses on open, and uses improved keyboard behavior: Ctrl+Enter inserts a newline; Enter submits only when the launcher is ready.
* **Tests**
  * Updated automated tests to validate multiline prompt behavior, newline insertion, conditional Enter submission, and task-name/launch outcomes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/terok-ai/terok/pull/976?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->