### PR TITLE
fix(image): strip podman's localhost/ prefix in classification + cleanup

### DIFF
--- a/src/terok/cli/commands/image.py
+++ b/src/terok/cli/commands/image.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 
 import argparse
 
-from ...lib.api import cleanup_images, list_images, require_project_exists
+from ...lib.api import find_orphaned_images, list_images, remove_images, require_project_exists
 from . import _storage_view
 from ._completers import complete_project_ids as _complete_project_ids, set_completer
 
@@ -85,6 +85,13 @@ def register(subparsers: argparse._SubParsersAction[argparse.ArgumentParser]) ->
         action="store_true",
         help="Show what would be removed without removing",
     )
+    p_cleanup.add_argument(
+        "-y",
+        "--yes",
+        action="store_true",
+        dest="assume_yes",
+        help="Skip the confirmation prompt and remove immediately.",
+    )
 
     # image usage — disk usage summary (was top-level `storage`)
     p_usage = image_sub.add_parser(
@@ -126,7 +133,10 @@ def dispatch(args: argparse.Namespace) -> bool:
         case "list":
             _cmd_list(getattr(args, "project_id", None))
         case "cleanup":
-            _cmd_cleanup(dry_run=getattr(args, "dry_run", False))
+            _cmd_cleanup(
+                dry_run=getattr(args, "dry_run", False),
+                assume_yes=getattr(args, "assume_yes", False),
+            )
         case "usage":
             _cmd_usage(
                 project_id=getattr(args, "project", None),
@@ -236,28 +246,40 @@ def _cmd_list(project_id: str | None) -> None:
     print(f"\n{len(images)} image(s)")
 
 
-def _cmd_cleanup(dry_run: bool) -> None:
-    """Remove orphaned terok images."""
-    result = cleanup_images(dry_run=dry_run)
+def _cmd_cleanup(*, dry_run: bool, assume_yes: bool) -> None:
+    """List orphaned terok images and ask before removing them.
 
-    if not result.removed and not result.failed:
+    ``--dry-run`` lists only and never prompts.  ``--yes`` (``-y``) skips the
+    prompt for non-interactive use.  Default: list, then confirm.
+    """
+    orphaned = find_orphaned_images()
+    if not orphaned:
         print("No orphaned terok images found.")
         return
 
-    label = "Would remove" if dry_run else "Removed"
-    for name in result.removed:
-        print(f"  {label}: {name}")
-
-    if result.failed:
-        for name in result.failed:
-            print(f"  Failed: {name}")
+    for img in orphaned:
+        print(f"  {img.full_name}")
 
     if dry_run:
-        print(f"\n{len(result.removed)} image(s) would be removed.")
-    else:
-        removed_count = len(result.removed)
-        failed_count = len(result.failed)
-        msg = f"\n{removed_count} image(s) removed."
-        if failed_count:
-            msg += f" {failed_count} failed (may be in use)."
-        print(msg)
+        print(f"\n{len(orphaned)} image(s) would be removed.")
+        return
+
+    if not assume_yes:
+        try:
+            answer = input(f"\nRemove {len(orphaned)} image(s)? [y/N] ").strip().lower()
+        except (EOFError, KeyboardInterrupt):
+            answer = ""
+        if answer not in ("y", "yes"):
+            print("Cancelled.")
+            return
+
+    result = remove_images(orphaned)
+    for name in result.removed:
+        print(f"  Removed: {name}")
+    for name in result.failed:
+        print(f"  Failed: {name}")
+
+    msg = f"\n{len(result.removed)} image(s) removed."
+    if result.failed:
+        msg += f" {len(result.failed)} failed (may be in use)."
+    print(msg)

--- a/src/terok/lib/api.py
+++ b/src/terok/lib/api.py
@@ -80,6 +80,7 @@ from .domain.image_cleanup import (  # noqa: F401 — re-exported public API
     cleanup_images,
     find_orphaned_images,
     list_images,
+    remove_images,
 )
 
 # Cross-project lockdown.
@@ -282,6 +283,7 @@ __all__ = [
     "list_images",
     "find_orphaned_images",
     "cleanup_images",
+    "remove_images",
     "installed_agents",
     "installed_agents_for_project",
     # Project lifecycle

--- a/src/terok/lib/domain/image_cleanup.py
+++ b/src/terok/lib/domain/image_cleanup.py
@@ -19,6 +19,8 @@ from ..core.projects import list_projects
 # without having to chase a module-level singleton.
 
 if TYPE_CHECKING:
+    from collections.abc import Iterable
+
     from terok.lib.integrations.sandbox import Image
 
 
@@ -38,6 +40,17 @@ class ImageInfo:
         if self.repository == "<none>" and self.tag == "<none>":
             return f"<none> ({self.image_id[:12]})"
         return f"{self.repository}:{self.tag}"
+
+    @property
+    def project_key(self) -> str:
+        """Normalised repository, stripped of podman's ``localhost/`` prefix.
+
+        Podman labels every locally-built image with a ``localhost/`` registry
+        prefix.  terok's classification (global vs L2) and project lookups key
+        off bare project ids, so callers compare against this property rather
+        than the raw [`repository`][terok.lib.domain.image_cleanup.ImageInfo.repository] string.
+        """
+        return self.repository.removeprefix("localhost/")
 
     @classmethod
     def from_image(cls, image: Image) -> ImageInfo:
@@ -134,7 +147,7 @@ def find_orphaned_images() -> list[ImageInfo]:
             img
             for img in all_images
             if _is_terok_l2_image(img.repository, img.tag)
-            and img.repository not in known_ids
+            and img.project_key not in known_ids
             and _is_terok_built_image(img.image_id)
         ]
 
@@ -174,20 +187,23 @@ def _is_terok_built_image(image_id: str) -> bool:
     return any("terok-l0" in line or "terok-l1" in line for line in image.history())
 
 
-def cleanup_images(dry_run: bool = False) -> CleanupResult:
-    """Remove orphaned terok images.
+def remove_images(images: Iterable[ImageInfo], *, dry_run: bool = False) -> CleanupResult:
+    """Remove a pre-computed set of images (or just report under *dry_run*).
+
+    Split out from [`cleanup_images`][terok.lib.domain.image_cleanup.cleanup_images]
+    so the CLI can present the orphan list, prompt for confirmation, and only
+    then act — without paying the discovery cost twice.
 
     Args:
-        dry_run: If True, only report what would be removed without removing.
+        images: The images to remove.  Iterated once.
+        dry_run: If True, only report names without invoking the runtime.
 
     Returns:
         CleanupResult with lists of removed and failed image display names.
     """
-    orphaned = find_orphaned_images()
     removed: list[str] = []
     failed: list[str] = []
-
-    for img in orphaned:
+    for img in images:
         if dry_run:
             removed.append(img.full_name)
             continue
@@ -201,5 +217,20 @@ def cleanup_images(dry_run: bool = False) -> CleanupResult:
 
             log_warning(f"Image cleanup failed for {img.full_name}: {exc}")
             failed.append(img.full_name)
-
     return CleanupResult(removed=removed, failed=failed, dry_run=dry_run)
+
+
+def cleanup_images(dry_run: bool = False) -> CleanupResult:
+    """Find and remove orphaned terok images in one shot.
+
+    Thin convenience over [`find_orphaned_images`][terok.lib.domain.image_cleanup.find_orphaned_images]
+    + [`remove_images`][terok.lib.domain.image_cleanup.remove_images] for callers that
+    don't need to inspect the list first.
+
+    Args:
+        dry_run: If True, only report what would be removed without removing.
+
+    Returns:
+        CleanupResult with lists of removed and failed image display names.
+    """
+    return remove_images(find_orphaned_images(), dry_run=dry_run)

--- a/src/terok/lib/domain/image_cleanup.py
+++ b/src/terok/lib/domain/image_cleanup.py
@@ -117,11 +117,12 @@ def list_images(project_id: str | None = None) -> list[ImageInfo]:
     """
     images: list[ImageInfo] = []
     for image in PodmanRuntime().images():
-        if not _is_terok_image(image.repository, image.tag):
+        repo = image.repository.removeprefix("localhost/")
+        if not _is_terok_image(repo, image.tag):
             continue
         if project_id is not None:
             # Filter: L2 images must match the project; L0/L1 always shown
-            if _is_terok_l2_image(image.repository, image.tag) and image.repository != project_id:
+            if _is_terok_l2_image(repo, image.tag) and repo != project_id:
                 continue
         images.append(ImageInfo.from_image(image))
     return images

--- a/src/terok/lib/domain/storage.py
+++ b/src/terok/lib/domain/storage.py
@@ -86,12 +86,20 @@ def format_bytes(n: int) -> str:
 
 _GLOBAL_PREFIXES = ("terok-l0", "terok-l1-cli")
 
+ORPHAN_PROJECT_ID = "(orphans)"
+"""Synthetic project id for the overview row that collects L2 images whose
+project no longer exists in the config.
+
+Parentheses are forbidden in real project ids (validated against
+``[a-z0-9][a-z0-9_-]*`` in ``project_model``), so this value can never
+collide with a configured project."""
+
 
 def _is_global_image(img: ImageInfo) -> bool:
     """L0/L1 base images and dangling images belong to the global section."""
     if img.repository == "<none>":
         return True
-    return img.repository.startswith(_GLOBAL_PREFIXES)
+    return img.project_key.startswith(_GLOBAL_PREFIXES)
 
 
 def _image_project_id(img: ImageInfo) -> str | None:
@@ -99,7 +107,7 @@ def _image_project_id(img: ImageInfo) -> str | None:
     if _is_global_image(img):
         return None
     if img.tag in ("l2-cli", "l2-dev"):
-        return img.repository
+        return img.project_key
     return None
 
 
@@ -220,6 +228,20 @@ def get_storage_overview() -> StorageOverview:
                 image_bytes=project_image_bytes.get(proj.id, 0),
                 workspace_bytes=sum(t.workspace_bytes for t in tasks),
                 task_count=len(tasks),
+            )
+        )
+
+    # Surface L2 images whose project is no longer configured so they roll up
+    # into the grand total instead of vanishing from the overview.
+    known_ids = {p.id for p in projects_conf}
+    orphan_bytes = sum(b for pid, b in project_image_bytes.items() if pid not in known_ids)
+    if orphan_bytes:
+        summaries.append(
+            ProjectSummary(
+                project_id=ORPHAN_PROJECT_ID,
+                image_bytes=orphan_bytes,
+                workspace_bytes=0,
+                task_count=0,
             )
         )
 

--- a/tach.toml
+++ b/tach.toml
@@ -746,11 +746,11 @@ expose = [
 from = ["terok.lib.orchestration.image"]
 
 [[interfaces]]
-expose = ["list_images", "find_orphaned_images", "cleanup_images", "ImageInfo", "CleanupResult"]
+expose = ["list_images", "find_orphaned_images", "cleanup_images", "remove_images", "ImageInfo", "CleanupResult"]
 from = ["terok.lib.domain.image_cleanup"]
 
 [[interfaces]]
-expose = ["StorageOverview", "ProjectDetail", "ProjectSummary", "get_storage_overview", "get_project_storage_detail", "format_bytes", "parse_image_size"]
+expose = ["StorageOverview", "ProjectDetail", "ProjectSummary", "get_storage_overview", "get_project_storage_detail", "format_bytes", "parse_image_size", "ORPHAN_PROJECT_ID"]
 from = ["terok.lib.domain.storage"]
 
 [[interfaces]]

--- a/tests/unit/cli/test_cli_image.py
+++ b/tests/unit/cli/test_cli_image.py
@@ -42,33 +42,101 @@ def test_cmd_list_outputs_expected(
     assert_output_contains(capsys.readouterr().out, expected_lines)
 
 
-@pytest.mark.parametrize(
-    ("result", "expected_lines"),
-    [
-        (CleanupResult(removed=[], failed=[], dry_run=False), ["No orphaned terok images found"]),
-        (
-            CleanupResult(removed=["old-proj:l2-cli"], failed=[], dry_run=True),
-            ["Would remove", "1 image(s) would be removed"],
-        ),
-        (
-            CleanupResult(
-                removed=["old-proj:l2-cli"],
-                failed=["in-use-proj:l2-cli"],
-                dry_run=False,
-            ),
-            ["Removed", "Failed", "1 failed"],
-        ),
-    ],
-    ids=["nothing-to-clean", "dry-run", "with-failures"],
-)
-def test_cmd_cleanup_outputs_expected(
-    result: CleanupResult,
-    expected_lines: list[str],
+_ORPHAN = ImageInfo("old-proj", "l2-cli", "sha256:abc", "1GB", "5 days ago")
+
+
+def test_cmd_cleanup_nothing_to_clean(capsys: pytest.CaptureFixture[str]) -> None:
+    """Empty orphan list short-circuits before any prompt."""
+    with patch("terok.cli.commands.image.find_orphaned_images", return_value=[]):
+        _cmd_cleanup(dry_run=False, assume_yes=False)
+    assert "No orphaned terok images found" in capsys.readouterr().out
+
+
+def test_cmd_cleanup_dry_run_lists_without_prompting(
     capsys: pytest.CaptureFixture[str],
 ) -> None:
-    with patch("terok.cli.commands.image.cleanup_images", return_value=result):
-        _cmd_cleanup(dry_run=result.dry_run)
-    assert_output_contains(capsys.readouterr().out, expected_lines)
+    """``--dry-run`` lists the orphans and never invokes the runtime."""
+    with (
+        patch("terok.cli.commands.image.find_orphaned_images", return_value=[_ORPHAN]),
+        patch("terok.cli.commands.image.remove_images") as mock_remove,
+        patch("builtins.input") as mock_input,
+    ):
+        _cmd_cleanup(dry_run=True, assume_yes=False)
+    out = capsys.readouterr().out
+    assert "old-proj:l2-cli" in out
+    assert "1 image(s) would be removed" in out
+    mock_remove.assert_not_called()
+    mock_input.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    ("user_input", "should_remove"),
+    [("y", True), ("yes", True), ("YES", True), ("", False), ("n", False), ("no", False)],
+    ids=["y", "yes", "uppercase-yes", "blank", "n", "no"],
+)
+def test_cmd_cleanup_prompts_before_removing(
+    user_input: str,
+    should_remove: bool,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Default mode asks ``[y/N]`` and only removes on an affirmative answer."""
+    result = CleanupResult(removed=["old-proj:l2-cli"], failed=[], dry_run=False)
+    with (
+        patch("terok.cli.commands.image.find_orphaned_images", return_value=[_ORPHAN]),
+        patch("terok.cli.commands.image.remove_images", return_value=result) as mock_remove,
+        patch("builtins.input", return_value=user_input),
+    ):
+        _cmd_cleanup(dry_run=False, assume_yes=False)
+    out = capsys.readouterr().out
+    assert "old-proj:l2-cli" in out
+    if should_remove:
+        mock_remove.assert_called_once()
+        assert "Removed: old-proj:l2-cli" in out
+    else:
+        mock_remove.assert_not_called()
+        assert "Cancelled" in out
+
+
+def test_cmd_cleanup_yes_flag_skips_prompt(capsys: pytest.CaptureFixture[str]) -> None:
+    """``--yes`` removes without asking."""
+    result = CleanupResult(removed=["old-proj:l2-cli"], failed=[], dry_run=False)
+    with (
+        patch("terok.cli.commands.image.find_orphaned_images", return_value=[_ORPHAN]),
+        patch("terok.cli.commands.image.remove_images", return_value=result),
+        patch("builtins.input") as mock_input,
+    ):
+        _cmd_cleanup(dry_run=False, assume_yes=True)
+    assert "Removed: old-proj:l2-cli" in capsys.readouterr().out
+    mock_input.assert_not_called()
+
+
+def test_cmd_cleanup_reports_failures(capsys: pytest.CaptureFixture[str]) -> None:
+    """Failed removals are surfaced in the summary."""
+    result = CleanupResult(
+        removed=["old-proj:l2-cli"],
+        failed=["in-use-proj:l2-cli"],
+        dry_run=False,
+    )
+    with (
+        patch("terok.cli.commands.image.find_orphaned_images", return_value=[_ORPHAN]),
+        patch("terok.cli.commands.image.remove_images", return_value=result),
+    ):
+        _cmd_cleanup(dry_run=False, assume_yes=True)
+    out = capsys.readouterr().out
+    assert "Failed: in-use-proj:l2-cli" in out
+    assert "1 failed" in out
+
+
+def test_cmd_cleanup_ctrl_c_at_prompt_cancels(capsys: pytest.CaptureFixture[str]) -> None:
+    """Ctrl-C / EOF at the prompt is treated as 'no'."""
+    with (
+        patch("terok.cli.commands.image.find_orphaned_images", return_value=[_ORPHAN]),
+        patch("terok.cli.commands.image.remove_images") as mock_remove,
+        patch("builtins.input", side_effect=KeyboardInterrupt),
+    ):
+        _cmd_cleanup(dry_run=False, assume_yes=False)
+    assert "Cancelled" in capsys.readouterr().out
+    mock_remove.assert_not_called()
 
 
 class TestImageDispatch:
@@ -109,16 +177,16 @@ class TestImageDispatch:
             assert dispatch(args) is True
         mock.assert_called_once_with(None)
 
-    def test_cleanup_forwards_dry_run_flag(self) -> None:
-        """``image cleanup --dry-run`` forwards the flag."""
+    def test_cleanup_forwards_flags(self) -> None:
+        """``image cleanup --dry-run --yes`` forwards both flags."""
         import argparse
 
         from terok.cli.commands.image import dispatch
 
-        args = argparse.Namespace(cmd="image", image_cmd="cleanup", dry_run=True)
+        args = argparse.Namespace(cmd="image", image_cmd="cleanup", dry_run=True, assume_yes=True)
         with patch("terok.cli.commands.image._cmd_cleanup") as mock:
             assert dispatch(args) is True
-        mock.assert_called_once_with(dry_run=True)
+        mock.assert_called_once_with(dry_run=True, assume_yes=True)
 
     def test_usage_forwards_project_and_json_flags(self) -> None:
         """``image usage --project X --json`` routes to the usage helper."""

--- a/tests/unit/lib/test_image_cleanup.py
+++ b/tests/unit/lib/test_image_cleanup.py
@@ -59,6 +59,21 @@ class TestImageInfo:
         """Dangling images get the short-id display; tagged images get ``repo:tag``."""
         assert image.full_name == expected
 
+    @pytest.mark.parametrize(
+        ("repository", "expected"),
+        [
+            ("myproj", "myproj"),
+            ("localhost/myproj", "myproj"),
+            ("localhost/terok-l1-cli", "terok-l1-cli"),
+            ("<none>", "<none>"),
+        ],
+        ids=["bare", "localhost-prefixed", "localhost-prefixed-l1", "dangling"],
+    )
+    def test_project_key_strips_localhost(self, repository: str, expected: str) -> None:
+        """``project_key`` strips podman's ``localhost/`` registry prefix."""
+        img = ImageInfo(repository, "l2-cli", "sha256:x", "1GB", "1 day")
+        assert img.project_key == expected
+
 
 class TestListImages:
     """Tests for ``list_images()``."""
@@ -185,6 +200,29 @@ class TestFindOrphanedImages:
         assert {image.image_id for image in orphaned} == expected_ids
         if known_projects is None:
             mock_list.assert_not_called()
+
+    @unittest.mock.patch("terok.lib.domain.image_cleanup._is_terok_built_image", return_value=True)
+    @unittest.mock.patch(
+        "terok.lib.domain.image_cleanup._find_dangling_terok_images", return_value=[]
+    )
+    @unittest.mock.patch("terok.lib.domain.image_cleanup.list_images")
+    @unittest.mock.patch("terok.lib.domain.image_cleanup._known_project_ids")
+    def test_localhost_prefixed_image_matches_bare_project_id(
+        self,
+        mock_known: unittest.mock.Mock,
+        mock_list: unittest.mock.Mock,
+        _dangling: unittest.mock.Mock,
+        _built: unittest.mock.Mock,
+    ) -> None:
+        """Podman's ``localhost/`` prefix on the repo must not break the in-use check."""
+        mock_known.return_value = {"proj-a"}
+        mock_list.return_value = [
+            ImageInfo("localhost/proj-a", "l2-cli", "sha256:aaa", "1GB", "1 day"),
+            ImageInfo("localhost/old-renamed", "l2-cli", "sha256:bbb", "1GB", "5 days"),
+        ]
+        orphaned = find_orphaned_images()
+        # ``proj-a`` is in use; only ``old-renamed`` should be flagged.
+        assert {img.image_id for img in orphaned} == {"sha256:bbb"}
 
 
 class TestCleanupImages:

--- a/tests/unit/lib/test_image_cleanup.py
+++ b/tests/unit/lib/test_image_cleanup.py
@@ -108,7 +108,6 @@ class TestListImages:
         ],
         ids=["all-terok-images", "filtered-by-project", "dev-tag"],
     )
-    # removed — mock_runtime fixture handles it
     def test_list_images(
         self,
         mock_runtime: unittest.mock.Mock,
@@ -119,6 +118,39 @@ class TestListImages:
         """Runtime enumeration is filtered to terok images (optionally by project)."""
         mock_runtime.images.return_value = [
             _mock_image(ref=ref, repository=repo, tag=tag) for ref, repo, tag in images_spec
+        ]
+        images = list_images(project_id)
+        assert {image.full_name for image in images} == expected_names
+
+    @pytest.mark.parametrize(
+        ("project_id", "expected_names"),
+        [
+            (
+                None,
+                {
+                    "localhost/terok-l0:ubuntu-24.04",
+                    "localhost/proj-a:l2-cli",
+                    "localhost/proj-b:l2-cli",
+                },
+            ),
+            (
+                "proj-a",
+                {"localhost/terok-l0:ubuntu-24.04", "localhost/proj-a:l2-cli"},
+            ),
+        ],
+        ids=["unfiltered", "filtered-by-project"],
+    )
+    def test_list_images_handles_localhost_prefix(
+        self,
+        mock_runtime: unittest.mock.Mock,
+        project_id: str | None,
+        expected_names: set[str],
+    ) -> None:
+        """Podman's ``localhost/`` prefix on the repo must not hide terok images."""
+        mock_runtime.images.return_value = [
+            _mock_image(ref="sha256:l0", repository="localhost/terok-l0", tag="ubuntu-24.04"),
+            _mock_image(ref="sha256:aa", repository="localhost/proj-a", tag="l2-cli"),
+            _mock_image(ref="sha256:bb", repository="localhost/proj-b", tag="l2-cli"),
         ]
         images = list_images(project_id)
         assert {image.full_name for image in images} == expected_names

--- a/tests/unit/lib/test_storage.py
+++ b/tests/unit/lib/test_storage.py
@@ -14,6 +14,7 @@ from unittest.mock import patch
 
 from terok.lib.domain.image_cleanup import ImageInfo
 from terok.lib.domain.storage import (
+    ORPHAN_PROJECT_ID,
     ProjectSummary,
     StorageOverview,
     _is_global_image,
@@ -99,6 +100,15 @@ class TestImageClassification:
         img = ImageInfo("myproject", "l2-cli", "sha256:jkl", "3GB", "1d ago")
         assert not _is_global_image(img)
 
+    def test_localhost_prefixed_l0_is_global(self):
+        """Podman's ``localhost/`` registry prefix must not disqualify a base image."""
+        img = ImageInfo("localhost/terok-l0", "fedora-43", "sha256:m", "1GB", "1d")
+        assert _is_global_image(img)
+
+    def test_localhost_prefixed_l1_is_global(self):
+        img = ImageInfo("localhost/terok-l1-cli", "fedora-43", "sha256:n", "2GB", "1d")
+        assert _is_global_image(img)
+
 
 # ---------------------------------------------------------------------------
 # StorageOverview properties
@@ -157,6 +167,63 @@ class TestGetStorageOverview:
     def test_empty_system(self, _mounts, _imgs, _projects, _tasks, _shared):
         overview = get_storage_overview()
         assert overview.grand_total == 0
+
+    @patch("terok.lib.domain.storage.get_shared_mounts_storage", return_value=[])
+    @patch("terok.lib.domain.storage.get_tasks_storage", return_value=[])
+    @patch("terok.lib.domain.storage.list_projects")
+    @patch("terok.lib.domain.storage.list_images")
+    @patch("terok.lib.domain.storage.sandbox_live_mounts_dir", return_value=MOCK_BASE / "mounts")
+    def test_localhost_prefix_attributes_to_project(
+        self, _mounts, mock_images, mock_projects, _tasks, _shared
+    ):
+        """L2 images with podman's ``localhost/`` prefix roll up to the bare project id."""
+        mock_images.return_value = [
+            ImageInfo("localhost/myproject", "l2-cli", "id", "3GB", "1d ago"),
+        ]
+        mock_projects.return_value = [_fake_project("myproject")]
+        overview = get_storage_overview()
+        assert len(overview.projects) == 1
+        assert overview.projects[0].project_id == "myproject"
+        assert overview.projects[0].image_bytes == 3_000_000_000
+
+    @patch("terok.lib.domain.storage.get_shared_mounts_storage", return_value=[])
+    @patch("terok.lib.domain.storage.get_tasks_storage", return_value=[])
+    @patch("terok.lib.domain.storage.list_projects")
+    @patch("terok.lib.domain.storage.list_images")
+    @patch("terok.lib.domain.storage.sandbox_live_mounts_dir", return_value=MOCK_BASE / "mounts")
+    def test_orphan_l2_image_surfaces_in_overview(
+        self, _mounts, mock_images, mock_projects, _tasks, _shared
+    ):
+        """L2 images whose project is gone roll up under an "(orphans)" pseudo-project."""
+        mock_images.return_value = [
+            ImageInfo("localhost/myproject", "l2-cli", "id1", "1GB", "1d ago"),
+            ImageInfo("localhost/old-renamed", "l2-cli", "id2", "2GB", "5d ago"),
+        ]
+        mock_projects.return_value = [_fake_project("myproject")]
+        overview = get_storage_overview()
+        project_ids = [p.project_id for p in overview.projects]
+        assert ORPHAN_PROJECT_ID in project_ids
+        orphan = next(p for p in overview.projects if p.project_id == ORPHAN_PROJECT_ID)
+        assert orphan.image_bytes == 2_000_000_000
+        assert orphan.task_count == 0
+        # Orphan bytes contribute to the grand total.
+        assert overview.grand_total == 1_000_000_000 + 2_000_000_000
+
+    @patch("terok.lib.domain.storage.get_shared_mounts_storage", return_value=[])
+    @patch("terok.lib.domain.storage.get_tasks_storage", return_value=[])
+    @patch("terok.lib.domain.storage.list_projects")
+    @patch("terok.lib.domain.storage.list_images")
+    @patch("terok.lib.domain.storage.sandbox_live_mounts_dir", return_value=MOCK_BASE / "mounts")
+    def test_no_orphan_row_when_everything_matches(
+        self, _mounts, mock_images, mock_projects, _tasks, _shared
+    ):
+        """The orphan row appears only when there's something to put in it."""
+        mock_images.return_value = [
+            ImageInfo("localhost/myproject", "l2-cli", "id1", "1GB", "1d ago"),
+        ]
+        mock_projects.return_value = [_fake_project("myproject")]
+        overview = get_storage_overview()
+        assert all(p.project_id != ORPHAN_PROJECT_ID for p in overview.projects)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Strip Podman's `localhost/` registry prefix once via a new `ImageInfo.project_key` property, then route classification (`storage._is_global_image`, `_image_project_id`) and cleanup (`find_orphaned_images`'s in-use check) through it.
- Surface L2 images with no matching project as an `(orphans)` row in `terok image usage` so they contribute to the grand total instead of silently disappearing.
- Make `terok image cleanup` ask before removing: list what's about to be deleted, prompt `Remove N image(s)? [y/N]` (Ctrl-C/EOF cancels), and add `-y/--yes` for non-interactive runs. `--dry-run` is unchanged.

## Why

Podman labels every locally-built image with a `localhost/` prefix (`localhost/terok:l2-cli`). Existing classification and cleanup compared against bare ids and prefixes, so on a real system:

- L0/L1 base images were never recognised as global — the Global section of `image usage` lost its Images sub-block entirely.
- Per-project IMAGES columns all reported `0 B`.
- L2 images whose project was renamed/removed silently vanished from the overview.
- `terok image cleanup` would have flagged **every in-use L2 image** as orphaned (only saved by the `_is_terok_built_image` ancestry gate — a thin guard for a destructive action).

Internally `cleanup_images` is now a thin wrapper over `find_orphaned_images` + a new public `remove_images(images, dry_run=...)`, so the CLI can list → prompt → act without paying the discovery cost twice.

## Test plan

- [x] `make lint` (ruff check + format)
- [x] `make tach` (module-boundary check — `ORPHAN_PROJECT_ID` + `remove_images` added to the relevant interfaces)
- [x] `make lint-imports` (import-boundary contracts)
- [x] `make security` (bandit — no new medium/high findings)
- [x] `make reuse` (SPDX compliance)
- [x] `make test` — 2633 passed
- [x] New unit coverage for: `localhost/`-prefix normalization, in-use image not flagged as orphaned, orphan L2 surfaces in overview, prompt branches (`y`/`yes`/`YES`/`n`/`no`/blank/Ctrl-C), `--yes` skips prompt, `--dry-run` skips prompt and runtime
- [ ] Manual smoke: run `terok image list && terok image usage` and confirm Images section + per-project bytes now populate; run `terok image cleanup --dry-run` and confirm in-use images are no longer listed as removable

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `-y/--yes` to skip confirmation for image cleanup.
  * `--dry-run` now shows orphan list and skips removal.
  * Cleanup now reports per-image removed/failed results and a clear removed vs failed summary.

* **Bug Fixes**
  * Orphan detection correctly handles `localhost/`-prefixed image repositories.
  * Storage overview now groups truly orphaned images under a distinct orphan summary.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/terok-ai/terok/pull/1014?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->