### PR TITLE
fix(tui): resume interrupted task deletes instead of stranding them

### DIFF
--- a/src/terok/tui/app.py
+++ b/src/terok/tui/app.py
@@ -312,6 +312,12 @@ if _HAS_TEXTUAL:
             # Tasks whose CLI/Toad launch worker is in flight; drives the
             # ⏳ badge via ``TaskMeta.starting``.
             self._launching_tasks: set[tuple[str, str]] = set()
+            # Tasks whose delete worker is in flight *this session*.  The
+            # on-disk ``deleting`` flag persists across restarts (and survives
+            # a crash mid-delete); this set tracks only live workers, so the
+            # delete guard can tell an active teardown apart from a stale flag
+            # left by an interrupted session.
+            self._deleting_tasks: set[tuple[str, str]] = set()
 
         def _update_title(self) -> None:
             """Update the TUI title with version and branch information.
@@ -381,6 +387,9 @@ if _HAS_TEXTUAL:
             self._load_selection_state()
 
             await self.refresh_projects()
+            # Re-drive any teardown a previous session left half-finished
+            # before the operator can interact — see the method docstring.
+            self._resume_interrupted_deletes()
             # Defer layout logging until after the first refresh cycle so
             # widgets have real sizes. This will help compare left vs right
             # panes and confirm whether the task list/details get space.
@@ -824,6 +833,28 @@ if _HAS_TEXTUAL:
             # Update project state panel (Dockerfiles/images/SSH/cache + task count)
             self._refresh_project_state(task_count=task_count)
 
+        def _resume_interrupted_deletes(self) -> None:
+            """Re-queue deletes a previous session started but never finished.
+
+            A task is flagged ``deleting`` on disk the instant a delete begins,
+            *before* the background teardown runs.  If the TUI dies in between,
+            the flag survives the crash (and reboots) yet no worker is left to
+            act on it — the task is stranded ``deleting`` forever, and the
+            delete guard refuses to retry it.  On startup we sweep every loaded
+            project for such orphans and re-queue their teardown, which is
+            idempotent and best-effort, so the interrupted delete simply runs
+            to completion.
+            """
+            resumed = 0
+            for pid in self._projects_by_id:
+                for task in get_tasks(pid):
+                    if not task.deleting or (pid, task.task_id) in self._deleting_tasks:
+                        continue
+                    self._queue_task_delete(pid, task.task_id, task.name or "")
+                    resumed += 1
+            if resumed:
+                self.notify(f"Resuming {resumed} interrupted task deletion(s)...")
+
         def _update_task_details(self) -> None:
             """Refresh the task details panel for the currently selected task."""
             details = self.query_one("#task-details", TaskDetails)
@@ -1114,6 +1145,7 @@ if _HAS_TEXTUAL:
                 if not result:
                     return
                 project_id, task_id, task_name, error, warnings = result
+                self._deleting_tasks.discard((project_id, task_id))
                 task_label = f"{project_id} {task_id}" + (f" {task_name}" if task_name else "")
                 if error:
                     self.notify(f"Delete error for task {task_label}: {error}")

--- a/src/terok/tui/task_actions.py
+++ b/src/terok/tui/task_actions.py
@@ -114,6 +114,7 @@ class TaskActionsMixin(_MixinBase):
         current_project_id: str | None
         current_task: Any
         _last_selected_tasks: dict[str, str]
+        _deleting_tasks: set[tuple[str, str]]
 
         async def refresh_tasks(self) -> None: ...
         def _log_debug(self, message: str) -> None: ...
@@ -184,6 +185,7 @@ class TaskActionsMixin(_MixinBase):
 
     def _queue_task_delete(self, project_id: str, task_id: str, task_name: str) -> None:
         """Schedule a background worker to delete a task."""
+        self._deleting_tasks.add((project_id, task_id))
         self.run_worker(
             lambda: self._delete_task(project_id, task_id, task_name),
             name=f"task-delete:{project_id}:{task_id}",
@@ -731,8 +733,11 @@ class TaskActionsMixin(_MixinBase):
         tname = self.current_task.name or ""
         pid = self.current_project_id
         task_label = f"{pid} {tid}" + (f" {tname}" if tname else "")
-        if self.current_task.deleting:
-            self.notify(f"Task {task_label} is already deleting.")
+        # Guard on the live in-flight set, not the on-disk ``deleting`` flag:
+        # a flag left behind by a crashed session is stale and must stay
+        # retriable, whereas a worker running *now* must not be double-queued.
+        if (pid, tid) in self._deleting_tasks:
+            self.notify(f"Task {task_label} is already being deleted.")
             return
 
         self._log_debug(f"delete: start project_id={pid} task_id={tid}")

--- a/tests/unit/tui/test_delete_resume.py
+++ b/tests/unit/tui/test_delete_resume.py
@@ -1,0 +1,160 @@
+# SPDX-FileCopyrightText: 2026 Jiri Vyskocil
+# SPDX-License-Identifier: Apache-2.0
+
+"""Recovery from interrupted task deletes.
+
+A task is flagged ``deleting`` on disk the instant a delete starts, before the
+background teardown runs.  A crash in between strands the task ``deleting``
+forever.  These tests cover the two halves of the fix: the startup sweep that
+re-queues such orphans, and the delete guard keying on a live in-flight set
+(so a stale flag stays retriable while an active worker is not double-queued).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import types
+from typing import Any
+from unittest import mock
+
+from tests.unit.tui.tui_test_helpers import import_app
+
+
+def run(coro: object) -> object:
+    """Run an async test coroutine."""
+    return asyncio.run(coro)
+
+
+def _task(task_id: str, *, name: str = "", deleting: bool = False) -> types.SimpleNamespace:
+    """Build a minimal TaskMeta stand-in for the sweep/guard logic."""
+    return types.SimpleNamespace(task_id=task_id, name=name, deleting=deleting)
+
+
+def _instance(app_class: type) -> Any:
+    """Fresh TerokTUI instance with the noisy helpers stubbed out.
+
+    Built from a class the caller already imported, so the instance and any
+    module the caller patches share one ``import_app`` generation — the helper
+    re-imports fresh on every call, so a second import would desync them.
+    """
+    instance = app_class()
+    instance.notify = mock.Mock()
+    instance._queue_task_delete = mock.Mock()
+    return instance
+
+
+class TestResumeInterruptedDeletes:
+    """The startup sweep re-queues exactly the stranded deletes."""
+
+    def test_requeues_only_deleting_tasks_across_projects(self) -> None:
+        app_mod, app_class = import_app()
+        instance = _instance(app_class)
+        instance._projects_by_id = {"p1": object(), "p2": object()}
+        tasks = {
+            "p1": [_task("1", name="a", deleting=True), _task("2", name="b")],
+            "p2": [_task("3", name="c", deleting=True)],
+        }
+        with mock.patch.object(app_mod, "get_tasks", lambda pid: tasks[pid]):
+            instance._resume_interrupted_deletes()
+
+        assert instance._queue_task_delete.call_args_list == [
+            mock.call("p1", "1", "a"),
+            mock.call("p2", "3", "c"),
+        ]
+        # One summary toast naming the count of resumed deletions.
+        instance.notify.assert_called_once()
+        assert "2" in instance.notify.call_args[0][0]
+
+    def test_skips_tasks_already_in_flight(self) -> None:
+        app_mod, app_class = import_app()
+        instance = _instance(app_class)
+        instance._projects_by_id = {"p1": object()}
+        instance._deleting_tasks.add(("p1", "1"))
+        tasks = {"p1": [_task("1", deleting=True), _task("2", name="b", deleting=True)]}
+        with mock.patch.object(app_mod, "get_tasks", lambda pid: tasks[pid]):
+            instance._resume_interrupted_deletes()
+
+        instance._queue_task_delete.assert_called_once_with("p1", "2", "b")
+
+    def test_no_orphans_is_silent(self) -> None:
+        app_mod, app_class = import_app()
+        instance = _instance(app_class)
+        instance._projects_by_id = {"p1": object()}
+        with mock.patch.object(app_mod, "get_tasks", lambda pid: [_task("1"), _task("2")]):
+            instance._resume_interrupted_deletes()
+
+        instance._queue_task_delete.assert_not_called()
+        instance.notify.assert_not_called()
+
+
+class TestDeleteGuard:
+    """The guard keys on the live in-flight set, not the on-disk flag."""
+
+    def _ready_instance(self, app_class: type) -> Any:
+        """Instance wired for a single ``action_delete_task`` call."""
+        instance = _instance(app_class)
+        instance.current_project_id = "p1"
+        instance._log_debug = mock.Mock()
+        instance._update_task_details = mock.Mock()
+        instance.query_one = mock.Mock(return_value=mock.Mock())
+        return instance
+
+    def test_blocks_a_delete_already_in_flight(self) -> None:
+        _, app_class = import_app()
+        instance = self._ready_instance(app_class)
+        instance.current_task = _task("5", name="x")
+        instance._deleting_tasks.add(("p1", "5"))
+
+        globals_ = app_class.action_delete_task.__globals__
+        with mock.patch.dict(globals_, {"mark_task_deleting": mock.Mock()}):
+            run(instance.action_delete_task())
+            globals_["mark_task_deleting"].assert_not_called()
+
+        instance._queue_task_delete.assert_not_called()
+        assert "already being deleted" in instance.notify.call_args[0][0]
+
+    def test_stale_flag_stays_retriable(self) -> None:
+        _, app_class = import_app()
+        instance = self._ready_instance(app_class)
+        # ``deleting`` set on disk/in-memory by a prior crashed session, but the
+        # task is *not* in the live set — the delete must proceed, not refuse.
+        instance.current_task = _task("5", name="x", deleting=True)
+
+        globals_ = app_class.action_delete_task.__globals__
+        with mock.patch.dict(globals_, {"mark_task_deleting": mock.Mock()}):
+            run(instance.action_delete_task())
+            globals_["mark_task_deleting"].assert_called_once_with("p1", "5")
+
+        instance._queue_task_delete.assert_called_once_with("p1", "5", "x")
+
+
+class TestInFlightBookkeeping:
+    """Queue registers the in-flight key; the worker handler clears it."""
+
+    def test_queue_registers_in_flight(self) -> None:
+        _, app_class = import_app()
+        instance = app_class()
+        instance.run_worker = mock.Mock()
+        instance._queue_task_delete("p1", "7", "name")
+
+        assert ("p1", "7") in instance._deleting_tasks
+        instance.run_worker.assert_called_once()
+
+    def test_worker_completion_clears_in_flight(self) -> None:
+        app_mod, app_class = import_app()
+        instance = app_class()
+        instance.notify = mock.Mock()
+        # A different current project so the handler returns before refresh_tasks.
+        instance.current_project_id = "other"
+        instance._deleting_tasks.add(("p1", "7"))
+
+        worker = mock.Mock()
+        worker.group = "task-delete"
+        worker.result = ("p1", "7", "name", None, [])
+        event = mock.Mock()
+        event.worker = worker
+        event.state = app_mod.WorkerState.SUCCESS
+
+        run(instance.handle_worker_state_changed(event))
+
+        assert ("p1", "7") not in instance._deleting_tasks


### PR DESCRIPTION
## Problem

A task is flagged `deleting` on disk the **instant** a delete begins — before the background teardown runs. If the TUI dies in between (crash, kill, `t`-killed session), the flag survives the crash *and host reboots*, yet no worker is left to act on it. The task is stranded `deleting` forever, and the delete guard — which keyed on that same on-disk flag — refused to retry it:

```python
if self.current_task.deleting:
    self.notify(f"Task {task_label} is already deleting.")
    return
```

So the task could neither finish deleting nor be deleted again from the TUI. (The CLI `terok task delete` was the only escape hatch — it has no such guard.)

## Fix

The `deleting` flag had quietly conflated two meanings: *"persistently marked for teardown"* and *"a worker is running right now."* This splits them:

- The on-disk `deleting` flag stays for persistence and the UI "deleting" badge.
- A new in-flight set `_deleting_tasks` (mirroring the existing `_launching_tasks`) tracks only deletes with a **live worker this session**.

**The guard now keys on the in-flight set, not the disk flag** — a stale flag left by a crashed session stays retriable, while an active worker is still never double-queued.

**On startup, `_resume_interrupted_deletes()`** sweeps every loaded project for stranded `deleting` tasks and re-queues their teardown. `task_delete` is idempotent and best-effort ("Always completes — each cleanup step is independent"), so an interrupted delete simply runs to completion. The operator gets one summary toast: *"Resuming N interrupted task deletion(s)…"*.

## Tests

New `tests/unit/tui/test_delete_resume.py` (7 tests):
- Startup sweep re-queues only stranded orphans, skips already in-flight, stays silent when there are none.
- Guard blocks a live in-flight delete but keeps a stale flag retriable.
- Queue registers the in-flight key; the worker handler clears it on completion.

`make lint`, `tach`, `reuse`, `security` green; full unit suite (2478 tests) passes; docstring coverage 96.7%.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved task deletion reliability by resuming interrupted deletions when the app restarts
  * Enhanced duplicate deletion prevention with more robust tracking during active sessions

* **Tests**
  * Added unit tests for delete recovery and concurrency guarding to ensure deletion operations work correctly across app restarts

<!-- end of auto-generated comment: release notes by coderabbit.ai -->