### PR TITLE
fix(tui): Enter submits the CLI Task launch dialog (was inserting newline)

### DIFF
--- a/src/terok/tui/screens.py
+++ b/src/terok/tui/screens.py
@@ -1238,10 +1238,18 @@ if TextArea is not None:
         screen from treating Enter as form submit.  This subclass forwards
         ``enter`` and ``ctrl+enter`` upstream untouched — the host screen's
         ``on_key`` distinguishes them (Enter submits, Ctrl+Enter inserts).
+
+        ``event.prevent_default()`` is the load-bearing call: returning early
+        from ``_on_key`` is *not* enough — Textual's message-pump runs the
+        widget's default handler after the user override unless that flag is
+        set, and TextArea's default would insert ``\\n`` for ``enter``.
+        ``event.stop()`` is deliberately *not* called so the host screen's
+        ``on_key`` still sees the key and can submit.
         """
 
         async def _on_key(self, event: events.Key) -> None:
             if event.key in {"enter", "ctrl+enter"}:
+                event.prevent_default()
                 return
             await super()._on_key(event)
 else:  # pragma: no cover - stub TextArea in test envs

--- a/tests/unit/tui/test_new_task_flow.py
+++ b/tests/unit/tui/test_new_task_flow.py
@@ -794,44 +794,120 @@ class TestTaskLaunchScreenCompose:
 
 
 class TestSubmittablePromptArea:
-    """Verify the prompt TextArea forwards Enter/Ctrl+Enter to the parent screen."""
+    """Verify the prompt TextArea forwards Enter/Ctrl+Enter to the parent screen.
 
-    def test_on_key_returns_early_on_enter(self) -> None:
-        screens, _ = import_screens()
-        area = screens._SubmittablePromptArea()
-        event = mock.Mock()
-        event.key = "enter"
-        # Should return without stopping the event or invoking ``super()._on_key``
-        # (which would explode against the test-stub TextArea).
-        asyncio.run(area._on_key(event))
-        event.stop.assert_not_called()
-        event.prevent_default.assert_not_called()
+    These tests use Textual's ``Pilot`` against a real ``App`` so the
+    actual message-pump dispatch is exercised — the previous mock-event
+    shape couldn't catch a regression where the override returned early
+    but Textual still ran the default handler, because the assertion only
+    checked that ``event.stop`` / ``event.prevent_default`` were *not*
+    called.  That's exactly how the missing-``prevent_default()`` bug
+    that surfaced as "Enter inserts a newline instead of submitting"
+    got past CI.
 
-    def test_on_key_returns_early_on_ctrl_enter(self) -> None:
-        screens, _ = import_screens()
-        area = screens._SubmittablePromptArea()
-        event = mock.Mock()
-        event.key = "ctrl+enter"
-        asyncio.run(area._on_key(event))
-        event.stop.assert_not_called()
-        event.prevent_default.assert_not_called()
+    Imports the real ``terok.tui.screens`` (not via the stub-injecting
+    ``import_screens`` helper used elsewhere in this file) because a stub
+    Textual won't dispatch events through a real message-pump.
+    """
 
-    def test_on_key_delegates_other_keys_to_super(self) -> None:
-        """Non-Enter keys fall through to ``TextArea._on_key`` unchanged."""
-        screens, _ = import_screens()
-        area = screens._SubmittablePromptArea()
-        event = mock.Mock()
-        event.key = "a"
+    @pytest.mark.asyncio
+    async def test_enter_does_not_insert_into_textarea(self) -> None:
+        """Pressing Enter while the prompt has focus must not write ``\\n``.
 
-        called: list[Any] = []
+        The override needs ``event.prevent_default()``; without it the
+        widget's stock handler still runs and inserts a newline.
+        """
+        from textual.app import App
+        from textual.widgets import TextArea
 
-        async def fake_parent(self: Any, ev: Any) -> None:
-            called.append(ev)
+        from terok.tui.screens import _SubmittablePromptArea
 
-        with mock.patch.object(screens.TextArea, "_on_key", fake_parent, create=True):
-            asyncio.run(area._on_key(event))
+        class _Host(App):
+            def compose(self):
+                yield _SubmittablePromptArea(id="probe")
 
-        assert called == [event]
+        app = _Host()
+        async with app.run_test() as pilot:
+            area = app.query_one("#probe", TextArea)
+            area.focus()
+            await pilot.pause()
+            await pilot.press("enter")
+            await pilot.pause()
+        assert area.text == "", "Enter must not insert into the prompt"
+
+    @pytest.mark.asyncio
+    async def test_ctrl_enter_does_not_insert_into_textarea(self) -> None:
+        """Pressing Ctrl+Enter while the prompt has focus must not insert.
+
+        The host screen handles Ctrl+Enter explicitly (it does its own
+        ``prompt.insert("\\n")``); the TextArea must NOT also insert one,
+        or every Ctrl+Enter would double-up.
+        """
+        from textual.app import App
+        from textual.widgets import TextArea
+
+        from terok.tui.screens import _SubmittablePromptArea
+
+        class _Host(App):
+            def compose(self):
+                yield _SubmittablePromptArea(id="probe")
+
+        app = _Host()
+        async with app.run_test() as pilot:
+            area = app.query_one("#probe", TextArea)
+            area.focus()
+            await pilot.pause()
+            await pilot.press("ctrl+enter")
+            await pilot.pause()
+        assert area.text == ""
+
+    @pytest.mark.asyncio
+    async def test_enter_bubbles_to_parent_screen_on_key(self) -> None:
+        """The override must *not* call ``event.stop()`` — the host screen's
+        ``on_key`` is what turns Enter into a form-submit."""
+        from textual.app import App
+        from textual.widgets import TextArea
+
+        from terok.tui.screens import _SubmittablePromptArea
+
+        seen: list[str] = []
+
+        class _Host(App):
+            def compose(self):
+                yield _SubmittablePromptArea(id="probe")
+
+            def on_key(self, event) -> None:  # type: ignore[no-untyped-def]
+                seen.append(event.key)
+
+        app = _Host()
+        async with app.run_test() as pilot:
+            area = app.query_one("#probe", TextArea)
+            area.focus()
+            await pilot.pause()
+            await pilot.press("enter")
+            await pilot.pause()
+        assert "enter" in seen, "Enter must bubble to the parent for submission"
+
+    @pytest.mark.asyncio
+    async def test_other_keys_still_insert_normally(self) -> None:
+        """Non-Enter keys fall through to TextArea's default — typing still works."""
+        from textual.app import App
+        from textual.widgets import TextArea
+
+        from terok.tui.screens import _SubmittablePromptArea
+
+        class _Host(App):
+            def compose(self):
+                yield _SubmittablePromptArea(id="probe")
+
+        app = _Host()
+        async with app.run_test() as pilot:
+            area = app.query_one("#probe", TextArea)
+            area.focus()
+            await pilot.pause()
+            await pilot.press("h", "i")
+            await pilot.pause()
+        assert area.text == "hi"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

In the CLI Task launch dialog (post-task-creation modal), pressing **Enter** in the prompt input box used to submit (i.e. press Login) and **Ctrl+Enter** inserted a newline.  Currently both insert a newline — Enter is broken.

## Root cause

``_SubmittablePromptArea._on_key`` (added in #979) returns early on ``enter`` / ``ctrl+enter`` expecting that to skip TextArea's default ``\n``-insert.  Empirically it doesn't: Textual's message-pump runs the widget's default handler *after* the user override unless ``event.prevent_default()`` is called.  Returning early without that flag let the default fire and insert.

Verified locally with a tiny Pilot reproduction:

```python
class Override(TextArea):
    async def _on_key(self, event):
        if event.key in {'enter', 'ctrl+enter'}:
            return                              # <-- not enough
        await super()._on_key(event)
```

→ ``area.text == '\n'`` after pressing enter.  Adding ``event.prevent_default()`` before ``return`` gives ``area.text == ''``.

## Fix

Add the missing ``event.prevent_default()``.  ``event.stop()`` stays absent on purpose so the host screen's ``on_key`` still sees the key and can submit.

## Why this got past CI

The original tests asserted that ``event.stop`` / ``event.prevent_default`` were *not* called on a Mock event.  That assertion shape proves the override returns "untouched" but does not prove the actual UI doesn't insert a newline — exactly the bug that slipped through.

Rewrites the four tests as ``Pilot``-driven integration tests against a real ``App`` that mounts the prompt area and asserts on ``area.text`` after pressing each key.  All four pass against the fix; the missing-``prevent_default()`` regression fails the first one immediately.

## Test plan

- [x] ``make lint`` clean
- [x] Four rewritten ``Pilot`` tests pass:
  - ``test_enter_does_not_insert_into_textarea``
  - ``test_ctrl_enter_does_not_insert_into_textarea``
  - ``test_enter_bubbles_to_parent_screen_on_key``
  - ``test_other_keys_still_insert_normally``
- [x] ``tests/unit/tui/test_new_task_flow.py`` — all 71 pass
- [ ] Manual: in the CLI Task launch dialog, type a prompt, press Enter once container is ready → Login fires; Ctrl+Enter inserts ``\n``

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Adjusted keyboard event handling in prompt areas to prevent unintended newline insertion when pressing Enter or Ctrl+Enter.

* **Tests**
  * Upgraded internal test suite to use real integration tests for more reliable verification of keyboard behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/terok-ai/terok/pull/993?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->