### PR TITLE
feat(sickbay): surface AppArmor dnsmasq confinement advisory

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -2538,14 +2538,14 @@ re2 = ["google-re2 (>=1.1)"]
 
 [[package]]
 name = "platformdirs"
-version = "4.9.6"
+version = "4.10.0"
 description = "A small Python package for determining appropriate platform-specific dirs, e.g. a `user data dir`."
 optional = false
 python-versions = ">=3.10"
 groups = ["main", "dev", "docs"]
 files = [
-    {file = "platformdirs-4.9.6-py3-none-any.whl", hash = "sha256:e61adb1d5e5cb3441b4b7710bea7e4c12250ca49439228cc1021c00dcfac0917"},
-    {file = "platformdirs-4.9.6.tar.gz", hash = "sha256:3bfa75b0ad0db84096ae777218481852c0ebc6c727b3168c1b9e0118e458cf0a"},
+    {file = "platformdirs-4.10.0-py3-none-any.whl", hash = "sha256:fb516cdb12eb0d857d0cd85a7c57cea4d060bee4578d6cf5a14dfdf8cbf8784a"},
+    {file = "platformdirs-4.10.0.tar.gz", hash = "sha256:31e761a6a0ca04faf7353ea759bdba55652be214725111e5aac52dfa29d4bef7"},
 ]
 
 [[package]]
@@ -3602,9 +3602,8 @@ description = "Single-agent task runner for hardened Podman containers"
 optional = false
 python-versions = ">=3.12,<3.15"
 groups = ["main"]
-files = [
-    {file = "terok_executor-0.0.149a27-py3-none-any.whl", hash = "sha256:c848a637b9a4404dd1e6ca52731260d317955120b0f4aca497ca3b95dd6908ce"},
-]
+files = []
+develop = false
 
 [package.dependencies]
 agent-client-protocol = ">=0.10.1"
@@ -3613,13 +3612,15 @@ prompt-toolkit = ">=3.0"
 pydantic = ">=2.9"
 rich = ">=13.0"
 "ruamel.yaml" = ">=0.18"
-terok_sandbox = {url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.0.124a21/terok_sandbox-0.0.124a21-py3-none-any.whl"}
+terok-sandbox = {git = "https://github.com/sliwowitz/terok-sandbox.git", rev = "feat/apparmor-dnsmasq-profile"}
 terok_util = {url = "https://github.com/terok-ai/terok-util/releases/download/v0.0.2a1/terok_util-0.0.2a1-py3-none-any.whl"}
 tomli-w = ">=1.0"
 
 [package.source]
-type = "url"
-url = "https://github.com/terok-ai/terok-executor/releases/download/v0.0.149a27/terok_executor-0.0.149a27-py3-none-any.whl"
+type = "git"
+url = "https://github.com/sliwowitz/terok-executor.git"
+reference = "feat/apparmor-dnsmasq-profile"
+resolved_reference = "508c794dd9af8fe7fb8387635da31e04fccb5aa8"
 
 [[package]]
 name = "terok-sandbox"
@@ -3628,9 +3629,8 @@ description = "Hardened Podman container runner with gate server and shield inte
 optional = false
 python-versions = ">=3.12,<4.0"
 groups = ["main"]
-files = [
-    {file = "terok_sandbox-0.0.124a21-py3-none-any.whl", hash = "sha256:0919ce1dbf89613be6743e20c43007595ee7bc43e132e5387712beed9ddc0916"},
-]
+files = []
+develop = false
 
 [package.dependencies]
 aiohttp = ">=3.9"
@@ -3638,18 +3638,20 @@ cryptography = ">=46.0.7"
 jinja2 = ">=3.1"
 keyring = ">=25.0"
 packaging = ">=24"
-platformdirs = ">=4.9.6"
+platformdirs = ">=4.10.0"
 prompt-toolkit = ">=3.0"
 pydantic = ">=2.9"
 "ruamel.yaml" = ">=0.18"
 sqlcipher3 = ">=0.6.2"
 terok_clearance = {url = "https://github.com/terok-ai/terok-clearance/releases/download/v0.6.14a7/terok_clearance-0.6.14a7-py3-none-any.whl"}
-terok_shield = {url = "https://github.com/terok-ai/terok-shield/releases/download/v0.6.42a9/terok_shield-0.6.42a9-py3-none-any.whl"}
+terok-shield = {git = "https://github.com/sliwowitz/terok-shield.git", rev = "feat/apparmor-dnsmasq-profile"}
 terok_util = {url = "https://github.com/terok-ai/terok-util/releases/download/v0.0.2a1/terok_util-0.0.2a1-py3-none-any.whl"}
 
 [package.source]
-type = "url"
-url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.0.124a21/terok_sandbox-0.0.124a21-py3-none-any.whl"
+type = "git"
+url = "https://github.com/sliwowitz/terok-sandbox.git"
+reference = "feat/apparmor-dnsmasq-profile"
+resolved_reference = "89dbfd43336fde182d2311bc13f40f072369ef1c"
 
 [[package]]
 name = "terok-shield"
@@ -3658,9 +3660,8 @@ description = "nftables-based egress firewalling for Podman containers"
 optional = false
 python-versions = ">=3.12,<4.0"
 groups = ["main"]
-files = [
-    {file = "terok_shield-0.6.42a9-py3-none-any.whl", hash = "sha256:0b70cd297908a96b2c5fcc483c81a31c3103f0c798a4e493454f20120476e48d"},
-]
+files = []
+develop = false
 
 [package.dependencies]
 pydantic = ">=2.0"
@@ -3668,8 +3669,10 @@ PyYAML = ">=6.0"
 terok_util = {url = "https://github.com/terok-ai/terok-util/releases/download/v0.0.2a1/terok_util-0.0.2a1-py3-none-any.whl"}
 
 [package.source]
-type = "url"
-url = "https://github.com/terok-ai/terok-shield/releases/download/v0.6.42a9/terok_shield-0.6.42a9-py3-none-any.whl"
+type = "git"
+url = "https://github.com/sliwowitz/terok-shield.git"
+reference = "feat/apparmor-dnsmasq-profile"
+resolved_reference = "dba9e1808dd4a737565e55cdd9ea69e60606b453"
 
 [[package]]
 name = "terok-util"
@@ -4568,4 +4571,4 @@ propcache = ">=0.2.1"
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.12,<3.15"
-content-hash = "2bce96e768d889f4fbdec563020a88b5d0ecd4970aa26323f66826be26d7a89c"
+content-hash = "63ce60f365f450b33fa9bc4cc3f91b94859153dc5cf70bf48637b02395d8fe04"

--- a/poetry.lock
+++ b/poetry.lock
@@ -3597,13 +3597,14 @@ url = "https://github.com/terok-ai/terok-clearance/releases/download/v0.6.14a7/t
 
 [[package]]
 name = "terok-executor"
-version = "0.0.149a27"
+version = "0.0.149a28"
 description = "Single-agent task runner for hardened Podman containers"
 optional = false
 python-versions = ">=3.12,<3.15"
 groups = ["main"]
-files = []
-develop = false
+files = [
+    {file = "terok_executor-0.0.149a28-py3-none-any.whl", hash = "sha256:f9e90eb8cc76e085f341ac3b8c8b7b46beca3a225e08255e5f9b2058bc154ddb"},
+]
 
 [package.dependencies]
 agent-client-protocol = ">=0.10.1"
@@ -3612,25 +3613,24 @@ prompt-toolkit = ">=3.0"
 pydantic = ">=2.9"
 rich = ">=13.0"
 "ruamel.yaml" = ">=0.18"
-terok-sandbox = {git = "https://github.com/sliwowitz/terok-sandbox.git", rev = "feat/apparmor-dnsmasq-profile"}
+terok_sandbox = {url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.0.124a22/terok_sandbox-0.0.124a22-py3-none-any.whl"}
 terok_util = {url = "https://github.com/terok-ai/terok-util/releases/download/v0.0.2a1/terok_util-0.0.2a1-py3-none-any.whl"}
 tomli-w = ">=1.0"
 
 [package.source]
-type = "git"
-url = "https://github.com/sliwowitz/terok-executor.git"
-reference = "feat/apparmor-dnsmasq-profile"
-resolved_reference = "508c794dd9af8fe7fb8387635da31e04fccb5aa8"
+type = "url"
+url = "https://github.com/terok-ai/terok-executor/releases/download/v0.0.149a28/terok_executor-0.0.149a28-py3-none-any.whl"
 
 [[package]]
 name = "terok-sandbox"
-version = "0.0.124a21"
+version = "0.0.124a22"
 description = "Hardened Podman container runner with gate server and shield integration"
 optional = false
 python-versions = ">=3.12,<4.0"
 groups = ["main"]
-files = []
-develop = false
+files = [
+    {file = "terok_sandbox-0.0.124a22-py3-none-any.whl", hash = "sha256:2831bac04641d79a33fc43f594c6b047acbb0ee2f2146dc87e10c6fca0978a81"},
+]
 
 [package.dependencies]
 aiohttp = ">=3.9"
@@ -3644,24 +3644,23 @@ pydantic = ">=2.9"
 "ruamel.yaml" = ">=0.18"
 sqlcipher3 = ">=0.6.2"
 terok_clearance = {url = "https://github.com/terok-ai/terok-clearance/releases/download/v0.6.14a7/terok_clearance-0.6.14a7-py3-none-any.whl"}
-terok-shield = {git = "https://github.com/sliwowitz/terok-shield.git", rev = "feat/apparmor-dnsmasq-profile"}
+terok_shield = {url = "https://github.com/terok-ai/terok-shield/releases/download/v0.6.42a10/terok_shield-0.6.42a10-py3-none-any.whl"}
 terok_util = {url = "https://github.com/terok-ai/terok-util/releases/download/v0.0.2a1/terok_util-0.0.2a1-py3-none-any.whl"}
 
 [package.source]
-type = "git"
-url = "https://github.com/sliwowitz/terok-sandbox.git"
-reference = "feat/apparmor-dnsmasq-profile"
-resolved_reference = "89dbfd43336fde182d2311bc13f40f072369ef1c"
+type = "url"
+url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.0.124a22/terok_sandbox-0.0.124a22-py3-none-any.whl"
 
 [[package]]
 name = "terok-shield"
-version = "0.6.42a9"
+version = "0.6.42a10"
 description = "nftables-based egress firewalling for Podman containers"
 optional = false
 python-versions = ">=3.12,<4.0"
 groups = ["main"]
-files = []
-develop = false
+files = [
+    {file = "terok_shield-0.6.42a10-py3-none-any.whl", hash = "sha256:fedb948bb7fa2dd063b03056675679f11af89f9a188438f4ebc27a8e52abbc7a"},
+]
 
 [package.dependencies]
 pydantic = ">=2.0"
@@ -3669,10 +3668,8 @@ PyYAML = ">=6.0"
 terok_util = {url = "https://github.com/terok-ai/terok-util/releases/download/v0.0.2a1/terok_util-0.0.2a1-py3-none-any.whl"}
 
 [package.source]
-type = "git"
-url = "https://github.com/sliwowitz/terok-shield.git"
-reference = "feat/apparmor-dnsmasq-profile"
-resolved_reference = "dba9e1808dd4a737565e55cdd9ea69e60606b453"
+type = "url"
+url = "https://github.com/terok-ai/terok-shield/releases/download/v0.6.42a10/terok_shield-0.6.42a10-py3-none-any.whl"
 
 [[package]]
 name = "terok-util"
@@ -4571,4 +4568,4 @@ propcache = ">=0.2.1"
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.12,<3.15"
-content-hash = "63ce60f365f450b33fa9bc4cc3f91b94859153dc5cf70bf48637b02395d8fe04"
+content-hash = "f90c90366789132e66e184747ca446f8cbdf3cd4a19437280005547c3497db41"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,9 +27,9 @@ dependencies = [
     "unique-namer>=1.3",
     "textual-serve>=1.1.0",
     "jinja2>=3.1",
-    "terok-executor @ git+https://github.com/sliwowitz/terok-executor.git@feat/apparmor-dnsmasq-profile",
-    "terok-sandbox @ git+https://github.com/sliwowitz/terok-sandbox.git@feat/apparmor-dnsmasq-profile",
-    "terok-shield @ git+https://github.com/sliwowitz/terok-shield.git@feat/apparmor-dnsmasq-profile",
+    "terok-executor @ https://github.com/terok-ai/terok-executor/releases/download/v0.0.149a28/terok_executor-0.0.149a28-py3-none-any.whl",
+    "terok-sandbox @ https://github.com/terok-ai/terok-sandbox/releases/download/v0.0.124a22/terok_sandbox-0.0.124a22-py3-none-any.whl",
+    "terok-shield @ https://github.com/terok-ai/terok-shield/releases/download/v0.6.42a10/terok_shield-0.6.42a10-py3-none-any.whl",
     "terok-clearance @ https://github.com/terok-ai/terok-clearance/releases/download/v0.6.14a7/terok_clearance-0.6.14a7-py3-none-any.whl",
     "terok-util @ https://github.com/terok-ai/terok-util/releases/download/v0.0.2a1/terok_util-0.0.2a1-py3-none-any.whl",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,9 +27,9 @@ dependencies = [
     "unique-namer>=1.3",
     "textual-serve>=1.1.0",
     "jinja2>=3.1",
-    "terok-executor @ https://github.com/terok-ai/terok-executor/releases/download/v0.0.149a27/terok_executor-0.0.149a27-py3-none-any.whl",
-    "terok-sandbox @ https://github.com/terok-ai/terok-sandbox/releases/download/v0.0.124a21/terok_sandbox-0.0.124a21-py3-none-any.whl",
-    "terok-shield @ https://github.com/terok-ai/terok-shield/releases/download/v0.6.42a9/terok_shield-0.6.42a9-py3-none-any.whl",
+    "terok-executor @ git+https://github.com/sliwowitz/terok-executor.git@feat/apparmor-dnsmasq-profile",
+    "terok-sandbox @ git+https://github.com/sliwowitz/terok-sandbox.git@feat/apparmor-dnsmasq-profile",
+    "terok-shield @ git+https://github.com/sliwowitz/terok-shield.git@feat/apparmor-dnsmasq-profile",
     "terok-clearance @ https://github.com/terok-ai/terok-clearance/releases/download/v0.6.14a7/terok_clearance-0.6.14a7-py3-none-any.whl",
     "terok-util @ https://github.com/terok-ai/terok-util/releases/download/v0.0.2a1/terok_util-0.0.2a1-py3-none-any.whl",
 ]

--- a/src/terok/cli/commands/sickbay.py
+++ b/src/terok/cli/commands/sickbay.py
@@ -164,12 +164,14 @@ def _check_shield() -> _CheckResult:
         return ("warn", label, f"unexpected health: {ec.health}")
     dns = getattr(ec, "dns_tier", "unknown")
     detail = f"active ({ec.hooks}, {dns} DNS)"
-    # Surface the dnsmasq install hint when shield demoted to a lower
-    # tier: the lower tiers (dig, getent) work — they just can't handle
-    # runtime IP rotation or live domain allow-list updates, which is
-    # the daily-driver benefit dnsmasq pays for.
+    # On a lower tier (dig/getent) surface shield's own reason: dnsmasq
+    # missing and dnsmasq AppArmor-confined need different fixes, and
+    # shield reports the precise one (with any docs pointer) in ec.issues.
     if dns != "dnsmasq":
-        detail += " — install dnsmasq for live IP rotation + domain updates"
+        hint = (
+            ec.issues[0] if ec.issues else "install dnsmasq for live IP rotation + domain updates"
+        )
+        detail += f" — {hint}"
     return ("ok", label, detail)
 
 

--- a/tests/unit/cli/test_cli_sickbay.py
+++ b/tests/unit/cli/test_cli_sickbay.py
@@ -270,6 +270,34 @@ def test_check_shield_states(
     assert expected_detail in detail
 
 
+def test_check_shield_surfaces_apparmor_advisory_on_lower_tier() -> None:
+    """On a dnsmasq→dig downgrade, _check_shield surfaces shield's precise reason."""
+    advisory = (
+        "dnsmasq is present but AppArmor confines it from the shield state "
+        "directory — install the terok AppArmor profile (see docs/apparmor.md)"
+    )
+    mock_ec = MagicMock(
+        health="ok", hooks="per-container", dns_tier="dig", setup_hint="", issues=[advisory]
+    )
+    with patch("terok.cli.commands.sickbay.check_environment", return_value=mock_ec):
+        status, _label, detail = _check_shield()
+    assert status == "ok"
+    assert "AppArmor" in detail
+    assert "docs/apparmor.md" in detail
+    assert "install dnsmasq for live IP rotation" not in detail
+
+
+def test_check_shield_generic_dnsmasq_hint_without_reported_reason() -> None:
+    """With no shield-reported reason, the generic dnsmasq hint is still shown."""
+    mock_ec = MagicMock(
+        health="ok", hooks="per-container", dns_tier="dig", setup_hint="", issues=[]
+    )
+    with patch("terok.cli.commands.sickbay.check_environment", return_value=mock_ec):
+        status, _label, detail = _check_shield()
+    assert status == "ok"
+    assert "install dnsmasq" in detail
+
+
 @pytest.mark.parametrize(
     ("running", "mode", "systemd_avail", "side_effect", "expected_status", "expected_detail"),
     [


### PR DESCRIPTION
## What

Completes the AppArmor / dnsmasq fallback feature on the terok side: `terok sickbay`'s **Shield** check now reports the *accurate* reason when the DNS tier is degraded.

On hosts that confine `/usr/sbin/dnsmasq` with an enforcing AppArmor profile (Arch/Manjaro, the `apparmor.d` set), terok-shield now detects the confinement and falls back to the `dig` tier instead of failing the container launch. `_check_shield` previously appended a blanket `"install dnsmasq for live IP rotation…"` hint on *any* non-dnsmasq tier — misleading when dnsmasq is installed but AppArmor-blocked. It now surfaces shield's precise reason from `EnvironmentCheck.issues`:

- dnsmasq missing → "install dnsmasq …"
- dnsmasq AppArmor-confined → "install the terok AppArmor profile (see `docs/apparmor.md`)"

The generic hint is retained as a fallback when shield reports no specific reason.

## Tests

- Two new `_check_shield` tests: precise-advisory surfacing on a lower tier, and the generic-hint fallback when `issues` is empty.
- `tests/unit/cli/test_cli_sickbay.py` + `test_sickbay.py` green (79 passed); ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package dependencies to use development versions from Git.

* **Bug Fixes**
  * Improved Shield health-check output to prioritize and display specific reported issues when available, with intelligent fallback for generic installation hints.

* **Tests**
  * Added test coverage for Shield health-check scenarios, including DNS tier fallback cases and advisory issue reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->