### PR TITLE
docs(runtimes): drop wrong sudo+kvm-group claims, tighten env-var note

### DIFF
--- a/docs/runtimes.md
+++ b/docs/runtimes.md
@@ -22,7 +22,7 @@ terok supports two OCI runtimes:
 |---|---|---|
 | `crun-krun` | Adds libkrun and points podman's `--runtime krun` at the right binary | `dnf install crun-krun` (or `rpm-ostree install` on Silverblue, then reboot) |
 
-User must be in the `kvm` group to read `/dev/kvm`.  Verify with `ls -l /dev/kvm` and `groups`.
+Check `ls -l /dev/kvm` — if it's world-rw (`crw-rw-rw-`, the Fedora default) you're done; if it's `crw-rw---- root:kvm` (Debian/Ubuntu default), add your user to the owning group.
 
 ## Enabling krun
 
@@ -71,13 +71,12 @@ For one-off testing without editing any file:
 TEROK_RUNTIME=krun terok task start <project>
 ```
 
-Accepted values: `crun` (default), `krun`, `null` (in-memory stub for CI).
+Accepted values: `crun`, `krun`, `null` (in-memory stub for tests).
+Unset means "fall through to project/global config".
 
 ## krun runner behaviour
 
-- The container's PID 1 runs as `root`.
-- `sudo` is not available inside the guest.
-- `run.nested_containers: true` is rejected at launch.
+The container's PID 1 runs as `root`, and `run.nested_containers: true` is rejected at launch.
 
 ## Login
 


### PR DESCRIPTION
## Summary

Three corrections to `docs/runtimes.md` that were caught by running krun for real and noticing the docs lie:

- **Drop the \"sudo is not available inside the guest\" bullet.** The L0 image installs sudo with NOPASSWD for `dev`, and nothing in `krun_launch_args` strips capabilities or sets `no-new-privileges`. Sudo works the same under krun as under crun — the claim was unsupported.
- **Rewrite the `/dev/kvm` access note to be distro-aware.** Fedora's udev rule ships the device world-rw (`crw-rw-rw-`), so the original \"must be in the `kvm` group\" line was wrong on the very distro the page's install instructions target. Debian/Ubuntu still need the group, so cover both.
- **Tighten the `TEROK_RUNTIME` accepted-values line.** The env var has no default — when unset, the chain falls through to project/global config — and the stub is for tests, not CI specifically (matches the code comment in `lib/core/runtime.py`).

Also collapses the now-two-bullet \"krun runner behaviour\" list into a single sentence.

## Test plan

- [ ] Docs render cleanly (no broken markdown).
- [ ] Spot-check on a Fedora host: `sudo apt`/`sudo dnf` inside a krun task does what `sudo` always does.
- [ ] Spot-check on a Debian host: `/dev/kvm` is `0660 root:kvm` and the user needs `kvm` group membership.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated krun runtime setup guidance with `/dev/kvm` permission requirements and user group instructions
  * Clarified accepted `TEROK_RUNTIME` environment variable values and fallback configuration behavior
  * Improved krun runner behavior documentation

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/terok-ai/terok/pull/1009?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->