### PR TITLE
feat(tui): reflect tasks created or deleted outside the TUI

### DIFF
--- a/src/terok/tui/app.py
+++ b/src/terok/tui/app.py
@@ -1124,8 +1124,16 @@ if _HAS_TEXTUAL:
                 project_id, states = result
                 if project_id != self.current_project_id:
                     return
-                # Update container_state on all TaskMeta instances
                 task_list = self.query_one("#task-list", TaskList)
+                # The batch query re-reads the on-disk task set every tick, so
+                # its keys reveal tasks created or deleted outside the TUI.
+                # Reconcile membership first: this level-triggered diff against
+                # the source of truth can't miss a change the way edge-polling
+                # could, and it converges in a single tick.
+                if set(states) != {tm.task_id for tm in task_list.tasks}:
+                    await self.refresh_tasks()
+                    return
+                # Update container_state on all TaskMeta instances
                 changed = False
                 for tm in task_list.tasks:
                     new_state = states.get(tm.task_id)

--- a/tests/unit/tui/test_task_list_reconcile.py
+++ b/tests/unit/tui/test_task_list_reconcile.py
@@ -1,0 +1,100 @@
+# SPDX-FileCopyrightText: 2026 Jiri Vyskocil
+# SPDX-License-Identifier: Apache-2.0
+
+"""The container-state poll reconciles the task set with what's on disk.
+
+The 2-second batch query already re-reads every task from disk, so its result
+keys reveal tasks created or deleted *outside* the TUI.  The handler diffs that
+membership against the displayed rows (level-triggered, so it cannot miss a
+change) and reloads the list only when it actually differs — otherwise it just
+maps fresh container states onto the existing rows, as before.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import types
+from typing import Any
+from unittest import mock
+
+from tests.unit.tui.tui_test_helpers import import_app
+
+
+def run(coro: object) -> object:
+    """Run an async test coroutine."""
+    return asyncio.run(coro)
+
+
+def _task(task_id: str, state: str | None = None) -> types.SimpleNamespace:
+    """Minimal displayed-row stand-in carrying an id and a container state."""
+    return types.SimpleNamespace(task_id=task_id, container_state=state)
+
+
+def _instance(app_class: type, displayed: list[Any]) -> Any:
+    """App wired with a fake task list and an async ``refresh_tasks`` spy."""
+    instance = app_class()
+    instance.current_project_id = "p1"
+    instance.current_task = None
+    instance.refresh_tasks = mock.AsyncMock()
+    task_list = mock.Mock()
+    task_list.tasks = displayed
+    instance.query_one = mock.Mock(return_value=task_list)
+    instance._task_list = task_list  # handle for assertions
+    return instance
+
+
+def _poll(instance: Any, app_mod: Any, states: dict[str, str | None], pid: str = "p1") -> None:
+    """Drive a completed container-state poll through the worker handler."""
+    worker = mock.Mock()
+    worker.group = "container-state"
+    worker.result = (pid, states)
+    event = mock.Mock()
+    event.worker = worker
+    event.state = app_mod.WorkerState.SUCCESS
+    run(instance.handle_worker_state_changed(event))
+
+
+class TestMembershipReconcile:
+    """Membership drift between disk and the displayed rows forces a reload."""
+
+    def test_external_create_triggers_refresh(self) -> None:
+        app_mod, app_class = import_app()
+        instance = _instance(app_class, [_task("1")])
+        _poll(instance, app_mod, {"1": None, "2": None})  # task 2 appeared on disk
+        instance.refresh_tasks.assert_awaited_once()
+
+    def test_external_delete_triggers_refresh(self) -> None:
+        app_mod, app_class = import_app()
+        instance = _instance(app_class, [_task("1"), _task("2")])
+        _poll(instance, app_mod, {"1": None})  # task 2 vanished from disk
+        instance.refresh_tasks.assert_awaited_once()
+
+
+class TestStateOnlyUpdate:
+    """Stable membership keeps the in-place state update — no reload."""
+
+    def test_state_change_updates_in_place(self) -> None:
+        app_mod, app_class = import_app()
+        instance = _instance(app_class, [_task("1", None)])
+        _poll(instance, app_mod, {"1": "running"})
+        instance.refresh_tasks.assert_not_awaited()
+        assert instance._task_list.tasks[0].container_state == "running"
+        instance._task_list.refresh_labels.assert_called_once()
+
+    def test_no_change_is_a_noop(self) -> None:
+        app_mod, app_class = import_app()
+        instance = _instance(app_class, [_task("1", None)])
+        _poll(instance, app_mod, {"1": None})
+        instance.refresh_tasks.assert_not_awaited()
+        instance._task_list.refresh_labels.assert_not_called()
+
+
+class TestProjectGuard:
+    """A result for a project the user already switched away from is dropped."""
+
+    def test_stale_project_result_ignored(self) -> None:
+        app_mod, app_class = import_app()
+        instance = _instance(app_class, [_task("1")])
+        _poll(instance, app_mod, {"1": None, "2": None}, pid="other")
+        instance.refresh_tasks.assert_not_awaited()
+        instance.query_one.assert_not_called()


### PR DESCRIPTION
## Problem

The task list only reloads on explicit actions — project switch, task launch/delete/rename, returning from certain screens. A task created or removed **outside** the TUI (e.g. `terok task delete` from the CLI, or any out-of-band change to the metadata dir) stays invisible until some unrelated action forces a refresh. Notably, entering a project's detail view and returning does *not* refresh.

## Approach — level-triggered reconcile on the existing poll tick

No new polling. The 2-second container-state poll (`polling.py`) already re-reads the **entire** on-disk task set every tick via `get_tasks(project_id)`, and `get_all_task_states` returns one entry per task — so the poll result's keys *already are* the current on-disk membership. That membership was simply being discarded; the handler only mapped states onto the already-displayed rows.

This reconciles it: when the set of task ids from the poll differs from the displayed rows, reload the list; otherwise keep the existing in-place state update.

```python
task_list = self.query_one("#task-list", TaskList)
if set(states) != {tm.task_id for tm in task_list.tasks}:
    await self.refresh_tasks()
    return
# ... unchanged in-place container_state update ...
```

### Why this isn't "flaky polling"

It's a **level-triggered** diff against the source of truth (the metadata dir), not edge-triggered sampling. It compares full current state to displayed state, so it cannot miss a transition the way edge-polling between ticks could, and it converges in a single tick. This is the reconcile-loop pattern; the periodic tick is just the cadence.

### Cost

Effectively zero: no new timer, no new dependency, no extra disk I/O — the `get_tasks` read already happens every 2s and was being thrown away. Latency to reflect an external change is ≤ one poll interval (2s).

## Tests

New `tests/unit/tui/test_task_list_reconcile.py` (5 tests): external create and external delete each force a reload; stable membership keeps the in-place state update (and the no-change case stays a no-op); a result for a project the user already switched away from is dropped before touching the UI.

Full unit suite passes; `make lint`, `tach`, `reuse`, `security`, docstrings (96.7%) all green.

## Follow-up (not in this PR)

If sub-2s latency is ever wanted, an inotify/`watchdog` watcher could call the same reconcile sooner as a *hint* — but it would still back onto this diff, since inotify has its own drop modes (`IN_Q_OVERFLOW`). Real-time *container status* (running→exited) is the separate `podman events` story and a sibling-package change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved synchronization of task state when tasks are created or deleted outside the TUI; the interface now properly detects external changes and refreshes accordingly.

* **Tests**
  * Added comprehensive test coverage for task state reconciliation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->