### PR TITLE
fix(tui): externally-created tasks reach "running", not stuck on "init"

### DIFF
--- a/src/terok/lib/orchestration/tasks/query.py
+++ b/src/terok/lib/orchestration/tasks/query.py
@@ -98,6 +98,25 @@ class TaskMeta(TaskState):
         """Compute effective status from live container state + metadata."""
         return effective_status(self)
 
+    def adopt_live_state(self, fresh: TaskMeta) -> None:
+        """Copy disk-derived live fields from a fresher snapshot, in place.
+
+        The TUI's container-state poll re-reads every task each tick but keeps
+        the displayed row objects.  Those rows carry more than a container
+        state: the ``ready_at`` init marker, work status and exit code all
+        drift while a row stays put — so a container that is already
+        ``running`` still needs its ``initialized`` flag synced to move from
+        ``init`` to ``running``.  This refreshes exactly those fields and
+        leaves identity and the TUI-local ``starting`` launch flag untouched.
+        """
+        self.container_state = fresh.container_state
+        self.exit_code = fresh.exit_code
+        self.deleting = fresh.deleting
+        self.initialized = fresh.initialized
+        self.work_status = fresh.work_status
+        self.work_message = fresh.work_message
+        self.web_port = fresh.web_port
+
     @classmethod
     def load(cls, project_id: str, task_id: str) -> TaskMeta:
         """Load a TaskMeta from disk, with live container state hydrated.

--- a/src/terok/tui/app.py
+++ b/src/terok/tui/app.py
@@ -1175,24 +1175,31 @@ if _HAS_TEXTUAL:
                 result = worker.result
                 if not result:
                     return
-                project_id, states = result
+                project_id, metas = result
                 if project_id != self.current_project_id:
                     return
                 task_list = self.query_one("#task-list", TaskList)
                 # The batch query re-reads the on-disk task set every tick, so
-                # its keys reveal tasks created or deleted outside the TUI.
+                # its task IDs reveal tasks created or deleted outside the TUI.
                 # Reconcile membership first: this level-triggered diff against
                 # the source of truth can't miss a change the way edge-polling
                 # could, and it converges in a single tick.
-                if set(states) != {tm.task_id for tm in task_list.tasks}:
+                fresh_by_id = {m.task_id: m for m in metas}
+                if set(fresh_by_id) != {tm.task_id for tm in task_list.tasks}:
                     await self.refresh_tasks()
                     return
-                # Update container_state on all TaskMeta instances
+                # Membership matches: refresh the live lifecycle fields on each
+                # displayed row in place.  The poll re-reads more than the
+                # container state — the ``ready_at`` init marker, work status
+                # and exit code drift while a row stays put — so a row whose
+                # container is already "running" still needs its ``initialized``
+                # flag synced to flip from "init" to "running".  Repaint only
+                # when a row's rendered status badge actually moves.
                 changed = False
                 for tm in task_list.tasks:
-                    new_state = states.get(tm.task_id)
-                    if tm.container_state != new_state:
-                        tm.container_state = new_state
+                    before = (tm.status, tm.work_status, tm.web_port)
+                    tm.adopt_live_state(fresh_by_id[tm.task_id])
+                    if (tm.status, tm.work_status, tm.web_port) != before:
                         changed = True
                 if changed:
                     # Regenerate labels on visible list items so status badges update

--- a/src/terok/tui/polling.py
+++ b/src/terok/tui/polling.py
@@ -130,23 +130,31 @@ class PollingMixin(_MixinBase):
             exclusive=True,
         )
 
-    async def _load_container_state_worker(
-        self, project_id: str
-    ) -> tuple[str, dict[str, str | None]]:
-        """Background worker to batch-query all container states for a project."""
+    async def _load_container_state_worker(self, project_id: str) -> tuple[str, list["TaskMeta"]]:
+        """Batch-snapshot every task for a project with live container state.
+
+        Returns fresh ``TaskMeta`` instances — the task set on disk plus each
+        one's live container state — so the handler can both detect tasks
+        created or deleted outside the TUI *and* refresh the lifecycle fields
+        (init marker, work status, exit code) that drift on rows already shown.
+        """
         import asyncio
 
         from ..lib.api import get_all_task_states, get_tasks
 
+        def _snapshot() -> list["TaskMeta"]:
+            tasks = get_tasks(project_id)
+            states = get_all_task_states(project_id, tasks)
+            for task in tasks:
+                task.container_state = states.get(task.task_id)
+            return tasks
+
         try:
-            tasks = await asyncio.get_event_loop().run_in_executor(None, get_tasks, project_id)
-            states = await asyncio.get_event_loop().run_in_executor(
-                None, get_all_task_states, project_id, tasks
-            )
-            return (project_id, states)
+            tasks = await asyncio.get_event_loop().run_in_executor(None, _snapshot)
+            return (project_id, tasks)
         except (Exception, SystemExit) as e:  # noqa: BLE001 — background worker; must not crash TUI
             self._log_debug(f"container state batch check error: {e}")
-            return (project_id, {})
+            return (project_id, [])
 
     def _poll_upstream(self) -> None:
         """Check upstream for changes and update staleness info.

--- a/tests/unit/tui/test_task_list_reconcile.py
+++ b/tests/unit/tui/test_task_list_reconcile.py
@@ -3,20 +3,22 @@
 
 """The container-state poll reconciles the task set with what's on disk.
 
-The 2-second batch query already re-reads every task from disk, so its result
-keys reveal tasks created or deleted *outside* the TUI.  The handler diffs that
-membership against the displayed rows (level-triggered, so it cannot miss a
-change) and reloads the list only when it actually differs — otherwise it just
-maps fresh container states onto the existing rows, as before.
+The 2-second batch query already re-reads every task from disk, so its fresh
+``TaskMeta`` snapshots reveal tasks created or deleted *outside* the TUI.  The
+handler diffs that membership against the displayed rows (level-triggered, so it
+cannot miss a change) and reloads the list only when it actually differs —
+otherwise it syncs the live lifecycle fields (container state plus the
+``ready_at`` init marker, work status and exit code) onto the existing rows so a
+running container's badge can move from "init" to "running" without a reload.
 """
 
 from __future__ import annotations
 
 import asyncio
-import types
 from typing import Any
 from unittest import mock
 
+from terok.lib.api import TaskMeta
 from tests.unit.tui.tui_test_helpers import import_app
 
 
@@ -25,9 +27,24 @@ def run(coro: object) -> object:
     return asyncio.run(coro)
 
 
-def _task(task_id: str, state: str | None = None) -> types.SimpleNamespace:
-    """Minimal displayed-row stand-in carrying an id and a container state."""
-    return types.SimpleNamespace(task_id=task_id, container_state=state)
+def _meta(
+    task_id: str,
+    *,
+    container_state: str | None = None,
+    initialized: bool = False,
+    work_status: str | None = None,
+    web_port: int | None = None,
+) -> TaskMeta:
+    """A real ``TaskMeta`` row carrying the live fields the poll reconciles."""
+    return TaskMeta(
+        task_id=task_id,
+        mode="cli",
+        workspace="",
+        web_port=web_port,
+        container_state=container_state,
+        initialized=initialized,
+        work_status=work_status,
+    )
 
 
 def _instance(app_class: type, displayed: list[Any]) -> Any:
@@ -43,11 +60,11 @@ def _instance(app_class: type, displayed: list[Any]) -> Any:
     return instance
 
 
-def _poll(instance: Any, app_mod: Any, states: dict[str, str | None], pid: str = "p1") -> None:
+def _poll(instance: Any, app_mod: Any, metas: list[TaskMeta], pid: str = "p1") -> None:
     """Drive a completed container-state poll through the worker handler."""
     worker = mock.Mock()
     worker.group = "container-state"
-    worker.result = (pid, states)
+    worker.result = (pid, metas)
     event = mock.Mock()
     event.worker = worker
     event.state = app_mod.WorkerState.SUCCESS
@@ -59,14 +76,14 @@ class TestMembershipReconcile:
 
     def test_external_create_triggers_refresh(self) -> None:
         app_mod, app_class = import_app()
-        instance = _instance(app_class, [_task("1")])
-        _poll(instance, app_mod, {"1": None, "2": None})  # task 2 appeared on disk
+        instance = _instance(app_class, [_meta("1")])
+        _poll(instance, app_mod, [_meta("1"), _meta("2")])  # task 2 appeared on disk
         instance.refresh_tasks.assert_awaited_once()
 
     def test_external_delete_triggers_refresh(self) -> None:
         app_mod, app_class = import_app()
-        instance = _instance(app_class, [_task("1"), _task("2")])
-        _poll(instance, app_mod, {"1": None})  # task 2 vanished from disk
+        instance = _instance(app_class, [_meta("1"), _meta("2")])
+        _poll(instance, app_mod, [_meta("1")])  # task 2 vanished from disk
         instance.refresh_tasks.assert_awaited_once()
 
 
@@ -75,16 +92,33 @@ class TestStateOnlyUpdate:
 
     def test_state_change_updates_in_place(self) -> None:
         app_mod, app_class = import_app()
-        instance = _instance(app_class, [_task("1", None)])
-        _poll(instance, app_mod, {"1": "running"})
+        instance = _instance(app_class, [_meta("1", initialized=True)])
+        _poll(instance, app_mod, [_meta("1", container_state="running", initialized=True)])
         instance.refresh_tasks.assert_not_awaited()
         assert instance._task_list.tasks[0].container_state == "running"
         instance._task_list.refresh_labels.assert_called_once()
 
+    def test_running_marker_flips_init_to_running(self) -> None:
+        """The ``ready_at`` init marker landing must move "init" → "running".
+
+        Regression: an externally-created task appears with a running container
+        before it has initialised, so its badge is "init".  The marker is
+        persisted moments later; the steady-state poll must sync ``initialized``
+        (not just the container state) or the row stays yellow forever.
+        """
+        app_mod, app_class = import_app()
+        row = _meta("1", container_state="running", initialized=False)
+        assert row.status == "init"  # precondition: yellow before the marker
+        instance = _instance(app_class, [row])
+        _poll(instance, app_mod, [_meta("1", container_state="running", initialized=True)])
+        instance.refresh_tasks.assert_not_awaited()
+        assert instance._task_list.tasks[0].status == "running"
+        instance._task_list.refresh_labels.assert_called_once()
+
     def test_no_change_is_a_noop(self) -> None:
         app_mod, app_class = import_app()
-        instance = _instance(app_class, [_task("1", None)])
-        _poll(instance, app_mod, {"1": None})
+        instance = _instance(app_class, [_meta("1")])
+        _poll(instance, app_mod, [_meta("1")])
         instance.refresh_tasks.assert_not_awaited()
         instance._task_list.refresh_labels.assert_not_called()
 
@@ -94,7 +128,7 @@ class TestProjectGuard:
 
     def test_stale_project_result_ignored(self) -> None:
         app_mod, app_class = import_app()
-        instance = _instance(app_class, [_task("1")])
-        _poll(instance, app_mod, {"1": None, "2": None}, pid="other")
+        instance = _instance(app_class, [_meta("1")])
+        _poll(instance, app_mod, [_meta("1"), _meta("2")], pid="other")
         instance.refresh_tasks.assert_not_awaited()
         instance.query_one.assert_not_called()


### PR DESCRIPTION
## Problem

A recent change (#1056) made externally-created tasks appear in the TUI via the 2-second container-state poll. But once they appeared they were stuck on the yellow **"init"** badge and never moved to green **"running"**, even though the container was already running — until an unrelated action (starting another task, switching projects) happened to call `refresh_tasks`.

## Root cause

`effective_status()` renders a task whose container is `running` as **"init"** while `initialized` is still `False`, and **"running"** only once `initialized` (the on-disk `ready_at` marker) flips true.

The poll's steady-state path (taken once a row's membership is stable) only ever copied `container_state` onto the displayed row — it never re-read `initialized`. An externally-created task's container comes up *before* `ready_at` lands, so:

1. First tick: membership differs → `refresh_tasks()` reads disk, when `initialized` is still `False`.
2. `ready_at` is persisted moments later — but membership is now stable, so `refresh_tasks` never runs again. The in-place update keeps `container_state="running"` and leaves `initialized` frozen → **stuck on "init" forever**.

This was latent before #1056 (external tasks never showed at all).

## Fix

The poll already re-reads everything via `get_tasks` each tick — it was just discarding the lifecycle fields:

- The batch worker now returns fresh `TaskMeta` snapshots (with live `container_state` hydrated) instead of a bare `{id: state}` dict.
- `TaskMeta.adopt_live_state()` copies the disk-derived fields that actually drift while a row stays put (`container_state`, `initialized`, `exit_code`, `deleting`, `work_status`, `work_message`, `web_port`), leaving identity and the TUI-local `starting` launch flag untouched.
- The handler repaints only when a row's rendered badge `(status, work_status, web_port)` actually moves.

So `init → running` (and work-status / port drift on already-shown rows) now converge on the very next tick.

## Tests

- New regression test `test_running_marker_flips_init_to_running` locks the exact bug.
- Reconcile suite updated to the new worker contract (6/6 pass).
- `tests/unit/tui/` + `tests/unit/lib/` — 2014 passed. `make lint`, `make docstrings`, `make tach`, `make lint-imports`, `make reuse`, `make security` all green. (Podman-dependent tests not run locally — no podman in dev container.)

## Follow-up

This fixes the bug within the existing 2-second polling model. A separate effort will move the TUI to an event-driven (inotify + `podman events`) model so the happy path stops re-reading disk every 2 s — prototype incoming.

🤖 Generated with [Claude Code](https://claude.com/claude-code)