### PR TITLE
feat(krun): drop resolv.conf workaround; route runtime through RunSpec

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -3598,13 +3598,14 @@ url = "https://github.com/terok-ai/terok-clearance/releases/download/v0.6.14a4/t
 
 [[package]]
 name = "terok-executor"
-version = "0.0.149a17"
+version = "0.0.149a18"
 description = "Single-agent task runner for hardened Podman containers"
 optional = false
 python-versions = ">=3.12,<3.15"
 groups = ["main"]
-files = []
-develop = false
+files = [
+    {file = "terok_executor-0.0.149a18-py3-none-any.whl", hash = "sha256:c26837803527604c92e524e853144ec76ac25507bc0837b6a571b1dca5eed245"},
+]
 
 [package.dependencies]
 agent-client-protocol = ">=0.10"
@@ -3613,24 +3614,23 @@ prompt-toolkit = ">=3.0"
 pydantic = ">=2.9"
 rich = ">=13.0"
 "ruamel.yaml" = ">=0.18"
-terok-sandbox = {git = "https://github.com/sliwowitz/terok-sandbox.git", rev = "feat/shield-runtime-thread"}
+terok_sandbox = {url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.0.124a14/terok_sandbox-0.0.124a14-py3-none-any.whl"}
 tomli-w = ">=1.0"
 
 [package.source]
-type = "git"
-url = "https://github.com/sliwowitz/terok-executor.git"
-reference = "feat/krun-launch-docstring"
-resolved_reference = "d42dc73869daf5e3b0bab3549f9b64b42adfb336"
+type = "url"
+url = "https://github.com/terok-ai/terok-executor/releases/download/v0.0.149a18/terok_executor-0.0.149a18-py3-none-any.whl"
 
 [[package]]
 name = "terok-sandbox"
-version = "0.0.124a13"
+version = "0.0.124a14"
 description = "Hardened Podman container runner with gate server and shield integration"
 optional = false
 python-versions = ">=3.12,<4.0"
 groups = ["main"]
-files = []
-develop = false
+files = [
+    {file = "terok_sandbox-0.0.124a14-py3-none-any.whl", hash = "sha256:92f9014d74e7e5c6ea79859edc5796f30ab5f3ab625a9153450a7a442880fde0"},
+]
 
 [package.dependencies]
 aiohttp = ">=3.9"
@@ -3643,33 +3643,30 @@ pydantic = ">=2.9"
 "ruamel.yaml" = ">=0.18"
 sqlcipher3 = ">=0.6.2"
 terok_clearance = {url = "https://github.com/terok-ai/terok-clearance/releases/download/v0.6.14a4/terok_clearance-0.6.14a4-py3-none-any.whl"}
-terok-shield = {git = "https://github.com/sliwowitz/terok-shield.git", rev = "feat/krun-dnsmasq-bind"}
+terok_shield = {url = "https://github.com/terok-ai/terok-shield/releases/download/v0.6.42a5/terok_shield-0.6.42a5-py3-none-any.whl"}
 
 [package.source]
-type = "git"
-url = "https://github.com/sliwowitz/terok-sandbox.git"
-reference = "feat/shield-runtime-thread"
-resolved_reference = "679f41c97d100effb314f14fc06cc83be00552db"
+type = "url"
+url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.0.124a14/terok_sandbox-0.0.124a14-py3-none-any.whl"
 
 [[package]]
 name = "terok-shield"
-version = "0.6.42a4"
+version = "0.6.42a5"
 description = "nftables-based egress firewalling for Podman containers"
 optional = false
 python-versions = ">=3.12,<4.0"
 groups = ["main"]
-files = []
-develop = false
+files = [
+    {file = "terok_shield-0.6.42a5-py3-none-any.whl", hash = "sha256:4e670fb7040bb39e9c1a2ec449db7fe82dd99678d9841ce97c08a146af127604"},
+]
 
 [package.dependencies]
 pydantic = ">=2.0"
 PyYAML = ">=6.0"
 
 [package.source]
-type = "git"
-url = "https://github.com/sliwowitz/terok-shield.git"
-reference = "feat/krun-dnsmasq-bind"
-resolved_reference = "7b654ee41c8da839f73819898ae5a46ff6bc00d3"
+type = "url"
+url = "https://github.com/terok-ai/terok-shield/releases/download/v0.6.42a5/terok_shield-0.6.42a5-py3-none-any.whl"
 
 [[package]]
 name = "textual"
@@ -4549,4 +4546,4 @@ propcache = ">=0.2.1"
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.12,<3.15"
-content-hash = "912c23d0a3d6e43dd30bac6198c5365c0849479158fb7f74afe1a4919d498e5c"
+content-hash = "b06dee720f98324b1a510fa31daf1196f2ca272535168fc836d449711dd2ec80"

--- a/poetry.lock
+++ b/poetry.lock
@@ -3603,9 +3603,8 @@ description = "Single-agent task runner for hardened Podman containers"
 optional = false
 python-versions = ">=3.12,<3.15"
 groups = ["main"]
-files = [
-    {file = "terok_executor-0.0.149a17-py3-none-any.whl", hash = "sha256:d32018590ba9541de6b6d0532e5a2858ea24270a32bd38d086512facbb7ea2d1"},
-]
+files = []
+develop = false
 
 [package.dependencies]
 agent-client-protocol = ">=0.10"
@@ -3614,12 +3613,14 @@ prompt-toolkit = ">=3.0"
 pydantic = ">=2.9"
 rich = ">=13.0"
 "ruamel.yaml" = ">=0.18"
-terok_sandbox = {url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.0.124a13/terok_sandbox-0.0.124a13-py3-none-any.whl"}
+terok-sandbox = {git = "https://github.com/sliwowitz/terok-sandbox.git", rev = "feat/shield-runtime-thread"}
 tomli-w = ">=1.0"
 
 [package.source]
-type = "url"
-url = "https://github.com/terok-ai/terok-executor/releases/download/v0.0.149a17/terok_executor-0.0.149a17-py3-none-any.whl"
+type = "git"
+url = "https://github.com/sliwowitz/terok-executor.git"
+reference = "feat/krun-launch-docstring"
+resolved_reference = "d42dc73869daf5e3b0bab3549f9b64b42adfb336"
 
 [[package]]
 name = "terok-sandbox"
@@ -3628,9 +3629,8 @@ description = "Hardened Podman container runner with gate server and shield inte
 optional = false
 python-versions = ">=3.12,<4.0"
 groups = ["main"]
-files = [
-    {file = "terok_sandbox-0.0.124a13-py3-none-any.whl", hash = "sha256:0a2cecf6accd55964249eba25ed290b7f74554db403475317059c256983fc7fb"},
-]
+files = []
+develop = false
 
 [package.dependencies]
 aiohttp = ">=3.9"
@@ -3643,11 +3643,13 @@ pydantic = ">=2.9"
 "ruamel.yaml" = ">=0.18"
 sqlcipher3 = ">=0.6.2"
 terok_clearance = {url = "https://github.com/terok-ai/terok-clearance/releases/download/v0.6.14a4/terok_clearance-0.6.14a4-py3-none-any.whl"}
-terok_shield = {url = "https://github.com/terok-ai/terok-shield/releases/download/v0.6.42a4/terok_shield-0.6.42a4-py3-none-any.whl"}
+terok-shield = {git = "https://github.com/sliwowitz/terok-shield.git", rev = "feat/krun-dnsmasq-bind"}
 
 [package.source]
-type = "url"
-url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.0.124a13/terok_sandbox-0.0.124a13-py3-none-any.whl"
+type = "git"
+url = "https://github.com/sliwowitz/terok-sandbox.git"
+reference = "feat/shield-runtime-thread"
+resolved_reference = "679f41c97d100effb314f14fc06cc83be00552db"
 
 [[package]]
 name = "terok-shield"
@@ -3656,17 +3658,18 @@ description = "nftables-based egress firewalling for Podman containers"
 optional = false
 python-versions = ">=3.12,<4.0"
 groups = ["main"]
-files = [
-    {file = "terok_shield-0.6.42a4-py3-none-any.whl", hash = "sha256:4d9751f814785ac202944a10239dadbde352e2e814e9509b56d5393a06870a08"},
-]
+files = []
+develop = false
 
 [package.dependencies]
 pydantic = ">=2.0"
 PyYAML = ">=6.0"
 
 [package.source]
-type = "url"
-url = "https://github.com/terok-ai/terok-shield/releases/download/v0.6.42a4/terok_shield-0.6.42a4-py3-none-any.whl"
+type = "git"
+url = "https://github.com/sliwowitz/terok-shield.git"
+reference = "feat/krun-dnsmasq-bind"
+resolved_reference = "7b654ee41c8da839f73819898ae5a46ff6bc00d3"
 
 [[package]]
 name = "textual"
@@ -4546,4 +4549,4 @@ propcache = ">=0.2.1"
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.12,<3.15"
-content-hash = "ce96e89e20923ecec51e0560b7ecaeae063769a353f5c0db45a2edeb7f03730d"
+content-hash = "912c23d0a3d6e43dd30bac6198c5365c0849479158fb7f74afe1a4919d498e5c"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,9 +27,9 @@ dependencies = [
     "unique-namer>=1.3",
     "textual-serve>=1.1.0",
     "jinja2>=3.1",
-    "terok-executor @ git+https://github.com/sliwowitz/terok-executor.git@feat/krun-launch-docstring",
-    "terok-sandbox @ git+https://github.com/sliwowitz/terok-sandbox.git@feat/shield-runtime-thread",
-    "terok-shield @ git+https://github.com/sliwowitz/terok-shield.git@feat/krun-dnsmasq-bind",
+    "terok-executor @ https://github.com/terok-ai/terok-executor/releases/download/v0.0.149a18/terok_executor-0.0.149a18-py3-none-any.whl",
+    "terok-sandbox @ https://github.com/terok-ai/terok-sandbox/releases/download/v0.0.124a14/terok_sandbox-0.0.124a14-py3-none-any.whl",
+    "terok-shield @ https://github.com/terok-ai/terok-shield/releases/download/v0.6.42a5/terok_shield-0.6.42a5-py3-none-any.whl",
     "terok-clearance @ https://github.com/terok-ai/terok-clearance/releases/download/v0.6.14a4/terok_clearance-0.6.14a4-py3-none-any.whl",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,9 +27,9 @@ dependencies = [
     "unique-namer>=1.3",
     "textual-serve>=1.1.0",
     "jinja2>=3.1",
-    "terok-executor @ https://github.com/terok-ai/terok-executor/releases/download/v0.0.149a17/terok_executor-0.0.149a17-py3-none-any.whl",
-    "terok-sandbox @ https://github.com/terok-ai/terok-sandbox/releases/download/v0.0.124a13/terok_sandbox-0.0.124a13-py3-none-any.whl",
-    "terok-shield @ https://github.com/terok-ai/terok-shield/releases/download/v0.6.42a4/terok_shield-0.6.42a4-py3-none-any.whl",
+    "terok-executor @ git+https://github.com/sliwowitz/terok-executor.git@feat/krun-launch-docstring",
+    "terok-sandbox @ git+https://github.com/sliwowitz/terok-sandbox.git@feat/shield-runtime-thread",
+    "terok-shield @ git+https://github.com/sliwowitz/terok-shield.git@feat/krun-dnsmasq-bind",
     "terok-clearance @ https://github.com/terok-ai/terok-clearance/releases/download/v0.6.14a4/terok_clearance-0.6.14a4-py3-none-any.whl",
 ]
 

--- a/src/terok/lib/core/yaml_schema.py
+++ b/src/terok/lib/core/yaml_schema.py
@@ -434,7 +434,6 @@ class RawGlobalConfig(ExecutorConfigView):
     logs: RawLogsSection = Field(default_factory=RawLogsSection)
     tasks: RawTasksGlobalSection = Field(default_factory=RawTasksGlobalSection)
     git: RawGlobalGitSection = Field(default_factory=RawGlobalGitSection)
-    experimental: bool = False
     default_agent: str | None = None
     default_login: str | None = None
     agent: dict[str, Any] = Field(default_factory=dict)

--- a/src/terok/lib/orchestration/task_runners/container.py
+++ b/src/terok/lib/orchestration/task_runners/container.py
@@ -11,12 +11,11 @@ and ``_project_runtime_flags`` assemble the podman invocation.
 
 from __future__ import annotations
 
-import dataclasses
 import math
 import shlex
 from typing import TYPE_CHECKING
 
-from terok.lib.core.config import is_experimental
+from terok.lib.core.config import get_services_mode, is_experimental
 from terok.lib.integrations.executor import (
     AgentRunner,
     BuildError,
@@ -180,7 +179,6 @@ def _run_container(
     annotations = {"dossier.meta_path": str(task_dossier_path)}
     merged_args = list(extra_args or ()) + _project_runtime_flags(project, cname=cname)
     if project.runtime == "krun":
-        hooks = _chain_krun_dns_rewrite(hooks, task_dir)
         # ``--cpus`` is only a cgroup CFS quota — crun-krun does not
         # read it to size the microVM and defaults to host CPU
         # affinity instead (so ``nproc`` reports all host cores even
@@ -207,6 +205,7 @@ def _run_container(
             sealed=project.is_sealed,
             hooks=hooks,
             extra_args=merged_args,
+            runtime=project.runtime,
             hostname=cname,
             annotations=annotations,
         )
@@ -261,7 +260,6 @@ def _project_runtime_flags(project: ProjectConfig, *, cname: str) -> list[str]:
         flags += ["--security-opt", "label=nested", "--device", "/dev/fuse"]
     if project.runtime == "krun":
         _validate_krun_compatibility(project)
-        flags += ["--runtime", "krun"]
         # Reserve a free loopback TCP port and forward it to the guest's
         # sshd.  ``reserve_port`` binds-then-releases, so there's a
         # small race window before podman picks the port back up — same
@@ -283,46 +281,6 @@ def _project_runtime_flags(project: ProjectConfig, *, cname: str) -> list[str]:
     return flags
 
 
-def _chain_krun_dns_rewrite(hooks: LifecycleHooks | None, task_dir: Path) -> LifecycleHooks:
-    """WORKAROUND(krun-shield-dns): point shield's bind-mounted resolv.conf
-    at pasta's forwarder instead of the in-netns dnsmasq.
-
-    Shield writes ``nameserver 127.0.0.1`` at ``<task>/shield/resolv.conf``
-    and bind-mounts it over ``/etc/resolv.conf`` so the in-netns dnsmasq
-    can intercept DNS for clearance + audit.  Under krun the guest's
-    ``127.0.0.1`` is the microVM's own loopback (TSI doesn't redirect
-    127.0.0.0/8), so queries land nowhere and name resolution dies.
-
-    Rewrite the file to ``nameserver 169.254.1.1`` — pasta's link-local
-    forwarder, the same address shield's nft already permits ``:53`` to.
-    TSI surfaces the guest's connect to a host-side socket inside the
-    netns, pasta answers, the guest resolves.  Cost: dnsmasq sits idle,
-    so the clearance flow no longer fires on hostnames (IP-based
-    clearance still works — egress filtering on TCP/UDP is unaffected
-    because TSI surfaces traffic where shield's nft hooks live).
-
-    Fires from ``LifecycleHooks.pre_start``, which runs after shield's
-    own ``pre_start`` wrote the file and before podman exec — the only
-    window where the file is guaranteed to exist and the container has
-    not yet read it.
-
-    Proper fix: shield-side krun awareness (have shield write the right
-    address itself, conditional on the target runtime).  Remove this
-    helper when shield grows that.
-    """
-    shield_resolv = task_dir / "shield" / "resolv.conf"
-    prior = hooks.pre_start if hooks else None
-
-    def _patch() -> None:
-        if prior is not None:
-            prior()
-        if shield_resolv.is_file():
-            shield_resolv.write_text("nameserver 169.254.1.1\noptions ndots:0\n")
-
-    base = hooks or LifecycleHooks()
-    return dataclasses.replace(base, pre_start=_patch)
-
-
 def _validate_krun_compatibility(project: ProjectConfig) -> None:
     """Reject combinations that can't be honoured under krun.
 
@@ -336,6 +294,10 @@ def _validate_krun_compatibility(project: ProjectConfig) -> None:
     - ``experimental``: required for krun selection by any path.
     - ``nested_containers``: krun guests can't host nested podman/docker
       with our current image; ask the operator to drop one of the two.
+    - ``services.mode``: krun needs ``tcp``.  socket mode relies on
+      host-side unix sockets that the microVM's kernel can't see (no
+      shared mount namespace), so token-broker and ssh-signer bridges
+      silently fail to establish.
     """
     if not is_experimental():
         raise SystemExit(
@@ -349,6 +311,16 @@ def _validate_krun_compatibility(project: ProjectConfig) -> None:
             "run.runtime: krun is incompatible with run.nested_containers: true — "
             "the krun guest's hardened sshd doesn't host a nested-container stack.  "
             "Pick one or move the nested workload to a crun task."
+        )
+
+    if get_services_mode() == "socket":
+        raise SystemExit(
+            "run.runtime: krun is incompatible with services.mode: socket — "
+            "the microVM's kernel doesn't see the host's unix sockets, so the "
+            "token-broker and ssh-signer bridges can't establish.  Set "
+            "``services.mode: tcp`` in your config.yml (and re-run "
+            "``terok setup`` so the host services bind to TCP) before "
+            "launching krun tasks."
         )
 
 

--- a/tests/unit/lib/test_krun_runtime_wiring.py
+++ b/tests/unit/lib/test_krun_runtime_wiring.py
@@ -135,24 +135,14 @@ class TestKrunCompatibilityGuard:
     """`_validate_krun_compatibility` rejects nested-container combos
     and refuses krun selection without the experimental flag."""
 
-    def test_rejects_nested_containers(self) -> None:
+    def test_rejects_nested_containers(self, _experimental_enabled) -> None:
         project = _krun_project(nested_containers=True)
-        with (
-            patch(
-                "terok.lib.orchestration.task_runners.container.is_experimental",
-                return_value=True,
-            ),
-            pytest.raises(SystemExit, match="incompatible.*nested_containers"),
-        ):
+        with pytest.raises(SystemExit, match="incompatible.*nested_containers"):
             _validate_krun_compatibility(project)
 
-    def test_accepts_krun_without_nested(self) -> None:
+    def test_accepts_krun_without_nested(self, _experimental_enabled) -> None:
         project = _krun_project()
-        with patch(
-            "terok.lib.orchestration.task_runners.container.is_experimental",
-            return_value=True,
-        ):
-            _validate_krun_compatibility(project)  # no raise
+        _validate_krun_compatibility(project)  # no raise
 
     def test_rejects_krun_without_experimental_flag(self) -> None:
         """run.runtime: krun is gated on `experimental: true`.
@@ -172,18 +162,48 @@ class TestKrunCompatibilityGuard:
         ):
             _validate_krun_compatibility(project)
 
+    def test_rejects_krun_under_socket_services_mode(self) -> None:
+        """run.runtime: krun + services.mode: socket fail-fast with a fix hint.
+
+        The microVM's kernel can't see the host's unix sockets (no
+        shared mount namespace), so token-broker / ssh-signer bridges
+        silently fail to establish.  Refusing at launch with a clear
+        pointer to ``services.mode: tcp`` beats a baffling timeout
+        deeper in the bring-up.
+        """
+        project = _krun_project()
+        with (
+            patch(
+                "terok.lib.orchestration.task_runners.container.is_experimental",
+                return_value=True,
+            ),
+            patch(
+                "terok.lib.orchestration.task_runners.container.get_services_mode",
+                return_value="socket",
+            ),
+            pytest.raises(SystemExit, match="incompatible.*services.mode: socket"),
+        ):
+            _validate_krun_compatibility(project)
+
 
 @pytest.fixture()
 def _experimental_enabled():
-    """Patch ``is_experimental`` true for tests that exercise the krun path.
+    """Patch the krun guards open for tests that exercise the krun path.
 
-    The compatibility guard refuses krun selection unless the
-    experimental flag is set; these tests verify the happy-path
-    *after* the gate, so the gate is patched out.
+    ``_validate_krun_compatibility`` refuses krun without the
+    experimental flag AND under ``services.mode: socket`` (the new
+    default); these tests verify the happy-path *after* the gate, so
+    both guards are patched out.
     """
-    with patch(
-        "terok.lib.orchestration.task_runners.container.is_experimental",
-        return_value=True,
+    with (
+        patch(
+            "terok.lib.orchestration.task_runners.container.is_experimental",
+            return_value=True,
+        ),
+        patch(
+            "terok.lib.orchestration.task_runners.container.get_services_mode",
+            return_value="tcp",
+        ),
     ):
         yield
 
@@ -240,14 +260,18 @@ class TestProjectRuntimeFlags:
 
         assert _project_runtime_flags(_project(), cname="terok-cli-demoproj-task-a") == []
 
-    def test_krun_emits_runtime_flag(
+    def test_krun_does_not_emit_runtime_flag(
         self, _experimental_enabled, _krun_launch_args_stub, _stub_port_reservation
     ) -> None:
+        """``--runtime krun`` flows through ``RunSpec.runtime`` (a typed
+        channel sandbox already turns into both podman's flag and shield's
+        dnsmasq-bind selection), not through this flag list.  Emitting it
+        here too would land ``--runtime`` twice on the podman invocation.
+        """
         from terok.lib.orchestration.task_runners.container import _project_runtime_flags
 
         flags = _project_runtime_flags(_project(runtime="krun"), cname="terok-cli-demoproj-task-a")
-        assert "--runtime" in flags
-        assert flags[flags.index("--runtime") + 1] == "krun"
+        assert "--runtime" not in flags
 
     def test_krun_emits_loopback_pinned_port_forward(
         self, _experimental_enabled, _krun_launch_args_stub, _stub_port_reservation
@@ -345,66 +369,15 @@ class TestProjectRuntimeFlags:
         _krun_launch_args_stub.assert_not_called()
 
 
-class TestChainKrunDnsRewrite:
-    """`_chain_krun_dns_rewrite` retargets shield's bind-mounted resolv.conf
-    from ``127.0.0.1`` (dnsmasq, unreachable from inside the krun guest)
-    to ``169.254.1.1`` (pasta forwarder, both reachable via TSI and
-    permitted by shield's nft policy)."""
+class TestKrunDnsTopologyDelegated:
+    """The krun DNS topology now lives in terok-shield itself: shield picks
+    the dnsmasq bind from a runtime hint that flows through
+    ``RunSpec.runtime``.  No post-pre_start workaround anywhere in terok.
+    """
 
-    def test_rewrites_existing_shield_resolv_conf(self, tmp_path) -> None:
-        from terok.lib.orchestration.task_runners.container import _chain_krun_dns_rewrite
+    def test_no_chain_krun_dns_rewrite_helper(self) -> None:
+        """The old ``_chain_krun_dns_rewrite`` workaround is gone — shield
+        owns its own resolv.conf address now."""
+        from terok.lib.orchestration.task_runners import container
 
-        shield_dir = tmp_path / "shield"
-        shield_dir.mkdir()
-        resolv = shield_dir / "resolv.conf"
-        resolv.write_text("nameserver 127.0.0.1\noptions ndots:0\n")
-
-        chained = _chain_krun_dns_rewrite(None, tmp_path)
-        chained.pre_start()
-
-        assert resolv.read_text() == "nameserver 169.254.1.1\noptions ndots:0\n"
-
-    def test_no_op_when_shield_did_not_write_file(self, tmp_path) -> None:
-        """Shield bypass / non-dnsmasq tier → no file → no error, no write."""
-        from terok.lib.orchestration.task_runners.container import _chain_krun_dns_rewrite
-
-        chained = _chain_krun_dns_rewrite(None, tmp_path)
-        chained.pre_start()  # no raise
-        assert not (tmp_path / "shield" / "resolv.conf").exists()
-
-    def test_runs_caller_pre_start_first(self, tmp_path) -> None:
-        """An existing ``pre_start`` callback is fired before the rewrite,
-        not silently dropped."""
-        from terok.lib.integrations.sandbox import LifecycleHooks
-        from terok.lib.orchestration.task_runners.container import _chain_krun_dns_rewrite
-
-        events: list[str] = []
-        shield_dir = tmp_path / "shield"
-        shield_dir.mkdir()
-        (shield_dir / "resolv.conf").write_text("nameserver 127.0.0.1\n")
-
-        def _prior() -> None:
-            events.append("prior")
-
-        chained = _chain_krun_dns_rewrite(LifecycleHooks(pre_start=_prior), tmp_path)
-        chained.pre_start()
-
-        assert events == ["prior"]
-        assert "169.254.1.1" in (shield_dir / "resolv.conf").read_text()
-
-    def test_preserves_other_hook_slots(self, tmp_path) -> None:
-        """``post_start`` / ``post_ready`` / ``post_stop`` pass through
-        untouched — only ``pre_start`` is the chain point."""
-        from terok.lib.integrations.sandbox import LifecycleHooks
-        from terok.lib.orchestration.task_runners.container import _chain_krun_dns_rewrite
-
-        post_start = lambda: None  # noqa: E731 — identity matters, not contents
-        post_ready = lambda: None  # noqa: E731
-        post_stop = lambda: None  # noqa: E731
-        chained = _chain_krun_dns_rewrite(
-            LifecycleHooks(post_start=post_start, post_ready=post_ready, post_stop=post_stop),
-            tmp_path,
-        )
-        assert chained.post_start is post_start
-        assert chained.post_ready is post_ready
-        assert chained.post_stop is post_stop
+        assert not hasattr(container, "_chain_krun_dns_rewrite")

--- a/tests/unit/lib/test_shield.py
+++ b/tests/unit/lib/test_shield.py
@@ -150,7 +150,15 @@ def test_shield_functions_delegate_to_per_task_shield(
 
     result = func("my-container", MOCK_TASK_DIR)
 
-    mock_make.assert_called_once_with(MOCK_TASK_DIR, None)
+    # pre_start carries a runtime hint through to ``make_shield`` so shield
+    # picks the right dnsmasq bind for crun vs krun.  Other wrappers
+    # operate on already-running containers and don't take it.
+    if method_name == "pre_start":
+        from terok_shield import ShieldRuntime
+
+        mock_make.assert_called_once_with(MOCK_TASK_DIR, None, runtime=ShieldRuntime.DEFAULT)
+    else:
+        mock_make.assert_called_once_with(MOCK_TASK_DIR, None)
     if method_name == "down":
         getattr(mock_shield, method_name).assert_called_once_with("my-container", allow_all=False)
     else:

--- a/tests/unit/lib/test_task_runner_internals.py
+++ b/tests/unit/lib/test_task_runner_internals.py
@@ -628,10 +628,6 @@ class TestRunContainer:
                 "terok.lib.orchestration.task_runners.container._project_runtime_flags",
                 return_value=[],  # bypass krun port-reservation etc.
             ),
-            patch(
-                "terok.lib.orchestration.task_runners.container._chain_krun_dns_rewrite",
-                side_effect=lambda hooks, _: hooks,
-            ),
         ):
             _run_container(
                 task_id="t1",
@@ -660,10 +656,6 @@ class TestRunContainer:
             patch(
                 "terok.lib.orchestration.task_runners.container._project_runtime_flags",
                 return_value=[],
-            ),
-            patch(
-                "terok.lib.orchestration.task_runners.container._chain_krun_dns_rewrite",
-                side_effect=lambda hooks, _: hooks,
             ),
         ):
             _run_container(


### PR DESCRIPTION
## Summary

Top of the krun-dnsmasq PR chain (terok-shield#327 → terok-sandbox#347 → terok-executor#361 → here).  With shield owning the runtime-aware dnsmasq bind, executor carrying a typed `runtime=` through `launch_prepared`, and sandbox owning the canonical top-level `experimental:` schema field, terok can:

- Delete `_chain_krun_dns_rewrite` and its lifecycle-hook chain — shield's bind-mounted resolv.conf now points at a krun-reachable listener by itself, so hostname-based clearance fires under krun without any post-write hack.
- Pass `project.runtime` to `launch_prepared` directly.  The `RunSpec.runtime` channel is what sandbox already turns into both `--runtime` and the shield runtime hint, so a single source of truth replaces two parallel paths.
- Drop the redundant `experimental: bool = False` declaration on `RawGlobalConfig` — sandbox's `SandboxConfigView` now owns the canonical top-level field and terok's schema inherits it via the SandboxConfigView → ExecutorConfigView → RawGlobalConfig chain.  `is_experimental()` keeps working unchanged; sandbox honors the same key when run standalone.

Net diff: +60 / -138.  All tests still pass (2632 unit tests green).

## Test plan

- [x] `make check` clean (lint, tach, test, docstr, security, reuse all green)
- [ ] Smoke on a krun-capable host (paired with the shield + sandbox PRs):
  - [ ] `terok task new` with `run.runtime: krun` → hostname clearance prompts fire
  - [ ] Existing crun tasks unchanged
  - [ ] `terok-sandbox setup` standalone with `experimental: true` in `config.yml` probes for `ip`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Switched three core dependencies to Git-based feature-branch sources
  * Consolidated experimental configuration so it’s inherited from the global config chain

* **Refactor**
  * Simplified container runtime wiring and removed legacy runtime flag/workaround behavior

* **Tests**
  * Updated unit tests to reflect new runtime wiring, DNS/topology delegation, and pre-start shield handling

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/terok-ai/terok/pull/1016?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->