### PR TITLE
fix(krun): override USER directive to root at launch

### DIFF
--- a/src/terok/lib/orchestration/task_runners/container.py
+++ b/src/terok/lib/orchestration/task_runners/container.py
@@ -284,6 +284,15 @@ def _project_runtime_flags(project: ProjectConfig, *, cname: str) -> list[str]:
         # non-empty authorized_keys placeholder can't accidentally
         # expose sshd under crun.
         flags += ["-e", "TEROK_CONTAINER_RUNTIME=krun"]
+        # Override the L0's ``USER dev`` directive — the in-guest sshd
+        # needs to start as root so it can listen on TCP 22, write to
+        # /run/sshd, etc., and drop to the authenticated user
+        # (``dev`` or ``root``) on connection.  ``USER dev`` is the
+        # right default under crun for AI agents that refuse uid 0;
+        # under krun the sshd-via-podman model takes over and the
+        # agent's session uid comes from which ``ssh user@…`` the
+        # operator picks, not from the container's PID 1.
+        flags += ["--user", "root"]
     return flags
 
 

--- a/tests/unit/lib/test_krun_runtime_wiring.py
+++ b/tests/unit/lib/test_krun_runtime_wiring.py
@@ -311,6 +311,28 @@ class TestProjectRuntimeFlags:
         env_assignments = [flags[i + 1] for i, t in enumerate(flags) if t == "-e"]
         assert not any(e.startswith("TEROK_CONTAINER_RUNTIME") for e in env_assignments)
 
+    def test_krun_launches_as_root_overriding_image_user(
+        self, _experimental_enabled, _krun_keypair, _stub_port_reservation
+    ) -> None:
+        """``--user root`` overrides the L0's ``USER dev`` directive only
+        under krun — the in-guest sshd needs to start as root so it can
+        listen on TCP 22, write to /run/sshd, and drop to the authenticated
+        user on connection.  Crun keeps the image's ``USER dev`` (correct
+        for AI agents that refuse uid 0)."""
+        from terok.lib.orchestration.task_runners.container import _project_runtime_flags
+
+        flags = _project_runtime_flags(_project(runtime="krun"), cname="terok-cli-demoproj-task-a")
+        user_idx = flags.index("--user")
+        assert flags[user_idx + 1] == "root"
+
+    def test_non_krun_does_not_override_image_user(self) -> None:
+        """Under crun the image's ``USER dev`` is what we want — terok must
+        not pass ``--user`` and silently elevate the agent to root."""
+        from terok.lib.orchestration.task_runners.container import _project_runtime_flags
+
+        flags = _project_runtime_flags(_project(), cname="terok-cli-demoproj-task-a")
+        assert "--user" not in flags
+
     def test_krun_emits_cpu_and_ram_when_set(
         self, _experimental_enabled, _krun_keypair, _stub_port_reservation
     ) -> None:


### PR DESCRIPTION
## Summary

The L0 ships ``USER dev`` so AI agents that refuse uid 0 run as dev under crun.  Under krun, that same directive runs the container as dev too — and dev can't write to root-owned paths like ``/run/sshd`` or modify root-owned files, which broke the in-guest sshd launch chain we've been chasing.

(My earlier theories about libkrun virtio-fs being read-only or refusing setuid were wrong.  The real story turned out to be ordinary Unix perms: terok's L0 runs as dev, fedora/alpine run as root — that's the whole difference.  See empirical comparison in the diagnostic that led here.)

## Fix

Pass ``--user root`` to ``podman run`` only when ``project.runtime == \"krun\"``.  L0 stays ``USER dev`` (correct for crun).  Under krun the in-guest sshd starts as root, listens on 22, and drops to the authenticated user (``dev`` or ``root``) on connection — so the agent's session uid comes from ``ssh user@…``, not from the container's PID 1.

## Pairs with

[terok-executor#346](https://github.com/terok-ai/terok-executor/pull/346) — drops the now-unneeded runtime ``/root/.ssh`` wiring from the init script.  Either order to merge; they're orthogonal.

## Test plan

- [x] ``make check`` clean
- [x] Two new unit tests in ``tests/unit/lib/test_krun_runtime_wiring.py``:
  - ``test_krun_launches_as_root_overriding_image_user``
  - ``test_non_krun_does_not_override_image_user`` (regression guard so we never elevate the crun agent to root by accident)
- [ ] On Silverblue, with executor#346 merged + repin: ``terok task run terok-k`` boots cleanly past the previous mkdir EACCES, ``ssh dev@…`` and ``ssh root@…`` both work

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected container startup user configuration for krun runtime to ensure proper SSH access and authenticated user privileges
* **Tests**
  * Added tests validating container user configuration behavior for different runtime environments

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/terok-ai/terok/pull/995?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->