### PR TITLE
fix(tui): re-running setup from the palette no longer silently no-ops

### DIFF
--- a/src/terok/tui/app.py
+++ b/src/terok/tui/app.py
@@ -503,7 +503,7 @@ if _HAS_TEXTUAL:
                 )
                 raise
 
-        async def _run_setup_flow(self, verdict: SetupVerdict) -> bool:
+        async def _run_setup_flow(self, verdict: SetupVerdict, *, force: bool = False) -> bool:
             """Show the setup screen + worker log; return True if the wizard may follow.
 
             ``True`` covers both "setup completed cleanly" and "verdict
@@ -513,8 +513,14 @@ if _HAS_TEXTUAL:
             failure: the wizard is gated behind a working sandbox stack,
             so chaining into it on a known-broken host would just
             produce confusing follow-on errors.
+
+            *force* bypasses the OK short-circuit: the auto-first-run
+            flow uses ``force=False`` (don't nag a healthy install);
+            palette invocations use ``force=True`` (the user explicitly
+            asked for the dialog, so honour it — re-running setup is
+            idempotent and the screen's headline already says so).
             """
-            if verdict is SetupVerdict.OK:
+            if verdict is SetupVerdict.OK and not force:
                 return True
 
             outcome = await self.push_screen_wait(SetupScreen(verdict=verdict))
@@ -629,6 +635,9 @@ if _HAS_TEXTUAL:
             Always probes the current verdict so the user sees the live
             state — useful even on a healthy install when they want to
             re-apply the (idempotent) systemd cycle after an upgrade.
+            Passes ``force=True`` so an OK verdict shows the dialog
+            (with its "re-running is safe but optional" headline)
+            instead of silently no-op'ing on healthy installs.
 
             Runs on a worker because ``_run_setup_flow`` calls
             ``push_screen_wait``, which requires a worker context.
@@ -637,7 +646,7 @@ if _HAS_TEXTUAL:
                 verdict = needs_setup()
             except Exception:
                 verdict = SetupVerdict.FIRST_RUN
-            await self._run_setup_flow(verdict)
+            await self._run_setup_flow(verdict, force=True)
 
         def _log_layout_debug(self) -> None:
             """Write a one-shot snapshot of key widget sizes to the state dir.

--- a/tests/unit/tui/test_app_setup_flow.py
+++ b/tests/unit/tui/test_app_setup_flow.py
@@ -1,0 +1,85 @@
+# SPDX-FileCopyrightText: 2026 Jiri Vyskocil
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for [`TerokTUI._run_setup_flow`][terok.tui.app] OK-verdict gating.
+
+Pins the difference between the two callers:
+
+- The auto-first-run flow uses ``force=False`` (default) so an OK verdict
+  short-circuits — a healthy install isn't nagged with a useless dialog.
+- The command-palette action ``Run terok setup`` uses ``force=True`` so
+  the dialog is shown even when the verdict is OK — the user explicitly
+  asked for the (idempotent) re-run.
+
+The bug this fixes: without ``force``, palette clicks on a healthy install
+silently no-op'd and no log entry was created — looked like the action
+hadn't fired at all.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from terok.lib.integrations.sandbox import SetupVerdict
+from terok.tui.app import TerokTUI
+from terok.tui.setup_screen import SetupOutcome, SetupScreen
+
+
+@pytest.mark.asyncio
+async def test_ok_verdict_skips_dialog_without_force() -> None:
+    """Auto-first-run: OK verdict ⇒ no dialog, no subprocess, returns True."""
+    stub = SimpleNamespace(
+        push_screen_wait=AsyncMock(),
+        _run_setup_subprocess=AsyncMock(),
+        notify=MagicMock(),
+    )
+    result = await TerokTUI._run_setup_flow(stub, SetupVerdict.OK)
+    assert result is True
+    stub.push_screen_wait.assert_not_called()
+    stub._run_setup_subprocess.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_ok_verdict_shows_dialog_when_forced() -> None:
+    """Palette path: OK + force=True ⇒ dialog is shown.
+
+    The user explicitly invoked ``Run terok setup`` from the palette;
+    short-circuiting on OK would silently swallow their request (the
+    original bug).  Outcome=SKIPPED here means the user then bailed
+    — but the *dialog appeared*, which is the contract this test pins.
+    """
+    stub = SimpleNamespace(
+        push_screen_wait=AsyncMock(return_value=SetupOutcome.SKIPPED),
+        notify=MagicMock(),
+    )
+    await TerokTUI._run_setup_flow(stub, SetupVerdict.OK, force=True)
+    stub.push_screen_wait.assert_awaited_once()
+    pushed = stub.push_screen_wait.await_args.args[0]
+    assert isinstance(pushed, SetupScreen)
+
+
+@pytest.mark.asyncio
+async def test_ok_verdict_forced_dispatch_runs_subprocess() -> None:
+    """Palette + Run-clicked: dialog returns SHOULD_RUN ⇒ subprocess dispatched."""
+    stub = SimpleNamespace(
+        push_screen_wait=AsyncMock(return_value=SetupOutcome.SHOULD_RUN),
+        _run_setup_subprocess=AsyncMock(return_value=True),
+        notify=MagicMock(),
+    )
+    result = await TerokTUI._run_setup_flow(stub, SetupVerdict.OK, force=True)
+    assert result is True
+    stub._run_setup_subprocess.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_non_ok_verdict_shows_dialog_without_force() -> None:
+    """Non-OK verdicts always show the dialog — force is irrelevant."""
+    stub = SimpleNamespace(
+        push_screen_wait=AsyncMock(return_value=SetupOutcome.SKIPPED),
+        notify=MagicMock(),
+    )
+    await TerokTUI._run_setup_flow(stub, SetupVerdict.FIRST_RUN)
+    stub.push_screen_wait.assert_awaited_once()


### PR DESCRIPTION
## Summary

The command-palette action **Run terok setup** silently did nothing on every healthy install — clicking it produced no dialog, no log entry, no visible change.

## Root cause

``action_run_setup`` calls ``_run_setup_flow(verdict)``.  That method short-circuits with ``return True`` whenever the verdict is OK:

```python
if verdict is SetupVerdict.OK:
    return True
outcome = await self.push_screen_wait(SetupScreen(verdict=verdict))
```

That short-circuit is correct for the **auto-first-run** flow — a healthy install shouldn't be nagged with a setup dialog at startup.  But it's wrong for the **palette** path: the user explicitly asked for the dialog, so honouring it (re-running is idempotent, and the screen's headline already says so) is the right behaviour.

## Fix

Add a ``force`` flag to ``_run_setup_flow``; the palette action passes ``force=True``.  Auto-first-run keeps the default ``force=False`` so the no-nag behaviour is unchanged.

## Test plan

- [x] Four new unit tests in ``tests/unit/tui/test_app_setup_flow.py``:
  - ``test_ok_verdict_skips_dialog_without_force`` — pins the auto-first-run path
  - ``test_ok_verdict_shows_dialog_when_forced`` — palette path: dialog is pushed
  - ``test_ok_verdict_forced_dispatch_runs_subprocess`` — palette + Run-clicked path: subprocess dispatched
  - ``test_non_ok_verdict_shows_dialog_without_force`` — non-OK verdicts always show, regression guard
- [ ] Manual: on a healthy install, ``ctrl+p`` → ``Run terok setup`` → dialog appears, Run dispatches, log entry shows in Console output

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The setup dialog now respects a force option, allowing users to reconfigure their installation even when the system is already properly configured.

* **Tests**
  * Added unit tests verifying setup flow behavior with the new force option, ensuring the dialog displays correctly across different system states.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/terok-ai/terok/pull/992?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->