### PR TITLE
chore: trim stale tach interface entries (post-W5 audit)

### DIFF
--- a/tach.toml
+++ b/tach.toml
@@ -659,7 +659,6 @@ depends_on = []
 expose = [
     "ProjectConfig",
     "PresetInfo",
-    "effective_ssh_key_name",
     "is_valid_project_id",
     "validate_project_id",
 ]
@@ -677,9 +676,7 @@ expose = [
     "load_preset",
     "list_presets",
     "derive_project",
-    "effective_ssh_key_name",
     "require_project_exists",
-    "resolve_ssh_host_dir",
     "set_project_image_agents",
     "validate_project_id",
 ]
@@ -828,7 +825,6 @@ from = ["terok.lib.domain.panic"]
 [[interfaces]]
 expose = [
     "projects_dir",
-    "state_dir",
     "gate_repos_dir",
     "sandbox_live_dir",
     "sandbox_live_mounts_dir",
@@ -846,7 +842,6 @@ expose = [
     "get_global_default_agent",
     "get_global_default_login",
     "get_global_image_agents",
-    "get_global_image_base_image",
     "global_config_path",
     "global_config_search_paths",
     "load_global_config",
@@ -950,13 +945,7 @@ expose = [
 from = ["terok.lib.domain.project"]
 
 [[interfaces]]
-expose = [
-    "maybe_pause_for_ssh_key_registration",
-    "project_needs_key_registration",
-    "provision_ssh_key",
-    "register_ssh_key",
-    "summarize_ssh_init",
-]
+expose = ["summarize_ssh_init"]
 from = ["terok.lib.domain.ssh"]
 
 [[interfaces]]


### PR DESCRIPTION
## Summary

Cross-checked every \`[[interfaces]] expose = [...]\` entry against the actual module attributes. Ten names left behind by the W5 chain no longer exist on the modules that advertised them — removed.

## What was checked

Three follow-up cleanups were considered, only one moved the needle:

**1. Tach interface trim (this PR)** — 10 stale names removed:
- \`terok.lib.core.config\`: \`state_dir\`, \`get_global_image_base_image\`
- \`terok.lib.core.project_model\`: \`effective_ssh_key_name\`
- \`terok.lib.core.projects\`: \`effective_ssh_key_name\`, \`resolve_ssh_host_dir\`
- \`terok.lib.domain.ssh\`: \`maybe_pause_for_ssh_key_registration\`, \`project_needs_key_registration\`, \`provision_ssh_key\`, \`register_ssh_key\` (the four moved to \`Project\` in W5.C.2)

\`tach check\` still passes; the contract surface no longer advertises symbols that would fail an actual lookup.

**2. \`lib/api/*\` facade audit (no change)** — AST-walked every \`from terok.lib.api[.*] import …\` site across src/ + tests/. 160 unique exports, 13 truly unused via any api path — all recently-added classes (\`KrunHost\`, \`Authenticator\`, \`SharedMountStorageInfo\`, \`TaskStorageInfo\`, \`HubService\`, \`NotifierService\`) that consumers may still adopt. The facade is in good shape; removing those would be premature.

**3. Inline-import sweep (no change)** — Each TUI / CLI module's inline imports are documented as deliberate:
- \`tui/worker_actions.py\`: each function runs in a fresh child process; lazy imports = minimal per-action cost
- \`tui/app.py:main()\`: lazy textual = fast CLI startup
- CLI command modules: deferred until dispatched

Pulling them up would regress startup / dispatch latency in exchange for code-organization only.

## Test plan

- [x] \`make check\` clean (2608 unit tests, lint, mypy, tach, lint-imports, reuse, bandit, docstrings, dead-code)
- [ ] CI: GitHub Actions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Refined module interfaces to streamline the internal API surface by restricting publicly exposed symbols, improving code organization and maintainability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/terok-ai/terok/pull/1032?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->