### PR TITLE
test(unit): pin _SYSTEMCTL_PATH so gate tests pass without systemctl on PATH

### DIFF
--- a/tests/unit/lib/test_gate_server.py
+++ b/tests/unit/lib/test_gate_server.py
@@ -38,6 +38,24 @@ SYSTEMD_SERVICE = "terok-gate@.service"
 VERSION_STAMP = f"# terok-gate-version: {_UNIT_VERSION}"
 
 
+@pytest.fixture(autouse=True)
+def _force_systemctl_resolved(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Pin ``_SYSTEMCTL_PATH`` so ``_systemctl.{run,query}`` reaches ``subprocess.run``.
+
+    ``terok_sandbox._util._systemctl`` resolves ``systemctl`` once at import
+    via ``shutil.which`` and short-circuits when the binary is absent.  On
+    hosts without ``systemctl`` on PATH (nix-wrapped Python, minimal CI
+    containers) every helper bails out before ``subprocess.run`` is ever
+    called, defeating the per-test ``mock.patch("subprocess.run", …)``.
+    Pinning the resolved path to a sentinel forces the call through, so
+    the existing mocks behave the same on every host.
+    """
+    monkeypatch.setattr(
+        "terok_sandbox._util._systemctl._SYSTEMCTL_PATH",
+        "/usr/bin/systemctl",
+    )
+
+
 def make_status(
     mode: str = "none",
     *,


### PR DESCRIPTION
## Summary

`terok_sandbox._util._systemctl` resolves the `systemctl` binary once at module import via `shutil.which` and stores it in `_SYSTEMCTL_PATH`. When that constant is `None`, both `_systemctl.run()` and `_systemctl.query()` short-circuit *before* calling `subprocess.run`.

On hosts without `systemctl` on `PATH` (the nix-wrapped Python lane of `tests/containers/run-matrix.sh`, minimal CI containers, …) the gate-server tests in `tests/unit/lib/test_gate_server.py` fail — their `mock.patch("subprocess.run", …)` decorators never get a chance to take effect, because the call chain bails out one frame above. Six tests regress this way:

- `TestSystemdDetection::test_systemd_present_for_any_real_returncode[running|non-zero-1|2|3]`
- `TestSocketActive::test_socket_active_from_systemctl[active]`
- `TestInstallUninstall::test_install_writes_files` (raises `SystemExit: systemctl: command not found on PATH`)

The fix is a single autouse fixture at the top of the test file that pins `_SYSTEMCTL_PATH` to a sentinel for the duration of every test. The helpers then reach `subprocess.run` on every host, and the existing per-test mocks behave the same regardless of whether the runner has the binary.

No production code is touched.

## Test plan

- [x] `pytest tests/unit/lib/test_gate_server.py` — 45/45 pass on a normal host (systemctl present)
- [x] `PATH=$VENV/bin:/tmp/no-such-dir pytest tests/unit/lib/test_gate_server.py` — 45/45 pass with systemctl removed from PATH (faithful simulation of the nix env where the regression was reported)
- [x] `ruff check` / `ruff format --check` clean
- [ ] `./tests/containers/run-matrix.sh nix` on the reporter's hardware

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test stability across different host and CI environments.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/terok-ai/terok/pull/1013?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->