### PR TITLE
chore: cut hex task IDs + task-metadata-rename compatibility

### DIFF
--- a/src/terok/cli/commands/auth.py
+++ b/src/terok/cli/commands/auth.py
@@ -54,15 +54,6 @@ def register(subparsers: argparse._SubParsersAction[argparse.ArgumentParser]) ->
     )
     set_completer(
         p_auth.add_argument(
-            "project_id",
-            nargs="?",
-            default=None,
-            help="(Legacy positional — prefer --project.)",
-        ),
-        _complete_project_ids,
-    )
-    set_completer(
-        p_auth.add_argument(
             "--project",
             dest="project_flag",
             default=None,
@@ -76,8 +67,7 @@ def dispatch(args: argparse.Namespace) -> bool:
     """Handle ``terok auth``.  Returns True if handled."""
     if args.cmd != "auth":
         return False
-    # --project wins over the legacy positional if both happen to be given.
-    project_id = args.project_flag or args.project_id
+    project_id = args.project_flag
     if args.provider is None:
         _run_interactive(project_id)
     else:

--- a/src/terok/lib/orchestration/tasks/archive.py
+++ b/src/terok/lib/orchestration/tasks/archive.py
@@ -10,8 +10,7 @@ import json
 from dataclasses import dataclass
 from pathlib import Path
 
-from ...util.yaml import load as _yaml_load
-from .meta import _to_plain, tasks_archive_dir
+from .meta import tasks_archive_dir
 
 
 @dataclass
@@ -27,26 +26,14 @@ class ArchivedTask:
 
 
 def _load_archived_task_meta(entry: Path) -> dict | None:
-    """Load an archived task's snapshot — JSON or legacy YAML — or ``None`` on miss.
-
-    Older archives wrote ``task.yml``; new ones write ``task.json``.  Both
-    are tolerated indefinitely on the read path because archives are
-    immutable once written and there's no operator action that would
-    rewrite them.
-    """
+    """Load an archived task's ``task.json`` snapshot, or ``None`` on miss/error."""
     json_path = entry / "task.json"
-    if json_path.is_file():
-        try:
-            text = json_path.read_text(encoding="utf-8")
-            return json.loads(text) if text.strip() else {}
-        except (OSError, ValueError):
-            return None
-    yml_path = entry / "task.yml"
-    if not yml_path.is_file():
+    if not json_path.is_file():
         return None
     try:
-        return _to_plain(_yaml_load(yml_path.read_text(encoding="utf-8")) or {})
-    except Exception:
+        text = json_path.read_text(encoding="utf-8")
+        return json.loads(text) if text.strip() else {}
+    except (OSError, ValueError):
         return None
 
 

--- a/src/terok/lib/orchestration/tasks/identity.py
+++ b/src/terok/lib/orchestration/tasks/identity.py
@@ -6,14 +6,12 @@
 Task IDs are Crockford-base32 with a structural signature: a 16-letter
 non-hex head + a digit + three full-alphabet chars.  The shape makes a
 terok task ID unmistakable from a podman container ID or git SHA at a
-glance.  Pre-0.8.0 hex IDs are still accepted (with a deprecation
-warning) on the read path.
+glance.
 """
 
 import re
 import secrets
 import string
-import warnings
 
 from .meta import iter_task_ids, task_exists, tasks_meta_dir
 
@@ -44,12 +42,6 @@ Crockford chars rather than 5.
 
 _TASK_ID_PREFIX_RE = re.compile(r"[ghjkmnp-tv-z](?:[0-9][0-9a-hjkmnp-tv-z]{0,3})?")
 """Prefix-match regex for a current-format task ID (1 to `_TASK_ID_LEN` chars)."""
-
-_LEGACY_HEX_TASK_ID_PREFIX_RE = re.compile(r"[0-9a-f]{1,8}")
-"""Prefix-match regex for pre-0.8.0 hex task IDs.  Deprecated in 0.8.0; removal in 0.9.0."""
-
-_LEGACY_HEX_TASK_ID_FULL_RE = re.compile(r"[0-9a-f]{8}")
-"""Full-form validator for pre-0.8.0 hex task IDs.  Deprecated; removal in 0.9.0."""
 
 _TASK_ID_AMBIGUOUS_LETTERS = "ilo"
 """Crockford's visually ambiguous letters: ``I``/``L`` → ``1`` and ``O`` → ``0``.
@@ -83,10 +75,8 @@ def normalize_task_id_input(raw: str) -> str:
 
 
 def is_task_id(text: str) -> bool:
-    """Return True if *text* is a well-formed task ID (current or legacy)."""
-    return bool(
-        _TASK_ID_CROCKFORD_4_5_RE.fullmatch(text) or _LEGACY_HEX_TASK_ID_FULL_RE.fullmatch(text)
-    )
+    """Return True if *text* is a well-formed task ID."""
+    return bool(_TASK_ID_CROCKFORD_4_5_RE.fullmatch(text))
 
 
 def _gen_task_id() -> str:
@@ -107,23 +97,8 @@ def _generate_unique_id(existing: set[str]) -> str:
 
 
 def _validate_task_id_prefix(prefix: str) -> None:
-    """Validate *prefix* and warn on the deprecated legacy-hex format.
-
-    Raises ``SystemExit`` if *prefix* matches neither the current
-    Crockford-4.5 format nor the legacy pre-0.8.0 hex format.  Dispatch
-    is unambiguous: Crockford IDs always start with ``[g-z]`` minus
-    ``i l o u``, which is disjoint from hex.
-    """
+    """Raise ``SystemExit`` if *prefix* isn't a valid Crockford-4.5 task-ID prefix."""
     if _TASK_ID_PREFIX_RE.fullmatch(prefix):
-        return
-    if _LEGACY_HEX_TASK_ID_PREFIX_RE.fullmatch(prefix):
-        warnings.warn(
-            f"Task ID {prefix!r} uses the pre-0.8.0 hex format; "
-            "support will be removed in 0.9.0 — recreate the task to "
-            "adopt the current format.",
-            DeprecationWarning,
-            stacklevel=3,
-        )
         return
     raise SystemExit(
         f"Invalid task ID prefix {prefix!r}; "

--- a/src/terok/lib/orchestration/tasks/lifecycle.py
+++ b/src/terok/lib/orchestration/tasks/lifecycle.py
@@ -315,7 +315,7 @@ def _remove_workspace(workspace: Path, warnings: list[str]) -> None:
 
 
 def _remove_meta_files(paths: tuple[Path, ...], warnings: list[str]) -> None:
-    """Unlink the on-disk meta-file pair plus any legacy single-file remnants.
+    """Unlink the on-disk meta-file pair.
 
     Each path is unlinked independently so a failure on one (e.g. a
     permission error) still lets the rest be cleaned up.
@@ -366,11 +366,6 @@ def _task_delete(project: ProjectConfig, task_id: str) -> TaskDeleteResult:
     meta_dir = tasks_meta_dir(project.id)
     dossier_file = dossier_path(meta_dir, task_id)
     meta_file = meta_path(meta_dir, task_id)
-    # Pre-self-describing layout (`<id>.json` / `<id>.yml`) — clean too,
-    # in case the task was created before the rename and never since
-    # touched (no read = no migration).
-    legacy_json = meta_dir / f"{task_id}.json"
-    legacy_yml = meta_dir / f"{task_id}.yml"
     _log_debug(
         f"task_delete: workspace={workspace} dossier_file={dossier_file} meta_file={meta_file}"
     )
@@ -406,7 +401,7 @@ def _task_delete(project: ProjectConfig, task_id: str) -> TaskDeleteResult:
         )
 
     _remove_workspace(workspace, warnings)
-    _remove_meta_files((dossier_file, meta_file, legacy_json, legacy_yml), warnings)
+    _remove_meta_files((dossier_file, meta_file), warnings)
     _release_task_web_port(project.id, task_id, containers_removed, warnings)
 
     _log_debug("task_delete: finished")

--- a/src/terok/lib/orchestration/tasks/meta.py
+++ b/src/terok/lib/orchestration/tasks/meta.py
@@ -19,8 +19,7 @@ comments and round-trip ergonomics cheap.
 The split is reconciled at the I/O boundary: ``read_task_meta``
 returns one merged dict in internal-storage shape (``project_id``,
 ``task_id``, …), ``write_task_meta`` splits a single dict back to
-both files atomically.  Pre-self-describing names (``<id>.json`` /
-``<id>.yml``) are migrated to the new layout in place on first read.
+both files atomically.
 """
 
 import json
@@ -104,23 +103,6 @@ def meta_path(meta_dir: Path, task_id: str) -> Path:
     return meta_dir / f"{task_id}{_META_SUFFIX}"
 
 
-def _migrate_legacy_filenames(meta_dir: Path, task_id: str) -> None:
-    """Rename pre-self-describing meta files in place — one-shot, idempotent.
-
-    Earlier iterations stored the dossier and meta as ``<task_id>.json``
-    and ``<task_id>.yml``; the new names spell out their audience.
-    Rename eagerly so every other read/write/iter helper deals with the
-    canonical layout exclusively.  Idempotent: a second call is a no-op.
-    """
-    pairs = (
-        (meta_dir / f"{task_id}.json", dossier_path(meta_dir, task_id)),
-        (meta_dir / f"{task_id}.yml", meta_path(meta_dir, task_id)),
-    )
-    for old, new in pairs:
-        if old.is_file() and not new.is_file():
-            old.rename(new)
-
-
 def read_task_meta(meta_dir: Path, task_id: str) -> dict | None:
     """Compose the orchestrator's logical task-meta dict from the on-disk pair.
 
@@ -128,24 +110,14 @@ def read_task_meta(meta_dir: Path, task_id: str) -> dict | None:
     JSON's wire keys back to internal storage names, and returns the
     union.  Either file may be absent.  Returns ``None`` only when
     neither file is on disk.
-
-    A pre-self-describing layout (``<task_id>.json`` / ``<task_id>.yml``)
-    is migrated to the new names in place before the read so callers
-    never see the legacy paths.
     """
-    _migrate_legacy_filenames(meta_dir, task_id)
     json_path = dossier_path(meta_dir, task_id)
     yml_path = meta_path(meta_dir, task_id)
 
     if not (json_path.is_file() or yml_path.is_file()):
         return None
 
-    merged = _merge_dossier_into(_read_yml_meta(yml_path), _read_json_meta(json_path))
-    if _backfill_project_id(merged, meta_dir):
-        # Normalise on disk so the backfilled project_id persists.
-        write_task_meta(dossier_path(meta_dir, task_id), merged)
-
-    return merged
+    return _merge_dossier_into(_read_yml_meta(yml_path), _read_json_meta(json_path))
 
 
 def _read_json_meta(json_path: Path) -> dict:
@@ -178,36 +150,17 @@ def _merge_dossier_into(yml_data: dict, dossier_data: dict) -> dict:
     return merged
 
 
-def _backfill_project_id(merged: dict, meta_dir: Path) -> bool:
-    """Backfill ``project_id`` from the meta-dir path for legacy records.
-
-    Records that predate the field landing in TaskMeta carry no
-    ``project_id``; without it a task-rename lands a half-populated
-    dossier (no ``project``) on the wire.  Path layout is
-    ``<state>/projects/<project_id>/tasks``.  Returns ``True`` when a
-    value was filled in, so the caller knows the record needs
-    re-normalising on disk.
-    """
-    if merged.get("project_id"):
-        return False
-    if meta_dir.parent.parent.name != "projects":
-        return False
-    merged["project_id"] = meta_dir.parent.name
-    return True
-
-
 def write_task_meta(dossier_handle: Path, meta: dict) -> None:
     """Atomic split-write: ``_dossier.json`` + ``_meta.yml`` in one atomic step each.
 
     *dossier_handle* is a dossier-file handle — what
     [`dossier_path`][terok.lib.orchestration.tasks.dossier_path] returns
     and what [`load_task_meta`][terok.lib.orchestration.tasks.load_task_meta]
-    hands back.  Pre-self-describing handles (``<id>.json``) are accepted
-    too and canonicalized on write.  The companion bookkeeping path is
-    derived by swapping the suffix.  Atomic-rename writes (``.tmp`` +
-    ``os.replace``) on each file mean a partial write under EINTR /
-    power loss can leave one stale and the other fresh, but never a
-    half-written file — readers always get a parseable shape.
+    hands back.  The companion bookkeeping path is derived by swapping
+    the suffix.  Atomic-rename writes (``.tmp`` + ``os.replace``) on each
+    file mean a partial write under EINTR / power loss can leave one
+    stale and the other fresh, but never a half-written file — readers
+    always get a parseable shape.
     """
     meta_dir, task_id = _dossier_handle_to_dir_and_id(dossier_handle)
     meta_dir.mkdir(parents=True, exist_ok=True)
@@ -229,17 +182,13 @@ def write_task_meta(dossier_handle: Path, meta: dict) -> None:
 def _dossier_handle_to_dir_and_id(path: Path) -> tuple[Path, str]:
     """Decompose a dossier-file handle into ``(meta_dir, task_id)``.
 
-    Accepts both the canonical ``<task_id>_dossier.json`` and the
-    pre-self-describing ``<task_id>.json`` so callers caching a handle
-    across the migration boundary keep working.  Raises on anything
-    else — silently inferring a task_id from a foreign filename would
-    let bugs pass undetected.
+    Accepts the canonical ``<task_id>_dossier.json`` shape and raises
+    on anything else — silently inferring a task_id from a foreign
+    filename would let bugs pass undetected.
     """
     name = path.name
     if name.endswith(_DOSSIER_SUFFIX):
         return path.parent, name[: -len(_DOSSIER_SUFFIX)]
-    if name.endswith(".json"):
-        return path.parent, name[: -len(".json")]
     raise ValueError(f"not a dossier-file handle: {path}")
 
 
@@ -266,14 +215,7 @@ def _to_plain(obj: Any) -> Any:
 
 
 def iter_task_ids(meta_dir: Path) -> Iterator[str]:
-    """Yield every task ID with at least one meta file in *meta_dir*.
-
-    Recognises both the canonical layout (``<id>_dossier.json`` /
-    ``<id>_meta.yml``) and the pre-self-describing layout
-    (``<id>.json`` / ``<id>.yml``) — the latter is migrated lazily on
-    the next ``read_task_meta`` call, so transient mixed states are
-    yielded under their canonical task ID without double-counting.
-    """
+    """Yield every task ID with at least one meta file in *meta_dir*."""
     if not meta_dir.is_dir():
         return
     seen: set[str] = set()
@@ -288,26 +230,16 @@ def iter_task_ids(meta_dir: Path) -> Iterator[str]:
 
 def _task_id_from_filename(name: str) -> str:
     """Strip the meta-file suffix to recover the task ID, ``""`` if unrecognised."""
-    for suffix in (_DOSSIER_SUFFIX, _META_SUFFIX, ".json", ".yml"):
+    for suffix in (_DOSSIER_SUFFIX, _META_SUFFIX):
         if name.endswith(suffix):
             return name[: -len(suffix)]
     return ""
 
 
 def task_exists(project_id: str, task_id: str) -> bool:
-    """Return ``True`` if any task-meta file exists for ``(project_id, task_id)``.
-
-    Considers both the canonical (``<task_id>_dossier.json`` /
-    ``<task_id>_meta.yml``) and legacy (``<task_id>.json`` /
-    ``<task_id>.yml``) on-disk layouts.
-    """
+    """Return ``True`` if any task-meta file exists for ``(project_id, task_id)``."""
     meta_dir = tasks_meta_dir(project_id)
-    return (
-        dossier_path(meta_dir, task_id).is_file()
-        or meta_path(meta_dir, task_id).is_file()
-        or (meta_dir / f"{task_id}.json").is_file()
-        or (meta_dir / f"{task_id}.yml").is_file()
-    )
+    return dossier_path(meta_dir, task_id).is_file() or meta_path(meta_dir, task_id).is_file()
 
 
 def tasks_meta_dir(project_id: str) -> Path:

--- a/src/terok/tui/screens.py
+++ b/src/terok/tui/screens.py
@@ -2220,8 +2220,8 @@ def render_vault_status(status: VaultStatus | None) -> Text:
 
     # Two orthogonal axes, two lines: ``Activation:`` (lifecycle —
     # systemd / daemon / none) vs ``Transport:`` (wire — tcp / socket).
-    # The legacy single ``Mode:`` overloaded both onto one label and
-    # operators consistently read it as transport.
+    # Splitting them keeps operators from confusing lifecycle state
+    # with the transport their containers actually ride.
     lines: list[Text] = [
         Text.assemble("Activation:  ", mode_s),
         Text(f"Transport:   {transport or '(not configured)'}"),

--- a/tests/unit/cli/test_cli_auth.py
+++ b/tests/unit/cli/test_cli_auth.py
@@ -6,9 +6,8 @@
 Three invocation shapes to verify:
 
 - ``terok auth``                           → interactive menu (no provider).
-- ``terok auth <p>``                       → host-wide auth (no project_id).
-- ``terok auth <p> <id>``                  → legacy positional project.
-- ``terok auth <p> --project <id>``        → named project flag.
+- ``terok auth <p>``                       → host-wide auth.
+- ``terok auth <p> --project <id>``        → project-scoped auth.
 """
 
 from __future__ import annotations
@@ -38,20 +37,10 @@ def _make_parser() -> argparse.ArgumentParser:
 # ── argparse registration ──────────────────────────────────────────────
 
 
-def test_auth_parses_positional_provider_and_project() -> None:
-    """``auth claude myproj`` keeps parsing via the legacy two-positional form."""
-    args = _make_parser().parse_args(["auth", "claude", "myproj"])
-    assert args.cmd == "auth"
-    assert args.provider == "claude"
-    assert args.project_id == "myproj"
-    assert args.project_flag is None
-
-
 def test_auth_parses_provider_only() -> None:
-    """``auth claude`` (no project) sets project_id to None — host-wide shape."""
+    """``auth claude`` (no project) — host-wide shape."""
     args = _make_parser().parse_args(["auth", "claude"])
     assert args.provider == "claude"
-    assert args.project_id is None
     assert args.project_flag is None
 
 
@@ -59,16 +48,14 @@ def test_auth_parses_no_arguments() -> None:
     """``auth`` on its own leaves provider None — interactive shape."""
     args = _make_parser().parse_args(["auth"])
     assert args.provider is None
-    assert args.project_id is None
     assert args.project_flag is None
 
 
 def test_auth_parses_project_flag() -> None:
-    """``auth claude --project p`` populates project_flag; positional stays None."""
+    """``auth claude --project p`` populates project_flag."""
     args = _make_parser().parse_args(["auth", "claude", "--project", "p"])
     assert args.provider == "claude"
     assert args.project_flag == "p"
-    assert args.project_id is None
 
 
 def test_auth_rejects_unknown_provider() -> None:
@@ -88,7 +75,7 @@ def test_dispatch_ignores_other_commands() -> None:
 
 def test_dispatch_host_wide_skips_project_loading() -> None:
     """``auth <provider>`` never touches ``load_project`` / ``require_agent_installed``."""
-    args = argparse.Namespace(cmd="auth", provider="claude", project_id=None, project_flag=None)
+    args = argparse.Namespace(cmd="auth", provider="claude", project_flag=None)
     with (
         patch("terok.cli.commands.auth.load_project") as mock_load,
         patch("terok.cli.commands.auth.require_agent_installed") as mock_check,
@@ -101,10 +88,10 @@ def test_dispatch_host_wide_skips_project_loading() -> None:
     mock_auth.assert_called_once_with("claude", None)
 
 
-def test_dispatch_project_positional_runs_install_check() -> None:
-    """Legacy ``auth <p> <id>`` loads the project and verifies the agent."""
+def test_dispatch_project_flag_runs_install_check() -> None:
+    """``auth <p> --project <id>`` loads the project and verifies the agent."""
     fake_project = SimpleNamespace(id="p1")
-    args = argparse.Namespace(cmd="auth", provider="claude", project_id="p1", project_flag=None)
+    args = argparse.Namespace(cmd="auth", provider="claude", project_flag="p1")
     with (
         patch("terok.cli.commands.auth.load_project", return_value=fake_project),
         patch("terok.cli.commands.auth.require_agent_installed") as mock_check,
@@ -116,26 +103,9 @@ def test_dispatch_project_positional_runs_install_check() -> None:
     mock_auth.assert_called_once_with("claude", "p1")
 
 
-def test_dispatch_project_flag_wins_over_positional() -> None:
-    """``--project`` wins when both the flag and the legacy positional are set."""
-    fake_project = SimpleNamespace(id="flagged")
-    args = argparse.Namespace(
-        cmd="auth", provider="claude", project_id="positional", project_flag="flagged"
-    )
-    with (
-        patch("terok.cli.commands.auth.load_project", return_value=fake_project) as mock_load,
-        patch("terok.cli.commands.auth.require_agent_installed"),
-        patch("terok.cli.commands.auth.authenticate") as mock_auth,
-    ):
-        dispatch(args)
-
-    mock_load.assert_called_once_with("flagged")
-    mock_auth.assert_called_once_with("claude", "flagged")
-
-
 def test_dispatch_no_provider_runs_interactive() -> None:
     """``auth`` with no provider routes into the chained interactive flow."""
-    args = argparse.Namespace(cmd="auth", provider=None, project_id=None, project_flag=None)
+    args = argparse.Namespace(cmd="auth", provider=None, project_flag=None)
     with patch("terok.cli.commands.auth._run_interactive") as mock_inter:
         dispatch(args)
     mock_inter.assert_called_once_with(None)

--- a/tests/unit/cli/test_sickbay.py
+++ b/tests/unit/cli/test_sickbay.py
@@ -205,7 +205,7 @@ class TestCheckTaskHook:
             mock_hook.assert_called_once()
 
     def test_bad_metadata_returns_warn(self, task_meta_dir: Path) -> None:
-        bad_path = task_meta_dir / "g1abc.yml"
+        bad_path = task_meta_dir / "g1abc_meta.yml"
         bad_path.write_bytes(b"\x80\x81\x82")  # invalid UTF-8
         project = unittest.mock.MagicMock()
         with unittest.mock.patch(
@@ -219,7 +219,7 @@ class TestCheckTaskHook:
 
 class TestReconcilePostStop:
     def test_success(self, tmp_path: Path) -> None:
-        meta_path = tmp_path / "g1abc.yml"
+        meta_path = tmp_path / "g1abc_meta.yml"
         meta_path.write_text(yaml_dump({"mode": "cli"}))
         project = unittest.mock.MagicMock()
         project.hook_post_stop = "echo done"
@@ -231,7 +231,7 @@ class TestReconcilePostStop:
             assert result[0] == "ok"
 
     def test_failure(self, tmp_path: Path) -> None:
-        meta_path = tmp_path / "g1abc.yml"
+        meta_path = tmp_path / "g1abc_meta.yml"
         meta_path.write_text(yaml_dump({"mode": "cli"}))
         project = unittest.mock.MagicMock()
         project.hook_post_stop = "exit 1"
@@ -652,7 +652,7 @@ class TestCheckTaskShieldAnnotation:
         """Bad metadata → skipped silently (_check_task_hook owns the warn)."""
         from terok.cli.commands.sickbay import _check_task_shield_annotation
 
-        (tmp_path / "g1abc.yml").write_bytes(b"\x80\x81")  # invalid UTF-8
+        (tmp_path / "g1abc_meta.yml").write_bytes(b"\x80\x81")  # invalid UTF-8
         project = self._project(tmp_path)
         with unittest.mock.patch(
             "terok.cli.commands.sickbay.tasks_meta_dir", return_value=tmp_path

--- a/tests/unit/lib/test_container_doctor.py
+++ b/tests/unit/lib/test_container_doctor.py
@@ -171,9 +171,9 @@ class TestRunContainerDoctor:
     def test_returns_warn_for_never_started(
         self, mock_meta_dir: MagicMock, mock_load: MagicMock, tmp_path: Path
     ) -> None:
-        (tmp_path / "42.yml").write_text("name: test\n")
+        (tmp_path / "42_meta.yml").write_text("name: test\n")
         mock_meta_dir.return_value = tmp_path
-        mock_load.return_value = ({}, tmp_path / "42.yml")
+        mock_load.return_value = ({}, tmp_path / "42_meta.yml")
         results = run_container_doctor("proj", "42")
         assert results[0][0] == "warn"
         assert "never started" in results[0][2]
@@ -187,9 +187,9 @@ class TestRunContainerDoctor:
         tmp_path: Path,
         mock_runtime,
     ) -> None:
-        (tmp_path / "42.yml").write_text("mode: cli\nname: test\n")
+        (tmp_path / "42_meta.yml").write_text("mode: cli\nname: test\n")
         mock_meta_dir.return_value = tmp_path
-        mock_load.return_value = ({"mode": "cli"}, tmp_path / "42.yml")
+        mock_load.return_value = ({"mode": "cli"}, tmp_path / "42_meta.yml")
         mock_runtime.container.return_value.state = "exited"
         results = run_container_doctor("proj", "42")
         assert results[0][0] == "info"
@@ -225,9 +225,9 @@ class TestRunContainerDoctor:
         mock_runtime,
     ) -> None:
         # Arrange: task metadata exists and container is running
-        (tmp_path / "42.yml").write_text("mode: cli\n")
+        (tmp_path / "42_meta.yml").write_text("mode: cli\n")
         mock_meta_dir.return_value = tmp_path
-        mock_load_meta.return_value = ({"mode": "cli"}, tmp_path / "42.yml")
+        mock_load_meta.return_value = ({"mode": "cli"}, tmp_path / "42_meta.yml")
         mock_runtime.container.return_value.state = "running"
         mock_sandbox_cfg.return_value = MagicMock()
         mock_broker_port.return_value = 8080
@@ -290,9 +290,9 @@ class TestRunContainerDoctor:
         mock_runtime,
     ) -> None:
         # Arrange
-        (tmp_path / "42.yml").write_text("mode: cli\n")
+        (tmp_path / "42_meta.yml").write_text("mode: cli\n")
         mock_meta_dir.return_value = tmp_path
-        mock_load_meta.return_value = ({"mode": "cli"}, tmp_path / "42.yml")
+        mock_load_meta.return_value = ({"mode": "cli"}, tmp_path / "42_meta.yml")
         mock_runtime.container.return_value.state = "running"
         mock_sandbox_cfg.return_value = MagicMock()
         mock_broker_port.return_value = 8080
@@ -365,9 +365,9 @@ class TestRunContainerDoctor:
         mock_runtime,
     ) -> None:
         # Arrange
-        (tmp_path / "42.yml").write_text("mode: cli\n")
+        (tmp_path / "42_meta.yml").write_text("mode: cli\n")
         mock_meta_dir.return_value = tmp_path
-        mock_load_meta.return_value = ({"mode": "cli"}, tmp_path / "42.yml")
+        mock_load_meta.return_value = ({"mode": "cli"}, tmp_path / "42_meta.yml")
         mock_runtime.container.return_value.state = "running"
         mock_sandbox_cfg.return_value = MagicMock()
         mock_broker_port.return_value = 8080
@@ -481,7 +481,7 @@ class TestStreamingGrouping:
         )
         from terok.lib.util.check_reporter import CheckReporter
 
-        (tmp_path / "42.yml").write_text("mode: cli\n")
+        (tmp_path / "42_meta.yml").write_text("mode: cli\n")
 
         net_a = DoctorCheck(
             category="network",
@@ -525,7 +525,7 @@ class TestStreamingGrouping:
             ),
             patch(
                 "terok.lib.orchestration.container_doctor.load_task_meta",
-                return_value=({"mode": "cli"}, tmp_path / "42.yml"),
+                return_value=({"mode": "cli"}, tmp_path / "42_meta.yml"),
             ),
             patch(
                 "terok.lib.orchestration.container_doctor.make_sandbox_config",
@@ -577,7 +577,7 @@ class TestStreamingGrouping:
             run_container_doctor,
         )
 
-        (tmp_path / "42.yml").write_text("mode: cli\n")
+        (tmp_path / "42_meta.yml").write_text("mode: cli\n")
 
         only_check = DoctorCheck(
             category="shield",
@@ -605,7 +605,7 @@ class TestStreamingGrouping:
             ),
             patch(
                 "terok.lib.orchestration.container_doctor.load_task_meta",
-                return_value=({"mode": "cli"}, tmp_path / "42.yml"),
+                return_value=({"mode": "cli"}, tmp_path / "42_meta.yml"),
             ),
             patch(
                 "terok.lib.orchestration.container_doctor.make_sandbox_config",

--- a/tests/unit/lib/test_task_ids.py
+++ b/tests/unit/lib/test_task_ids.py
@@ -200,45 +200,6 @@ class TestResolveTaskId:
                 resolve_task_id("test-proj", ID_A + "x")
 
 
-# ---------- Legacy hex compatibility ----------
-
-
-class TestLegacyHexCompat:
-    """Legacy pre-0.8.0 hex task IDs remain readable with a deprecation warning."""
-
-    LEGACY = "abcd1234"
-
-    def _write_meta(self, project_id: str, task_id: str) -> None:
-        """Write a minimal task metadata file."""
-        meta = {"task_id": task_id, "name": "legacy", "mode": None, "workspace": "/tmp/ws"}
-        write_task_meta(dossier_path(tasks_meta_dir(project_id), task_id), meta)
-
-    def test_legacy_hex_resolves_with_deprecation(self) -> None:
-        """A legacy 8-char hex task on disk should still resolve, with a DeprecationWarning."""
-        with project_env(MINIMAL_PROJECT) as _ctx:
-            self._write_meta("test-proj", self.LEGACY)
-            with pytest.warns(DeprecationWarning, match="pre-0.8.0 hex format"):
-                assert resolve_task_id("test-proj", self.LEGACY) == self.LEGACY
-
-    def test_legacy_hex_prefix_resolves_with_deprecation(self) -> None:
-        """Legacy hex prefix resolution should also work and warn."""
-        with project_env(MINIMAL_PROJECT) as _ctx:
-            self._write_meta("test-proj", self.LEGACY)
-            with pytest.warns(DeprecationWarning):
-                assert resolve_task_id("test-proj", "abcd") == self.LEGACY
-
-    def test_current_format_does_not_warn(self) -> None:
-        """Resolving a current-format ID must not emit a deprecation warning."""
-        import warnings
-
-        with project_env(MINIMAL_PROJECT) as _ctx:
-            meta = {"task_id": ID_A, "name": "n", "mode": None, "workspace": "/tmp/ws"}
-            write_task_meta(dossier_path(tasks_meta_dir("test-proj"), ID_A), meta)
-            with warnings.catch_warnings():
-                warnings.simplefilter("error", DeprecationWarning)
-                assert resolve_task_id("test-proj", ID_A) == ID_A
-
-
 # ---------- container_name ----------
 
 

--- a/tests/unit/lib/test_tasks.py
+++ b/tests/unit/lib/test_tasks.py
@@ -142,46 +142,6 @@ class TestTask:
             assert not meta_path.exists()
             assert not workspace.exists()
 
-    def test_read_task_meta_backfills_legacy_project_id(self) -> None:
-        """A pre-``project_id``-field record gets the field populated from the meta-dir path.
-
-        Tasks created before ``project_id`` joined ``TaskMeta`` had only
-        ``task_id`` on disk; without backfill, the next ``write_task_meta``
-        would land an empty wire dossier (no ``project`` key) and the
-        clearance UI would render a half-identity until some unrelated
-        write happened to repopulate the field.  The backfill leans on
-        the meta-dir path layout (``…/projects/<project_id>/tasks/``)
-        rather than threading ``project_id`` through every reader.
-        """
-        from terok.lib.util.yaml import dump as yaml_dump
-
-        project_id = "proj_backfill"
-        with project_env(
-            f"project:\n  id: {project_id}\n",
-            project_id=project_id,
-        ) as ctx:
-            meta_dir = ctx.state_dir / "projects" / project_id / "tasks"
-            meta_dir.mkdir(parents=True, exist_ok=True)
-            tid = "x9y1z"
-            # Seed a legacy single-YAML record (pre-self-describing,
-            # pre-project_id-field).  Mimics what an upgrading operator
-            # has on disk.
-            (meta_dir / f"{tid}.yml").write_text(
-                yaml_dump({"task_id": tid, "name": "diligent-octopus", "mode": "cli"})
-            )
-
-            meta = read_task_meta(meta_dir, tid)
-
-            assert meta is not None
-            assert meta["project_id"] == project_id
-            # The on-disk dossier now carries the wire shape.
-            dossier = json.loads((meta_dir / f"{tid}_dossier.json").read_text(encoding="utf-8"))
-            assert dossier == {
-                "project": project_id,
-                "task": tid,
-                "name": "diligent-octopus",
-            }
-
     def test_task_new_records_created_at(self) -> None:
         """task_new writes an ISO 8601 created_at timestamp that round-trips via get_tasks.
 
@@ -1894,30 +1854,7 @@ class TestTaskDeleteWarnings:
 
 
 class TestArchiveMetaLoading:
-    """_load_archived_task_meta tolerates legacy task.yml and corrupt snapshots."""
-
-    def test_reads_legacy_yaml_snapshot(self, tmp_path: Path) -> None:
-        """An archive entry with only task.yml (no task.json) still loads."""
-        from terok.lib.orchestration.tasks.archive import _load_archived_task_meta
-
-        entry = tmp_path / "20260101T000000Z_g1v2h_old"
-        entry.mkdir()
-        (entry / "task.yml").write_text("task_id: g1v2h\nname: old-task\nmode: cli\n")
-        assert _load_archived_task_meta(entry) == {
-            "task_id": "g1v2h",
-            "name": "old-task",
-            "mode": "cli",
-        }
-
-    def test_json_takes_precedence_over_yaml(self, tmp_path: Path) -> None:
-        """When both task.json and task.yml exist, the JSON snapshot wins."""
-        from terok.lib.orchestration.tasks.archive import _load_archived_task_meta
-
-        entry = tmp_path / "entry"
-        entry.mkdir()
-        (entry / "task.json").write_text('{"task_id": "json"}')
-        (entry / "task.yml").write_text("task_id: yaml\n")
-        assert _load_archived_task_meta(entry) == {"task_id": "json"}
+    """_load_archived_task_meta reads task.json and tolerates corrupt snapshots."""
 
     def test_corrupt_json_returns_none(self, tmp_path: Path) -> None:
         """A malformed task.json yields None rather than raising."""
@@ -2048,18 +1985,13 @@ class TestDossierHandle:
             "k3v8h",
         )
 
-    def test_legacy_json_handle(self, tmp_path: Path) -> None:
-        """A pre-self-describing <id>.json handle still decomposes."""
-        from terok.lib.orchestration.tasks.meta import _dossier_handle_to_dir_and_id
-
-        assert _dossier_handle_to_dir_and_id(tmp_path / "k3v8h.json") == (tmp_path, "k3v8h")
-
-    def test_foreign_filename_raises(self, tmp_path: Path) -> None:
+    @pytest.mark.parametrize("name", ["k3v8h_meta.yml", "k3v8h.json", "random.txt"])
+    def test_foreign_filename_raises(self, tmp_path: Path, name: str) -> None:
         """A non-dossier filename raises rather than silently inferring a task ID."""
         from terok.lib.orchestration.tasks.meta import _dossier_handle_to_dir_and_id
 
         with pytest.raises(ValueError, match="not a dossier-file handle"):
-            _dossier_handle_to_dir_and_id(tmp_path / "k3v8h_meta.yml")
+            _dossier_handle_to_dir_and_id(tmp_path / name)
 
 
 class TestMetaMutations:


### PR DESCRIPTION
## Summary

Five pre-public dead-code clusters in terok-main — no operator with a public-release stake. Net **−258 LoC** across source + tests.

### Removed

- **Pre-0.8.0 hex task-ID acceptance** — `_LEGACY_HEX_TASK_ID_PREFIX_RE`, `_LEGACY_HEX_TASK_ID_FULL_RE`, the warn-branch in `_validate_task_id_prefix`, the legacy fallback in `is_task_id`, and the `warnings` import that backed the deprecation message. Pinned tests (`test_legacy_hex_resolves_with_deprecation`, `test_legacy_hex_prefix_resolves_with_deprecation`, `test_current_format_does_not_warn`) go with them.
- **Task-metadata-rename compatibility cluster (4 files)**:
  - `meta.py` — `_migrate_legacy_filenames`, `_backfill_project_id`, dual-suffix recognition in `_task_id_from_filename` / `iter_task_ids` / `task_exists` / `_dossier_handle_to_dir_and_id`.
  - `lifecycle.py` — `legacy_json` / `legacy_yml` paths in `_task_delete`'s cleanup tuple.
  - `archive.py` — `task.yml` legacy-archive read fallback + the YAML imports it pulled in.
  - `hooks.py` — dual-suffix `_DOSSIER_SUFFIXES` / `_BOOKKEEPING_SUFFIXES` collapsed to the canonical pair.
- **`terok auth` legacy positional `project_id`** + its three pinned tests. `--project` is now the only project-scope path.
- **`tui/screens.py` "legacy single `Mode:`" prose** rephrased as forward-looking lifecycle/transport-split rationale.

### Test fixture migration

Across `test_container_doctor.py` / `test_sickbay.py` 16 sites swap `<id>.yml` → `<id>_meta.yml` to match the canonical on-disk shape (the legacy-naming tolerance was the only thing keeping them green). A new parametrised `test_foreign_filename_raises` covers `.json` rejection alongside the existing canonical-mismatch cases.

## Test plan

- [x] `make lint` clean
- [x] `make test-unit` — 2627 pass; the 8 failures pre-fix mapped to legacy-filename test fixtures, all fixed in this PR
- [x] `make check` — full pipeline green
- [ ] Manual smoke: create a task, verify `<id>_dossier.json` + `<id>_meta.yml` shapes on disk, no legacy variants written.
- [ ] Operator with pre-0.8 on-disk task IDs (hex) or pre-self-describing meta files (`<id>.json`/`<id>.yml`) needs to recreate; documented in release notes alongside the plaintext-DB cycle (#1018).

🤖 Generated with [Claude Code](https://claude.com/claude-code)