### PR TITLE
refactor: consume BestEffortLogger and the YAML facade from terok-util

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -3579,11 +3579,10 @@ name = "terok-clearance"
 version = "0.7.0"
 description = "Shield clearance and desktop notifications for terok"
 optional = false
-python-versions = "<4.0,>=3.12"
+python-versions = ">=3.12,<4.0"
 groups = ["main"]
 files = [
     {file = "terok_clearance-0.7.0-py3-none-any.whl", hash = "sha256:c02c26cec9e3b3430fa7f39c825442a89af9ed4cf57606e7c7b445cfe5d25afb"},
-    {file = "terok_clearance-0.7.0.tar.gz", hash = "sha256:ebfde2d76ea3dead54c113e83149bb8073df0070b47ea9c088107a3b921591b5"},
 ]
 
 [package.dependencies]
@@ -3592,16 +3591,19 @@ dbus-fast = ">=4.3.0,<5.0"
 pyyaml = ">=6.0"
 terok-util = ">=0.1.0,<0.2.0"
 
+[package.source]
+type = "url"
+url = "https://github.com/terok-ai/terok-clearance/releases/download/v0.7.0/terok_clearance-0.7.0-py3-none-any.whl"
+
 [[package]]
 name = "terok-executor"
-version = "0.1.0"
+version = "0.1.1a1"
 description = "Single-agent task runner for hardened Podman containers"
 optional = false
-python-versions = "<3.15,>=3.12"
+python-versions = ">=3.12,<3.15"
 groups = ["main"]
 files = [
-    {file = "terok_executor-0.1.0-py3-none-any.whl", hash = "sha256:ebd87bc0753e28f2f01cd3284e9af18340d451dbcedb62330bc900c5c30fde6a"},
-    {file = "terok_executor-0.1.0.tar.gz", hash = "sha256:1d15c167406dc0dfa0380ff163c936710c385a863c203b06247ad7f4139534ae"},
+    {file = "terok_executor-0.1.1a1-py3-none-any.whl", hash = "sha256:a59b94fb66b71e70b6b5fe223fb3f0efc2d6f47040a10071498c35d2edfb5a81"},
 ]
 
 [package.dependencies]
@@ -3611,20 +3613,23 @@ prompt-toolkit = ">=3.0"
 pydantic = ">=2.9"
 rich = ">=13.0"
 "ruamel.yaml" = ">=0.18"
-terok-sandbox = ">=0.1.0,<0.2.0"
-terok-util = ">=0.1.0,<0.2.0"
+terok_sandbox = {url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.1.1a1/terok_sandbox-0.1.1a1-py3-none-any.whl"}
+terok_util = {url = "https://github.com/terok-ai/terok-util/releases/download/v0.1.1a1/terok_util-0.1.1a1-py3-none-any.whl"}
 tomli-w = ">=1.0"
+
+[package.source]
+type = "url"
+url = "https://github.com/terok-ai/terok-executor/releases/download/v0.1.1a1/terok_executor-0.1.1a1-py3-none-any.whl"
 
 [[package]]
 name = "terok-sandbox"
-version = "0.1.0"
+version = "0.1.1a1"
 description = "Hardened Podman container runner with gate server and shield integration"
 optional = false
-python-versions = "<4.0,>=3.12"
+python-versions = ">=3.12,<4.0"
 groups = ["main"]
 files = [
-    {file = "terok_sandbox-0.1.0-py3-none-any.whl", hash = "sha256:466b2cfa856c9ae8ca6f0d6666800c5cc4db8b276266d46481c3de8a5e5f192b"},
-    {file = "terok_sandbox-0.1.0.tar.gz", hash = "sha256:3b2eec3c5a5f76aace67fd15a8b11a60f675812ae10ec8745f3ed815e2296842"},
+    {file = "terok_sandbox-0.1.1a1-py3-none-any.whl", hash = "sha256:3edf129b29cb9136d7f462f5c73bb87a51457582ea77e02b689cd13dd30c4cb5"},
 ]
 
 [package.dependencies]
@@ -3638,20 +3643,23 @@ prompt-toolkit = ">=3.0"
 pydantic = ">=2.9"
 "ruamel.yaml" = ">=0.18"
 sqlcipher3 = ">=0.6.2"
-terok-clearance = ">=0.7.0,<0.8.0"
-terok-shield = ">=0.7.0,<0.8.0"
-terok-util = ">=0.1.0,<0.2.0"
+terok_clearance = {url = "https://github.com/terok-ai/terok-clearance/releases/download/v0.7.0/terok_clearance-0.7.0-py3-none-any.whl"}
+terok_shield = {url = "https://github.com/terok-ai/terok-shield/releases/download/v0.7.0/terok_shield-0.7.0-py3-none-any.whl"}
+terok_util = {url = "https://github.com/terok-ai/terok-util/releases/download/v0.1.1a1/terok_util-0.1.1a1-py3-none-any.whl"}
+
+[package.source]
+type = "url"
+url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.1.1a1/terok_sandbox-0.1.1a1-py3-none-any.whl"
 
 [[package]]
 name = "terok-shield"
 version = "0.7.0"
 description = "nftables-based egress firewalling for Podman containers"
 optional = false
-python-versions = "<4.0,>=3.12"
+python-versions = ">=3.12,<4.0"
 groups = ["main"]
 files = [
     {file = "terok_shield-0.7.0-py3-none-any.whl", hash = "sha256:f246e405a3c060af556b63f71fddc5ab80beb1e88f51d251cfd0267bf6ac8438"},
-    {file = "terok_shield-0.7.0.tar.gz", hash = "sha256:660133de84140e8fd79215e35c804a6e247951df9a73860361194cad8fa93808"},
 ]
 
 [package.dependencies]
@@ -3659,25 +3667,28 @@ pydantic = ">=2.0"
 PyYAML = ">=6.0"
 terok-util = ">=0.1.0,<0.2.0"
 
+[package.source]
+type = "url"
+url = "https://github.com/terok-ai/terok-shield/releases/download/v0.7.0/terok_shield-0.7.0-py3-none-any.whl"
+
 [[package]]
 name = "terok-util"
-version = "0.1.0"
+version = "0.1.1a1"
 description = "Shared utility library for the terok-* sibling packages"
 optional = false
 python-versions = ">=3.12,<4.0"
 groups = ["main"]
-files = []
-develop = false
+files = [
+    {file = "terok_util-0.1.1a1-py3-none-any.whl", hash = "sha256:76a7a40baaccf21744e34c365e586fa3880bc363d2f012327148c2f114955dad"},
+]
 
 [package.dependencies]
 platformdirs = ">=4.10.0"
 "ruamel.yaml" = ">=0.18"
 
 [package.source]
-type = "git"
-url = "https://github.com/terok-ai/terok-util.git"
-reference = "refs/pull/16/head"
-resolved_reference = "577ea02fde7a6ca4f1387967d14954c01512c59b"
+type = "url"
+url = "https://github.com/terok-ai/terok-util/releases/download/v0.1.1a1/terok_util-0.1.1a1-py3-none-any.whl"
 
 [[package]]
 name = "textual"
@@ -4533,4 +4544,4 @@ propcache = ">=0.2.1"
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.12,<3.15"
-content-hash = "af05d8ad04bd6ae70319c892bbb1dc486630cdbc85c63310dfa97bf6fdb07269"
+content-hash = "711477ef5758e4c26db6d8154df0a0191ffd551ba21445ce0d516d2c95a75eeb"

--- a/poetry.lock
+++ b/poetry.lock
@@ -3664,16 +3664,20 @@ name = "terok-util"
 version = "0.1.0"
 description = "Shared utility library for the terok-* sibling packages"
 optional = false
-python-versions = "<4.0,>=3.12"
+python-versions = ">=3.12,<4.0"
 groups = ["main"]
-files = [
-    {file = "terok_util-0.1.0-py3-none-any.whl", hash = "sha256:2e1dfa321bb1a574460a07caf578ed8020bb6aab01ce44158ed41528bf1ae577"},
-    {file = "terok_util-0.1.0.tar.gz", hash = "sha256:27bcb70b41fd86bc54b529120a7c53ca8bc4bf7b5d332478e80035b746526199"},
-]
+files = []
+develop = false
 
 [package.dependencies]
 platformdirs = ">=4.10.0"
 "ruamel.yaml" = ">=0.18"
+
+[package.source]
+type = "git"
+url = "https://github.com/terok-ai/terok-util.git"
+reference = "refs/pull/16/head"
+resolved_reference = "577ea02fde7a6ca4f1387967d14954c01512c59b"
 
 [[package]]
 name = "textual"
@@ -4529,4 +4533,4 @@ propcache = ">=0.2.1"
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.12,<3.15"
-content-hash = "a9b0929cca75d97099b6f247ef459d2a8820ac299699650fa5e82c0a5f7a5b59"
+content-hash = "af05d8ad04bd6ae70319c892bbb1dc486630cdbc85c63310dfa97bf6fdb07269"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ dependencies = [
     "terok-sandbox>=0.1.0,<0.2.0",
     "terok-shield>=0.7.0,<0.8.0",
     "terok-clearance>=0.7.0,<0.8.0",
-    "terok-util>=0.1.0,<0.2.0",
+    "terok-util @ git+https://github.com/terok-ai/terok-util.git@refs/pull/16/head",
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,11 +27,11 @@ dependencies = [
     "unique-namer>=1.3",
     "textual-serve>=1.1.0",
     "jinja2>=3.1",
-    "terok-executor>=0.1.0,<0.2.0",
-    "terok-sandbox>=0.1.0,<0.2.0",
-    "terok-shield>=0.7.0,<0.8.0",
-    "terok-clearance>=0.7.0,<0.8.0",
-    "terok-util @ git+https://github.com/terok-ai/terok-util.git@refs/pull/16/head",
+    "terok-executor @ https://github.com/terok-ai/terok-executor/releases/download/v0.1.1a1/terok_executor-0.1.1a1-py3-none-any.whl",
+    "terok-sandbox @ https://github.com/terok-ai/terok-sandbox/releases/download/v0.1.1a1/terok_sandbox-0.1.1a1-py3-none-any.whl",
+    "terok-shield @ https://github.com/terok-ai/terok-shield/releases/download/v0.7.0/terok_shield-0.7.0-py3-none-any.whl",
+    "terok-clearance @ https://github.com/terok-ai/terok-clearance/releases/download/v0.7.0/terok_clearance-0.7.0-py3-none-any.whl",
+    "terok-util @ https://github.com/terok-ai/terok-util/releases/download/v0.1.1a1/terok_util-0.1.1a1-py3-none-any.whl",
 ]
 
 [project.urls]

--- a/src/terok/lib/integrations/sandbox.py
+++ b/src/terok/lib/integrations/sandbox.py
@@ -25,7 +25,6 @@ from terok_sandbox import (  # noqa: F401 — re-exported public API
     DEFAULT_GUEST_SSHD_PORT,
     DEFAULT_SSH_HOST,
     SERVICES_TCP_OPTOUT_YAML,
-    BestEffortLogger,
     CheckVerdict,
     ContainerRuntime,
     CredentialDB,
@@ -94,7 +93,6 @@ from terok_sandbox.supervisor.install import (  # noqa: F401 — re-exported
 )
 
 __all__ = [
-    "BestEffortLogger",
     "CheckVerdict",
     "ContainerRuntime",
     "CredentialDB",

--- a/src/terok/lib/util/logging_utils.py
+++ b/src/terok/lib/util/logging_utils.py
@@ -3,19 +3,15 @@
 
 """Best-effort file logging + structured stderr warnings.
 
-Thin shim over
-[`terok_util.logging.BestEffortLogger`][terok_util.logging.BestEffortLogger] —
-the implementation lives once in terok-util, at the bottom of the
-dependency chain, so every sibling shares the same idiom.  Module-level
-functions preserve the legacy call shape so existing call sites stay
-untouched.
+Module-level helpers over
+[`terok_util.logging.BestEffortLogger`][terok_util.logging.BestEffortLogger]
+bound to terok's library log.
 
 [`warn_user`][terok.lib.util.logging_utils.warn_user] runs both the
 *component* tag and the *message* through
-[`sanitize_tty`][terok_util.security.sanitize_tty] before handing
-them off to the sandbox logger so a bad config file or remote-supplied
-string can't smuggle ANSI escape sequences into the operator's
-terminal (CWE-150).
+[`sanitize_tty`][terok_util.security.sanitize_tty] so a bad config file or
+remote-supplied string can't smuggle ANSI escape sequences into the
+operator's terminal (CWE-150).
 """
 
 from __future__ import annotations

--- a/src/terok/lib/util/logging_utils.py
+++ b/src/terok/lib/util/logging_utils.py
@@ -4,10 +4,11 @@
 """Best-effort file logging + structured stderr warnings.
 
 Thin shim over
-[`terok_sandbox.BestEffortLogger`][terok_sandbox.BestEffortLogger] —
-the implementation lives once in terok-sandbox so terok and the
-sandbox share the same idiom.  Module-level functions preserve the
-legacy call shape so existing call sites stay untouched.
+[`terok_util.logging.BestEffortLogger`][terok_util.logging.BestEffortLogger] —
+the implementation lives once in terok-util, at the bottom of the
+dependency chain, so every sibling shares the same idiom.  Module-level
+functions preserve the legacy call shape so existing call sites stay
+untouched.
 
 [`warn_user`][terok.lib.util.logging_utils.warn_user] runs both the
 *component* tag and the *message* through
@@ -21,9 +22,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from terok_util import sanitize_tty
-
-from terok.lib.integrations.sandbox import BestEffortLogger
+from terok_util import BestEffortLogger, sanitize_tty
 
 LOG_FILENAME = "terok.log"
 """Filename for the best-effort terok library log (written under ``core_state_dir()``)."""

--- a/src/terok/lib/util/yaml.py
+++ b/src/terok/lib/util/yaml.py
@@ -3,55 +3,20 @@
 
 """Centralised YAML I/O — round-trip mode everywhere.
 
-**Facade** over ``ruamel.yaml``'s ceremony-heavy ``YAML()`` class: callers get
-a minimal ``load`` / ``dump`` / ``YAMLError`` surface instead of instance
-creation, typ selection, stream management, and config attributes.
+Re-export of the shared facade in
+[`terok_util.yaml`][terok_util.yaml], which lives at the bottom of the
+dependency chain so every sibling shares one ``load`` / ``dump`` /
+``YAMLError`` surface.  This module keeps the ``terok.lib.util.yaml``
+import path stable for terok's own call sites.
 
-**Adapter** from ruamel.yaml's stream-oriented API to the string-based
-convention used throughout the codebase (``path.read_text()`` → ``load(text)``
-→ modify → ``dump(data)`` → ``path.write_text(text)``).
-
-``CommentedMap`` is a ``dict`` subclass — ``isinstance(x, dict)``, ``.get()``,
-``x["key"]``, ``.setdefault()`` all work transparently.  Pydantic v2
-``model_validate()`` accepts dict subclasses, so read-side validation is
-unchanged.
+The facade hands out a fresh ``ruamel.yaml`` instance per call: a shared
+module-level instance carries composer/parser/scanner state and races
+under concurrent ``load`` / ``dump`` from Textual worker threads (symptom
+``'MappingEndEvent' object has no attribute 'anchor'``).
 """
 
 from __future__ import annotations
 
-from io import StringIO
-from typing import Any
-
-from ruamel.yaml import YAML, YAMLError  # noqa: F401 — re-exported
+from terok_util.yaml import YAMLError, dump, load  # noqa: F401 — re-exported
 
 __all__ = ["load", "dump", "YAMLError"]
-
-
-def _rt() -> YAML:
-    # A fresh instance per call: ``YAML`` carries composer/parser/scanner state
-    # on the object, so a shared module-level instance races under concurrent
-    # ``load`` / ``dump`` from Textual worker threads — symptom is
-    # ``'MappingEndEvent' object has no attribute 'anchor'``.
-    yaml = YAML(typ="rt")
-    yaml.preserve_quotes = True
-    return yaml
-
-
-def load(text: str) -> Any:
-    """Round-trip load from a YAML string, preserving comments and order."""
-    return _rt().load(text)
-
-
-def dump(data: Any, *, default_flow_style: bool = False) -> str:
-    """Round-trip dump to a YAML string, preserving comments and order.
-
-    Key order is preserved (insertion order for new dicts, original order for
-    round-tripped data).  ``sort_keys`` is always ``False`` — the caller never
-    needs to pass it.
-    """
-    emitter = _rt()
-    if default_flow_style:
-        emitter.default_flow_style = True
-    buf = StringIO()
-    emitter.dump(data, buf)
-    return buf.getvalue()

--- a/src/terok/lib/util/yaml.py
+++ b/src/terok/lib/util/yaml.py
@@ -3,11 +3,8 @@
 
 """Centralised YAML I/O — round-trip mode everywhere.
 
-Re-export of the shared facade in
-[`terok_util.yaml`][terok_util.yaml], which lives at the bottom of the
-dependency chain so every sibling shares one ``load`` / ``dump`` /
-``YAMLError`` surface.  This module keeps the ``terok.lib.util.yaml``
-import path stable for terok's own call sites.
+Re-export of the shared [`terok_util.yaml`][terok_util.yaml] facade under
+terok's own ``terok.lib.util.yaml`` import path.
 
 The facade hands out a fresh ``ruamel.yaml`` instance per call: a shared
 module-level instance carries composer/parser/scanner state and races

--- a/tests/unit/test_error_surfacing.py
+++ b/tests/unit/test_error_surfacing.py
@@ -58,15 +58,15 @@ class TestWarnUser:
     def test_never_raises_on_stderr_failure(self) -> None:
         """Exception safety: writing to stderr fails silently.
 
-        After the cross-package logger unification (terok-sandbox#244)
-        the underlying ``sys`` reference lives in
-        ``terok_sandbox._util._logging`` — patch there.
+        The shared ``BestEffortLogger`` now lives in terok-util, so the
+        underlying ``sys`` reference whose stderr write must soft-fail is
+        ``terok_util.logging.sys`` — patch there.
         """
         import io
 
         broken = io.StringIO()
         broken.write = lambda _: (_ for _ in ()).throw(OSError("broken pipe"))
-        with patch("terok_sandbox._util._logging.sys") as mock_sys:
+        with patch("terok_util.logging.sys") as mock_sys:
             mock_sys.stderr = broken
             # Must not raise
             warn_user("test", "should not crash")


### PR DESCRIPTION
Final link in the #111 utility-extraction chain (terok-ai/terok-sandbox#111). Depends on **terok-ai/terok-util#15** (adds `terok_util.logging.BestEffortLogger` + `terok_util.yaml`). The terok-util pin bump to the alpha wheel is handled by the release script when the chain opens — this PR carries only the code change.

## What changed

- **`lib/util/logging_utils`** — imports `BestEffortLogger` straight from `terok_util` instead of bridging it through the terok-sandbox integration adapter. The module-level `_log` / `_log_debug` / `log_warning` / `warn_user` shims and their `sanitize_tty` wrapping are unchanged, so every call site stays put.
- **`lib/integrations/sandbox`** — drops the now-unneeded `BestEffortLogger` re-export (it was only a passthrough to sandbox, which no longer owns the symbol).
- **`lib/util/yaml`** — collapses to a thin re-export of `terok_util.yaml`, keeping the `terok.lib.util.yaml` import path stable for terok's callers (57 → 21 lines). The shared facade is byte-for-byte terok's own thread-safe per-call implementation.
- **`test_error_surfacing`** — the stderr soft-fail patch target follows the logger to `terok_util.logging.sys`.

## Tests

All green with the local terok-util branch overlaid: `make lint tach lint-imports docstrings security reuse typecheck deadcode` all pass (mypy: 0 issues in 133 files), and the podman-free unit suite is **2487 passed**. `needs_podman` tests run on the dedicated test machine.

## Chain

1. terok-ai/terok-util#15 — hosts both helpers (bottom of chain)
2. terok-ai/terok-sandbox#373 — sources `BestEffortLogger` from terok-util
3. terok-ai/terok-executor#390 — de-vendors the YAML loader
4. **this PR** — terok consumes both

Closes the two remaining boxes in terok-ai/terok-sandbox#111 once the chain lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)