### PR TITLE
fix(tui): instant CLI-task launch dialog with lazy agent dropdown

### DIFF
--- a/src/terok/tui/screens.py
+++ b/src/terok/tui/screens.py
@@ -1192,6 +1192,26 @@ class TaskCreateScreen(screen.ModalScreen["tuple[str, str] | None"]):
 # ---------------------------------------------------------------------------
 
 
+if TextArea is not None:
+
+    class _SubmittablePromptArea(TextArea):
+        """TextArea where Enter bubbles up to the parent screen for submission.
+
+        Textual's stock TextArea consumes ``enter`` in its ``_on_key`` (calls
+        ``event.stop()`` and inserts ``\\n``), which prevents an enclosing
+        screen from treating Enter as form submit.  This subclass forwards
+        ``enter`` and ``ctrl+enter`` upstream untouched — the host screen's
+        ``on_key`` distinguishes them (Enter submits, Ctrl+Enter inserts).
+        """
+
+        async def _on_key(self, event: events.Key) -> None:
+            if event.key in {"enter", "ctrl+enter"}:
+                return
+            await super()._on_key(event)
+else:  # pragma: no cover - stub TextArea in test envs
+    _SubmittablePromptArea = TextArea  # type: ignore[assignment,misc]
+
+
 class TaskLaunchScreen(screen.ModalScreen["tuple[str, str, str, str, str, str | None] | None"]):
     """Post-creation modal for CLI tasks: agent selection + optional prompt.
 
@@ -1257,9 +1277,13 @@ class TaskLaunchScreen(screen.ModalScreen["tuple[str, str, str, str, str, str | 
         """Create the launch screen with container context and default agent.
 
         *installed* is the set of agents present in the project's L1 image
-        (from the ``ai.terok.agents`` label).  When provided and non-empty,
-        the agent dropdown only lists those agents.  ``None`` or empty means
-        no filtering — every known provider is shown.
+        (from the ``ai.terok.agents`` label).  ``None`` means the lookup is
+        still in flight — the agent dropdown renders disabled with only
+        ``bash`` as a placeholder until the caller invokes
+        [`set_installed`][terok.tui.screens.TaskLaunchScreen.set_installed]
+        with the resolved set.  A non-empty frozenset filters the dropdown
+        to those agents; an empty frozenset means no filter (legacy /
+        unlabeled images) — every known provider is shown.
         """
         super().__init__()
         self._container_name = container_name
@@ -1279,25 +1303,28 @@ class TaskLaunchScreen(screen.ModalScreen["tuple[str, str, str, str, str, str | 
 
     def compose(self) -> ComposeResult:
         """Build prompt input, agent selector, status, and action buttons."""
-        from terok.lib.integrations.executor import AGENT_PROVIDERS
-
         with Vertical(id="launch-dialog") as dialog:
             yield Static("Status: Starting container\u2026", id="launch-status")
 
             # Prompt input first (multiline TextArea with Ctrl+Enter for newline)
-            yield TextArea(placeholder="Initial prompt (optional)", id="launch-prompt")
+            yield _SubmittablePromptArea(
+                placeholder="Initial prompt (optional)", id="launch-prompt"
+            )
 
             # bash is always offered (login shell); the rest are filtered by
-            # what's installed in the project's L1 image.
-            choices: list[tuple[str, str]] = [("bash", "bash")]
-            for name in _visible_providers(self._installed):
-                p = AGENT_PROVIDERS[name]
-                choices.append((p.label, p.name))
-
-            # Validate default_login against available choices; fall back to "bash"
+            # what's installed in the project's L1 image \u2014 populated lazily
+            # by ``set_installed`` once the (slow) image inspect returns.
+            loading = self._installed is None
+            choices = self._build_agent_choices()
             valid_values = {v for _, v in choices}
             login_value = self._default_login if self._default_login in valid_values else "bash"
-            yield Select(choices, value=login_value, id="login-agent")
+            yield Select(
+                choices,
+                value=login_value,
+                id="login-agent",
+                disabled=loading,
+                prompt="Loading agents\u2026" if loading else "Select an agent",
+            )
 
             with Horizontal(id="launch-buttons"):
                 if self._console_entry is not None:
@@ -1306,6 +1333,45 @@ class TaskLaunchScreen(screen.ModalScreen["tuple[str, str, str, str, str, str | 
                 yield Button("Login", id="btn-login", variant="primary", disabled=True)
         dialog.border_title = f"CLI Task {self._task_id} ({self._task_name})"
         dialog.border_subtitle = "Esc to dismiss"
+
+    def _build_agent_choices(self) -> list[tuple[str, str]]:
+        """Build the (label, value) list for the agent Select.
+
+        Returns only ``bash`` while the installed-agents lookup is in
+        flight (``_installed is None``); once populated, prepends ``bash``
+        to the visible providers.
+        """
+        from terok.lib.integrations.executor import AGENT_PROVIDERS
+
+        choices: list[tuple[str, str]] = [("bash", "bash")]
+        if self._installed is None:
+            return choices
+        for name in _visible_providers(self._installed):
+            p = AGENT_PROVIDERS[name]
+            choices.append((p.label, p.name))
+        return choices
+
+    def set_installed(self, installed: frozenset[str]) -> None:
+        """Populate the agent dropdown once the background lookup finishes.
+
+        Replaces the placeholder ``bash``-only choice list with the real
+        set of installed agents, restores the configured *default_login*
+        if it's now selectable, and enables the dropdown.  Safe to call
+        before ``compose`` has run \u2014 in that case it just updates state
+        and the dropdown renders enabled on first mount.
+        """
+        self._installed = installed
+        try:
+            select = self.query_one("#login-agent", Select)
+        except Exception:  # pragma: no cover - compose hasn't run yet
+            return
+        choices = self._build_agent_choices()
+        select.set_options(choices)
+        valid_values = {v for _, v in choices}
+        if self._default_login in valid_values:
+            select.value = self._default_login
+        select.prompt = "Select an agent"
+        select.disabled = False
 
     def on_mount(self) -> None:
         """Start polling for container readiness and focus the prompt input."""

--- a/src/terok/tui/screens.py
+++ b/src/terok/tui/screens.py
@@ -1367,9 +1367,11 @@ class TaskLaunchScreen(screen.ModalScreen["tuple[str, str, str, str, str, str | 
             return
         choices = self._build_agent_choices()
         select.set_options(choices)
+        # ``set_options`` resets the value; pick the configured login if it's
+        # still available, else fall back to ``bash`` (always in choices) so
+        # the dropdown is never left blank.
         valid_values = {v for _, v in choices}
-        if self._default_login in valid_values:
-            select.value = self._default_login
+        select.value = self._default_login if self._default_login in valid_values else "bash"
         select.prompt = "Select an agent"
         select.disabled = False
 

--- a/src/terok/tui/task_actions.py
+++ b/src/terok/tui/task_actions.py
@@ -207,6 +207,11 @@ class TaskActionsMixin(_MixinBase):
         The container start runs as a captured ConsoleLog entry — it
         stays in the background; the launch modal's "Show log" button is
         the only thing that foregrounds it.
+
+        The launch screen is pushed *immediately* with a placeholder
+        (loading) agent dropdown; the slow ``installed_agents`` lookup
+        runs in a worker and fills the dropdown when it returns.  This
+        keeps the prompt TextArea instantly typeable.
         """
         pid = self.current_project_id
         if not pid:
@@ -238,37 +243,54 @@ class TaskActionsMixin(_MixinBase):
             on_complete=_on_done,
         )
 
-        # Resolve default login agent: project → global → "bash"
+        # ``load_project`` is a fast file read, so it stays inline — that
+        # gives the launch screen its default login agent without delaying
+        # the push.  The slow ``installed_agents`` lookup (podman inspect)
+        # is offloaded to a worker so the screen surfaces immediately.
         default_login = "bash"
-        installed: frozenset[str] | None = None
+        project = None
         try:
             project = load_project(pid)
             default_login = project.default_login or "bash"
-            # podman inspect would block the event loop; offload it.
-            import asyncio
-
-            from ..lib.api import installed_agents_for_project
-
-            installed = await asyncio.to_thread(installed_agents_for_project, project)
         except (SystemExit, Exception) as exc:
             self._log_debug(
-                f"_action_login: project/agents lookup failed for {pid!r}; "
+                f"_start_cli_task_background: project lookup failed for {pid!r}; "
                 f"falling back to bash. {exc}"
             )
 
-        await self.push_screen(
-            TaskLaunchScreen(
-                container_name=cname,
-                project_id=pid,
-                task_id=task_id,
-                task_name=name,
-                default_login=default_login,
-                installed=installed,
-                console_entry=console_entry,
-            ),
-            self._on_launch_screen_result,
+        launch_screen = TaskLaunchScreen(
+            container_name=cname,
+            project_id=pid,
+            task_id=task_id,
+            task_name=name,
+            default_login=default_login,
+            installed=None,  # None = still loading; populated by the worker
+            console_entry=console_entry,
         )
+
+        if project is not None:
+            self.run_worker(self._fill_installed_agents(launch_screen, project))
+        else:
+            launch_screen.set_installed(frozenset())
+
+        await self.push_screen(launch_screen, self._on_launch_screen_result)
         await self.refresh_tasks()
+
+    async def _fill_installed_agents(self, launch_screen: TaskLaunchScreen, project: Any) -> None:
+        """Resolve installed agents off-thread and feed them to *launch_screen*."""
+        import asyncio
+
+        from ..lib.api import installed_agents_for_project
+
+        try:
+            installed = await asyncio.to_thread(installed_agents_for_project, project)
+        except (SystemExit, Exception) as exc:
+            self._log_debug(
+                f"_fill_installed_agents: agents lookup failed for project "
+                f"{getattr(project, 'id', '?')!r}; dropdown will show all. {exc}"
+            )
+            installed = frozenset()
+        launch_screen.set_installed(installed)
 
     async def _on_launch_screen_result(
         self, result: "tuple[str, str, str, str, str, str | None] | None"

--- a/tests/unit/tui/test_detail_screens.py
+++ b/tests/unit/tui/test_detail_screens.py
@@ -111,6 +111,7 @@ def make_creation_app(app_class: type) -> object:
     instance.refresh_tasks = mock.AsyncMock()
     instance.push_screen = fake_push_screen
     instance._mark_launching = mock.Mock()
+    instance.run_worker = mock.Mock()
     return instance
 
 

--- a/tests/unit/tui/test_new_task_flow.py
+++ b/tests/unit/tui/test_new_task_flow.py
@@ -394,6 +394,98 @@ class TestTaskLaunchScreen:
 
 
 # ---------------------------------------------------------------------------
+# TaskLaunchScreen — lazy agent dropdown
+# ---------------------------------------------------------------------------
+
+
+class TestTaskLaunchScreenLazyAgents:
+    """Tests for the loading → loaded transition on the agent Select."""
+
+    def test_build_agent_choices_loading_returns_bash_only(self) -> None:
+        screens, _ = import_screens()
+        screen = screens.TaskLaunchScreen(
+            container_name="c", project_id="p", task_id="1", installed=None
+        )
+        assert screen._build_agent_choices() == [("bash", "bash")]
+
+    def test_build_agent_choices_loaded_prepends_bash_to_providers(self) -> None:
+        from terok.lib.integrations.executor import AGENT_PROVIDERS
+
+        screens, _ = import_screens()
+        # Filter to a single known provider so the assertion is stable.
+        target = next(iter(AGENT_PROVIDERS))
+        screen = screens.TaskLaunchScreen(
+            container_name="c",
+            project_id="p",
+            task_id="1",
+            installed=frozenset({target}),
+        )
+        choices = screen._build_agent_choices()
+        assert choices[0] == ("bash", "bash")
+        assert (AGENT_PROVIDERS[target].label, target) in choices
+
+    def test_set_installed_populates_select_and_restores_default(self) -> None:
+        from terok.lib.integrations.executor import AGENT_PROVIDERS
+
+        screens, _ = import_screens()
+        target = next(iter(AGENT_PROVIDERS))
+        screen = screens.TaskLaunchScreen(
+            container_name="c",
+            project_id="p",
+            task_id="1",
+            default_login=target,
+            installed=None,
+        )
+        mock_select = mock.Mock()
+        mock_select.disabled = True
+        screen.query_one = mock.Mock(return_value=mock_select)
+
+        screen.set_installed(frozenset({target}))
+
+        assert screen._installed == frozenset({target})
+        mock_select.set_options.assert_called_once()
+        passed_choices = mock_select.set_options.call_args[0][0]
+        assert ("bash", "bash") in passed_choices
+        assert (AGENT_PROVIDERS[target].label, target) in passed_choices
+        assert mock_select.value == target
+        assert mock_select.prompt == "Select an agent"
+        assert mock_select.disabled is False
+
+    def test_set_installed_falls_back_to_bash_when_default_unavailable(self) -> None:
+        """If the configured default_login isn't installed, the dropdown still picks bash."""
+        screens, _ = import_screens()
+        screen = screens.TaskLaunchScreen(
+            container_name="c",
+            project_id="p",
+            task_id="1",
+            default_login="not-installed-agent",
+            installed=None,
+        )
+        mock_select = mock.Mock()
+        screen.query_one = mock.Mock(return_value=mock_select)
+
+        # Empty frozenset means "no filter" → all providers visible, but
+        # ``not-installed-agent`` isn't a registered provider, so the
+        # fallback should kick in.
+        screen.set_installed(frozenset())
+
+        assert mock_select.value == "bash"
+        assert mock_select.disabled is False
+
+    def test_set_installed_returns_silently_when_select_missing(self) -> None:
+        """Calling set_installed before compose mounted the Select is a no-op."""
+        screens, _ = import_screens()
+        screen = screens.TaskLaunchScreen(
+            container_name="c", project_id="p", task_id="1", installed=None
+        )
+        screen.query_one = mock.Mock(side_effect=RuntimeError("not mounted"))
+        # Must not raise.
+        screen.set_installed(frozenset())
+        # State is still updated even if the Select can't be reached.
+        assert screen._installed == frozenset()
+
+
+# ---------------------------------------------------------------------------
 # Launch command shape — prompt travels via the on-disk file, not as a CLI arg
 # ---------------------------------------------------------------------------
 
@@ -658,6 +750,89 @@ class TestTaskLaunchScreenCompose:
         assert dialog is not None
         assert dialog.border_title == "CLI Task 7 (7)"
 
+    def test_compose_renders_select_disabled_while_loading(self) -> None:
+        """While ``_installed is None`` the agent Select is rendered disabled."""
+        screens, _ = import_screens()
+        screen = screens.TaskLaunchScreen(
+            container_name="c", project_id="p", task_id="1", installed=None
+        )
+        widgets = list(screen.compose())
+        selects = [w for w in widgets if isinstance(w, screens.Select)]
+        assert selects, "compose() yielded no Select widget"
+        sel = selects[0]
+        assert sel._stub_kwargs.get("disabled") is True
+        assert sel._stub_kwargs.get("prompt") == "Loading agents…"
+        # In the loading state only bash is in choices.
+        choices = sel._stub_args[0]
+        assert choices == [("bash", "bash")]
+
+    def test_compose_renders_select_enabled_when_loaded(self) -> None:
+        """Once ``_installed`` is set, the dropdown renders enabled with providers."""
+        from terok.lib.integrations.executor import AGENT_PROVIDERS
+
+        screens, _ = import_screens()
+        target = next(iter(AGENT_PROVIDERS))
+        screen = screens.TaskLaunchScreen(
+            container_name="c",
+            project_id="p",
+            task_id="1",
+            installed=frozenset({target}),
+        )
+        widgets = list(screen.compose())
+        selects = [w for w in widgets if isinstance(w, screens.Select)]
+        sel = selects[0]
+        assert sel._stub_kwargs.get("disabled") is False
+        assert sel._stub_kwargs.get("prompt") == "Select an agent"
+        choices = sel._stub_args[0]
+        assert ("bash", "bash") in choices
+        assert (AGENT_PROVIDERS[target].label, target) in choices
+
+
+# ---------------------------------------------------------------------------
+# _SubmittablePromptArea — Enter / Ctrl+Enter bubble up instead of inserting
+# ---------------------------------------------------------------------------
+
+
+class TestSubmittablePromptArea:
+    """Verify the prompt TextArea forwards Enter/Ctrl+Enter to the parent screen."""
+
+    def test_on_key_returns_early_on_enter(self) -> None:
+        screens, _ = import_screens()
+        area = screens._SubmittablePromptArea()
+        event = mock.Mock()
+        event.key = "enter"
+        # Should return without stopping the event or invoking ``super()._on_key``
+        # (which would explode against the test-stub TextArea).
+        asyncio.run(area._on_key(event))
+        event.stop.assert_not_called()
+        event.prevent_default.assert_not_called()
+
+    def test_on_key_returns_early_on_ctrl_enter(self) -> None:
+        screens, _ = import_screens()
+        area = screens._SubmittablePromptArea()
+        event = mock.Mock()
+        event.key = "ctrl+enter"
+        asyncio.run(area._on_key(event))
+        event.stop.assert_not_called()
+        event.prevent_default.assert_not_called()
+
+    def test_on_key_delegates_other_keys_to_super(self) -> None:
+        """Non-Enter keys fall through to ``TextArea._on_key`` unchanged."""
+        screens, _ = import_screens()
+        area = screens._SubmittablePromptArea()
+        event = mock.Mock()
+        event.key = "a"
+
+        called: list[Any] = []
+
+        async def fake_parent(self: Any, ev: Any) -> None:
+            called.append(ev)
+
+        with mock.patch.object(screens.TextArea, "_on_key", fake_parent, create=True):
+            asyncio.run(area._on_key(event))
+
+        assert called == [event]
+
 
 # ---------------------------------------------------------------------------
 # _action_login uses _login_title
@@ -898,6 +1073,109 @@ class TestStartCliTaskBackgroundPassesName:
         assert launch_screen._task_id == "7"
         assert launch_screen._project_id == "proj1"
         assert launch_screen._default_login == "claude"
+        # Launch screen is pushed in the "loading" state so the prompt
+        # TextArea is typeable immediately — the agent dropdown fills in
+        # when the worker resolves _fill_installed_agents.
+        assert launch_screen._installed is None
+        # The worker for the agents lookup was kicked off.
+        instance.run_worker.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# _start_cli_task_background — load_project failure path
+# ---------------------------------------------------------------------------
+
+
+class TestStartCliTaskBackgroundLoadFailure:
+    """When ``load_project`` fails, the launch screen still surfaces immediately.
+
+    The agent dropdown is finalised with an empty (no-filter) installed set
+    in-line — no worker — and a debug line records the failure.
+    """
+
+    def test_launch_screen_finalised_when_load_project_fails(self) -> None:
+        _, app_class = import_app()
+        instance = app_class()
+        instance.current_project_id = "proj1"
+        instance._last_selected_tasks = {}
+        instance._save_selection_state = mock.Mock()
+        instance.notify = mock.Mock()
+        instance.dispatch_console_action = mock.Mock()
+        instance.push_screen = mock.AsyncMock()
+        instance.refresh_tasks = mock.AsyncMock()
+        instance._mark_launching = mock.Mock()
+        instance.run_worker = mock.Mock()
+        instance._log_debug = mock.Mock()
+
+        action_globals = app_class._start_cli_task_background.__globals__
+        with mock.patch.dict(
+            action_globals,
+            {
+                "task_new": mock.Mock(return_value="9"),
+                "load_project": mock.Mock(side_effect=RuntimeError("boom")),
+                "container_name": lambda *a: "terok-proj1-cli-9",
+            },
+        ):
+            run(app_class._start_cli_task_background(instance, "fix-thing"))
+
+        # Failure was logged via _log_debug (the project lookup failure path).
+        instance._log_debug.assert_called()
+        # No worker — the helper short-circuits to set_installed(frozenset()).
+        instance.run_worker.assert_not_called()
+        # Launch screen was pushed with installed already resolved (empty set).
+        instance.push_screen.assert_awaited_once()
+        launch_screen = instance.push_screen.call_args[0][0]
+        assert launch_screen._installed == frozenset()
+        assert launch_screen._default_login == "bash"
+
+
+# ---------------------------------------------------------------------------
+# _fill_installed_agents — off-thread worker that feeds set_installed
+# ---------------------------------------------------------------------------
+
+
+class TestFillInstalledAgents:
+    """The worker that resolves installed agents and pushes them into the screen."""
+
+    def test_resolves_and_feeds_set_installed(self) -> None:
+        _, app_class = import_app()
+        instance = app_class()
+        instance._log_debug = mock.Mock()
+
+        fake_project = mock.Mock()
+        launch_screen = mock.Mock()
+
+        # The helper does ``from ..lib.api import installed_agents_for_project``
+        # at call time, so patch the symbol on the source module.
+        with mock.patch(
+            "terok.lib.api.installed_agents_for_project",
+            return_value=frozenset({"claude"}),
+        ):
+            run(app_class._fill_installed_agents(instance, launch_screen, fake_project))
+
+        launch_screen.set_installed.assert_called_once_with(frozenset({"claude"}))
+        instance._log_debug.assert_not_called()
+
+    def test_failure_falls_back_to_empty_and_logs(self) -> None:
+        _, app_class = import_app()
+        instance = app_class()
+        instance._log_debug = mock.Mock()
+
+        fake_project = mock.Mock()
+        fake_project.id = "proj1"
+        launch_screen = mock.Mock()
+
+        with mock.patch(
+            "terok.lib.api.installed_agents_for_project",
+            side_effect=RuntimeError("podman exploded"),
+        ):
+            run(app_class._fill_installed_agents(instance, launch_screen, fake_project))
+
+        launch_screen.set_installed.assert_called_once_with(frozenset())
+        instance._log_debug.assert_called_once()
+        msg = instance._log_debug.call_args[0][0]
+        assert "podman exploded" in msg
+        assert "proj1" in msg
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/tui/test_new_task_flow.py
+++ b/tests/unit/tui/test_new_task_flow.py
@@ -875,6 +875,7 @@ class TestStartCliTaskBackgroundPassesName:
         instance.push_screen = mock.AsyncMock()
         instance.refresh_tasks = mock.AsyncMock()
         instance._mark_launching = mock.Mock()
+        instance.run_worker = mock.Mock()
 
         fake_project = mock.Mock()
         fake_project.default_login = "claude"


### PR DESCRIPTION
## Summary

Two small fixes to the CLI task launch flow introduced in #976:

- **No more main-screen flash between the name dialog and the launch dialog.** `_start_cli_task_background` now pushes `TaskLaunchScreen` immediately, rendering the agent `Select` disabled with a "Loading agents…" placeholder. The slow `installed_agents_for_project` (podman inspect) runs in a worker; when it returns, `TaskLaunchScreen.set_installed()` populates the dropdown and enables it. Login is still gated on container readiness, so the dropdown becoming editable mid-wait is harmless.
- **Enter in the prompt now submits; Ctrl+Enter inserts a newline.** Stock `TextArea._on_key` consumes `enter` with `event.stop()` before the Screen handler runs, so previously both keys ended up inserting `\n`. A small `_SubmittablePromptArea` subclass forwards `enter` and `ctrl+enter` upstream untouched; the existing `TaskLaunchScreen.on_key` then routes Enter → Login and Ctrl+Enter → newline.

Also picked up #974's `_log_debug` pattern on the failure paths in `_start_cli_task_background` / `_fill_installed_agents`.

## Test plan

- [x] `make lint`, `make tach`, `make lint-imports` clean
- [x] `poetry run pytest tests/unit/ --no-cov` — 2462 passed
- [ ] Manual: open the new-CLI-task flow in the TUI, confirm the name dialog → launch dialog transition no longer flashes the main screen
- [ ] Manual: type a prompt with Enter (submits when container ready) and Ctrl+Enter (inserts newline)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Task launch modal shows "Loading agents..." with a disabled agent selector (fallback to bash) and preserves multiline prompt submit behavior with Enter/Ctrl+Enter.
  * Agent selector repopulates and applies the configured default login once discovery completes.

* **Bug Fixes**
  * Agent discovery now runs in background so UI remains responsive; failures log debug info and fall back to a safe empty/bash state.

* **Tests**
  * Tests expanded to cover lazy agent loading, prompt submit keys, launch flow behaviors, and worker mocking.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/terok-ai/terok/pull/979?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->