### PR TITLE
fix(cli): fail fast on a nonexistent project ID

### DIFF
--- a/src/terok/cli/commands/auth.py
+++ b/src/terok/cli/commands/auth.py
@@ -24,7 +24,7 @@ from terok.lib.integrations.executor import AUTH_PROVIDERS
 from ...lib.api import authenticate
 from ...lib.core.config import is_oauth_enabled_for
 from ...lib.core.images import require_agent_installed
-from ...lib.core.projects import load_project
+from ...lib.core.projects import load_project, require_project_exists
 from ._completers import complete_project_ids as _complete_project_ids, set_completer
 
 
@@ -100,6 +100,9 @@ def _run_one(provider: str, project_id: str | None) -> None:
 
 def _run_interactive(project_id: str | None) -> None:
     """Interactively pick one or more providers and authenticate each in turn."""
+    if project_id is not None:
+        require_project_exists(project_id)
+
     provider_names = list(AUTH_PROVIDERS)
     print("Authenticate agents — pick one or more (comma-separated):")
     for i, name in enumerate(provider_names, 1):

--- a/src/terok/cli/commands/image.py
+++ b/src/terok/cli/commands/image.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 
 import argparse
 
-from ...lib.api import cleanup_images, list_images
+from ...lib.api import cleanup_images, list_images, require_project_exists
 from . import _storage_view
 from ._completers import complete_project_ids as _complete_project_ids, set_completer
 
@@ -212,6 +212,8 @@ def _cmd_usage(*, project_id: str | None, json_output: bool) -> None:
 
 def _cmd_list(project_id: str | None) -> None:
     """List terok-managed images with sizes."""
+    if project_id is not None:
+        require_project_exists(project_id)
     images = list_images(project_id)
     if not images:
         scope = f" for project '{project_id}'" if project_id else ""

--- a/src/terok/cli/commands/setup.py
+++ b/src/terok/cli/commands/setup.py
@@ -41,7 +41,7 @@ from ...lib.api import (
     provision_ssh_key,
     summarize_ssh_init,
 )
-from ...lib.core.projects import load_project
+from ...lib.core.projects import load_project, require_project_exists
 from ...lib.domain.project import make_git_gate
 
 # ── CLI wiring ─────────────────────────────────────────────────────────
@@ -348,6 +348,8 @@ def cmd_project_init(project_id: str) -> None:
     blocking SSH, corporate proxy, offline laptop) while the container's
     network path still works.
     """
+    require_project_exists(project_id)
+
     print("==> Initializing SSH...")
     summarize_ssh_init(provision_ssh_key(project_id))
     maybe_pause_for_ssh_key_registration(project_id)

--- a/src/terok/cli/commands/task.py
+++ b/src/terok/cli/commands/task.py
@@ -17,6 +17,7 @@ from ...lib.api import (
     LogViewOptions,
     build_images,
     project_image_exists,
+    require_project_exists,
     task_archive_list,
     task_archive_logs,
     task_delete,
@@ -572,6 +573,8 @@ def _ensure_project_image(project_id: str) -> None:
     TTY → interactive ``Build now? [Y/n]`` prompt, then ``build_images()``
     inline.  Non-TTY → exit with a hint so scripts stay deterministic.
     """
+    require_project_exists(project_id)
+
     if project_image_exists(project_id):
         return
 
@@ -702,6 +705,7 @@ def _dispatch_task_sub(args: argparse.Namespace) -> bool:
         return True
 
     pid = args.project_id
+    require_project_exists(pid)
     tid = resolve_task_id(pid, args.task_id) if hasattr(args, "task_id") else ""
     if args.task_cmd == "list":
         task_list(

--- a/src/terok/lib/api.py
+++ b/src/terok/lib/api.py
@@ -48,6 +48,7 @@ from .core.projects import (  # noqa: F401 — re-exported public API
     ProjectConfig,
     discover_projects,
     load_project,
+    require_project_exists,
     set_project_image_agents,
 )
 
@@ -273,6 +274,7 @@ __all__ = [
     "BrokenProject",
     "discover_projects",
     "load_project",
+    "require_project_exists",
     "set_project_image_agents",
     # Image management
     "generate_dockerfiles",

--- a/src/terok/lib/core/projects.py
+++ b/src/terok/lib/core/projects.py
@@ -393,6 +393,18 @@ def _find_project_root(project_id: str) -> Path:
     raise SystemExit(f"Project '{project_id}' not found in {user_root} or {sys_root}")
 
 
+def require_project_exists(project_id: str) -> None:
+    """Raise [`SystemExit`][SystemExit] unless *project_id* names a known project.
+
+    Cheap stat-based check — no YAML parse, no pydantic validation.  Use
+    this in CLI entry points that want to fail before any user-visible
+    side effect (interactive prompt, status print, image build offer).
+    The downstream [`load_project`][terok.lib.core.projects.load_project]
+    call still catches malformed YAML.
+    """
+    _find_project_root(project_id)
+
+
 # ---------- Project listing ----------
 
 

--- a/tach.toml
+++ b/tach.toml
@@ -613,6 +613,7 @@ expose = [
     "list_presets",
     "derive_project",
     "effective_ssh_key_name",
+    "require_project_exists",
     "resolve_ssh_host_dir",
     "set_project_image_agents",
     "validate_project_id",

--- a/tests/unit/cli/test_cli_auth.py
+++ b/tests/unit/cli/test_cli_auth.py
@@ -180,6 +180,7 @@ def test_run_interactive_runs_each_selected_provider() -> None:
     """Selected providers are authenticated in order, sharing the same project scope."""
     with (
         patch("sys.stdin", new=StringIO("claude, codex\n")),
+        patch("terok.cli.commands.auth.require_project_exists"),
         patch("terok.cli.commands.auth._run_one") as mock_run,
     ):
         _run_interactive(project_id="myproj")

--- a/tests/unit/cli/test_cli_autopilot.py
+++ b/tests/unit/cli/test_cli_autopilot.py
@@ -25,7 +25,10 @@ def _bypass_setup_verdict_gate():
     of that gate; the gate's own behaviour is pinned by
     ``test_cli_task_verdict_gate.py``.
     """
-    with patch("terok.cli.commands.task._setup_verdict_or_exit"):
+    with (
+        patch("terok.cli.commands.task._setup_verdict_or_exit"),
+        patch("terok.cli.commands.task.require_project_exists"),
+    ):
         yield
 
 

--- a/tests/unit/cli/test_cli_workflows.py
+++ b/tests/unit/cli/test_cli_workflows.py
@@ -21,7 +21,11 @@ def _bypass_setup_verdict_gate():
     gate; they run in a stamp-free tmp env where the real gate would
     always raise exit 3 before dispatch ever happens.
     """
-    with unittest.mock.patch("terok.cli.commands.task._setup_verdict_or_exit"):
+    with (
+        unittest.mock.patch("terok.cli.commands.task._setup_verdict_or_exit"),
+        unittest.mock.patch("terok.cli.commands.task.require_project_exists"),
+        unittest.mock.patch("terok.cli.commands.setup.require_project_exists"),
+    ):
         yield
 
 


### PR DESCRIPTION
## Summary

Five CLI command entry points used to ask the user for input or print progress output *before* discovering that the project ID was bogus. Repro:

```
$ terok task run nonsense
Image for project 'nonsense' is missing. Build now? [Y/n]: Y
Project 'nonsense' not found in /home/dev/.config/terok/projects/nonsense or /home/dev/.config/terok/projects/nonsense
```

Same wart in `terok auth --project`, `terok project init` (printed `==> Initializing SSH...` first), `terok task list|stop|status|...` (lied with `No tasks found for project X`), and `terok image list` (lied with `No terok images found for project 'X'`).

## Fix

Adds a cheap `require_project_exists(project_id)` predicate next to `_find_project_root` in `lib/core/projects.py` — two `is_file()` stats, no YAML parse, no pydantic validation, no git subprocess. Calls it as the first line of each affected handler:

- `auth._run_interactive`
- `image._cmd_list`
- `setup.cmd_project_init`
- `task._ensure_project_image`
- `task._dispatch_task_sub`

Re-exported through `lib.api` and listed in `tach.toml`'s public interface for `lib.core.projects`. The downstream `load_project()` call inside the actual operation still catches malformed YAML — this just moves the existence check earlier on the hot path.

## Test plan

- [x] `make lint`
- [x] `make tach`
- [x] `make test` (2611 passed)
- [x] Manual smoke: `terok task run nonsense`, `terok auth --project nonsense`, `terok project init nonsense`, `terok task list nonsense`, `terok image list nonsense` — all exit immediately with `Project 'nonsense' not found in ...` before any prompt or progress output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * CLI commands (`auth`, `image list`, `setup`, `task`) now validate that a project exists before proceeding, ensuring faster failure with clear errors when an invalid project ID is provided.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/terok-ai/terok/pull/1005?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->