### PR TITLE
docs: retarget CommandDef family autorefs to terok_util.cli_types

### DIFF
--- a/src/terok/cli/main.py
+++ b/src/terok/cli/main.py
@@ -43,10 +43,10 @@ except ImportError:  # pragma: no cover - optional dep
 
 
 def _commandtree_dispatch(args: argparse.Namespace) -> bool:
-    """Dispatch verbs wired by [`CommandTree.wire`][terok_sandbox.commands.CommandTree.wire].
+    """Dispatch verbs wired by [`CommandTree.wire`][terok_util.cli_types.CommandTree.wire].
 
-    Each leaf parser sets ``_cmd`` to its [`CommandDef`][terok_sandbox.commands.CommandDef];
-    we hand off to [`CommandTree.dispatch`][terok_sandbox.commands.CommandTree.dispatch]
+    Each leaf parser sets ``_cmd`` to its [`CommandDef`][terok_util.cli_types.CommandDef];
+    we hand off to [`CommandTree.dispatch`][terok_util.cli_types.CommandTree.dispatch]
     which extracts kwargs from *args* and calls the (possibly cfg-wrapped)
     handler.  Returns ``True`` if a wired command was matched.
     """
@@ -239,7 +239,7 @@ def main(prog: str = "terok") -> None:
 def _build_wired_tree() -> CommandTree:
     """Compose terok's sibling-wired command tree.
 
-    Pulls executor's full [`CommandTree`][terok_sandbox.commands.CommandTree]
+    Pulls executor's full [`CommandTree`][terok_util.cli_types.CommandTree]
     (already containing executor's overlays + sandbox spliced under
     ``sandbox``), applies terok's
     [`SandboxConfig`][terok_sandbox.SandboxConfig] injection at every
@@ -250,7 +250,7 @@ def _build_wired_tree() -> CommandTree:
     - ``terok sandbox <verb>``       — shortcut for the sandbox subtree
       (same children as ``terok executor sandbox``).
     - ``terok {vault,gate,ssh} <verb>`` — shortcuts that reference the
-      same [`CommandDef`][terok_sandbox.commands.CommandDef] instances
+      same [`CommandDef`][terok_util.cli_types.CommandDef] instances
       living under ``sandbox`` so terok's cfg wrap propagates uniformly.
     """
     from terok.lib.api.agents import EXECUTOR_COMMANDS

--- a/src/terok/cli/tree.py
+++ b/src/terok/cli/tree.py
@@ -3,7 +3,7 @@
 
 """Terok-side composition of the unified command tree.
 
-Consumes the [`CommandTree`][terok_sandbox.commands.CommandTree]
+Consumes the [`CommandTree`][terok_util.cli_types.CommandTree]
 exposed by terok-executor (which already has executor's vault
 overlays applied + sandbox tree spliced under the ``sandbox`` node),
 applies terok-specific overlays (terok's
@@ -13,7 +13,7 @@ local ``serve`` verb, and exposes the result both as deep paths and
 as top-level shortcuts — identity-preserving so any terok wrap reaches
 every entry point.
 
-The wiring API is [`CommandTree`][terok_sandbox.commands.CommandTree]
+The wiring API is [`CommandTree`][terok_util.cli_types.CommandTree]
 from terok-sandbox; this module only contains the *composition*
 specific to terok.
 """
@@ -46,11 +46,11 @@ def inject_cfg_factory(
     aren't gratuitously wrapped.
 
     Identity is preserved for every untouched node so a shortcut that
-    references the same modified subtree via [`find_at`][terok_sandbox.commands.CommandTree.find_at]
+    references the same modified subtree via [`find_at`][terok_util.cli_types.CommandTree.find_at]
     sees the same wrap; both ``terok vault start`` (shortcut) and
     ``terok executor sandbox vault start`` (deep path) share the same
     wrapped handler when they reference the same
-    [`CommandDef`][terok_sandbox.commands.CommandDef] instance.
+    [`CommandDef`][terok_util.cli_types.CommandDef] instance.
     """
     overrides: dict[tuple[str, ...], Callable[..., Any]] = {}
     for path, cmd in tree.walk():

--- a/src/terok/lib/api/__init__.py
+++ b/src/terok/lib/api/__init__.py
@@ -23,8 +23,8 @@ This module owns the cross-cutting bits: the
 [`Config`][terok.lib.api.Config] snapshot, the runtime peek
 [`get_container_state`][terok.lib.api.get_container_state], a small
 number of shared sandbox types (``SandboxConfig`` and the CLI
-[`CommandDef`][terok_sandbox.commands.CommandDef] /
-[`CommandTree`][terok_sandbox.commands.CommandTree]), and the ANSI helpers
+[`CommandDef`][terok_util.cli_types.CommandDef] /
+[`CommandTree`][terok_util.cli_types.CommandTree]), and the ANSI helpers
 ``bold``/``red``/``yellow``/``stage_line``.
 
 For backward compatibility every sub-module's exports are also bound on


### PR DESCRIPTION
## Bug

Master's Documentation workflow failed at `properdocs build --strict`:

```
WARNING -  mkdocs_autorefs: reference/terok/lib/api/index.md: from .../api/__init__.py:26:
  (terok.lib.api) Could not find cross-reference target 'terok_sandbox.commands.CommandDef'
Aborted with N warnings in strict mode!
```

W2.5 moved `CommandDef` / `ArgDef` / `CommandTree` / `KeyRow` from `terok_sandbox.commands._types` to `terok_util.cli_types`. Sandbox keeps a `_types.py` **re-export shim** so call-site imports keep working — but the **published inventory** (`https://raw.githubusercontent.com/terok-ai/docs-inventories/master/terok-sandbox/objects.inv`) is rebuilt from the new source, where those exact attribute paths no longer exist as documented symbols.

Local `properdocs build --strict` resolves the refs via the in-process re-export shim and silently passes; the strict CI run that fetches the published sandbox inventory catches the real breakage.

## Fix

Retarget every stale ``[`CommandDef`][terok_sandbox.commands.CommandDef]`` (and its three siblings + the `.wire` / `.dispatch` / `.find_at` attribute autorefs) to `terok_util.cli_types.<Symbol>` — the canonical home and the inventory mkdocstrings actually resolves against.

Three files swept:
- `src/terok/lib/api/__init__.py`
- `src/terok/cli/main.py`
- `src/terok/cli/tree.py`

Per AGENTS.md: "For external symbols, use the dependency's own path."

## Test plan

- [x] `properdocs build --strict` locally — clean
- [x] No stale `terok_sandbox.commands.{CommandDef,ArgDef,CommandTree,KeyRow}` autorefs remain in `src/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)