### PR TITLE
fix(krun): SELinux-relabel the host-pubkey bind-mount so sshd can read it

### DIFF
--- a/src/terok/lib/orchestration/task_runners/container.py
+++ b/src/terok/lib/orchestration/task_runners/container.py
@@ -275,7 +275,7 @@ def _project_runtime_flags(project: ProjectConfig, *, cname: str) -> list[str]:
         keypair = ensure_krun_host_keypair(cfg=make_sandbox_config())
         flags += [
             "-v",
-            f"{keypair.public_path}:/etc/ssh/authorized_keys.d/terok:ro",
+            f"{keypair.public_path}:/etc/ssh/authorized_keys.d/terok:ro,z",
         ]
         # Explicit runtime signal for the in-container init script's
         # sshd launch.  init-ssh-and-repo.sh gates the sshd supervisor

--- a/tests/unit/lib/test_krun_runtime_wiring.py
+++ b/tests/unit/lib/test_krun_runtime_wiring.py
@@ -277,15 +277,18 @@ class TestProjectRuntimeFlags:
         This is what keeps the L0 image byte-identical across crun/krun:
         no per-installation secret baked at build time; the orchestrator
         threads ``ensure_krun_host_keypair().public_path`` in at launch.
+        ``z`` (shared SELinux relabel — never ``Z``, the source is
+        host-wide and concurrent containers share it).
         """
         from terok.lib.orchestration.task_runners.container import _project_runtime_flags
 
         flags = _project_runtime_flags(_project(runtime="krun"), cname="terok-cli-demoproj-task-a")
-        # The volume mount is added as ``-v <host>:<guest>:ro``.
         v_idx = flags.index("-v")
         mount_spec = flags[v_idx + 1]
         assert "/etc/ssh/authorized_keys.d/terok:ro" in mount_spec
         assert str(_krun_keypair.public_path) in mount_spec
+        assert ",z" in mount_spec or ":z" in mount_spec
+        assert ",Z" not in mount_spec and ":Z" not in mount_spec
 
     def test_krun_emits_container_runtime_env_var(
         self, _experimental_enabled, _krun_keypair, _stub_port_reservation


### PR DESCRIPTION
## Summary

One-char fix plus a comma.  The krun host-pubkey bind-mount went in as ``:ro`` instead of ``:ro,z``, so the file kept the host's runtime-dir SELinux context and the in-guest sshd's confined domain couldn't open it for the authorized_keys lookup.  Auth died with:

```
Could not open user 'dev' authorized keys '/etc/ssh/authorized_keys.d/terok': Permission denied
```

(sshd stderr, captured by ``podman logs``).  Both ``ssh dev@…`` and ``ssh root@…`` failed identically because the file was unreadable regardless of the authenticating user.

## Fix

Add ``,z`` to the bind-mount spec.  Every other config bind-mount in the launch argv already uses it (``_blablador-config``, ``_claude-config``, ``_gh-config``, ...) — the krun pubkey was a one-off oversight.

Lowercase ``z`` (shared label), not ``Z`` (private): the host pubkey is host-wide, not per-task — concurrent containers share the source file and a private relabel would fight itself across them.

## Test plan

- [x] ``make check`` clean
- [x] Existing ``test_krun_emits_pubkey_bind_mount`` extended to pin the relabel — asserts shared ``z`` is present and that ``Z`` (private) never sneaks in
- [ ] On Silverblue: ``terok task run terok-k`` then ``ssh dev@…`` opens an actual shell

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed SSH public-key mounting in containerized environments to include SELinux shared relabeling, restoring reliable SSH authentication.

* **Tests**
  * Strengthened tests to require the shared SELinux relabel and ensure private relabeling is not used.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/terok-ai/terok/pull/996?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->