### PR TITLE
chore(pyproject): pin static version below packages so dynver build is a no-op

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,6 @@ terok-clearance = "terok.tui.clearance_screen:main"
 terok-askpass = "terok.tui.askpass:main"
 
 [tool.poetry]
-version = "0.7.8"
 classifiers = [
     "Development Status :: 3 - Alpha",
     "Environment :: Console",
@@ -77,6 +76,7 @@ include = [
   { path = "docs/*.md" },
   { path = "examples/**" },
 ]
+version = "0.7.8"
 
 [tool.poetry.group.dev.dependencies]
 pydevd-pycharm = "262.4852.46"


### PR DESCRIPTION
## Summary

`poetry-dynamic-versioning` rewrites `pyproject.toml` at every build and restores the `version` key at the bottom of `[tool.poetry]`, not where it originally sat. Running `pipx install .` (or any `poetry build`) from a clean clone therefore left a dirty worktree:

```diff
 [tool.poetry]
-version = "X.Y.Z"
 classifiers = [ ... ]
 packages = [ ... ]
+version = "X.Y.Z"
```

Pre-positioning `version` where dynver restores it makes the build idempotent against the file. Verified locally: `cp pyproject.toml /tmp/before && poetry build && diff /tmp/before pyproject.toml` is empty.

## Release-script impact

terok-warden/terok-toolbox bumps this key on tag day. The new location is still inside `[tool.poetry]`, so a regex like `^version = "..."` keeps matching. If the script looks at line number rather than section context, it will need a one-line update.

## Test plan

- [x] `poetry build` leaves `pyproject.toml` unchanged.
- [ ] Same on consumer side via `pipx install .` from clean clone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)