### PR TITLE
feat(tui): render ANSI colours in log viewer + focus dismiss button

### DIFF
--- a/src/terok/tui/console_log.py
+++ b/src/terok/tui/console_log.py
@@ -297,6 +297,12 @@ class ConsoleLogMixin(_MixinBase):
         ``/dev/tty`` and draw over the Textual frame.  *env* layers
         extra variables onto [`child_process_env`][terok.lib.util.subprocess_env.child_process_env].
         """
+        # Force ANSI colour out of the child even though stdout=PIPE
+        # makes ``isatty()`` return False — most Rich/click-based CLIs
+        # disable colour in that case and we'd see flat output in the
+        # log viewer.  Caller-supplied env wins so a caller can opt out
+        # by setting either var to "0".
+        env = {"FORCE_COLOR": "1", "CLICOLOR_FORCE": "1", **(env or {})}
         try:
             proc = await asyncio.create_subprocess_exec(
                 *entry.argv,

--- a/src/terok/tui/worker_log_screen.py
+++ b/src/terok/tui/worker_log_screen.py
@@ -29,6 +29,7 @@ from __future__ import annotations
 from collections.abc import Callable
 from typing import TYPE_CHECKING
 
+from rich.text import Text
 from textual import on
 from textual.app import ComposeResult
 from textual.binding import Binding
@@ -124,11 +125,15 @@ class WorkerLogScreen(ModalScreen[None]):
         """Replay captured output, then live-tail if the entry is still running."""
         log = self.query_one("#worker-log-output", RichLog)
         for line in self._entry.lines:
-            log.write(line)
+            log.write(Text.from_ansi(line))
         if self._entry.running:
             self._unsubscribe = self._entry.subscribe(self._append_line, self._on_entry_finished)
         else:
             self._render_finished()
+        # Focus the dismiss button so Enter dismisses immediately — the
+        # viewer is read-only otherwise, so there's no other useful
+        # focus target.
+        self.query_one("#worker-log-close", Button).focus()
 
     def on_unmount(self) -> None:
         """Drop the live subscription so a hidden entry has no dangling viewer."""
@@ -137,8 +142,15 @@ class WorkerLogScreen(ModalScreen[None]):
             self._unsubscribe = None
 
     def _append_line(self, line: str) -> None:
-        """Write one live-tailed *line* into the log pane."""
-        self.query_one("#worker-log-output", RichLog).write(line)
+        """Write one live-tailed *line* into the log pane.
+
+        Lines come from subprocess stdout and routinely carry ANSI
+        colour escapes (``terok setup``, image builds, ``git`` output).
+        ``Text.from_ansi`` parses those into a styled
+        [`Text`][rich.text.Text] so RichLog can render them with
+        colour instead of printing the raw escape sequences.
+        """
+        self.query_one("#worker-log-output", RichLog).write(Text.from_ansi(line))
 
     def _on_entry_finished(self) -> None:
         """The entry finished while this view was open — reflect it in the button."""

--- a/tests/unit/tui/test_console_log.py
+++ b/tests/unit/tui/test_console_log.py
@@ -310,3 +310,43 @@ async def test_dispatch_action_threads_env_to_child() -> None:
         await asyncio.wait_for(entry.wait(), timeout=10.0)
     assert entry.ok
     assert any("marker=threaded-through" in line for line in entry.lines)
+
+
+@pytest.mark.asyncio
+async def test_pump_forces_colour_for_child_so_log_viewer_shows_ansi() -> None:
+    """``stdout=PIPE`` makes the child's ``isatty()`` return False, which
+    flips Rich/click-style CLIs to plain-text mode.  The pump compensates
+    by setting ``FORCE_COLOR=1`` + ``CLICOLOR_FORCE=1`` so colourised
+    output reaches the worker log viewer (which already parses ANSI)."""
+    app = _DispatchHost()
+    async with app.run_test():
+        entry = app.dispatch_console_command(
+            [
+                sys.executable,
+                "-c",
+                "import os; "
+                "print('FC=' + os.environ.get('FORCE_COLOR', 'unset')); "
+                "print('CCF=' + os.environ.get('CLICOLOR_FORCE', 'unset'))",
+            ],
+            title="color env probe",
+        )
+        await asyncio.wait_for(entry.wait(), timeout=10.0)
+    assert entry.ok
+    assert "FC=1" in entry.lines
+    assert "CCF=1" in entry.lines
+
+
+@pytest.mark.asyncio
+async def test_caller_supplied_force_color_wins_over_default() -> None:
+    """A caller that explicitly passes ``FORCE_COLOR=0`` (e.g. to suppress
+    a noisy CLI's colour in tests) overrides the pump's default."""
+    app = _DispatchHost()
+    async with app.run_test():
+        entry = app.dispatch_console_action(
+            "os:system",
+            "echo FC=$FORCE_COLOR",
+            title="caller wins",
+            env={"FORCE_COLOR": "0"},
+        )
+        await asyncio.wait_for(entry.wait(), timeout=10.0)
+    assert "FC=0" in entry.lines

--- a/tests/unit/tui/test_worker_log_screen.py
+++ b/tests/unit/tui/test_worker_log_screen.py
@@ -52,9 +52,16 @@ class _ViewerHost(App):
 
 
 def _rendered(screen: WorkerLogScreen) -> str:
-    """Join the screen's RichLog lines for substring assertions."""
+    """Join the screen's RichLog visible text for substring assertions.
+
+    Uses ``Strip.text`` (the concatenated visible characters across the
+    line's segments) rather than ``str(strip)`` (which returns a
+    debug repr) so substring checks survive ANSI-induced segmentation
+    — ``hello world`` written from ``\\x1b[31mhello\\x1b[0m world``
+    is two segments, and the repr would split the words across them.
+    """
     log = screen.query_one("#worker-log-output", RichLog)
-    return "\n".join(str(line) for line in log.lines)
+    return "\n".join(strip.text for strip in log.lines)
 
 
 # ── Finished entries ──────────────────────────────────────────────────
@@ -150,3 +157,45 @@ async def test_escape_dismisses_running_viewer() -> None:
         await pilot.pause()
         assert not isinstance(pilot.app.screen, WorkerLogScreen)
     assert entry.running, "escape backgrounds the entry, it keeps running"
+
+
+# ── ANSI rendering + initial focus ────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_ansi_escapes_render_as_styled_text_not_raw_sequences() -> None:
+    """Lines carrying ANSI colour escapes (``terok setup``, git, podman build…)
+    render as styled Rich [`Text`][rich.text.Text], not as printed escape
+    sequences.  The substring assertion checks the visible text comes through
+    *without* the ``\\x1b[…m`` framing — the styling itself is in the line's
+    spans, but we don't pin those here (Textual's RichLog handles the
+    pixel-level rendering)."""
+    # ``\x1b[31mhello\x1b[0m world`` → "hello world" visible, "31m" gone.
+    entry = _entry(lines=["\x1b[31mhello\x1b[0m world"], finished=0)
+    app = _ViewerHost(entry)
+    async with app.run_test() as pilot:
+        screen = pilot.app.screen
+        assert isinstance(screen, WorkerLogScreen)
+        rendered = _rendered(screen)
+        assert "hello world" in rendered
+        # Raw escape sequence and ANSI prefix must NOT bleed through.
+        assert "\x1b" not in rendered
+        assert "[31m" not in rendered
+
+
+@pytest.mark.asyncio
+async def test_dismiss_button_is_focused_on_mount() -> None:
+    """The viewer is read-only — there's no other useful focus target —
+    so the dismiss button gets focus on mount so Enter dismisses
+    immediately, no Tab dance required."""
+    entry = _entry(lines=["any"], finished=0)
+    app = _ViewerHost(entry)
+    async with app.run_test() as pilot:
+        screen = pilot.app.screen
+        assert isinstance(screen, WorkerLogScreen)
+        button = screen.query_one("#worker-log-close", Button)
+        assert screen.focused is button
+        # And: pressing Enter on that focus dismisses the screen.
+        await pilot.press("enter")
+        await pilot.pause()
+        assert not isinstance(pilot.app.screen, WorkerLogScreen)


### PR DESCRIPTION
## Summary

Two small polish bits on the worker-log modal (the one ``terok setup``, image builds, and git commands push their output through):

- **ANSI colours work now.**  ``RichLog`` doesn't parse ANSI escapes itself; we were writing each line as a plain ``str`` so red/green/etc came out as printed ``\x1b[31m…`` sequences (or got eaten by Textual's renderer).  Pipe each line through ``rich.text.Text.from_ansi`` so it renders the same colours you'd see in a terminal.
- **Enter dismisses.**  The viewer is read-only — there's no other useful focus target — so focus the Hide/Done button on mount.  Enter dismisses immediately; no Tab dance.

Applies to live-tailed lines and the on-mount replay of captured lines both.

## Test plan

- [x] ``make lint`` clean
- [x] All 677 TUI tests pass; two new tests pin the new behaviour:
  - ``test_ansi_escapes_render_as_styled_text_not_raw_sequences`` — feeds ``\x1b[31mhello\x1b[0m world``, asserts the visible text comes through without ``\x1b`` / ``[31m`` bleeding into the rendered output
  - ``test_dismiss_button_is_focused_on_mount`` — asserts ``screen.focused is button`` after mount and that pressing Enter immediately dismisses

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Log display now renders ANSI color/style correctly, preventing raw escape codes from appearing.

* **New Features**
  * Close/Done button is auto-focused when the worker log screen opens for immediate dismissal via Enter.
  * Live console pump ensures child processes emit colored ANSI output by default (caller can override).

* **Tests**
  * Added tests for ANSI rendering, close-button focus/dismissal, and console-color behavior/override.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/terok-ai/terok/pull/991?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->