### PR TITLE
feat(tui): surface transport + live listeners in vault status pane

### DIFF
--- a/src/terok/tui/screens.py
+++ b/src/terok/tui/screens.py
@@ -86,6 +86,16 @@ def _modal_binding(key: str, action: str, description: str) -> Any:
     return Binding(key, action, description, show=False)
 
 
+_LOCALHOST = "127.0.0.1"
+"""Loopback bind address for TCP-mode listener strings rendered in the vault pane.
+
+Defined locally per the project's no-magic-literals convention; the same
+literal lives in [`terok.lib.orchestration.task_runners.toad`][terok.lib.orchestration.task_runners.toad]
+and [`terok.tui.serve`][terok.tui.serve], neither of which is a shared
+constants module to import from.
+"""
+
+
 # ---------------------------------------------------------------------------
 # Shared CSS for full-page detail screens
 # ---------------------------------------------------------------------------
@@ -2235,9 +2245,9 @@ def render_vault_status(status: VaultStatus | None) -> Text:
         broker_port = get_token_broker_port()
         signer_port = get_ssh_signer_port()
         if broker_port is not None:
-            lines.append(Text(f"TCP broker:  127.0.0.1:{broker_port}"))
+            lines.append(Text(f"TCP broker:  {_LOCALHOST}:{broker_port}"))
         if signer_port is not None:
-            lines.append(Text(f"TCP signer:  127.0.0.1:{signer_port}"))
+            lines.append(Text(f"TCP signer:  {_LOCALHOST}:{signer_port}"))
         socket_suffix = "  (fast-path probe only)"
 
     lines.append(Text(f"Socket:      {status.socket_path}{socket_suffix}"))

--- a/src/terok/tui/screens.py
+++ b/src/terok/tui/screens.py
@@ -2197,21 +2197,67 @@ def render_vault_status(status: VaultStatus | None) -> Text:
     else:
         running_s = Text("stopped", style=err)
 
+    # Allow-list the transport so an unset attribute (test ``Mock``s)
+    # or a future value can't leak a raw repr into operator-facing
+    # output.  Mirrors the executor CLI in ``vault_commands._handle_status``
+    # so the TUI and shell views stay in lockstep.
+    transport_raw = getattr(status, "transport", None)
+    transport = transport_raw if transport_raw in ("tcp", "socket") else None
+
     locked_label = (
         Text("yes — no tier resolved", style=err) if status.locked else Text("no", style=ok)
     )
+
+    # Two orthogonal axes, two lines: ``Activation:`` (lifecycle —
+    # systemd / daemon / none) vs ``Transport:`` (wire — tcp / socket).
+    # The legacy single ``Mode:`` overloaded both onto one label and
+    # operators consistently read it as transport.
     lines: list[Text] = [
-        Text.assemble("Mode:        ", mode_s),
+        Text.assemble("Activation:  ", mode_s),
+        Text(f"Transport:   {transport or '(not configured)'}"),
         Text.assemble("Status:      ", running_s),
-        Text(f"Socket:      {status.socket_path}"),
-        Text(f"DB:          {status.db_path}"),
-        Text(f"Routes:      {status.routes_path} ({status.routes_configured} configured)"),
-        Text(f"SSH keys:    {status.ssh_keys_stored}"),
-        # ``Locked:`` is the operator-facing yes/no; ``Passphrase:`` adds
-        # WHICH tier resolved it when unlocked.  Mirror the executor CLI
-        # (``vault status``) so the TUI and shell views agree at a glance.
-        Text.assemble("Locked:      ", locked_label),
     ]
+
+    # TCP mode: surface the actual listeners that container traffic
+    # rides.  The daemon still binds ``vault.sock`` as a local
+    # fast-path probe target, but no client traffic touches it —
+    # annotate so the headline ``Socket:`` line doesn't imply
+    # otherwise.  Socket mode: surface the SSH signer socket
+    # alongside the broker socket so both bind-mounted endpoints
+    # are visible at a glance.
+    socket_suffix = ""
+    if transport == "tcp":
+        from terok.lib.integrations.sandbox import (
+            get_ssh_signer_port,
+            get_token_broker_port,
+        )
+
+        broker_port = get_token_broker_port()
+        signer_port = get_ssh_signer_port()
+        if broker_port is not None:
+            lines.append(Text(f"TCP broker:  127.0.0.1:{broker_port}"))
+        if signer_port is not None:
+            lines.append(Text(f"TCP signer:  127.0.0.1:{signer_port}"))
+        socket_suffix = "  (fast-path probe only)"
+
+    lines.append(Text(f"Socket:      {status.socket_path}{socket_suffix}"))
+
+    if transport == "socket":
+        from terok.lib.api import make_sandbox_config
+
+        lines.append(Text(f"SSH signer:  {make_sandbox_config().ssh_signer_socket_path}"))
+
+    lines.extend(
+        [
+            Text(f"DB:          {status.db_path}"),
+            Text(f"Routes:      {status.routes_path} ({status.routes_configured} configured)"),
+            Text(f"SSH keys:    {status.ssh_keys_stored}"),
+            # ``Locked:`` is the operator-facing yes/no; ``Passphrase:`` adds
+            # WHICH tier resolved it when unlocked.  Mirror the executor CLI
+            # (``vault status``) so the TUI and shell views agree at a glance.
+            Text.assemble("Locked:      ", locked_label),
+        ]
+    )
 
     if not status.locked and status.passphrase_source is not None:
         lines.append(Text(f"Passphrase:  resolved via {status.passphrase_source}"))

--- a/tests/unit/tui/test_detail_screens.py
+++ b/tests/unit/tui/test_detail_screens.py
@@ -1483,6 +1483,7 @@ def make_vault_status(
     *,
     mode: str = "daemon",
     running: bool = True,
+    transport: str | None = None,
     routes_configured: int = 3,
     credentials_stored: tuple[str, ...] = ("claude", "gh"),
     ssh_keys_stored: int = 0,
@@ -1496,10 +1497,16 @@ def make_vault_status(
     truthiness doesn't accidentally trip the locked branch or the
     plaintext-warning branch in
     [`render_vault_status`][terok.tui.screens.render_vault_status].
+
+    ``transport`` defaults to ``None`` so existing tests get the
+    ``(not configured)`` rendering instead of leaking a ``Mock`` repr.
+    Tests that exercise the TCP / socket port surfacing pass
+    ``transport="tcp"`` / ``"socket"`` explicitly.
     """
     status = mock.Mock()
     status.mode = mode
     status.running = running
+    status.transport = transport
     status.socket_path = MOCK_VAULT_SOCKET
     status.db_path = MOCK_VAULT_DB
     status.routes_path = MOCK_VAULT_ROUTES
@@ -1672,6 +1679,87 @@ class TestRenderVaultStatus:
         text_str = str(screens.render_vault_status(status))
         assert "WARNING" not in text_str
         assert "plaintext" not in text_str
+
+    def test_render_vault_status_renames_mode_to_activation(self) -> None:
+        """The legacy ``Mode:`` label is gone — lifecycle now reads as ``Activation:``.
+
+        Guards the rename so a future regression that re-introduces the
+        old label gets caught here.  The two TUI / CLI views are kept in
+        lockstep (executor#356), so a one-sided revert would leave the
+        operator looking at two different vocabularies.
+        """
+        screens, _ = import_screens()
+        status = make_vault_status(mode="systemd", transport=None)
+        text_str = str(screens.render_vault_status(status))
+        assert "Activation:  systemd" in text_str
+        assert "Mode:        " not in text_str
+
+    def test_render_vault_status_tcp_surfaces_ports_and_annotates_socket(self) -> None:
+        """TCP mode surfaces ``TCP broker:`` / ``TCP signer:`` and tags ``Socket:``.
+
+        Mirrors the executor CLI behaviour from terok-ai/terok-executor#356:
+        the daemon still binds ``vault.sock`` as a local fast-path probe
+        target but no client traffic touches it, so surfacing the TCP
+        listeners and annotating the lingering Unix line is what keeps
+        operator-readable.
+        """
+        screens, _ = import_screens()
+        status = make_vault_status(mode="systemd", transport="tcp")
+        with (
+            mock.patch(
+                "terok.lib.integrations.sandbox.get_token_broker_port",
+                return_value=18701,
+            ),
+            mock.patch(
+                "terok.lib.integrations.sandbox.get_ssh_signer_port",
+                return_value=18702,
+            ),
+        ):
+            text_str = str(screens.render_vault_status(status))
+        assert "Transport:   tcp" in text_str
+        assert "TCP broker:  127.0.0.1:18701" in text_str
+        assert "TCP signer:  127.0.0.1:18702" in text_str
+        assert "(fast-path probe only)" in text_str
+
+    def test_render_vault_status_socket_surfaces_signer_socket(self, tmp_path) -> None:
+        """Socket mode surfaces the SSH signer socket alongside the broker socket.
+
+        Both bind-mounted endpoints (broker + signer) appear in the
+        rendered block so the TUI matches what containers actually see
+        per the executor env wiring.  TCP-only embellishments must stay
+        absent.
+        """
+        from terok_sandbox import SandboxConfig
+
+        cfg = SandboxConfig(
+            state_dir=tmp_path / "state",
+            runtime_dir=tmp_path / "run",
+            vault_dir=tmp_path / "vault",
+            services_mode="socket",
+        )
+        screens, _ = import_screens()
+        status = make_vault_status(mode="systemd", transport="socket")
+        with mock.patch("terok.lib.api.make_sandbox_config", return_value=cfg):
+            text_str = str(screens.render_vault_status(status))
+        assert "Transport:   socket" in text_str
+        assert f"SSH signer:  {cfg.ssh_signer_socket_path}" in text_str
+        # TCP-only embellishments stay out of the socket-mode render.
+        assert "TCP broker:" not in text_str
+        assert "TCP signer:" not in text_str
+        assert "(fast-path probe only)" not in text_str
+
+    def test_render_vault_status_unknown_transport_falls_back(self) -> None:
+        """``status.transport is None`` (or unexpected) renders ``(not configured)``.
+
+        Also guards the allow-list against any future widening that
+        might leak a raw ``Mock`` / repr into operator-facing output.
+        """
+        screens, _ = import_screens()
+        status = make_vault_status(mode="none", running=False, transport=None)
+        text_str = str(screens.render_vault_status(status))
+        assert "Transport:   (not configured)" in text_str
+        assert "TCP broker:" not in text_str
+        assert "SSH signer:" not in text_str
 
 
 class TestVaultUnlockModal:


### PR DESCRIPTION
## Summary

Mirrors [terok-ai/terok-executor#356](https://github.com/terok-ai/terok-executor/pull/356) in the TUI so the two views read the same vocabulary — an operator looking at ``terok vault status`` (CLI) and the operator looking at the TUI vault pane should see the same labels and the same listeners.

- ``Mode:`` → ``Activation:`` (lifecycle channel: systemd / daemon / none).
- New ``Transport:`` line carrying ``tcp`` / ``socket`` / ``(not configured)``.  Allow-listed so an unset attribute on a ``Mock`` (or a future value) can't leak a raw repr into the rendered text.
- **TCP mode**: adds ``TCP broker: 127.0.0.1:<port>`` and ``TCP signer: 127.0.0.1:<port>``; annotates the still-bound ``Socket:`` line as ``(fast-path probe only)`` so operators don't read the Unix path as the wire endpoint.
- **Socket mode**: adds ``SSH signer: <path>`` next to ``Socket:`` so both endpoints containers actually mount land in the same rendered block.

Before / after — same vault, TCP mode:

```diff
-Mode:        systemd
+Activation:  systemd
+Transport:   tcp
 Status:      running
-Socket:      /run/user/1000/terok/sandbox/vault.sock
+TCP broker:  127.0.0.1:18701
+TCP signer:  127.0.0.1:18702
+Socket:      /run/user/1000/terok/sandbox/vault.sock  (fast-path probe only)
 DB:          ...
```

## Test plan

- [x] ``make lint`` clean (ruff + ruff-format)
- [x] ``make tach`` clean
- [x] ``make lint-imports`` clean (5/5 contracts kept)
- [x] ``make security`` (bandit) — 0 medium/high
- [x] ``make docstrings`` — 96.7%
- [x] ``make reuse`` clean (after removing a stray patch file from the working tree)
- [x] ``make test`` — 2615/2615 unit tests pass (4 new tests covering the rename, TCP rendering, socket rendering, and the unknown-transport fallback)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Vault status display now separates "Activation" and "Transport", showing transport-specific listener details: TCP mode shows broker/signer ports and a fast-path probe note; socket mode shows the SSH signer socket path; unknown transport renders "(not configured)".

* **Tests**
  * Unit tests extended to verify the new Activation/Transport layout and transport-specific outputs.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/terok-ai/terok/pull/1007?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->