### PR TITLE
feat(tui): surface pending bg workers on quit; trim title to 'Terok <ver>'

### DIFF
--- a/src/terok/tui/app.py
+++ b/src/terok/tui/app.py
@@ -360,9 +360,9 @@ if _HAS_TEXTUAL:
             display_ver = _short_version(version)
 
             if branch_name:
-                title = f"Terok TUI v{display_ver} [{branch_name}]"
+                title = f"Terok {display_ver} [{branch_name}]"
             else:
-                title = f"Terok TUI v{display_ver}"
+                title = f"Terok {display_ver}"
 
             self.title = title
             self.sub_title = f"{getpass.getuser()}@{socket.gethostname()}"
@@ -1392,13 +1392,33 @@ if _HAS_TEXTUAL:
             )
 
         async def action_quit(self) -> None:
-            """Exit the TUI cleanly."""
+            """Exit the TUI cleanly.
+
+            If real-work workers (task delete, image build, etc.) are
+            still in flight after the pollers have been torn down, surface
+            them in Textual's exit message so the user knows the terminal
+            isn't hung — the process is just waiting for the threads to
+            drain before returning the prompt.
+            """
             self._stop_upstream_polling()
             self._stop_container_status_polling()
             self._stop_gate_server_polling()
             if self._askpass_service is not None:
                 await self._askpass_service.stop()
-            self.exit()
+
+            pending = [
+                w for w in self.workers if w.state in (WorkerState.PENDING, WorkerState.RUNNING)
+            ]
+            if pending:
+                groups = sorted({w.group for w in pending if w.group})
+                suffix = f" ({', '.join(groups)})" if groups else ""
+                self.exit(
+                    message=(
+                        f"Exiting. Waiting for {len(pending)} background task(s) to finish{suffix}."
+                    )
+                )
+            else:
+                self.exit()
 
         async def ensure_askpass_service(self) -> AskpassService:
             """Return the running [`AskpassService`][terok.tui.app.AskpassService], starting it on first use.

--- a/src/terok/tui/app.py
+++ b/src/terok/tui/app.py
@@ -2,7 +2,6 @@
 
 # SPDX-FileCopyrightText: 2025 Jiri Vyskocil
 # SPDX-License-Identifier: Apache-2.0
-# SPDX-License-Identifier: Apache-2.0
 
 """Terok TUI application built on Textual."""
 

--- a/tests/unit/tui/test_app_quit.py
+++ b/tests/unit/tui/test_app_quit.py
@@ -1,0 +1,90 @@
+# SPDX-FileCopyrightText: 2026 Jiri Vyskocil
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for [`TerokTUI.action_quit`][terok.tui.app] background-worker reporting.
+
+Pins the user-visible bit of the quit flow: if real-work workers (task
+delete, image build, etc.) are still in flight after the polling loops
+are torn down, surface a Textual exit message so the user knows the
+terminal isn't hung — it's just waiting for threads to drain before
+returning the prompt.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from textual.worker import WorkerState
+
+from terok.tui.app import TerokTUI
+
+
+def _worker(state: WorkerState, group: str = "") -> SimpleNamespace:
+    """Build a fake [`Worker`][textual.worker.Worker] just enough for the quit check."""
+    return SimpleNamespace(state=state, group=group, name="fake")
+
+
+@pytest.fixture
+def quit_stub() -> SimpleNamespace:
+    """Tiny duck for ``TerokTUI.action_quit`` — just the attrs the method touches."""
+    return SimpleNamespace(
+        workers=[],
+        _askpass_service=None,
+        _stop_upstream_polling=MagicMock(),
+        _stop_container_status_polling=MagicMock(),
+        _stop_gate_server_polling=MagicMock(),
+        exit=MagicMock(),
+    )
+
+
+class TestActionQuit:
+    """``action_quit`` tears down polling, then exits — with a message iff work is pending."""
+
+    @pytest.mark.asyncio
+    async def test_silent_exit_when_no_workers_pending(self, quit_stub: SimpleNamespace) -> None:
+        """No in-flight workers ⇒ plain ``exit()`` with no message."""
+        await TerokTUI.action_quit(quit_stub)
+        quit_stub.exit.assert_called_once_with()
+
+    @pytest.mark.asyncio
+    async def test_finished_workers_dont_trigger_message(self, quit_stub: SimpleNamespace) -> None:
+        """Workers in terminal states (success / error / cancelled) are not in-flight."""
+        quit_stub.workers = [
+            _worker(WorkerState.SUCCESS, "task-delete"),
+            _worker(WorkerState.ERROR, "image-build"),
+            _worker(WorkerState.CANCELLED, "container-state"),
+        ]
+        await TerokTUI.action_quit(quit_stub)
+        quit_stub.exit.assert_called_once_with()
+
+    @pytest.mark.asyncio
+    async def test_pending_work_surfaces_in_exit_message(self, quit_stub: SimpleNamespace) -> None:
+        """One ``RUNNING`` delete ⇒ a count-and-group exit message Textual prints after cleanup."""
+        quit_stub.workers = [_worker(WorkerState.RUNNING, "task-delete")]
+        await TerokTUI.action_quit(quit_stub)
+        message = quit_stub.exit.call_args.kwargs["message"]
+        assert "1 background task" in message
+        assert "task-delete" in message
+
+    @pytest.mark.asyncio
+    async def test_multiple_groups_listed_sorted(self, quit_stub: SimpleNamespace) -> None:
+        """Mixed in-flight groups appear together, sorted, in a single ``(group, group)`` suffix."""
+        quit_stub.workers = [
+            _worker(WorkerState.RUNNING, "task-delete"),
+            _worker(WorkerState.PENDING, "image-build"),
+            _worker(WorkerState.RUNNING, "task-delete"),
+        ]
+        await TerokTUI.action_quit(quit_stub)
+        message = quit_stub.exit.call_args.kwargs["message"]
+        assert "3 background task" in message
+        assert "(image-build, task-delete)" in message
+
+    @pytest.mark.asyncio
+    async def test_askpass_service_stopped_before_exit(self, quit_stub: SimpleNamespace) -> None:
+        """A bound askpass service must be torn down before exit (no orphaned socket)."""
+        quit_stub._askpass_service = SimpleNamespace(stop=AsyncMock())
+        await TerokTUI.action_quit(quit_stub)
+        quit_stub._askpass_service.stop.assert_awaited_once()
+        quit_stub.exit.assert_called_once()

--- a/tests/unit/tui/test_app_title.py
+++ b/tests/unit/tui/test_app_title.py
@@ -33,9 +33,9 @@ class TestUpdateTitle:
     """The title carries version + branch; ``sub_title`` carries ``user@host``."""
 
     def test_title_includes_version_and_branch(self, title_stub: SimpleNamespace) -> None:
-        """Title is unchanged from pre-#683 — version + branch in brackets."""
+        """Title is ``Terok <version> [<branch>]`` — bare version, no ``TUI`` prefix or ``v`` sigil."""
         TerokTUI._update_title(title_stub)
-        assert title_stub.title == "Terok TUI v1.2.3 [feat/foo]"
+        assert title_stub.title == "Terok 1.2.3 [feat/foo]"
 
     def test_sub_title_carries_user_at_host(self, title_stub: SimpleNamespace) -> None:
         """``sub_title`` is ``user@host`` — Textual renders that on the right."""
@@ -48,5 +48,5 @@ class TestUpdateTitle:
         """No branch → no brackets; sub_title is unaffected."""
         monkeypatch.setattr(app_mod, "_get_version_info", lambda: ("1.2.3", ""))
         TerokTUI._update_title(title_stub)
-        assert title_stub.title == "Terok TUI v1.2.3"
+        assert title_stub.title == "Terok 1.2.3"
         assert title_stub.sub_title == "strazce@spark"


### PR DESCRIPTION
## Summary

Two small TUI nuisances.

### Quit-time \"is the terminal hung?\"

`action_quit` previously called `self.exit()` immediately after tearing down the polling timers.  If a real-work worker (task delete, image build, …) was still in flight on a thread, the Textual app closed but the Python process kept running until the thread finished — and the user saw a dead terminal with no prompt back.

Now `action_quit` checks `self.workers` for any `PENDING`/`RUNNING` worker and, if present, passes a Textual exit `message=` so the user sees:

```
Exiting. Waiting for 1 background task(s) to finish (task-delete).
```

…printed after the curses cleanup but before the process returns control to the shell.  Pollers are stopped first so the message only surfaces the work the user actually cares about (most often a task delete).

### Title-bar tidy

`Terok TUI vX.Y.Z [branch]` → `Terok X.Y.Z [branch]`.  The window is obviously a TUI; the `v` sigil is noise.

## Test plan

- [x] `make check` clean (2602 tests; +5 for `test_app_quit.py`)
- [x] New `test_app_quit.py` covers: silent exit on no workers, terminal-state workers don't trigger the message, single in-flight worker surfaces in the message, multiple groups listed and sorted, askpass service torn down before exit
- [x] `test_app_title.py` updated for the new title format

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Simplified window title format to "Terok {version}" and include branch info when present.
  * Quit flow now reports pending background-task count and involved worker groups when tasks are in-flight; exits silently when none remain. Ensures any password/askpass service is stopped before exit.

* **Tests**
  * Added unit tests covering title format and detailed quit behavior, including multiple groups and service shutdown ordering.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/terok-ai/terok/pull/987?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->