### PR TITLE
refactor(tui): rename "autopilot" run mode to "unattended"

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ terok login myproj t3x                  # re-attach later by task ID prefix
 
 For manual project configuration or CI, see the [User Guide](docs/usage.md).
 
-### Headless agent runs (autopilot)
+### Headless agent runs (unattended)
 
 ```bash
 # Run an agent headlessly with a prompt (uses default_agent config; falls back to claude)

--- a/docs/index.md
+++ b/docs/index.md
@@ -83,7 +83,7 @@ terok                                   # bare `terok` on a TTY runs the TUI
 
 - Press **n** to run the project wizard (creates config, builds images, sets up SSH + gate)
 - Select your new project, press **a** to authenticate your agent
-- Press **t** to start a task (CLI, Toad, or autopilot)
+- Press **t** to start a task (CLI, Toad, or unattended)
 
 Or do the same from the command line:
 
@@ -97,7 +97,7 @@ terok login myproj a3                   # re-attach later by task ID prefix
 
 For manual project configuration or CI, see the [User Guide](usage.md).
 
-### Headless Agent Runs (Autopilot)
+### Headless Agent Runs (Unattended)
 
 ```bash
 # Run an agent headlessly with a prompt

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -14,7 +14,7 @@ Complete guide to installing, configuring, and using terok.
 - [Global Configuration](#global-configuration)
 - [From Zero to First Run](#from-zero-to-first-run)
 - [Authentication](#authentication)
-- [Headless Agent Runs (Autopilot)](#headless-agent-runs-autopilot)
+- [Headless Agent Runs (Unattended)](#headless-agent-runs-unattended)
 - [Presets](#presets)
 - [Task Lifecycle Hooks](#task-lifecycle-hooks)
 - [Image Management](#image-management)
@@ -533,7 +533,7 @@ tiers stay so the panic is reversible.
 
 ---
 
-## Headless Agent Runs (Autopilot)
+## Headless Agent Runs (Unattended)
 
 Run any supported agent headlessly in a container — no interactive session needed.
 Useful for CI/CD pipelines, batch tasks, or scripted workflows.

--- a/src/terok/cli/commands/task.py
+++ b/src/terok/cli/commands/task.py
@@ -137,7 +137,7 @@ def register(
 
     # Unified ``task run <project>`` — creates a new task and runs it in the
     # chosen mode.  CLI (interactive) is the default; ``--mode headless``
-    # runs autopilot (requires ``--prompt``); ``--mode toad`` starts the
+    # runs unattended (requires ``--prompt``); ``--mode toad`` starts the
     # Toad multi-agent TUI (browser access).
     t_run = tsub.add_parser(
         "run",
@@ -148,7 +148,7 @@ def register(
         "--mode",
         choices=("cli", "toad", "headless"),
         default="cli",
-        help="Runtime mode: cli (interactive, default), toad (browser TUI), headless (autopilot)",
+        help="Runtime mode: cli (interactive, default), toad (browser TUI), headless (unattended)",
     )
     t_run.add_argument(
         "--prompt",
@@ -517,7 +517,7 @@ def _cmd_task_run_interactive(args: argparse.Namespace, *, runner: Any, attach: 
 
 
 def _cmd_task_run_headless(args: argparse.Namespace) -> None:
-    """Autopilot path: create a task and run it headlessly against the prompt.
+    """Unattended path: create a task and run it headlessly against the prompt.
 
     Cheap validation (``--prompt`` present, ``--instructions`` file readable)
     runs first so the user sees those errors before the image preflight

--- a/src/terok/lib/core/task_display.py
+++ b/src/terok/lib/core/task_display.py
@@ -62,7 +62,7 @@ STATUS_DISPLAY: dict[str, StatusInfo] = {
 
 MODE_DISPLAY: dict[str | None, ModeInfo] = {
     "cli": ModeInfo(emoji="\U0001f4bb", label="CLI"),
-    "run": ModeInfo(emoji="\U0001f680", label="Autopilot"),
+    "run": ModeInfo(emoji="\U0001f680", label="Unattended"),
     "toad": ModeInfo(emoji="\U0001f438", label="Toad"),
     None: ModeInfo(emoji="\U0001f997", label=""),
 }

--- a/src/terok/lib/domain/log_format.py
+++ b/src/terok/lib/domain/log_format.py
@@ -323,7 +323,7 @@ def auto_detect_formatter(
     """Return the appropriate formatter for a task's mode and provider.
 
     Args:
-        mode: Task mode (``"run"`` for headless/autopilot, ``"cli"``, ``"web"``).
+        mode: Task mode (``"run"`` for headless/unattended, ``"cli"``, ``"web"``).
         streaming: Enable partial streaming for supported formatters.
         color: Force color on/off. ``None`` auto-detects from terminal.
         provider: Headless provider name.  When mode is ``"run"`` and

--- a/src/terok/lib/orchestration/task_runners/__init__.py
+++ b/src/terok/lib/orchestration/task_runners/__init__.py
@@ -18,7 +18,7 @@ The implementation is split per mode and per concern:
 * [`toad`][terok.lib.orchestration.task_runners.toad] — the Caddy-gated
   web-TUI runner.
 * [`headless`][terok.lib.orchestration.task_runners.headless] —
-  autopilot run + follow-up runners and their request value objects.
+  unattended run + follow-up runners and their request value objects.
 * [`restart`][terok.lib.orchestration.task_runners.restart] — stop +
   start an existing task container.
 

--- a/src/terok/lib/orchestration/task_runners/headless.py
+++ b/src/terok/lib/orchestration/task_runners/headless.py
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: 2025 Jiri Vyskocil
 # SPDX-License-Identifier: Apache-2.0
 
-"""Headless (autopilot) task runner.
+"""Headless (unattended) task runner.
 
 ``task_run_headless`` creates a fresh task and runs an agent to
 completion in a detached container; ``task_followup_headless`` sends a
@@ -60,7 +60,7 @@ _PROMPT_HISTORY_FILENAME = "prompt-history.txt"
 
 @dataclass(frozen=True)
 class HeadlessRunRequest:
-    """Groups all parameters for a headless (autopilot) agent run."""
+    """Groups all parameters for a headless (unattended) agent run."""
 
     project_id: str
     prompt: str
@@ -167,7 +167,7 @@ def _report_headless_result(
 
 
 def task_run_headless(request: HeadlessRunRequest) -> str:
-    """Run an agent headlessly (autopilot mode) in a new task container.
+    """Run an agent headlessly (unattended mode) in a new task container.
 
     Creates a new task, prepares the agent-config directory with the provider's
     wrapper function and filtered subagents, then launches a detached container
@@ -391,7 +391,7 @@ def task_followup_headless(
     if mode != "run":
         raise SystemExit(
             f"Task {task_id} is not a headless task (mode={mode!r}). "
-            f"Follow-up is only supported for autopilot (mode='run') tasks."
+            f"Follow-up is only supported for unattended (mode='run') tasks."
         )
 
     cname = container_name(project.id, "run", task_id)

--- a/src/terok/tui/app.py
+++ b/src/terok/tui/app.py
@@ -166,7 +166,7 @@ if _HAS_TEXTUAL:
     TASK_ACTION_HANDLERS: dict[str, str] = {
         "task_start_cli": "_action_task_start_cli",
         "task_start_toad": "_action_task_start_toad",
-        "task_start_autopilot": "_action_task_start_autopilot",
+        "task_start_unattended": "_action_task_start_unattended",
         "delete": "action_delete_task",
         "restart": "_action_restart_task",
         "followup": "_action_task_followup",
@@ -1227,32 +1227,32 @@ if _HAS_TEXTUAL:
                     return
                 await self.refresh_tasks()
 
-            if worker.group == "autopilot-launch":
+            if worker.group == "unattended-launch":
                 result = worker.result
                 if not result:
                     return
                 project_id, task_id, error = result
                 if error:
-                    self.notify(f"Autopilot error: {error}")
+                    self.notify(f"Unattended error: {error}")
                 elif task_id:
                     self._focus_task_after_creation(project_id, task_id)
-                    self.notify(f"Autopilot task {task_id} started for {project_id}")
-                    self._start_autopilot_watcher(project_id, task_id)
+                    self.notify(f"Unattended task {task_id} started for {project_id}")
+                    self._start_unattended_watcher(project_id, task_id)
                 if project_id == self.current_project_id:
                     await self.refresh_tasks()
                 return
 
-            if worker.group == "autopilot-wait":
+            if worker.group == "unattended-wait":
                 result = worker.result
                 if not result:
                     return
                 project_id, task_id, exit_code, error = result
                 if error:
-                    self.notify(f"Autopilot watcher error for task {task_id}: {error}")
+                    self.notify(f"Unattended watcher error for task {task_id}: {error}")
                 elif exit_code == 0:
-                    self.notify(f"Autopilot task {task_id} completed successfully")
+                    self.notify(f"Unattended task {task_id} completed successfully")
                 else:
-                    self.notify(f"Autopilot task {task_id} failed (exit {exit_code})")
+                    self.notify(f"Unattended task {task_id} failed (exit {exit_code})")
                 if project_id == self.current_project_id:
                     await self.refresh_tasks()
                 return
@@ -1266,7 +1266,7 @@ if _HAS_TEXTUAL:
                     self.notify(f"Follow-up error: {error}")
                 else:
                     self.notify(f"Follow-up started for task {task_id}")
-                    self._start_autopilot_watcher(project_id, task_id)
+                    self._start_unattended_watcher(project_id, task_id)
                 if project_id == self.current_project_id:
                     await self.refresh_tasks()
                 return

--- a/src/terok/tui/log_viewer.py
+++ b/src/terok/tui/log_viewer.py
@@ -303,7 +303,7 @@ class _TuiLogFormatter:
 
 
 # ---------------------------------------------------------------------------
-# Plain text formatter (non-autopilot modes)
+# Plain text formatter (non-unattended modes)
 # ---------------------------------------------------------------------------
 
 

--- a/src/terok/tui/screens.py
+++ b/src/terok/tui/screens.py
@@ -722,15 +722,15 @@ class AuthModeScreen(screen.ModalScreen["str | None"]):
 
 
 # ---------------------------------------------------------------------------
-# Autopilot Prompt Screen
+# Unattended Prompt Screen
 # ---------------------------------------------------------------------------
 
 
 class SubagentInfo(TypedDict):
-    """Metadata for a single sub-agent shown in the autopilot selection screen.
+    """Metadata for a single sub-agent shown in the unattended selection screen.
 
     Sub-agents are provider-specific assistants (currently Claude only) that can
-    be included in an autopilot run via ``--agents`` JSON.
+    be included in an unattended run via ``--agents`` JSON.
 
     Attributes:
         name: Unique sub-agent identifier used as the dict key in ``--agents`` JSON.
@@ -743,10 +743,10 @@ class SubagentInfo(TypedDict):
     default: bool
 
 
-class AutopilotPromptScreen(screen.ModalScreen[str | None]):
-    """Modal for entering an autopilot prompt.
+class UnattendedPromptScreen(screen.ModalScreen[str | None]):
+    """Modal for entering an unattended prompt.
 
-    A modal dialog that prompts the user to enter a prompt for the autopilot
+    A modal dialog that prompts the user to enter a prompt for the unattended
     (headless Claude) mode. The user can enter their prompt in a text area and
     submit it or cancel.
 
@@ -759,11 +759,11 @@ class AutopilotPromptScreen(screen.ModalScreen[str | None]):
     ]
 
     CSS = """
-    AutopilotPromptScreen {
+    UnattendedPromptScreen {
         align: center middle;
     }
 
-    #autopilot-dialog {
+    #unattended-dialog {
         width: 80;
         height: auto;
         max-height: 80%;
@@ -791,12 +791,12 @@ class AutopilotPromptScreen(screen.ModalScreen[str | None]):
 
     def compose(self) -> ComposeResult:
         """Build the prompt text area and submit/cancel buttons."""
-        with Vertical(id="autopilot-dialog") as dialog:
+        with Vertical(id="unattended-dialog") as dialog:
             yield _SubmittablePromptArea(id="prompt-area")
             with Horizontal(id="prompt-buttons"):
                 yield Button("Cancel", id="btn-cancel", variant="default")
                 yield Button("Run ▶", id="btn-run", variant="primary")
-        dialog.border_title = "Autopilot Prompt"
+        dialog.border_title = "Unattended Prompt"
         dialog.border_subtitle = "Enter to run · Ctrl+J newline · Esc cancel"
 
     def on_mount(self) -> None:
@@ -839,7 +839,7 @@ class AutopilotPromptScreen(screen.ModalScreen[str | None]):
 
 
 class AgentSelectionScreen(screen.ModalScreen[tuple[str, list[str] | None] | None]):
-    """Combined modal for selecting the autopilot agent and optional sub-agents.
+    """Combined modal for selecting the unattended agent and optional sub-agents.
 
     The top section lists all registered headless agents (Claude, Codex, etc.)
     with the project default marked ``*``.  The bottom section shows sub-agent
@@ -1141,7 +1141,7 @@ class TaskCreateScreen(screen.ModalScreen["tuple[str, str] | None"]):
     """Modal for creating a new task: name input + mode selection.
 
     Dismisses with ``(sanitized_name, mode)`` or ``None`` if cancelled.
-    Mode is one of ``"cli"``, ``"toad"``, ``"autopilot"``.
+    Mode is one of ``"cli"``, ``"toad"``, ``"unattended"``.
     """
 
     BINDINGS = [
@@ -1194,7 +1194,7 @@ class TaskCreateScreen(screen.ModalScreen["tuple[str, str] | None"]):
             options = [
                 Option("CLI", id="cli"),
                 Option("Toad (browser TUI)", id="toad"),
-                Option("Autopilot (headless)", id="autopilot"),
+                Option("Unattended (headless)", id="unattended"),
             ]
             yield OptionList(*options, id="create-mode-list")
             with Horizontal(id="create-buttons"):
@@ -1744,7 +1744,9 @@ class TaskDetailsScreen(screen.Screen[str | None]):
             Option("Start Toad task  \\[w]  (new task + browser TUI)", id="task_start_toad"),
         ]
         options.append(
-            Option("Start \\[A]utopilot task  (new task + run headless)", id="task_start_autopilot")
+            Option(
+                "Start \\[U]nattended task  (new task + run headless)", id="task_start_unattended"
+            )
         )
         if self._has_tasks:
             options.append(Option("\\[l]ogin to container", id="login"))
@@ -1827,9 +1829,9 @@ class TaskDetailsScreen(screen.Screen[str | None]):
             event.stop()
             return
 
-        # Shift keys (uppercase) — A always available, others require tasks
+        # Shift keys (uppercase) — U always available, others require tasks
         shift_map: dict[str, str] = {
-            "A": "task_start_autopilot",
+            "U": "task_start_unattended",
             "H": "diff_head",
             "P": "diff_prev",
             "X": "delete",

--- a/src/terok/tui/task_actions.py
+++ b/src/terok/tui/task_actions.py
@@ -3,7 +3,7 @@
 
 """TaskActionsMixin — task lifecycle operations for TerokTUI.
 
-Handles task creation, deletion, renaming, running (CLI/toad/autopilot),
+Handles task creation, deletion, renaming, running (CLI/toad/unattended),
 login, restart, follow-up, log viewing, and diff copying.
 """
 
@@ -36,11 +36,11 @@ from ..lib.api import (
 from .clipboard import copy_to_clipboard_detailed
 from .screens import (
     AgentSelectionScreen,
-    AutopilotPromptScreen,
     SubagentInfo,
     TaskCreateScreen,
     TaskLaunchScreen,
     TaskNameScreen,
+    UnattendedPromptScreen,
 )
 from .widgets import TaskList
 
@@ -107,7 +107,7 @@ class TaskActionsMixin(_MixinBase):
     interface plus the instance attributes initialised by ``TerokTUI.__init__``.
     """
 
-    _autopilot_pending_name: str | None = None
+    _unattended_pending_name: str | None = None
 
     if TYPE_CHECKING:
         # TerokTUI-specific state and helpers (not on textual.App).
@@ -419,8 +419,8 @@ class TaskActionsMixin(_MixinBase):
         self.notify("Starting Toad task\u2026")
         await self.refresh_tasks()
 
-    async def _action_task_start_autopilot(self) -> None:
-        """Create a new task and run Claude headlessly (autopilot)."""
+    async def _action_task_start_unattended(self) -> None:
+        """Create a new task and run Claude headlessly (unattended)."""
         if not self.current_project_id:
             self.notify("No project selected.")
             return
@@ -429,25 +429,25 @@ class TaskActionsMixin(_MixinBase):
         default_name = generate_task_name(self.current_project_id)
         await self.push_screen(
             TaskNameScreen(default_name=default_name),
-            self._on_autopilot_name_result,
+            self._on_unattended_name_result,
         )
 
-    _autopilot_pending_agent: tuple[str, list[str] | None] | None = None
+    _unattended_pending_agent: tuple[str, list[str] | None] | None = None
 
-    async def _on_autopilot_name_result(self, name: str | None) -> None:
-        """Handle the name returned from TaskNameScreen for autopilot."""
+    async def _on_unattended_name_result(self, name: str | None) -> None:
+        """Handle the name returned from TaskNameScreen for unattended."""
         if name is None or not self.current_project_id:
             return
 
         pid = self.current_project_id
 
         # Store the name and show agent selection screen
-        self._autopilot_pending_name = name
+        self._unattended_pending_name = name
 
         try:
             project = load_project(pid)
         except (SystemExit, Exception) as e:
-            self._autopilot_pending_name = None
+            self._unattended_pending_name = None
             self.notify(f"Error loading project: {e}")
             return
 
@@ -466,7 +466,7 @@ class TaskActionsMixin(_MixinBase):
         except (SystemExit, Exception):
             # podman missing or inspect failure — fall back to unfiltered picker
             # (unlabeled images are treated as unrestricted) rather than aborting
-            # the autopilot flow.
+            # the unattended flow.
             pass
 
         await self.push_screen(
@@ -481,24 +481,24 @@ class TaskActionsMixin(_MixinBase):
     async def _on_agent_selection_result(self, result: tuple[str, list[str] | None] | None) -> None:
         """Handle the result from AgentSelectionScreen, then show the prompt screen."""
         if result is None:
-            self._autopilot_pending_name = None
+            self._unattended_pending_name = None
             return
 
-        self._autopilot_pending_agent = result
+        self._unattended_pending_agent = result
         await self.push_screen(
-            AutopilotPromptScreen(),
-            self._on_autopilot_prompt_result,
+            UnattendedPromptScreen(),
+            self._on_unattended_prompt_result,
         )
 
-    async def _on_autopilot_prompt_result(self, prompt: str | None) -> None:
-        """Handle the prompt returned from AutopilotPromptScreen and launch."""
+    async def _on_unattended_prompt_result(self, prompt: str | None) -> None:
+        """Handle the prompt returned from UnattendedPromptScreen and launch."""
         if not prompt:
-            self._autopilot_pending_name = None
-            self._autopilot_pending_agent = None
+            self._unattended_pending_name = None
+            self._unattended_pending_agent = None
             return
 
-        result = self._autopilot_pending_agent
-        self._autopilot_pending_agent = None
+        result = self._unattended_pending_agent
+        self._unattended_pending_agent = None
         if not result:
             return
 
@@ -510,22 +510,22 @@ class TaskActionsMixin(_MixinBase):
         provider = AGENT_PROVIDERS.get(agent_name)
         agents = selected_subagents if provider and provider.supports_agents_json else None
 
-        await self._launch_autopilot(prompt, agents=agents, provider=agent_name)
+        await self._launch_unattended(prompt, agents=agents, provider=agent_name)
 
-    async def _launch_autopilot(
+    async def _launch_unattended(
         self, prompt: str, agents: list[str] | None = None, provider: str | None = None
     ) -> None:
-        """Launch a headless autopilot task in a background worker."""
+        """Launch a headless unattended task in a background worker."""
         if not self.current_project_id:
             return
         pid = self.current_project_id
-        name = getattr(self, "_autopilot_pending_name", None)
-        self._autopilot_pending_name = None
-        self.notify(f"Starting autopilot task for {pid}...")
+        name = getattr(self, "_unattended_pending_name", None)
+        self._unattended_pending_name = None
+        self.notify(f"Starting unattended task for {pid}...")
         self.run_worker(
             lambda: self._run_headless_worker(pid, prompt, agents, name, provider=provider),
-            name=f"autopilot-launch:{pid}",
-            group="autopilot-launch",
+            name=f"unattended-launch:{pid}",
+            group="unattended-launch",
             thread=True,
             exit_on_error=False,
         )
@@ -556,39 +556,39 @@ class TaskActionsMixin(_MixinBase):
         except Exception as e:
             return project_id, "", str(e)
 
-    def _start_autopilot_watcher(self, project_id: str, task_id: str) -> None:
+    def _start_unattended_watcher(self, project_id: str, task_id: str) -> None:
         """Spawn a background worker that waits for the container to finish
         and updates task metadata with the exit code."""
         cname = container_name(project_id, "run", task_id)
         self.run_worker(
-            lambda: self._autopilot_wait_worker(project_id, task_id, cname),
-            name=f"autopilot-wait:{project_id}:{task_id}",
-            group="autopilot-wait",
+            lambda: self._unattended_wait_worker(project_id, task_id, cname),
+            name=f"unattended-wait:{project_id}:{task_id}",
+            group="unattended-wait",
             thread=True,
             exit_on_error=False,
         )
 
-    def _autopilot_wait_worker(
+    def _unattended_wait_worker(
         self, project_id: str, task_id: str, cname: str
     ) -> tuple[str, str, int | None, str | None]:
         """Background worker: wait for the container to exit and update metadata."""
         exit_code, error = wait_for_container_exit(cname, project_id, task_id)
         return project_id, task_id, exit_code, error
 
-    # ── Follow-up on completed/failed autopilot tasks ──
+    # ── Follow-up on completed/failed unattended tasks ──
 
     async def _action_task_followup(self) -> None:
-        """Follow up on a completed/failed autopilot task with a new prompt."""
+        """Follow up on a completed/failed unattended task with a new prompt."""
         if not self.current_project_id or not self.current_task:
             self.notify("No task selected.")
             return
         task = self.current_task
         if task.mode != "run" or effective_status(task) not in {"completed", "failed"}:
-            self.notify("Follow-up is only available for completed/failed autopilot tasks.")
+            self.notify("Follow-up is only available for completed/failed unattended tasks.")
             return
 
         await self.push_screen(
-            AutopilotPromptScreen(),
+            UnattendedPromptScreen(),
             self._on_followup_prompt_result,
         )
 
@@ -946,12 +946,12 @@ class TaskActionsMixin(_MixinBase):
         """Login to the selected task from the main screen."""
         await self._action_login()
 
-    async def action_run_autopilot_from_main(self) -> None:
-        """Start a new autopilot task from the main screen."""
-        await self._action_task_start_autopilot()
+    async def action_run_unattended_from_main(self) -> None:
+        """Start a new unattended task from the main screen."""
+        await self._action_task_start_unattended()
 
     async def action_follow_logs_from_main(self) -> None:
-        """Follow logs for the selected autopilot task from the main screen."""
+        """Follow logs for the selected unattended task from the main screen."""
         await self._action_follow_logs()
 
     async def action_create_task_from_main(self) -> None:
@@ -974,5 +974,5 @@ class TaskActionsMixin(_MixinBase):
             await self._start_cli_task_background(name)
         elif mode == "toad":
             await self._start_toad_task_background(name)
-        elif mode == "autopilot":
-            await self._on_autopilot_name_result(name)
+        elif mode == "unattended":
+            await self._on_unattended_name_result(name)

--- a/src/terok/tui/widgets/task_detail.py
+++ b/src/terok/tui/widgets/task_detail.py
@@ -62,7 +62,7 @@ def render_task_details(
     m_info = mode_info(task.mode)
     m_emoji = render_emoji(m_info)
     # Empty label for an unset mode lets the cricket emoji speak for
-    # itself — modes are picked via the Start CLI/Toad/Autopilot menu,
+    # itself — modes are picked via the Start CLI/Toad/Unattended menu,
     # not from this panel.
     mode_display = m_info.label
 

--- a/src/terok/tui/widgets/task_list.py
+++ b/src/terok/tui/widgets/task_list.py
@@ -41,7 +41,7 @@ class TaskList(ListView):
         ("t", "app.create_task_from_main", "New"),
         ("H", "app.copy_diff_head", "Diff HEAD"),
         ("P", "app.copy_diff_prev", "Diff PREV"),
-        ("A", "app.run_autopilot_from_main", "Autopilot"),
+        ("U", "app.run_unattended_from_main", "Unattended"),
         ("c", "app.run_cli_from_main", "CLI"),
         ("w", "app.run_toad_from_main", "Toad"),
         ("i", "app.login_from_main", "Login"),

--- a/tests/unit/cli/test_cli_unattended.py
+++ b/tests/unit/cli/test_cli_unattended.py
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: 2026 Jiri Vyskocil
 # SPDX-License-Identifier: Apache-2.0
 
-"""Tests for autopilot CLI: ``terok task run --mode headless``."""
+"""Tests for unattended CLI: ``terok task run --mode headless``."""
 
 from __future__ import annotations
 
@@ -151,7 +151,7 @@ def test_run_forwards_optional_flags(
     field: str,
     expected: object,
 ) -> None:
-    """Optional autopilot flags are forwarded into the headless request."""
+    """Optional unattended flags are forwarded into the headless request."""
     assert getattr(capture_headless_request("myproject", "test", *extra_args), field) == expected
 
 

--- a/tests/unit/lib/domain/test_domain_api.py
+++ b/tests/unit/lib/domain/test_domain_api.py
@@ -658,7 +658,7 @@ class TestTaskImageIsOld:
 
 
 # ---------------------------------------------------------------------------
-# wait_for_container_exit (moved from orchestration.autopilot → tasks.lifecycle)
+# wait_for_container_exit (moved from orchestration.unattended → tasks.lifecycle)
 # ---------------------------------------------------------------------------
 
 

--- a/tests/unit/lib/test_effective_status.py
+++ b/tests/unit/lib/test_effective_status.py
@@ -49,7 +49,7 @@ EFFECTIVE_STATUS_CASES = [
 
 MODE_INFO_CASES = [
     ({"mode": "cli"}, "💻", "CLI"),
-    ({"mode": "run"}, "🚀", "Autopilot"),
+    ({"mode": "run"}, "🚀", "Unattended"),
     ({"mode": None}, "🦗", ""),
 ]
 

--- a/tests/unit/lib/test_unattended.py
+++ b/tests/unit/lib/test_unattended.py
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: 2026 Jiri Vyskocil
 # SPDX-License-Identifier: Apache-2.0
 
-"""Tests for autopilot (Level 1+2) features: terok task run and agent config."""
+"""Tests for unattended (Level 1+2) features: terok task run and agent config."""
 
 from __future__ import annotations
 

--- a/tests/unit/tui/test_detail_screens.py
+++ b/tests/unit/tui/test_detail_screens.py
@@ -205,16 +205,16 @@ class TestRenderHelpers:
         assert isinstance(result, Text)
         assert "No project" in str(result)
 
-    def test_render_task_details_autopilot_mode(self) -> None:
+    def test_render_task_details_unattended_mode(self) -> None:
         widgets = import_widgets()
         task = make_task(widgets, task_id="5", mode="run")
         result = widgets.render_task_details(task, project_id="proj1")
         assert isinstance(result, Text)
         text_str = str(result)
-        assert "Autopilot" in text_str
+        assert "Unattended" in text_str
         assert "terok task logs" in text_str
 
-    def test_render_task_details_autopilot_with_exit_code(self) -> None:
+    def test_render_task_details_unattended_with_exit_code(self) -> None:
         widgets = import_widgets()
         task = make_task(widgets, task_id="5", mode="run", exit_code=0)
         result = widgets.render_task_details(task, project_id="proj1")
@@ -378,7 +378,7 @@ class TestRenderHelpers:
                 {"task_id": "3", "mode": "run"},
                 ["🚀"],
                 [],
-                id="autopilot",
+                id="unattended",
             ),
         ],
     )
@@ -513,7 +513,7 @@ class TestScreenConstruction:
         assert screen._project_id == "proj1"
         assert not screen._image_old
 
-    @pytest.mark.parametrize("screen_name", ["AuthActionsScreen", "AutopilotPromptScreen"])
+    @pytest.mark.parametrize("screen_name", ["AuthActionsScreen", "UnattendedPromptScreen"])
     def test_simple_screen_construction(self, screen_name: str) -> None:
         screens, _ = import_screens()
         assert getattr(screens, screen_name)() is not None
@@ -594,7 +594,7 @@ class TestTaskScreenKeyBinding:
         [
             pytest.param("c", False, "task_start_cli", None, True, id="lower-c"),
             pytest.param("w", False, "task_start_toad", None, True, id="lower-w"),
-            pytest.param("A", False, "task_start_autopilot", None, True, id="shift-a"),
+            pytest.param("U", False, "task_start_unattended", None, True, id="shift-u"),
             pytest.param("H", True, "diff_head", None, None, id="shift-h"),
             pytest.param("P", True, "diff_prev", None, None, id="shift-p"),
             pytest.param("X", True, "delete", None, None, id="shift-x"),
@@ -605,7 +605,7 @@ class TestTaskScreenKeyBinding:
             pytest.param("s", True, "shield_up", None, None, id="lower-s"),
             pytest.param("escape", False, None, None, None, id="escape"),
             pytest.param("q", False, None, None, None, id="q"),
-            pytest.param("f", True, "follow_logs", "run", None, id="follow-autopilot"),
+            pytest.param("f", True, "follow_logs", "run", None, id="follow-unattended"),
             pytest.param("f", True, "follow_logs", "cli", None, id="follow-cli"),
         ],
     )
@@ -749,11 +749,11 @@ class TestActionDispatch:
         run(app_class.action_delete_task_from_main(instance))
         instance.action_delete_task.assert_called_once()
 
-    def test_action_run_autopilot_from_main(self) -> None:
+    def test_action_run_unattended_from_main(self) -> None:
         _, app_class = import_app()
         instance = mock.Mock(spec=app_class)
-        run(app_class.action_run_autopilot_from_main(instance))
-        instance._action_task_start_autopilot.assert_called_once()
+        run(app_class.action_run_unattended_from_main(instance))
+        instance._action_task_start_unattended.assert_called_once()
 
     def test_action_follow_logs_from_main(self) -> None:
         _, app_class = import_app()
@@ -1278,7 +1278,7 @@ class TestActionSelection:
         )
         instance.refresh_tasks.assert_awaited()
 
-    def test_autopilot_launch_selects_created_task(self) -> None:
+    def test_unattended_launch_selects_created_task(self) -> None:
         app_mod, app_class = import_app()
 
         instance = app_class()
@@ -1286,11 +1286,11 @@ class TestActionSelection:
         instance._last_selected_tasks = {}
         instance.notify = mock.Mock()
         instance._save_selection_state = mock.Mock()
-        instance._start_autopilot_watcher = mock.Mock()
+        instance._start_unattended_watcher = mock.Mock()
         instance.refresh_tasks = mock.AsyncMock()
 
         worker = mock.Mock()
-        worker.group = "autopilot-launch"
+        worker.group = "unattended-launch"
         worker.result = ("proj1", "123", None)
         event = mock.Mock()
         event.worker = worker
@@ -1300,7 +1300,7 @@ class TestActionSelection:
 
         assert instance._last_selected_tasks.get("proj1") == "123"
         instance._save_selection_state.assert_called_once()
-        instance._start_autopilot_watcher.assert_called_once_with("proj1", "123")
+        instance._start_unattended_watcher.assert_called_once_with("proj1", "123")
         instance.refresh_tasks.assert_awaited_once()
 
 

--- a/tests/unit/tui/test_new_task_flow.py
+++ b/tests/unit/tui/test_new_task_flow.py
@@ -109,9 +109,9 @@ class TestTaskCreateScreen:
         screen._submit = mock.Mock()
 
         event = mock.Mock()
-        event.option_id = "autopilot"
+        event.option_id = "unattended"
         screen.on_option_list_option_selected(event)
-        screen._submit.assert_called_once_with("autopilot")
+        screen._submit.assert_called_once_with("unattended")
 
 
 # ---------------------------------------------------------------------------
@@ -398,13 +398,13 @@ class TestTaskLaunchScreen:
         event.stop.assert_not_called()
 
 
-class TestAutopilotPromptOnKey:
-    """AutopilotPromptScreen submits on Enter only while the prompt has focus."""
+class TestUnattendedPromptOnKey:
+    """UnattendedPromptScreen submits on Enter only while the prompt has focus."""
 
     @staticmethod
     def _screen_with_focus(*, has_focus: bool):
         screens, _ = import_screens()
-        screen = screens.AutopilotPromptScreen()
+        screen = screens.UnattendedPromptScreen()
         screen._submit = mock.Mock()
         area = mock.Mock()
         area.has_focus = has_focus
@@ -412,7 +412,7 @@ class TestAutopilotPromptOnKey:
         return screen
 
     def test_enter_submits_when_prompt_focused(self) -> None:
-        """Enter (bubbled from the prompt area) runs the autopilot prompt."""
+        """Enter (bubbled from the prompt area) runs the unattended prompt."""
         screen = self._screen_with_focus(has_focus=True)
         event = mock.Mock()
         event.key = "enter"


### PR DESCRIPTION
## What

Renames the "autopilot" run mode to **"unattended"**.

"Autopilot" has acquired a specific, loaded meaning elsewhere; "unattended"
describes the mode plainly — a detached, non-interactive agent run. The rename
covers user-facing strings, internal vars / functions / worker-group names,
docs, and tests (the two test modules are renamed too), with no backward-compat
alias (the feature has no current users).

- Internal task-mode value (`"run"`) is unchanged.
- TUI shortcut moves `A → U` to match the `[U]nattended` first-letter mnemonic
  (both the main task-list binding and the new-task screen's shift-key map).

## Verification

`make check` is green: lint, 2503 unit tests, tach, lint-imports, mypy (133
files), bandit, docstrings (96.7%), vulture, reuse.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
