### PR TITLE
fix(ci): make docs treemap fetch tolerant of lint failures and stale baselines

### DIFF
--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -61,7 +61,7 @@ jobs:
           path: |
             reports/coverage.xml
             reports/coverage.json
-          retention-days: 1
+          retention-days: 14
 
       - name: Save PR metadata
         if: github.event_name == 'pull_request'

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -131,7 +131,7 @@ jobs:
         uses: dawidd6/action-download-artifact@b6e2e70617bc3265edd6dab6c906732b2f1ae151 # v21
         with:
           workflow: analysis.yml
-          workflow_conclusion: success
+          workflow_conclusion: completed
           commit: ${{ github.event.pull_request.head.sha || github.sha }}
           name: coverage
           path: reports


### PR DESCRIPTION
## Summary

Two bugs in the coverage-artifact handoff between `analysis.yml` and `docs.yml`:

1. **Same-SHA opportunistic fetch was over-strict.** The PR best-effort step in `docs.yml` filtered runs by `workflow_conclusion: success`. Because `analysis.yml` is split into `unit-tests`, `ruff`, and `bandit` jobs, any ruff/bandit failure marks the entire run as `failure` even though `unit-tests` already uploaded the coverage artifact. The action then reported _"no matching workflow run found with any artifacts"_ for the PR SHA. Switch this step to `workflow_conclusion: completed` so the treemap can still pick up the artifact when sibling jobs flag issues. The strict master-required path keeps `success`.

2. **Coverage artifact rotted within 24h.** `analysis.yml` uploaded coverage with `retention-days: 1`, so the master baseline expired within a day — every PR more than ~24h old failed the master fallback with `Error: no downloadable artifacts found (expired)`. Bump to 14d on the coverage upload only; other artifacts in this workflow (pr, ruff, bandit) stay at 1d since they're consumed by the same Sonar trigger.

## Test plan
- [ ] PR docs build picks up same-SHA coverage even when ruff/bandit fail
- [ ] master baseline available to PR builds for >1 day

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved continuous integration infrastructure for enhanced test coverage artifact handling and workflow reliability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/terok-ai/terok/pull/1008?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->