### PR TITLE
fix(docs): add complexipy, tach, pydantic to docs dependencies

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -4544,4 +4544,4 @@ propcache = ">=0.2.1"
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.12,<3.15"
-content-hash = "1f97d72dcd7ba2152800c99d92a7c4c974e942e9132e54d24739ce04dd5b3104"
+content-hash = "2a850524d001fe09848a594e31c2b113c17a5b3dd2a024634abbecd4c1eb9a02"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ dependencies = [
 ]
 
 [project.urls]
-Homepage = "https://terok.ai/"
+Homepage = "https://terok-ai.github.io/terok/"
 Repository = "https://github.com/terok-ai/terok"
 Documentation = "https://terok-ai.github.io/terok/"
 Issues = "https://github.com/terok-ai/terok/issues"
@@ -119,8 +119,8 @@ python-dbusmock = ">=0.32"
 
 [tool.poetry.group.docs.dependencies]
 properdocs = ">=1.6.7"
-mkdocs-material = ">=9.0"
-mkdocstrings = {extras = ["python"], version = ">=0.24"}
+mkdocs-material = ">=9.7.6"
+mkdocstrings = {extras = ["python"], version = ">=0.26"}
 mkdocs-gen-files = ">=0.5"
 mkdocs-literate-nav = ">=0.6"
 mkdocs-section-index = ">=0.3"


### PR DESCRIPTION
These are required for mkdocs-terok's code_metrics feature to work correctly. Without them, the cognitive complexity report shows "complexipy cache not found — skipping complexity report".

Part of fixing the code metrics cognitive complexity report across all terok sibling projects.