### PR TITLE
docs: add PyPI version badge and fix architecture SVG rendering on PyPI

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 
 # terok
 
+[![PyPI](https://img.shields.io/pypi/v/terok)](https://pypi.org/project/terok/)
 [![License: Apache-2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 [![REUSE status](https://api.reuse.software/badge/github.com/terok-ai/terok)](https://api.reuse.software/info/github.com/terok-ai/terok)
 [![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=terok-ai_terok&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=terok-ai_terok)
@@ -26,7 +27,7 @@ and a Textual TUI on top of a stack of independently-released
 Python packages.
 
 <p align="center">
-  <img src="docs/img/architecture.svg" alt="terok ecosystem at a glance">
+  <img src="https://terok-ai.github.io/terok/img/architecture.svg" alt="terok ecosystem at a glance">
 </p>
 
 ## What you get


### PR DESCRIPTION
Adds a **PyPI version badge** and fixes the **architecture diagram on PyPI**.

The diagram used a *relative* path (`docs/img/architecture.svg`), which PyPI cannot resolve (no repo base to anchor relatives against), so it showed broken on the project page — while the logo, an absolute github.io URL, rendered fine. It was never an SVG-vs-PNG problem. Switched to the canonical absolute URL `https://terok-ai.github.io/terok/img/architecture.svg` (this repo is the source of that published asset); renders on PyPI, GitHub, and IDE previews alike.

The PyPI version badge auto-colors via shields.io (orange pre-1.0 → blue at ≥1.0).

Takes effect on the live PyPI page at the next release — the `long_description` is baked into the published artifact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added PyPI version badge to README for quick reference
  * Updated architecture diagram to use externally hosted image for improved reliability

<!-- end of auto-generated comment: release notes by coderabbit.ai -->