### PR TITLE
fix(panic): SIGKILL containers instead of force-remove

### DIFF
--- a/src/terok/cli/commands/panic.py
+++ b/src/terok/cli/commands/panic.py
@@ -3,9 +3,9 @@
 
 """Emergency panic command — cut all resource access immediately.
 
-Raises shields on every running container, stops the vault
-and gate server.  Optionally stops the containers themselves (which
-can be slow on some platforms).  All actions are reversible.
+Raises shields on every running container, stops the vault and gate
+server.  Optionally also SIGKILLs the containers themselves; they are
+not removed.  All actions are reversible.
 
 Exit codes:
 - 0: all operations succeeded
@@ -35,7 +35,7 @@ def register(subparsers: argparse._SubParsersAction[argparse.ArgumentParser]) ->
     p.add_argument(
         "--stop",
         action="store_true",
-        help="Also stop all containers (skip confirmation prompt)",
+        help="Also kill all containers (skip confirmation prompt)",
     )
     p.add_argument(
         "--clear",
@@ -80,11 +80,11 @@ def _cmd_panic(*, stop: bool) -> None:
     if not stop and result.total_running > 0:
         print()
         try:
-            answer = input("Also stop all containers? [y/N] ").strip().lower()
+            answer = input("Also kill all containers? [y/N] ").strip().lower()
         except (EOFError, KeyboardInterrupt):
             answer = ""
         if answer in ("y", "yes"):
-            print("Stopping containers...", file=sys.stderr)
+            print("Killing containers...", file=sys.stderr)
             _stop_remaining(result)
 
     if result.has_errors:
@@ -92,15 +92,15 @@ def _cmd_panic(*, stop: bool) -> None:
 
 
 def _stop_remaining(result: PanicResult) -> None:
-    """Stop containers that were left running after Phase 1."""
+    """Kill containers that were left running after Phase 1."""
     from ...lib.domain.panic import panic_stop_containers
 
     stopped, errors = panic_stop_containers()
     if not stopped and not errors:
-        print("No running containers to stop.")
+        print("No running containers to kill.")
         return
     result.containers_stopped = stopped
     result.container_stop_errors = errors
-    print(f"Stopped {len(stopped)} container(s)")
+    print(f"Killed {len(stopped)} container(s)")
     for cname, err in errors:
         print(f"  FAILED {cname}: {err}")

--- a/src/terok/lib/domain/panic.py
+++ b/src/terok/lib/domain/panic.py
@@ -23,7 +23,7 @@ shields + stopped services already cut access.
 from __future__ import annotations
 
 import logging
-from concurrent.futures import Future, ThreadPoolExecutor, as_completed
+from concurrent.futures import Future, ThreadPoolExecutor, as_completed, wait
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from pathlib import Path
@@ -43,6 +43,7 @@ from ..orchestration.tasks import (
 logger = logging.getLogger(__name__)
 
 _LOCK_FILENAME = "panic.lock"
+_PHASE2_TIMEOUT_S = 15
 
 # (project_id, task_id, mode, cname, task_dir)
 type _Target = tuple[str, str, str, str, Path]
@@ -302,19 +303,26 @@ def _stop_containers(targets: list[_Target]) -> tuple[list[str], list[tuple[str,
     stopped: list[str] = []
     errors: list[tuple[str, str]] = []
 
-    with ThreadPoolExecutor(max_workers=max(len(targets), 4)) as pool:
+    pool = ThreadPoolExecutor(max_workers=max(len(targets), 4))
+    try:
         futs = {pool.submit(_kill_container, runtime, t[3]): t[3] for t in targets}
-        for fut in as_completed(futs):
+        done, not_done = wait(futs, timeout=_PHASE2_TIMEOUT_S)
+        for fut in done:
             cname = futs[fut]
-            try:
-                err = fut.result(timeout=30)
-            except Exception as exc:
-                errors.append((cname, str(exc)))
-                continue
+            err = fut.result()
             if err is None:
                 stopped.append(cname)
             else:
                 errors.append((cname, err))
+        # Any worker still running past the panic budget is treated as a
+        # timeout error.  ``shutdown(wait=False)`` below lets the caller
+        # return immediately; the threads exit on their own once the
+        # subprocess timeout in ``.stop()`` trips.
+        for fut in not_done:
+            fut.cancel()
+            errors.append((futs[fut], f"timed out after {_PHASE2_TIMEOUT_S}s"))
+    finally:
+        pool.shutdown(wait=False)
 
     return stopped, errors
 

--- a/src/terok/lib/domain/panic.py
+++ b/src/terok/lib/domain/panic.py
@@ -5,8 +5,8 @@
 
 Two-phase sequence: Phase 1 raises shields, locks the vault session
 tier + stops its daemon, and stops the gate server — all in parallel,
-all reversible.  Phase 2 optionally stops the containers themselves
-(slow on some platforms, so user-prompted).
+all reversible.  Phase 2 optionally SIGKILLs the containers themselves
+(``podman stop --time 0``) — they are *not* removed.
 
 The vault step deletes the session-unlock tmpfs file in addition to
 stopping the daemon so the next socket activation can't auto-resume
@@ -35,7 +35,6 @@ from ..core.config import get_shield_bypass_firewall_no_protection
 from ..core.paths import core_state_dir
 from ..core.projects import list_projects
 from ..orchestration.tasks import (
-    CONTAINER_MODES,
     container_name,
     get_all_task_states,
     get_tasks,
@@ -84,8 +83,8 @@ def execute_panic(
     """Execute the full panic sequence.
 
     Discovers every running container, then raises shields, stops vault
-    and gate — all in parallel.  If *stop_containers*, also stops the
-    containers afterwards.
+    and gate — all in parallel.  If *stop_containers*, also kills the
+    containers afterwards (SIGKILL; they are not removed).
     """
     result = PanicResult()
     targets = _discover_targets()
@@ -95,7 +94,7 @@ def execute_panic(
     _phase1_lockdown(result, targets)
     _write_panic_lock()
 
-    # Phase 2: optional container stop
+    # Phase 2: optional container kill
     if stop_containers and targets:
         result.containers_stopped, result.container_stop_errors = _stop_containers(targets)
 
@@ -103,7 +102,7 @@ def execute_panic(
 
 
 def panic_stop_containers() -> tuple[list[str], list[tuple[str, str]]]:
-    """Discover and stop all running containers (Phase 2 standalone)."""
+    """Discover and SIGKILL all running containers (Phase 2 standalone)."""
     return _stop_containers(_discover_targets())
 
 
@@ -127,7 +126,7 @@ def format_panic_report(result: PanicResult) -> str:
     ]
 
     if result.containers_stopped:
-        lines.append(f"Containers stopped: {len(result.containers_stopped)}")
+        lines.append(f"Containers killed: {len(result.containers_stopped)}")
 
     if result.has_errors:
         lines += ["", "Errors:", *_format_errors(result)]
@@ -206,7 +205,7 @@ def _format_errors(result: PanicResult) -> list[str]:
         lines.append(f"  vault: {result.vault_error}")
     if result.gate_error:
         lines.append(f"  gate: {result.gate_error}")
-    lines += [f"  stop {cname}: {err}" for cname, err in result.container_stop_errors]
+    lines += [f"  kill {cname}: {err}" for cname, err in result.container_stop_errors]
     return lines
 
 
@@ -285,22 +284,48 @@ def _stop_gate() -> tuple[bool, str | None]:
 
 
 def _stop_containers(targets: list[_Target]) -> tuple[list[str], list[tuple[str, str]]]:
-    """Stop all container modes for each target.
+    """SIGKILL each discovered container in parallel; do not remove them.
+
+    Uses ``podman stop --time 0`` rather than a graceful stop: panic
+    targets runaway containers, so the default 10 s SIGTERM window
+    would just hand a misbehaving process more time to misbehave.
 
     Panic crosses projects (possibly under different runtimes); plain
-    ``PodmanRuntime`` is correct here because ``force_remove`` is a
-    podman-level teardown that works identically regardless of which
+    ``PodmanRuntime`` is correct here because the kill is a
+    podman-level operation that works identically regardless of which
     OCI runtime booted any individual container.
     """
-    runtime = PodmanRuntime()
-    names = [container_name(pid, m, tid) for pid, tid, _, _, _ in targets for m in CONTAINER_MODES]
-    if not names:
+    if not targets:
         return [], []
+
+    runtime = PodmanRuntime()
+    stopped: list[str] = []
+    errors: list[tuple[str, str]] = []
+
+    with ThreadPoolExecutor(max_workers=max(len(targets), 4)) as pool:
+        futs = {pool.submit(_kill_container, runtime, t[3]): t[3] for t in targets}
+        for fut in as_completed(futs):
+            cname = futs[fut]
+            try:
+                err = fut.result(timeout=30)
+            except Exception as exc:
+                errors.append((cname, str(exc)))
+                continue
+            if err is None:
+                stopped.append(cname)
+            else:
+                errors.append((cname, err))
+
+    return stopped, errors
+
+
+def _kill_container(runtime: PodmanRuntime, cname: str) -> str | None:
+    """SIGKILL one container without removing it (``podman stop --time 0``)."""
     try:
-        runtime.force_remove([runtime.container(n) for n in names])
-        return names, []
+        runtime.container(cname).stop(timeout=0)
+        return None
     except Exception as exc:
-        return [], [(n, str(exc)) for n in names]
+        return str(exc)
 
 
 def _write_panic_lock() -> None:

--- a/src/terok/tui/app.py
+++ b/src/terok/tui/app.py
@@ -1319,11 +1319,9 @@ if _HAS_TEXTUAL:
                 if panic_result.total_running > 0:
                     await self.push_screen(
                         ConfirmDestructiveScreen(
-                            "Resource access has been cut.\n\n"
-                            "Also stop all containers?\n"
-                            "(This may be slow on some platforms.)",
-                            title="Stop Containers?",
-                            confirm_label="Stop",
+                            "Resource access has been cut.\n\nAlso kill all containers?",
+                            title="Kill Containers?",
+                            confirm_label="Kill",
                         ),
                         self._on_panic_stop_confirmed,
                     )
@@ -1336,11 +1334,11 @@ if _HAS_TEXTUAL:
                 stopped, errors = stop_result
                 if errors:
                     self.notify(
-                        f"Stopped {len(stopped)} container(s), {len(errors)} failed",
+                        f"Killed {len(stopped)} container(s), {len(errors)} failed",
                         severity="error",
                     )
                 else:
-                    self.notify(f"Stopped {len(stopped)} container(s)")
+                    self.notify(f"Killed {len(stopped)} container(s)")
                 await self.refresh_tasks()
                 return
 

--- a/tests/unit/cli/test_cli_panic.py
+++ b/tests/unit/cli/test_cli_panic.py
@@ -119,7 +119,7 @@ class TestStopRemaining:
         result = PanicResult()
         _stop_remaining(result)
         assert result.containers_stopped == ["c1", "c2"]
-        assert "Stopped 2" in capsys.readouterr().out
+        assert "Killed 2" in capsys.readouterr().out
 
     @patch("terok.lib.domain.panic.panic_stop_containers", return_value=([], [("c1", "fail")]))
     def test_reports_errors(self, _s, capsys):

--- a/tests/unit/lib/test_panic.py
+++ b/tests/unit/lib/test_panic.py
@@ -227,31 +227,57 @@ class TestPanicStopContainers:
 
 
 class TestStopContainers:
-    """Tests for _stop_containers internals."""
+    """Tests for _stop_containers internals (SIGKILL, no remove)."""
 
     @patch("terok.lib.domain.panic.PodmanRuntime")
-    def test_stops_all_modes(self, mock_podman_runtime):
-        """All container modes are generated for each target."""
+    def test_kills_each_target_with_zero_timeout(self, mock_podman_runtime):
+        """Each discovered container is killed via ``container.stop(timeout=0)``."""
         from terok.lib.domain.panic import _stop_containers
 
-        mock_podman_runtime.return_value.force_remove.return_value = []
+        runtime = mock_podman_runtime.return_value
+        container = runtime.container.return_value
         t = _target()
         stopped, errors = _stop_containers([t])
+
         assert not errors
-        # force_remove called once with a list of container handles
-        mock_podman_runtime.return_value.force_remove.assert_called_once()
-        handles = mock_podman_runtime.return_value.force_remove.call_args[0][0]
-        assert len(handles) > 0
+        assert stopped == [t[3]]
+        runtime.container.assert_called_once_with(t[3])
+        container.stop.assert_called_once_with(timeout=0)
+        # Panic must NOT remove containers — state preserved for inspection.
+        assert not runtime.force_remove.called
 
     @patch("terok.lib.domain.panic.PodmanRuntime")
     def test_stop_exception(self, mock_podman_runtime):
-        """Exception from force_remove yields errors."""
+        """A kill failure on one container is collected as an error."""
         from terok.lib.domain.panic import _stop_containers
 
-        mock_podman_runtime.return_value.force_remove.side_effect = Exception("podman died")
+        mock_podman_runtime.return_value.container.return_value.stop.side_effect = Exception(
+            "podman died"
+        )
         stopped, errors = _stop_containers([_target()])
         assert not stopped
         assert all("podman died" in e for _, e in errors)
+
+    @patch("terok.lib.domain.panic.PodmanRuntime")
+    def test_partial_failure(self, mock_podman_runtime):
+        """Failures on some containers don't block kills on the rest."""
+        from terok.lib.domain.panic import _stop_containers
+
+        runtime = mock_podman_runtime.return_value
+        t_ok = _target(task_id="1")
+        t_bad = _target(task_id="2")
+
+        def container_for(name):
+            handle = MagicMock()
+            if name == t_bad[3]:
+                handle.stop.side_effect = Exception("boom")
+            return handle
+
+        runtime.container.side_effect = container_for
+        stopped, errors = _stop_containers([t_ok, t_bad])
+
+        assert stopped == [t_ok[3]]
+        assert errors == [(t_bad[3], "boom")]
 
     def test_empty_targets(self):
         """Empty target list returns empty results."""
@@ -417,7 +443,7 @@ class TestFormatReport:
             total_running=1,
         )
         report = format_panic_report(r)
-        assert "stop c1: timeout" in report
+        assert "kill c1: timeout" in report
 
     def test_gate_error_in_report(self):
         """Gate error appears in error section."""
@@ -434,4 +460,4 @@ class TestFormatReport:
             containers_stopped=["c1", "c2"],
             total_running=2,
         )
-        assert "Containers stopped: 2" in format_panic_report(r)
+        assert "Containers killed: 2" in format_panic_report(r)


### PR DESCRIPTION
## Summary

- Phase 2 of panic was calling `PodmanRuntime.force_remove` (`podman rm -f`), which gives a runaway container a 10-second SIGTERM grace period and then deletes it. For a panic, both are wrong: a misbehaving container shouldn't get extra runtime, and removing it discards everything an operator might want left around afterwards.
- Switch to `container.stop(timeout=0)` per discovered target, dispatched in parallel via `ThreadPoolExecutor` — `podman stop --time 0`, immediate SIGKILL, no removal. The existing `task delete` path (which still wants the remove) continues to use `force_remove` unchanged.
- Reword the user-facing CLI prompt, `--stop` help, TUI confirm dialog, and panic report lines from "stop" → "kill" so the behaviour matches what's said.

## Test plan

- [x] `make lint`
- [x] `make tach`
- [x] `make docstrings`
- [x] `make reuse`
- [x] `make lint-imports`
- [x] Full unit suite (2634 passed)
- [x] Updated `TestStopContainers` to assert `container.stop(timeout=0)` is called and `force_remove` is *not*; added a partial-failure case
- [ ] Manual: hit PANIC in the TUI with a live container; confirm SIGKILL, no removal, container visible in `podman ps -a`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Panic flow now forcefully kills containers (SIGKILL-style) and reports them as killed.

* **Documentation**
  * Help text, prompts, confirmations, and notifications updated to use “kill/killed” wording.

* **Tests**
  * Unit tests updated to expect kill semantics and per-container error reporting.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/terok-ai/terok/pull/1017?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->