### PR TITLE
feat(tui): attach to existing tmux session instead of failing on duplicate name

### DIFF
--- a/docs/login-design.md
+++ b/docs/login-design.md
@@ -109,3 +109,10 @@ and the goal is a single coherent web-served login story.)
 `terok tui --tmux` wraps the TUI in a managed tmux session with the host config
 (blue status bar, usage hints). Login sessions become additional tmux windows.
 This is opt-in — without the flag, the TUI runs directly in the terminal as before.
+The global `tui.default_tmux` config setting flips the default so the flag is
+implied; `--no-tmux` overrides it for one launch.
+
+The wrapper uses `tmux new-session -A -s terok`, so a second `--tmux` launch
+**attaches** to the running `terok` session rather than erroring on the
+duplicate name. `--new-session` opts out, dropping `-s` so tmux auto-names a
+parallel session.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -441,6 +441,22 @@ This wraps the TUI in a managed tmux session with a blue status bar showing
 keyboard shortcuts. Login sessions open as additional tmux windows — press
 `^b n`/`^b p` to switch between TUI and container shells.
 
+To launch the TUI in tmux by default without passing `--tmux` every time, set
+it in your config:
+
+```yaml
+tui:
+  default_tmux: true
+```
+
+`--no-tmux` overrides the config setting for a single launch.
+
+When tmux mode is active, terok **attaches to the shared `terok` session** if
+one is already running, so a second `terok tui --tmux` reconnects to your
+existing TUI instead of failing on the duplicate session name. Pass
+`--new-session` to opt out and start a separate, tmux-named session alongside
+it.
+
 #### tmux Quick Reference
 
 | Context | Prefix | Status bar color | Common keys |

--- a/src/terok/tui/app.py
+++ b/src/terok/tui/app.py
@@ -1719,13 +1719,19 @@ if _HAS_TEXTUAL:
             """Open the clearance screen from the main screen."""
             await self.action_show_clearance()
 
-    def _launch_in_tmux() -> None:
+    def _launch_in_tmux(force_new: bool = False) -> None:
         """Launch the TUI inside a managed tmux session.
 
-        If already inside tmux, just run the TUI directly.
-        Otherwise, verify that tmux is installed and exec into it with the
-        terok host config (blue status bar, usage hints).  Exits with an
-        actionable error message if tmux is not found on ``$PATH``.
+        If already inside tmux, just run the TUI directly.  Otherwise verify
+        that tmux is installed and exec into it with the terok host config
+        (blue status bar, usage hints).  Exits with an actionable error
+        message if tmux is not found on ``$PATH``.
+
+        By default this attaches to the shared ``terok`` session if one is
+        already running (``new-session -A``), so a second ``terok --tmux``
+        reconnects rather than failing on the duplicate name.  Pass
+        ``force_new=True`` (``--new-session``) to spin up a fresh, tmux-named
+        session alongside the existing one instead.
         """
         if os.environ.get("TMUX"):
             # Already inside tmux — no double-wrap
@@ -1750,18 +1756,15 @@ if _HAS_TEXTUAL:
         # Note: os.execvp replaces this process so the context manager's
         # __exit__ never runs.  This is fine — tmux reads the config file
         # at startup, and OS process cleanup handles any temp resources.
+        # ``-A -s terok`` attaches to the shared session if it exists and
+        # creates it otherwise; ``--new-session`` drops the name so tmux
+        # auto-assigns one for a parallel session.  ``terok-tui`` is only run
+        # when tmux actually creates the session — on attach it is ignored.
+        session_args = ["new-session"] if force_new else ["new-session", "-A", "-s", "terok"]
         with _res.as_file(tmux_conf) as conf_path:
             os.execvp(
                 "tmux",
-                [
-                    "tmux",
-                    "-f",
-                    str(conf_path),
-                    "new-session",
-                    "-s",
-                    "terok",
-                    "terok-tui",
-                ],
+                ["tmux", "-f", str(conf_path), *session_args, "terok-tui"],
             )
 
     import argparse
@@ -1792,6 +1795,15 @@ if _HAS_TEXTUAL:
         )
         parser.set_defaults(tmux=None)
         parser.add_argument(
+            "--new-session",
+            action="store_true",
+            default=False,
+            help=(
+                "Start a fresh tmux session instead of attaching to the running "
+                "'terok' one (only meaningful in tmux mode)"
+            ),
+        )
+        parser.add_argument(
             "--experimental",
             action="store_true",
             default=False,
@@ -1816,6 +1828,10 @@ if _HAS_TEXTUAL:
           terminal.
         - When neither flag is passed, the global config setting
           ``tui.default_tmux`` decides (defaults to ``False``).
+
+        In tmux mode the TUI attaches to the shared ``terok`` session when one
+        is already running; ``--new-session`` opts out and starts a parallel,
+        tmux-named session instead.
         """
         args = _build_arg_parser().parse_args()
         set_experimental(args.experimental)
@@ -1836,7 +1852,7 @@ if _HAS_TEXTUAL:
         from .shell_launch import is_web_mode
 
         if use_tmux and not is_web_mode():
-            _launch_in_tmux()
+            _launch_in_tmux(force_new=args.new_session)
             return
         TerokTUI().run()
 

--- a/tests/unit/tui/test_app_arg_parser.py
+++ b/tests/unit/tui/test_app_arg_parser.py
@@ -56,3 +56,11 @@ class TestOtherFlags:
     def test_no_emoji_can_be_enabled(self) -> None:
         """``--no-emoji`` swaps emojis for plain-text labels."""
         assert _build_arg_parser().parse_args(["--no-emoji"]).no_emoji is True
+
+    def test_new_session_defaults_to_false(self) -> None:
+        """Without ``--new-session`` the launcher attaches to the shared session."""
+        assert _build_arg_parser().parse_args([]).new_session is False
+
+    def test_new_session_can_be_enabled(self) -> None:
+        """``--new-session`` opts out of attaching and forces a fresh session."""
+        assert _build_arg_parser().parse_args(["--new-session"]).new_session is True

--- a/tests/unit/tui/test_tui_module.py
+++ b/tests/unit/tui/test_tui_module.py
@@ -42,3 +42,35 @@ def test_tmux_configuration_integration(
         monkeypatch.setenv("TEROK_CONFIG_FILE", str(cfg_path))
 
     assert get_tui_default_tmux() is expected
+
+
+@pytest.mark.parametrize(
+    ("force_new", "expected_session_args"),
+    [
+        pytest.param(False, ["new-session", "-A", "-s", "terok"], id="attach-shared"),
+        pytest.param(True, ["new-session"], id="force-new"),
+    ],
+)
+def test_launch_in_tmux_attaches_or_forks(
+    monkeypatch: pytest.MonkeyPatch,
+    force_new: bool,
+    expected_session_args: list[str],
+) -> None:
+    """Default launch attaches to the shared ``terok`` session; ``--new-session`` forks."""
+    import shutil
+
+    from terok.tui import app
+
+    monkeypatch.delenv("TMUX", raising=False)
+    # ``_launch_in_tmux`` does a local ``import shutil``; patch the real module.
+    monkeypatch.setattr(shutil, "which", lambda _cmd: "/usr/bin/tmux")
+
+    captured: list[str] = []
+    monkeypatch.setattr(app.os, "execvp", lambda _file, argv: captured.extend(argv))
+
+    app._launch_in_tmux(force_new=force_new)
+
+    # argv is ["tmux", "-f", <conf>, *session_args, "terok-tui"]; the conf path
+    # is materialised at runtime so we assert around it rather than on it.
+    assert captured[:2] == ["tmux", "-f"]
+    assert captured[3:] == [*expected_session_args, "terok-tui"]


### PR DESCRIPTION
## Summary

Launching the TUI in tmux mode (`terok tui --tmux`, or `tui.default_tmux: true`) from **outside** tmux used to run `tmux new-session -s terok`. With the hardcoded session name, a second launch errors with `duplicate session: terok` rather than reconnecting to the running TUI.

This switches the launcher to `tmux new-session -A -s terok`, so a second `--tmux` launch **attaches** to the shared `terok` session. A new `--new-session` flag opts out, dropping `-s` so tmux auto-names a parallel session alongside the existing one.

## Behavior

- **Outside tmux, no session yet** → creates the `terok` host session (blue status bar) as before.
- **Outside tmux, session already running** → attaches to it (previously: error).
- **`--new-session`** → forces a fresh, tmux-named session in parallel.
- **Already inside tmux** → unchanged: runs the TUI directly (no double-wrap); container logins still open as new tmux windows in the current session.

## Config

`tui.default_tmux: true` already existed to default the TUI into tmux mode; this PR documents it alongside the new attach behavior. `--no-tmux` still overrides per-launch.

## Tests

- `test_app_arg_parser.py`: `--new-session` defaults off / can be enabled.
- `test_tui_module.py`: `_launch_in_tmux` builds `new-session -A -s terok` by default and bare `new-session` with `force_new=True`.

All 15 tmux-related unit tests pass. Podman/container-dependent suites not run (per project policy — run manually).

## Docs

`docs/usage.md` and `docs/login-design.md` updated to cover `tui.default_tmux`, the attach behavior, and `--new-session`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configuration option to enable tmux mode by default
  * Added `--new-session` flag to create separate tmux sessions instead of attaching to the shared session
  * Improved tmux session management to attach to existing sessions rather than fail on duplicate names

* **Documentation**
  * Updated documentation describing the new tmux configuration and behavior, including how to override defaults with command-line flags

* **Tests**
  * Added unit tests for new tmux session handling functionality

<!-- end of auto-generated comment: release notes by coderabbit.ai -->