### PR TITLE
feat(agents): add 'terok agents dir' to locate agent config mounts

### DIFF
--- a/src/terok/cli/commands/agents.py
+++ b/src/terok/cli/commands/agents.py
@@ -1,9 +1,9 @@
 # SPDX-FileCopyrightText: 2026 Jiri Vyskocil
 # SPDX-License-Identifier: Apache-2.0
 
-"""Lists installed AI coding agents and sets the global default selection.
+"""Lists installed AI coding agents, sets the default, and locates their mounts.
 
-Two leaf verbs:
+Three leaf verbs:
 
 - ``terok agents list [--all]`` — print the roster (agents only, or
   agents + tools when ``--all`` is passed).
@@ -11,6 +11,9 @@ Two leaf verbs:
   ``config.yml`` under ``image.agents``.  Interactive picker when
   ``SELECTION`` is omitted; same comma-list grammar that
   ``terok image build --agents`` and the new-project wizard accept.
+- ``terok agents dir [AGENT]`` — print the shared agent-config mounts
+  directory (or one agent's subdirectory), surfacing the otherwise-hidden
+  ``~/.local/share/terok/…/mounts/`` where skills and subagent definitions live.
 """
 
 from __future__ import annotations
@@ -68,6 +71,22 @@ def register(subparsers: argparse._SubParsersAction[argparse.ArgumentParser]) ->
         ),
     )
 
+    p_dir = sub.add_parser(
+        "dir",
+        help="Print the shared agent-config mounts directory (or one agent's subdir)",
+        description=(
+            "Print the host directory that holds the per-agent config mounts "
+            "bind-mounted into task containers.  With an AGENT, print that "
+            "agent's config subdirectory (e.g. _claude-config) instead."
+        ),
+    )
+    p_dir.add_argument(
+        "agent",
+        nargs="?",
+        default=None,
+        help="Optional agent name; print its config-mount subdirectory",
+    )
+
 
 def dispatch(args: argparse.Namespace) -> bool:
     """Handle ``terok agents …``.  Returns True if handled."""
@@ -78,9 +97,10 @@ def dispatch(args: argparse.Namespace) -> bool:
     if sub is None:
         # Bare ``terok agents`` — print the group's help so users see the verbs.
         print(
-            "usage: terok agents {list,set} ...\n\n"
+            "usage: terok agents {list,set,dir} ...\n\n"
             "  list  List available AI coding agents\n"
-            "  set   Set the global image.agents default in config.yml\n",
+            "  set   Set the global image.agents default in config.yml\n"
+            "  dir   Print the shared agent-config mounts directory\n",
             file=sys.stderr,
         )
         return True
@@ -90,6 +110,9 @@ def dispatch(args: argparse.Namespace) -> bool:
         return True
     if sub == "set":
         _set_global_default(selection=getattr(args, "selection", None))
+        return True
+    if sub == "dir":
+        _print_mounts_dir(agent=getattr(args, "agent", None))
         return True
     return False
 
@@ -132,3 +155,35 @@ def _set_global_default(*, selection: str | None) -> None:
     roster.validate_selection(raw)
     path = ExecutorConfigView.set_image_agents(raw)
     print(f"Wrote image.agents = {raw!r} to {path}")
+
+
+def _print_mounts_dir(*, agent: str | None) -> None:
+    """Print the shared agent-config mounts directory, or one agent's subdir.
+
+    The mounts directory holds the per-agent config trees (``_claude-config/``,
+    ``_codex-config/``, …) terok bind-mounts into task containers — the place to
+    drop skills, subagent definitions, or other per-agent settings.  It is
+    otherwise undiscoverable; this verb surfaces it.
+
+    With *agent*, the agent's config subdirectory is resolved from the roster;
+    an unknown agent exits ``2`` with the list of agents that have a mount.
+    """
+    from terok.lib.core.config import sandbox_live_mounts_dir
+
+    root = sandbox_live_mounts_dir()
+    if agent is None:
+        print(root)
+        return
+
+    from terok.lib.api.agents import AgentRoster
+
+    roster = AgentRoster.shared()
+    auth = roster.auth_providers.get(agent)
+    if auth is None:
+        available = ", ".join(sorted(roster.auth_providers)) or "(none)"
+        print(
+            f"Unknown agent {agent!r}.  Agents with a config mount: {available}",
+            file=sys.stderr,
+        )
+        raise SystemExit(2)
+    print(root / auth.host_dir_name)

--- a/tests/unit/cli/test_cli_agents.py
+++ b/tests/unit/cli/test_cli_agents.py
@@ -30,6 +30,11 @@ def _ns_set(selection: str | None = None) -> argparse.Namespace:
     return argparse.Namespace(cmd="agents", agents_cmd="set", selection=selection)
 
 
+def _ns_dir(agent: str | None = None) -> argparse.Namespace:
+    """Namespace shaped as ``terok agents dir [AGENT]`` post-parse."""
+    return argparse.Namespace(cmd="agents", agents_cmd="dir", agent=agent)
+
+
 def _fake_roster(
     *,
     agent_names: tuple[str, ...] = ("claude", "codex"),
@@ -224,6 +229,41 @@ def test_set_prompts_when_no_argument(tmp_path: Path, monkeypatch: pytest.Monkey
     write_mock.assert_called_once_with("all")
 
 
+# ── dir ───────────────────────────────────────────────────────────────
+
+
+def test_dir_prints_mounts_root(capsys: pytest.CaptureFixture[str]) -> None:
+    """``terok agents dir`` prints the shared mounts directory (tmp-isolated)."""
+    assert agents.dispatch(_ns_dir()) is True
+    assert capsys.readouterr().out.strip().endswith("mounts")
+
+
+def test_dir_prints_agent_config_subdir(capsys: pytest.CaptureFixture[str]) -> None:
+    """``terok agents dir AGENT`` resolves the agent's config-mount subdir from the roster."""
+    roster = _fake_roster()
+    roster.auth_providers = {"claude": SimpleNamespace(host_dir_name="_claude-config")}
+    with patch("terok.lib.integrations.executor.AgentRoster.shared", return_value=roster):
+        assert agents.dispatch(_ns_dir("claude")) is True
+    out = capsys.readouterr().out.strip()
+    assert out.endswith("_claude-config")
+    assert "mounts" in out
+
+
+def test_dir_rejects_unknown_agent(capsys: pytest.CaptureFixture[str]) -> None:
+    """An agent with no config mount exits 2 and lists the ones that have one."""
+    roster = _fake_roster()
+    roster.auth_providers = {"claude": SimpleNamespace(host_dir_name="_claude-config")}
+    with (
+        patch("terok.lib.integrations.executor.AgentRoster.shared", return_value=roster),
+        pytest.raises(SystemExit) as excinfo,
+    ):
+        agents.dispatch(_ns_dir("bogus"))
+    assert excinfo.value.code == 2
+    err = capsys.readouterr().err
+    assert "Unknown agent" in err
+    assert "claude" in err
+
+
 # ── registration ──────────────────────────────────────────────────────
 
 
@@ -244,3 +284,8 @@ def test_register_creates_group_with_list_and_set() -> None:
 
     parsed_bare_set = parser.parse_args(["agents", "set"])
     assert parsed_bare_set.selection is None
+
+    parsed_dir = parser.parse_args(["agents", "dir", "claude"])
+    assert parsed_dir.agents_cmd == "dir"
+    assert parsed_dir.agent == "claude"
+    assert parser.parse_args(["agents", "dir"]).agent is None


### PR DESCRIPTION
## What

Adds `terok agents dir [AGENT]` — a way to reach the shared agent-config mounts
directory, which was previously undiscoverable.

The per-agent config trees terok bind-mounts into task containers
(`_claude-config/`, `_codex-config/`, …) live under the sandbox-live mounts
directory (e.g. `~/.local/share/terok/.../mounts/`) — the place to drop skills,
subagent definitions, or other per-agent settings. There was no command to find
it; you had to parse `terok config` output.

- `terok agents dir` → prints the mounts root.
- `terok agents dir claude` → prints that agent's config subdir
  (`…/_claude-config`), resolved from the roster.
- Unknown agent → exit 2 with the list of agents that have a config mount.

Extends the existing `agents` group (consistent with `list` / `set`) rather than
adding a new singular `agent` group.

## Verification

`make check` green, incl. 3 new unit tests for the verb.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `terok agents dir` subcommand to display the host mounts directory used for agent configuration. Use with an agent name to show a specific agent's config subdirectory, or without an agent name to display the shared mounts root directory.

* **Tests**
  * Added test coverage for the new `dir` subcommand functionality, including tests for displaying mounts directories and handling unknown agents.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->