### PR TITLE
refactor: rename project_id to project_name; add project description

### DIFF
--- a/docs/container-lifecycle.md
+++ b/docs/container-lifecycle.md
@@ -93,7 +93,7 @@ All three persist independently and survive:
 ### Container Naming
 
 ```text
-<project-id>-<mode>-<task-id>
+<project-name>-<mode>-<task-id>
 
 Examples:
   myproject-cli-v9krt   # CLI container for task v9krt

--- a/docs/developer.md
+++ b/docs/developer.md
@@ -42,9 +42,9 @@ facade.get_project("myproj")  →  Project          (Aggregate Root)
 
 **Lazy Initialization.** `Project` subsystems (`gate`, `ssh`, `agents`) are created on first access, not at construction. This avoids I/O when only a subset of functionality is needed. Since `Project` uses `__slots__`, `cached_property` is not available — the manual pattern (`if self._gate is None: ...`) is used instead.
 
-**Identity-Based Equality.** `Project.__eq__` compares by project ID; `Task.__eq__` compares by `(project_id, task_id)`. Both are hashable, so they work correctly in sets and dicts.
+**Identity-Based Equality.** `Project.__eq__` compares by project name; `Task.__eq__` compares by `(project_name, task_id)`. Both are hashable, so they work correctly in sets and dicts.
 
-**Facade Pattern.** `lib.facade` provides factory functions (`get_project`, `list_projects`, `derive_project`) as the stable entry point. It also re-exports low-level service functions for CLI commands that operate on raw `project_id` strings.
+**Facade Pattern.** `lib.facade` provides factory functions (`get_project`, `list_projects`, `derive_project`) as the stable entry point. It also re-exports low-level service functions for CLI commands that operate on raw `project_name` strings.
 
 ### Module Boundaries
 
@@ -146,7 +146,7 @@ See [shared-dirs.md](shared-dirs.md) for detailed documentation.
 
 | Variable | Value | Purpose |
 |----------|-------|---------|
-| `PROJECT_ID` | Project ID from config | Identify current project |
+| `PROJECT_NAME` | Project name from config | Identify current project |
 | `TASK_ID` | Numeric task ID | Identify current task |
 | `REPO_ROOT` | `/workspace` | Init script clone target |
 | `CLAUDE_CONFIG_DIR` | `/home/dev/.claude` | Claude Code config location |

--- a/docs/developer.md
+++ b/docs/developer.md
@@ -228,7 +228,7 @@ sockets appear when supervisors come up and disappear when they exit.
 
 Third-party host tools (IDEs, scripts) that need the gate's repository
 do **not** go through the supervisor at all: they read the mirror
-clone directly over `file://` (`terok project gate-path <id>` prints
+clone directly over `file://` (`terok project gate-path <name>` prints
 the path).  The in-supervisor HTTP gate exists only to serve confined
 containers, whose egress shield otherwise blocks.
 

--- a/docs/git-gate-and-security-modes.md
+++ b/docs/git-gate-and-security-modes.md
@@ -111,7 +111,7 @@ gatekeeping:
 
 ```yaml
 project:
-  id: "myproject"
+  name: "myproject"
   security_class: "gatekeeping"
 
 git:
@@ -161,7 +161,7 @@ local mirror.
 
 ```yaml
 project:
-  id: cp2k
+  name: cp2k
   security_class: online
 git:
   upstream_url: git@github.com:user/cp2k.git

--- a/docs/shared-dirs.md
+++ b/docs/shared-dirs.md
@@ -9,7 +9,7 @@ When a task starts, terok mounts host directories into the container for workspa
 
 ## Per-Task Workspace
 
-- Host path: `<state_dir>/tasks/<project_id>/<task_id>/workspace-dangerous`
+- Host path: `<state_dir>/tasks/<project_name>/<task_id>/workspace-dangerous`
 - Mounted as: `<host_dir>:/workspace:Z`
 - Created automatically when the task runs (permissions `700`).
 - The project repository is cloned or synced here by `init-ssh-and-repo.sh`.
@@ -59,7 +59,7 @@ authenticated).  Public HTTPS repos don't need SSH setup at all.
 ### Setup
 
 ```bash
-terok project ssh-init <project_id> [--key-type ed25519|rsa] [--comment STRING] [--force]
+terok project ssh-init <project_name> [--key-type ed25519|rsa] [--comment STRING] [--force]
 ```
 
 Mints a keypair directly into the vault credential database; no on-disk

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -167,7 +167,7 @@ Every project needs these fields in its `project.yml`:
 
 ```yaml
 project:
-  id: myproj
+  name: myproj
   security_class: gatekeeping   # default — or "online" for direct push
 
 image:
@@ -217,7 +217,7 @@ mode is incoherent.
 # Host blocks outbound SSH to github, but the container's network
 # allowlist reaches github via its own rules.
 project:
-  id: cp2k
+  name: cp2k
   security_class: online
 git:
   upstream_url: git@github.com:user/cp2k.git
@@ -256,7 +256,7 @@ mkdir -p ~/.config/terok/projects/myproj
 ```yaml
 # ~/.config/terok/projects/myproj/project.yml
 project:
-  id: myproj
+  name: myproj
   security_class: gatekeeping   # default — or "online" for direct push
 
 image:
@@ -973,7 +973,7 @@ Hook commands receive task context via environment variables:
 | Variable | Description | Example |
 |----------|-------------|---------|
 | `TEROK_HOOK` | Hook name | `post_ready` |
-| `TEROK_PROJECT_ID` | Project ID | `myproject` |
+| `TEROK_PROJECT_NAME` | Project name | `myproject` |
 | `TEROK_TASK_ID` | Task number | `3` |
 | `TEROK_TASK_MODE` | Task mode | `cli`, `toad`, `run` |
 | `TEROK_CONTAINER_NAME` | Podman container name | `myproject-toad-3` |

--- a/examples/hooks/task-notify.sh
+++ b/examples/hooks/task-notify.sh
@@ -11,4 +11,4 @@
 #     post_ready: /path/to/task-notify.sh
 #     post_stop: /path/to/task-notify.sh
 
-echo "[hook] $TEROK_HOOK: project=$TEROK_PROJECT_ID task=$TEROK_TASK_ID mode=$TEROK_TASK_MODE container=$TEROK_CONTAINER_NAME${TEROK_WEB_PORT:+ port=$TEROK_WEB_PORT}" >&2
+echo "[hook] $TEROK_HOOK: project=$TEROK_PROJECT_NAME task=$TEROK_TASK_ID mode=$TEROK_TASK_MODE container=$TEROK_CONTAINER_NAME${TEROK_WEB_PORT:+ port=$TEROK_WEB_PORT}" >&2

--- a/examples/projects/alpaka3/project.yml
+++ b/examples/projects/alpaka3/project.yml
@@ -1,6 +1,6 @@
 project:
-  id: "alpaka3"
-  name: "Alpaka3"
+  name: "alpaka3"
+  description: "Alpaka3"
   # Gatekept: tasks can only push to a host-side staging repo, not upstream
   security_class: "gatekeeping"
 

--- a/examples/projects/cp2k/project.yml
+++ b/examples/projects/cp2k/project.yml
@@ -1,6 +1,6 @@
 project:
-  id: "cp2k"
-  name: "CP2K VM dev"
+  name: "cp2k"
+  description: "CP2K VM dev"
   security_class: "gatekeeping"
 
 git:

--- a/examples/projects/uc/project.yml
+++ b/examples/projects/uc/project.yml
@@ -1,6 +1,6 @@
 project:
-  id: "uc"
-  name: "Ultimate Container"
+  name: "uc"
+  description: "Ultimate Container"
   security_class: "online"      # agent can push directly to upstream
 
 git:

--- a/src/terok/cli/commands/_completers.py
+++ b/src/terok/cli/commands/_completers.py
@@ -3,9 +3,9 @@
 
 """Shared argcomplete completers and helpers for CLI commands.
 
-All completers assume the standard ``project_id`` / ``task_id`` dest
+All completers assume the standard ``project_name`` / ``task_id`` dest
 names.  Parsers whose positionals display as ``<project>`` / ``<task>``
-(e.g. ``sickbay``) should set ``dest="project_id"`` / ``dest="task_id"``
+(e.g. ``sickbay``) should set ``dest="project_name"`` / ``dest="task_id"``
 with a custom ``metavar=`` for display, so completers and argparse help
 stay decoupled.
 """
@@ -21,12 +21,12 @@ from ...lib.core.projects import list_presets, list_projects
 from ...lib.orchestration.tasks import normalize_task_id_input
 
 
-def complete_project_ids(
+def complete_project_names(
     prefix: str, parsed_args: argparse.Namespace, **kwargs: object
 ) -> list[str]:  # pragma: no cover
-    """Return project IDs matching *prefix* for argcomplete."""
+    """Return project names matching *prefix* for argcomplete."""
     try:
-        ids = [p.id for p in list_projects()]
+        ids = [p.name for p in list_projects()]
     except Exception:
         return []
     if prefix:
@@ -37,7 +37,7 @@ def complete_project_ids(
 def complete_task_ids(
     prefix: str, parsed_args: argparse.Namespace, **kwargs: object
 ) -> list[str]:  # pragma: no cover
-    """Return task IDs matching *prefix* within ``parsed_args.project_id``.
+    """Return task IDs matching *prefix* within ``parsed_args.project_name``.
 
     Returns an empty list when the project arg hasn't been typed yet —
     argcomplete uses the partially-parsed namespace, which is exactly
@@ -48,11 +48,11 @@ def complete_task_ids(
     form — the same surface-form tolerance ``resolve_task_id`` gives
     at dispatch time.
     """
-    project_id = getattr(parsed_args, "project_id", None)
-    if not project_id:
+    project_name = getattr(parsed_args, "project_name", None)
+    if not project_name:
         return []
     try:
-        tids = [t.task_id for t in get_tasks(project_id) if t.task_id]
+        tids = [t.task_id for t in get_tasks(project_name) if t.task_id]
     except Exception:
         return []
     normalized = normalize_task_id_input(prefix)
@@ -66,16 +66,16 @@ def complete_preset_names(
 ) -> list[str]:  # pragma: no cover
     """Return preset names matching *prefix* for the scoped project.
 
-    ``list_presets`` requires a project ID to resolve the full tier
+    ``list_presets`` requires a project name to resolve the full tier
     (bundled → global → project), so we only suggest presets once the
     user has typed the project arg.  No project typed yet → empty list,
     which leaves argcomplete silent rather than misleading.
     """
-    project_id = getattr(parsed_args, "project_id", None)
-    if not project_id:
+    project_name = getattr(parsed_args, "project_name", None)
+    if not project_name:
         return []
     try:
-        names = [p.name for p in list_presets(project_id)]
+        names = [p.name for p in list_presets(project_name)]
     except Exception:
         return []
     if prefix:
@@ -88,14 +88,14 @@ def set_completer(action: argparse.Action, fn: Callable[..., Any]) -> None:
     action.completer = fn  # type: ignore[attr-defined]
 
 
-def add_project_id(parser: argparse.ArgumentParser, **kwargs: Any) -> argparse.Action:
-    """Add a ``project_id`` positional with the project-ID completer attached.
+def add_project_name(parser: argparse.ArgumentParser, **kwargs: Any) -> argparse.Action:
+    """Add a ``project_name`` positional with the project name completer attached.
 
     Returns the argparse action so callers can further customise it.
     Accepts any argparse kwargs (``nargs``, ``metavar``, ``help``, etc.).
     """
-    action = parser.add_argument("project_id", **kwargs)
-    set_completer(action, complete_project_ids)
+    action = parser.add_argument("project_name", **kwargs)
+    set_completer(action, complete_project_names)
     return action
 
 
@@ -103,7 +103,7 @@ def add_task_id(parser: argparse.ArgumentParser, **kwargs: Any) -> argparse.Acti
     """Add a ``task_id`` positional with the task-ID completer attached.
 
     Returns the argparse action.  Callers should typically precede this
-    with `add_project_id` so argcomplete has a project scope to
+    with `add_project_name` so argcomplete has a project scope to
     look up tasks under.
     """
     action = parser.add_argument("task_id", **kwargs)

--- a/src/terok/cli/commands/_storage_view.py
+++ b/src/terok/cli/commands/_storage_view.py
@@ -113,7 +113,7 @@ def cmd_overview(*, json_output: bool = False) -> None:
     # ── Projects section ──
     if overview.projects:
         print(_section("Projects", c))
-        pid_w = max(len(p.project_id) for p in overview.projects)
+        pid_w = max(len(p.project_name) for p in overview.projects)
         img_sizes = [format_bytes(p.image_bytes) for p in overview.projects]
         ws_sizes = [format_bytes(p.workspace_bytes) for p in overview.projects]
         img_w = max(len(s) for s in img_sizes + ["IMAGES"])
@@ -129,7 +129,7 @@ def cmd_overview(*, json_output: bool = False) -> None:
         )
         for p, img_s, ws_s in zip(overview.projects, img_sizes, ws_sizes, strict=True):
             print(
-                f"  {p.project_id:<{pid_w}}  "
+                f"  {p.project_name:<{pid_w}}  "
                 f"{_size(f'{img_s:>{img_w}}', c)}  "
                 f"{_size(f'{ws_s:>{ws_w}}', c)}  "
                 f"{p.task_count:>{task_w}}"
@@ -158,18 +158,18 @@ def cmd_overview(*, json_output: bool = False) -> None:
 # ---------------------------------------------------------------------------
 
 
-def cmd_detail(project_id: str, *, json_output: bool = False) -> None:
+def cmd_detail(project_name: str, *, json_output: bool = False) -> None:
     """Print per-task storage detail for one project."""
     from ...lib.domain.storage import format_bytes, get_project_storage_detail
 
-    detail = get_project_storage_detail(project_id)
+    detail = get_project_storage_detail(project_name)
 
     if json_output:
         _json_detail(detail)
         return
 
     c = _c(supports_color())
-    print(_section(project_id, c))
+    print(_section(project_name, c))
 
     # Images
     if detail.images:
@@ -239,7 +239,7 @@ def _json_overview(overview: StorageOverview) -> None:
         },
         "projects": [
             {
-                "id": p.project_id,
+                "id": p.project_name,
                 "image_bytes": p.image_bytes,
                 "workspace_bytes": p.workspace_bytes,
                 "task_count": p.task_count,
@@ -259,7 +259,7 @@ def _json_detail(detail: ProjectDetail) -> None:
     from ...lib.domain.storage import parse_image_size
 
     data = {
-        "project_id": detail.project_id,
+        "project_name": detail.project_name,
         "images": [
             {"name": img.full_name, "size": img.size, "bytes": parse_image_size(img.size)}
             for img in detail.images

--- a/src/terok/cli/commands/_storage_view.py
+++ b/src/terok/cli/commands/_storage_view.py
@@ -239,7 +239,7 @@ def _json_overview(overview: StorageOverview) -> None:
         },
         "projects": [
             {
-                "id": p.project_name,
+                "project_name": p.project_name,
                 "image_bytes": p.image_bytes,
                 "workspace_bytes": p.workspace_bytes,
                 "task_count": p.task_count,

--- a/src/terok/cli/commands/acp.py
+++ b/src/terok/cli/commands/acp.py
@@ -12,7 +12,7 @@ This module owns only the orchestration glue terok adds on top of
 ``terok-executor``'s host-proxy daemon:
 
 - ``acp list`` walks projects → tasks → endpoints,
-- ``acp connect`` translates ``(project_id, task_id)`` to a container
+- ``acp connect`` translates ``(project_name, task_id)`` to a container
   name and per-task socket path, lazy-spawns the executor daemon
   (``python -m terok_executor.acp.daemon``), and bridges the caller's
   stdio to that socket so an ACP client (Zed, Toad, …) launching us
@@ -45,7 +45,7 @@ from ...lib.core.config import is_experimental
 from ...lib.core.paths import acp_log_path, acp_socket_path
 from ...lib.orchestration.tasks import resolve_task_id
 from ...lib.util.subprocess_env import child_process_env
-from ._completers import add_project_id, add_task_id
+from ._completers import add_project_name, add_task_id
 
 if TYPE_CHECKING:
     from terok.lib.api.agents import ACPEndpointStatus
@@ -67,13 +67,13 @@ def register(subparsers: argparse._SubParsersAction[argparse.ArgumentParser]) ->
     sub = p.add_subparsers(dest="acp_cmd", required=True)
 
     p_list = sub.add_parser("list", help="List ACP endpoints across running tasks")
-    add_project_id(p_list, nargs="?", default=None)
+    add_project_name(p_list, nargs="?", default=None)
 
     p_connect = sub.add_parser(
         "connect",
         help="Connect stdio to a task's ACP socket (spawning the daemon if needed)",
     )
-    add_project_id(p_connect)
+    add_project_name(p_connect)
     add_task_id(p_connect)
 
 
@@ -82,25 +82,25 @@ def dispatch(args: argparse.Namespace) -> bool:
     if args.cmd != "acp":
         return False
     if args.acp_cmd == "list":
-        _cmd_list(getattr(args, "project_id", None))
+        _cmd_list(getattr(args, "project_name", None))
     elif args.acp_cmd == "connect":
-        _cmd_connect(args.project_id, args.task_id)
+        _cmd_connect(args.project_name, args.task_id)
     return True
 
 
 # ── list ─────────────────────────────────────────────────────────────────
 
 
-def _cmd_list(project_id_filter: str | None) -> None:
+def _cmd_list(project_name_filter: str | None) -> None:
     """Print one row per ACP endpoint, grouped by project."""
-    projects = _projects_to_show(project_id_filter)
+    projects = _projects_to_show(project_name_filter)
     # ``from __future__ import annotations`` (top of module) makes the
     # ACPEndpointStatus reference below a deferred string — no runtime
     # import needed, so the executor stays out of the cold-start path.
     rows: list[tuple[str, str, ACPEndpointStatus, str | None, Path]] = []
     for project in projects:
         for ep in project.acp_endpoints():
-            rows.append((ep.project_id, ep.task_id, ep.status, ep.bound_agent, ep.socket_path))
+            rows.append((ep.project_name, ep.task_id, ep.status, ep.bound_agent, ep.socket_path))
 
     if not rows:
         print("No ACP endpoints found (no running tasks).")
@@ -121,14 +121,14 @@ def _cmd_list(project_id_filter: str | None) -> None:
         )
 
 
-def _projects_to_show(project_id_filter: str | None) -> list[Project]:
+def _projects_to_show(project_name_filter: str | None) -> list[Project]:
     """Resolve project filter to the list of project objects to walk."""
     from ...lib.api import get_project
 
-    if project_id_filter:
-        return [get_project(project_id_filter)]
+    if project_name_filter:
+        return [get_project(project_name_filter)]
     project_infos = list_projects()
-    return [get_project(info.id) for info in project_infos]
+    return [get_project(info.name) for info in project_infos]
 
 
 # ── connect ──────────────────────────────────────────────────────────────
@@ -167,7 +167,7 @@ def _check_experimental_ack() -> None:
     raise SystemExit(2)
 
 
-def _cmd_connect(project_id: str, task_id: str) -> None:
+def _cmd_connect(project_name: str, task_id: str) -> None:
     """Bridge the caller's stdio to a task's ACP socket.
 
     Refuses to run unless [`_check_experimental_ack`][terok.cli.commands.acp._check_experimental_ack] passes.
@@ -177,11 +177,11 @@ def _cmd_connect(project_id: str, task_id: str) -> None:
     either side reaches EOF.
     """
     _check_experimental_ack()
-    task_id = resolve_task_id(project_id, task_id)
-    sock_path = acp_socket_path(project_id, task_id)
-    log_path = acp_log_path(project_id, task_id)
+    task_id = resolve_task_id(project_name, task_id)
+    sock_path = acp_socket_path(project_name, task_id)
+    log_path = acp_log_path(project_name, task_id)
     if not acp_socket_is_live(sock_path):
-        daemon = _spawn_daemon(project_id, task_id, sock_path, log_path)
+        daemon = _spawn_daemon(project_name, task_id, sock_path, log_path)
         _wait_for_socket(
             sock_path, timeout=_DAEMON_BIND_TIMEOUT_SEC, daemon=daemon, log_path=log_path
         )
@@ -189,7 +189,7 @@ def _cmd_connect(project_id: str, task_id: str) -> None:
 
 
 def _spawn_daemon(
-    project_id: str, task_id: str, sock_path: Path, log_path: Path
+    project_name: str, task_id: str, sock_path: Path, log_path: Path
 ) -> subprocess.Popen:
     """Resolve project+task → container name and spawn the executor daemon.
 
@@ -207,10 +207,10 @@ def _spawn_daemon(
         get_task_meta,
     )
 
-    task_meta = get_task_meta(project_id, task_id)
+    task_meta = get_task_meta(project_name, task_id)
     if task_meta.mode is None:
         raise SystemExit(f"task {task_id} has no mode set; cannot resolve container name")
-    cname = resolve_container_name(project_id, task_meta.mode, task_id)
+    cname = resolve_container_name(project_name, task_meta.mode, task_id)
     log_path.parent.mkdir(parents=True, exist_ok=True)
     log_fd = open(log_path, "ab", buffering=0)  # noqa: SIM115 — handed to Popen
     try:

--- a/src/terok/cli/commands/auth.py
+++ b/src/terok/cli/commands/auth.py
@@ -60,7 +60,7 @@ def register(subparsers: argparse._SubParsersAction[argparse.ArgumentParser]) ->
             "Without arguments, opens an interactive menu to authenticate one "
             "or more providers in sequence.  ``terok auth <provider>`` "
             "authenticates host-wide — credentials are shared across every "
-            "project that uses the same agent.  Pass ``--project <id>`` to "
+            "project that uses the same agent.  Pass ``--project <name>`` to "
             "scope the auth to a specific project: the project's image is "
             "reused, and if the project opted into per-project credentials "
             "(``credentials.scope: project`` in project.yml) the captured "

--- a/src/terok/cli/commands/auth.py
+++ b/src/terok/cli/commands/auth.py
@@ -7,13 +7,13 @@ Three invocation shapes, in increasing specificity:
 
 - ``terok auth``                         — interactive chained menu.
 - ``terok auth <provider>``              — host-wide auth for one provider.
-- ``terok auth <provider> --project ID`` — project-scoped auth.
+- ``terok auth <provider> --project name`` — project-scoped auth.
 
 Where credentials land depends on the named project's
 [`credentials_scope`][terok.lib.core.project_model.ProjectConfig.credentials_scope]:
 ``"shared"`` (default) writes to the host-wide bucket every project
 sees, ``"project"`` carves out a private vault row and agent-config
-mount tree keyed by the project id.  Host-wide ``terok auth`` (no
+mount tree keyed by the project name.  Host-wide ``terok auth`` (no
 ``--project``) always writes to the shared bucket — there's no project
 context to override it.
 """
@@ -29,7 +29,7 @@ from ...lib.api import authenticate
 from ...lib.core.config import is_oauth_enabled_for
 from ...lib.core.images import require_agent_installed
 from ...lib.core.projects import load_project, require_project_exists
-from ._completers import complete_project_ids as _complete_project_ids, set_completer
+from ._completers import complete_project_names as _complete_project_names, set_completer
 
 
 def _provider_of() -> dict[str, str]:
@@ -83,7 +83,7 @@ def register(subparsers: argparse._SubParsersAction[argparse.ArgumentParser]) ->
             default=None,
             help="Scope auth to a project (image + project.yml credentials.scope)",
         ),
-        _complete_project_ids,
+        _complete_project_names,
     )
 
 
@@ -91,38 +91,38 @@ def dispatch(args: argparse.Namespace) -> bool:
     """Handle ``terok auth``.  Returns True if handled."""
     if args.cmd != "auth":
         return False
-    project_id = args.project_flag
+    project_name = args.project_flag
     if args.provider is None:
-        _run_interactive(project_id)
+        _run_interactive(project_name)
     else:
-        _run_one(args.provider, project_id)
+        _run_one(args.provider, project_name)
     return True
 
 
 # ── Implementation helpers ────────────────────────────────────────────
 
 
-def _run_one(provider: str, project_id: str | None) -> None:
+def _run_one(provider: str, project_name: str | None) -> None:
     """Authenticate a single provider, optionally scoped to a project.
 
     *provider* may be an auth-entry name or an LLM-provider alias of one;
     ``authenticate`` resolves it, and the install check resolves it too so the
     baked-agent lookup uses the agent name, not the provider alias.
     """
-    if project_id is not None:
+    if project_name is not None:
         # Project-scoped: verify the L2 image actually has the agent baked
         # in before launching.  Host-wide auth resolves the image in the
         # facade and does its own checks there.
         require_agent_installed(
-            load_project(project_id), resolve_auth_provider(provider), noun="Provider"
+            load_project(project_name), resolve_auth_provider(provider), noun="Provider"
         )
-    authenticate(provider, project_id)
+    authenticate(provider, project_name)
 
 
-def _run_interactive(project_id: str | None) -> None:
+def _run_interactive(project_name: str | None) -> None:
     """Interactively pick one or more providers and authenticate each in turn."""
-    if project_id is not None:
-        require_project_exists(project_id)
+    if project_name is not None:
+        require_project_exists(project_name)
 
     provider_names = list(AUTH_PROVIDERS)
     provider_of = _provider_of()
@@ -154,7 +154,7 @@ def _run_interactive(project_id: str | None) -> None:
 
     for provider in selected:
         print(f"\n── {provider} ─────────────────────")
-        _run_one(provider, project_id)
+        _run_one(provider, project_name)
 
 
 def _parse_provider_selection(raw: str, provider_names: list[str]) -> list[str]:

--- a/src/terok/cli/commands/image.py
+++ b/src/terok/cli/commands/image.py
@@ -9,7 +9,7 @@ import argparse
 
 from ...lib.api import find_orphaned_images, list_images, remove_images, require_project_exists
 from . import _storage_view
-from ._completers import complete_project_ids as _complete_project_ids, set_completer
+from ._completers import complete_project_names as _complete_project_names, set_completer
 
 
 def register(subparsers: argparse._SubParsersAction[argparse.ArgumentParser]) -> None:
@@ -33,12 +33,12 @@ def register(subparsers: argparse._SubParsersAction[argparse.ArgumentParser]) ->
     )
     set_completer(
         p_build.add_argument(
-            "project_id",
+            "project_name",
             nargs="?",
             default=None,
             help="Project whose base + agents to build for (optional)",
         ),
-        _complete_project_ids,
+        _complete_project_names,
     )
     p_build.add_argument(
         "--base",
@@ -74,8 +74,8 @@ def register(subparsers: argparse._SubParsersAction[argparse.ArgumentParser]) ->
     # image list
     p_list = image_sub.add_parser("list", help="List terok images with sizes")
     set_completer(
-        p_list.add_argument("project_id", nargs="?", default=None, help="Filter by project"),
-        _complete_project_ids,
+        p_list.add_argument("project_name", nargs="?", default=None, help="Filter by project"),
+        _complete_project_names,
     )
 
     # image cleanup
@@ -104,7 +104,7 @@ def register(subparsers: argparse._SubParsersAction[argparse.ArgumentParser]) ->
             default=None,
             help="Show detailed per-task breakdown for one project",
         ),
-        _complete_project_ids,
+        _complete_project_names,
     )
     p_usage.add_argument(
         "--json",
@@ -122,7 +122,7 @@ def dispatch(args: argparse.Namespace) -> bool:
     match args.image_cmd:
         case "build":
             _cmd_build(
-                project_id=getattr(args, "project_id", None),
+                project_name=getattr(args, "project_name", None),
                 base=getattr(args, "base", None),
                 agents=getattr(args, "agents", None),
                 family=getattr(args, "family", None),
@@ -131,7 +131,7 @@ def dispatch(args: argparse.Namespace) -> bool:
                 sidecar=getattr(args, "sidecar", False),
             )
         case "list":
-            _cmd_list(getattr(args, "project_id", None))
+            _cmd_list(getattr(args, "project_name", None))
         case "cleanup":
             _cmd_cleanup(
                 dry_run=getattr(args, "dry_run", False),
@@ -139,7 +139,7 @@ def dispatch(args: argparse.Namespace) -> bool:
             )
         case "usage":
             _cmd_usage(
-                project_id=getattr(args, "project", None),
+                project_name=getattr(args, "project", None),
                 json_output=getattr(args, "json_output", False),
             )
         case _:  # pragma: no cover — required=True makes argparse enforce this
@@ -149,7 +149,7 @@ def dispatch(args: argparse.Namespace) -> bool:
 
 def _cmd_build(
     *,
-    project_id: str | None,
+    project_name: str | None,
     base: str | None,
     agents: str | None,
     family: str | None,
@@ -159,7 +159,7 @@ def _cmd_build(
 ) -> None:
     """Build the L0+L1 images via the executor primitive.
 
-    With *project_id* set, derives the base image, family, and agent roster
+    With *project_name* set, derives the base image, family, and agent roster
     from the project's config (CLI overrides still win for any of the three).
     Without it, falls back to the user's global ``image.*`` defaults.
     """
@@ -173,7 +173,7 @@ def _cmd_build(
 
     from ...lib.core.projects import load_project
 
-    project = load_project(project_id) if project_id else None
+    project = load_project(project_name) if project_name else None
 
     try:
         if project is not None:
@@ -209,21 +209,21 @@ def _cmd_build(
         print(f"L1 (sidecar): {sidecar_tag}")
 
 
-def _cmd_usage(*, project_id: str | None, json_output: bool) -> None:
+def _cmd_usage(*, project_name: str | None, json_output: bool) -> None:
     """Dispatch usage display to the appropriate render mode."""
-    if project_id:
-        _storage_view.cmd_detail(project_id, json_output=json_output)
+    if project_name:
+        _storage_view.cmd_detail(project_name, json_output=json_output)
     else:
         _storage_view.cmd_overview(json_output=json_output)
 
 
-def _cmd_list(project_id: str | None) -> None:
+def _cmd_list(project_name: str | None) -> None:
     """List terok-managed images with sizes."""
-    if project_id is not None:
-        require_project_exists(project_id)
-    images = list_images(project_id)
+    if project_name is not None:
+        require_project_exists(project_name)
+    images = list_images(project_name)
     if not images:
-        scope = f" for project '{project_id}'" if project_id else ""
+        scope = f" for project '{project_name}'" if project_name else ""
         print(f"No terok images found{scope}.")
         return
 

--- a/src/terok/cli/commands/info.py
+++ b/src/terok/cli/commands/info.py
@@ -46,7 +46,7 @@ from ...ui_utils.terminal import (
     violet as _violet,
     yes_no as _yes_no,
 )
-from ._completers import complete_project_ids as _complete_project_ids, set_completer
+from ._completers import complete_project_names as _complete_project_names, set_completer
 from .completions import is_completion_installed as _is_completion_installed
 
 
@@ -69,7 +69,9 @@ def register(subparsers: argparse._SubParsersAction[argparse.ArgumentParser]) ->
         "resolved",
         help="Show resolved agent config for a project (with provenance per level)",
     )
-    set_completer(p_resolved.add_argument("project_id", help="Project ID"), _complete_project_ids)
+    set_completer(
+        p_resolved.add_argument("project_name", help="Project name"), _complete_project_names
+    )
     from ._completers import complete_preset_names
 
     set_completer(
@@ -112,7 +114,7 @@ def dispatch(args: argparse.Namespace) -> bool:
         case "get-root":
             _cmd_get_root()
         case "resolved":
-            _cmd_config_resolved(args.project_id, getattr(args, "preset", None))
+            _cmd_config_resolved(args.project_name, getattr(args, "preset", None))
         case "schema":
             _cmd_config_schema(args.scope, args.as_json)
         case "import-opencode":
@@ -191,7 +193,7 @@ def _print_read_paths(color: bool) -> None:
         print("- Project configs:")
         for proj in projs:
             print(
-                f"  • {_violet(str(proj.id), color)}: "
+                f"  • {_violet(str(proj.name), color)}: "
                 f"{_gray(str(proj.root / 'project.yml'), color)}"
             )
     else:
@@ -229,7 +231,7 @@ def _print_writable_paths(color: bool) -> None:
         return
     print("- Expected generated files per project:")
     for p in projs:
-        base = bdir / p.id
+        base = bdir / p.name
         for fname in (
             "L0.Dockerfile",
             "L1.cli.Dockerfile",
@@ -238,7 +240,7 @@ def _print_writable_paths(color: bool) -> None:
         ):
             path = base / fname
             print(
-                f"  • {_violet(str(p.id), color)}: "
+                f"  • {_violet(str(p.name), color)}: "
                 f"{_gray(str(path), color)} "
                 f"(exists: {_yes_no(path.is_file(), color)})"
             )
@@ -300,16 +302,16 @@ def _list_resource_names(pkg: Any, *, suffix: str | None, warn_label: str) -> li
 # ── config resolved ────────────────────────────────────────────────────
 
 
-def _cmd_config_resolved(project_id: str, preset: str | None) -> None:
+def _cmd_config_resolved(project_name: str, preset: str | None) -> None:
     """Show resolved agent config with provenance annotations."""
     from ...lib.core.projects import load_project
     from ...lib.orchestration.agent_config import build_agent_config_stack
 
     color = _supports_color()
 
-    project = load_project(project_id)
+    project = load_project(project_name)
     stack = build_agent_config_stack(
-        project_id,
+        project_name,
         agent_config=project.agent_config,
         project_root=project.root,
         preset=preset,
@@ -318,10 +320,10 @@ def _cmd_config_resolved(project_id: str, preset: str | None) -> None:
     scopes = stack.scopes
 
     if not scopes and not resolved:
-        print(f"No agent config defined for project '{project_id}'")
+        print(f"No agent config defined for project '{project_name}'")
         return
 
-    print(f"Resolved agent config for '{project_id}':")
+    print(f"Resolved agent config for '{project_name}':")
     if preset:
         print(f"  (with preset: {preset})")
     print()

--- a/src/terok/cli/commands/project.py
+++ b/src/terok/cli/commands/project.py
@@ -18,7 +18,7 @@ from ...lib.api import (
     set_project_image_agents,
     summarize_ssh_init,
 )
-from ...lib.core.projects import list_presets, list_projects, load_project
+from ...lib.core.projects import list_presets, list_projects, load_project, normalize_project_name
 from ...lib.domain.project import make_git_gate
 from ...lib.domain.wizards.new_project import offer_edit_then_init, run_wizard
 from ._completers import complete_project_names as _complete_project_names, set_completer
@@ -54,6 +54,19 @@ def register(subparsers: argparse._SubParsersAction[argparse.ArgumentParser]) ->
         _complete_project_names,
     )
     p_derive.add_argument("new_id", help="New project name")
+
+    # normalize-name
+    p_normalize = sub.add_parser(
+        "normalize-name",
+        help="Repair project.yml so project.name matches the project directory name",
+    )
+    _add_project_arg(
+        p_normalize,
+        help=(
+            "Project directory name to write into project.yml "
+            "(works even when that project is currently broken)"
+        ),
+    )
 
     # delete
     p_delete = sub.add_parser(
@@ -210,6 +223,8 @@ def dispatch(args: argparse.Namespace) -> bool:
             run_wizard(init_fn=cmd_project_init)
         case "derive":
             _cmd_project_derive(args.source_id, args.new_id)
+        case "normalize-name":
+            _cmd_project_normalize_name(args.project_name)
         case "delete":
             _cmd_project_delete(args.project_name, force=args.force)
         case "init":
@@ -269,6 +284,12 @@ def _cmd_project_derive(source_id: str, new_id: str) -> None:
         f"Config: {config_path}"
     )
     offer_edit_then_init(config_path, new_id, init_fn=cmd_project_init)
+
+
+def _cmd_project_normalize_name(project_name: str) -> None:
+    """Rewrite project.yml so ``project.name`` matches *project_name*."""
+    path = normalize_project_name(project_name)
+    print(f"Updated {path}: project.name = {project_name!r}")
 
 
 def _cmd_project_delete(project_name: str, *, force: bool = False) -> None:

--- a/src/terok/cli/commands/project.py
+++ b/src/terok/cli/commands/project.py
@@ -21,13 +21,13 @@ from ...lib.api import (
 from ...lib.core.projects import list_presets, list_projects, load_project
 from ...lib.domain.project import make_git_gate
 from ...lib.domain.wizards.new_project import offer_edit_then_init, run_wizard
-from ._completers import complete_project_ids as _complete_project_ids, set_completer
+from ._completers import complete_project_names as _complete_project_names, set_completer
 from .setup import cmd_project_init
 
 
 def _add_project_arg(parser: argparse.ArgumentParser, **kwargs: Any) -> None:
-    """Add a ``project_id`` positional with project-ID completion."""
-    set_completer(parser.add_argument("project_id", **kwargs), _complete_project_ids)
+    """Add a ``project_name`` positional with project name completion."""
+    set_completer(parser.add_argument("project_name", **kwargs), _complete_project_names)
 
 
 def register(subparsers: argparse._SubParsersAction[argparse.ArgumentParser]) -> None:
@@ -50,17 +50,17 @@ def register(subparsers: argparse._SubParsersAction[argparse.ArgumentParser]) ->
         help="Create a new project derived from an existing one (shared infra, fresh agent config)",
     )
     set_completer(
-        p_derive.add_argument("source_id", help="Source project ID to derive from"),
-        _complete_project_ids,
+        p_derive.add_argument("source_id", help="Source project name to derive from"),
+        _complete_project_names,
     )
-    p_derive.add_argument("new_id", help="New project ID")
+    p_derive.add_argument("new_id", help="New project name")
 
     # delete
     p_delete = sub.add_parser(
         "delete",
         help="Delete a project and all its associated data (non-recoverable)",
     )
-    _add_project_arg(p_delete, help="Project ID to delete")
+    _add_project_arg(p_delete, help="Project name to delete")
     p_delete.add_argument("--force", action="store_true", help="Skip confirmation prompt")
 
     # init — full setup
@@ -211,14 +211,14 @@ def dispatch(args: argparse.Namespace) -> bool:
         case "derive":
             _cmd_project_derive(args.source_id, args.new_id)
         case "delete":
-            _cmd_project_delete(args.project_id, force=args.force)
+            _cmd_project_delete(args.project_name, force=args.force)
         case "init":
-            cmd_project_init(args.project_id)
+            cmd_project_init(args.project_name)
         case "generate":
-            generate_dockerfiles(args.project_id)
+            generate_dockerfiles(args.project_name)
         case "build":
             build_images(
-                args.project_id,
+                args.project_name,
                 include_dev=getattr(args, "dev", False),
                 refresh_agents=getattr(args, "refresh_agents", False),
                 full_rebuild=getattr(args, "full_rebuild", False),
@@ -227,15 +227,15 @@ def dispatch(args: argparse.Namespace) -> bool:
         case "ssh-init":
             _cmd_ssh_init(args)
         case "gate-path":
-            _cmd_gate_path(args.project_id)
+            _cmd_gate_path(args.project_name)
         case "gate-sync":
             _cmd_gate_sync(args)
         case "presets":
             if args.presets_cmd == "list":
-                _cmd_presets(args.project_id)
+                _cmd_presets(args.project_name)
         case "agents":
             if args.agents_cmd == "set":
-                _cmd_agents_set(args.project_id, getattr(args, "selection", None))
+                _cmd_agents_set(args.project_name, getattr(args, "selection", None))
         case _:  # pragma: no cover — required=True makes argparse enforce this
             return False
     return True
@@ -254,7 +254,9 @@ def _cmd_project_list() -> None:
     for p in projs:
         upstream = p.upstream_url or "-"
         shared = f" shared={p.shared_dir}" if p.shared_dir else ""
-        print(f"- {p.id} [{p.security_class}] upstream={upstream}{shared} config_root={p.root}")
+        print(f"- {p.name} [{p.security_class}] upstream={upstream}{shared} config_root={p.root}")
+        if p.description:
+            print(f"    {p.description}")
 
 
 def _cmd_project_derive(source_id: str, new_id: str) -> None:
@@ -269,10 +271,10 @@ def _cmd_project_derive(source_id: str, new_id: str) -> None:
     offer_edit_then_init(config_path, new_id, init_fn=cmd_project_init)
 
 
-def _cmd_project_delete(project_id: str, *, force: bool = False) -> None:
+def _cmd_project_delete(project_name: str, *, force: bool = False) -> None:
     """Delete a project after confirmation (unless --force)."""
-    project = load_project(project_id)
-    pid = project.id
+    project = load_project(project_name)
+    pid = project.name
 
     print(f"Project: {pid}")
     print(f"  Config root: {project.root}")
@@ -319,7 +321,7 @@ def _cmd_project_delete(project_id: str, *, force: bool = False) -> None:
 
 def _cmd_ssh_init(args: argparse.Namespace) -> None:
     """Provision a vault-managed SSH keypair for the project."""
-    result = get_project(args.project_id).provision_ssh_key(
+    result = get_project(args.project_name).provision_ssh_key(
         key_type=getattr(args, "key_type", "ed25519"),
         comment=getattr(args, "comment", None),
         force=getattr(args, "force", False),
@@ -327,7 +329,7 @@ def _cmd_ssh_init(args: argparse.Namespace) -> None:
     summarize_ssh_init(result)
 
 
-def _cmd_gate_path(project_id: str) -> None:
+def _cmd_gate_path(project_name: str) -> None:
     """Print the project's host-side git gate mirror as a ``file://`` URL.
 
     Plain stdout so callers can paste the URL into an IDE or a host-side
@@ -345,17 +347,17 @@ def _cmd_gate_path(project_id: str) -> None:
     is printed even if the bare repo doesn't exist yet (run ``gate-sync``
     to create it).
     """
-    print(load_project(project_id).gate_path.as_uri())
+    print(load_project(project_name).gate_path.as_uri())
 
 
 def _cmd_gate_sync(args: argparse.Namespace) -> None:
     """Sync the host-side git gate for a project."""
     from terok.lib.api.gate import GateAuthNotConfigured
 
-    project = load_project(args.project_id)
+    project = load_project(args.project_name)
     if not project.gate_enabled:
         raise SystemExit(
-            f"Project {project.id!r} has gate.enabled: false — refusing to sync.\n"
+            f"Project {project.name!r} has gate.enabled: false — refusing to sync.\n"
             "Either set gate.enabled: true in project.yml, or drop the "
             "gate-sync step entirely (the container clones directly from "
             "upstream, if any)."
@@ -369,7 +371,7 @@ def _cmd_gate_sync(args: argparse.Namespace) -> None:
     except GateAuthNotConfigured as exc:
         raise SystemExit(
             f"{exc}\n\nEither:\n"
-            f"  * terok project ssh-init {args.project_id}  "
+            f"  * terok project ssh-init {args.project_name}  "
             "(generate a key, then register it with the remote), or\n"
             "  * pass --use-personal-ssh to fall through to ~/.ssh."
         ) from exc
@@ -383,23 +385,23 @@ def _cmd_gate_sync(args: argparse.Namespace) -> None:
     )
 
 
-def _cmd_presets(project_id: str) -> None:
+def _cmd_presets(project_name: str) -> None:
     """List available agent-config presets for a project."""
-    presets = list_presets(project_id)
+    presets = list_presets(project_name)
     if not presets:
-        print(f"No presets found for project '{project_id}'")
+        print(f"No presets found for project '{project_name}'")
         return
-    print(f"Presets for '{project_id}':")
+    print(f"Presets for '{project_name}':")
     for info in presets:
         print(f"  - {info.name} ({info.source})")
 
 
-def _cmd_agents_set(project_id: str, selection: str | None) -> None:
+def _cmd_agents_set(project_name: str, selection: str | None) -> None:
     """Validate *selection* and write it to the project's ``image.agents``."""
     from terok.lib.api.agents import AgentRoster
 
     roster = AgentRoster.shared()
     raw = selection if selection is not None else roster.prompt_selection()
     roster.validate_selection(raw)
-    path = set_project_image_agents(project_id, raw)
+    path = set_project_image_agents(project_name, raw)
     print(f"Wrote image.agents = {raw!r} to {path}")

--- a/src/terok/cli/commands/setup.py
+++ b/src/terok/cli/commands/setup.py
@@ -336,7 +336,7 @@ def _ensure_shell_completions() -> None:
 # ── Per-project setup ──────────────────────────────────────────────────
 
 
-def cmd_project_init(project_id: str) -> None:
+def cmd_project_init(project_name: str) -> None:
     """Full project setup: ssh-init, generate, build, gate-sync.
 
     The final gate-sync step is skipped when ``gate.enabled`` is false in
@@ -346,18 +346,18 @@ def cmd_project_init(project_id: str) -> None:
     blocking SSH, corporate proxy, offline laptop) while the container's
     network path still works.
     """
-    require_project_exists(project_id)
+    require_project_exists(project_name)
 
-    project = get_project(project_id)
+    project = get_project(project_name)
     print("==> Initializing SSH...")
     summarize_ssh_init(project.provision_ssh_key())
     project.pause_for_ssh_key_registration_if_needed()
 
     print("==> Generating Dockerfiles...")
-    generate_dockerfiles(project_id)
+    generate_dockerfiles(project_name)
 
     print("==> Building images...")
-    build_images(project_id)
+    build_images(project_name)
 
     if not project.config.gate_enabled:
         print("==> Gate disabled by project.yml — skipping gate-sync.")

--- a/src/terok/cli/commands/shield.py
+++ b/src/terok/cli/commands/shield.py
@@ -4,7 +4,7 @@
 """Shield egress firewall management commands.
 
 Uses the ``terok_shield`` command registry to build subcommands.
-Commands that need a container take positional ``project_id task_id``
+Commands that need a container take positional ``project_name task_id``
 (same convention as ``terok task …``), which are resolved to a
 container name + task directory for the registry handler.
 """
@@ -42,7 +42,7 @@ def _add_arg(parser: argparse.ArgumentParser, arg: ArgDef) -> None:
     parser.add_argument(arg.name, **kwargs)
 
 
-def _resolve_task(project_id: str, task_id: str) -> tuple[str, Path]:
+def _resolve_task(project_name: str, task_id: str) -> tuple[str, Path]:
     """Resolve project+task to (container_name, task_dir).
 
     Returns:
@@ -54,14 +54,14 @@ def _resolve_task(project_id: str, task_id: str) -> tuple[str, Path]:
     from ...lib.core.projects import load_project
     from ...lib.orchestration.tasks import container_name, load_task_meta
 
-    project = load_project(project_id)
-    meta, _ = load_task_meta(project.id, task_id)
+    project = load_project(project_name)
+    meta, _ = load_task_meta(project.name, task_id)
     mode = meta.get("mode")
     if mode is None:
         raise ValueError(
-            f"Task {task_id} in project {project_id!r} has never been run — no container exists"
+            f"Task {task_id} in project {project_name!r} has never been run — no container exists"
         )
-    cname = container_name(project.id, mode, task_id)
+    cname = container_name(project.name, mode, task_id)
     task_dir = project.tasks_root / str(task_id)
     return cname, task_dir
 
@@ -70,7 +70,7 @@ def _extract_handler_kwargs(args: argparse.Namespace, cmd_def: CommandDef) -> di
     """Extract keyword arguments for a registry handler from parsed args.
 
     Skips the positional ``container`` arg (the CLI resolves it from
-    ``project_id`` + ``task_id``) and ``--container-id``
+    ``project_name`` + ``task_id``) and ``--container-id``
     (the orchestrator resolves it from the container's UUID — see
     [`resolve_container_uuid`][terok.lib.orchestration.task_runners.shield.resolve_container_uuid]).
     """
@@ -121,18 +121,18 @@ def register(subparsers: argparse._SubParsersAction[argparse.ArgumentParser]) ->
 
         sp = sub.add_parser(cmd.name, help=cmd.help)
 
-        # Commands that need a container get positional project_id + task_id,
+        # Commands that need a container get positional project_name + task_id,
         # matching the ``terok task …`` convention.  Commands with an
         # *optional* container arg (like ``status``) get nargs="?" so they
         # work both with and without a task target.  Completers attach
         # either way so tab-complete works in both forms.
-        from ._completers import add_project_id, add_task_id
+        from ._completers import add_project_name, add_task_id
 
         if shield_needs_container(cmd):
-            add_project_id(sp, help="Project ID")
+            add_project_name(sp, help="Project name")
             add_task_id(sp, help="Task ID")
         elif any(a.name == "container" for a in cmd.args):
-            add_project_id(sp, nargs="?", help="Project ID")
+            add_project_name(sp, nargs="?", help="Project name")
             add_task_id(sp, nargs="?", help="Task ID")
 
         # ``--container-id`` is the per-container hub socket routing
@@ -174,19 +174,19 @@ def dispatch(args: argparse.Namespace) -> bool:
     if cmd_def is None or cmd_def.handler is None:
         return False
 
-    project_id = getattr(args, "project_id", None)
+    project_name = getattr(args, "project_name", None)
     task_id = getattr(args, "task_id", None)
-    if (project_id is None) != (task_id is None):
-        print("Error: provide both <project_id> and <task_id>, or neither", file=sys.stderr)
+    if (project_name is None) != (task_id is None):
+        print("Error: provide both <project_name> and <task_id>, or neither", file=sys.stderr)
         sys.exit(1)
-    has_task = project_id is not None and task_id is not None
+    has_task = project_name is not None and task_id is not None
 
     try:
         # mypy narrows the inner pair via the explicit check; ``has_task``
         # is kept around for the except branch's error wording below.
-        if project_id is not None and task_id is not None:
-            task_id = resolve_task_id(project_id, task_id)
-            cname, task_dir = _resolve_task(project_id, task_id)
+        if project_name is not None and task_id is not None:
+            task_id = resolve_task_id(project_name, task_id)
+            cname, task_dir = _resolve_task(project_name, task_id)
             shield = ShieldManager(task_dir, make_sandbox_config()).shield
             kwargs = _extract_handler_kwargs(args, cmd_def)
             if cmd_name in {"up", "down"}:

--- a/src/terok/cli/commands/sickbay.py
+++ b/src/terok/cli/commands/sickbay.py
@@ -34,7 +34,7 @@ from terok.lib.api.vault import VaultStatusSnapshot
 
 from ...lib.core import runtime as _rt
 from ...lib.core.config import get_services_mode, global_config_path
-from ...lib.core.project_model import ProjectConfig, is_valid_project_id
+from ...lib.core.project_model import ProjectConfig, is_valid_project_name
 from ...lib.core.projects import list_projects, load_project
 from ...lib.orchestration.container_doctor import ContainerDoctor
 from ...lib.orchestration.hooks import run_hook
@@ -56,11 +56,11 @@ _CheckResult = tuple[str, str, str]
 def register(subparsers: argparse._SubParsersAction[argparse.ArgumentParser]) -> None:
     """Register the ``sickbay`` subcommand."""
     p = subparsers.add_parser("sickbay", help="Run health checks and reconciliation")
-    # dest=project_id / task_id matches the rest of the CLI so the shared
+    # dest=project_name / task_id matches the rest of the CLI so the shared
     # completers work; metavar keeps the display ``<project>``/``<task>``.
-    from ._completers import add_project_id, add_task_id
+    from ._completers import add_project_name, add_task_id
 
-    add_project_id(p, nargs="?", metavar="project", help="Scope to a single project")
+    add_project_name(p, nargs="?", metavar="project", help="Scope to a single project")
     add_task_id(p, nargs="?", metavar="task", help="Scope to a single task")
     p.add_argument("--fix", action="store_true", help="Auto-remediate issues")
 
@@ -69,12 +69,12 @@ def dispatch(args: argparse.Namespace) -> bool:
     """Handle the sickbay command.  Returns True if handled."""
     if args.cmd != "sickbay":
         return False
-    project_id = getattr(args, "project_id", None)
+    project_name = getattr(args, "project_name", None)
     task_id = getattr(args, "task_id", None)
-    if project_id and task_id:
-        task_id = resolve_task_id(project_id, task_id)
+    if project_name and task_id:
+        task_id = resolve_task_id(project_name, task_id)
     _cmd_sickbay(
-        project_id=project_id,
+        project_name=project_name,
         task_id=task_id,
         fix=getattr(args, "fix", False),
     )
@@ -191,7 +191,7 @@ def _task_meta_path(pid: str, tid: str) -> Path | None:
     files from earlier installs are migrated by ``read_task_meta`` on
     the read path.
     """
-    if not is_valid_project_id(pid) or not is_task_id(tid):
+    if not is_valid_project_name(pid) or not is_task_id(tid):
         return None
     return meta_path(tasks_meta_dir(pid), tid)
 
@@ -200,7 +200,7 @@ def _check_task_hook(
     pid: str, tid: str, project: ProjectConfig, *, fix: bool
 ) -> _CheckResult | None:
     """Check a single task for unfired post_stop hook.  Returns None if ok."""
-    if not is_valid_project_id(pid) or not is_task_id(tid):
+    if not is_valid_project_name(pid) or not is_task_id(tid):
         return None
     meta_dir = tasks_meta_dir(pid)
     try:
@@ -244,7 +244,7 @@ def _reconcile_post_stop(
         run_hook(
             "post_stop",
             project.hook_post_stop,
-            project_id=pid,
+            project_name=pid,
             task_id=tid,
             mode=mode,
             cname=cname,
@@ -265,7 +265,7 @@ def _check_task_shield_annotation(
     TUI (which only know the container name) to the wrong state dir, or to
     nothing at all.  Non-shielded containers and stopped ones are skipped.
     """
-    if not is_valid_project_id(pid) or not is_task_id(tid):
+    if not is_valid_project_name(pid) or not is_task_id(tid):
         return None
     meta_dir = tasks_meta_dir(pid)
     try:
@@ -305,15 +305,15 @@ def _check_task_shield_annotation(
 
 
 def _check_unfired_hooks(
-    project_id: str | None, task_id: str | None, *, fix: bool
+    project_name: str | None, task_id: str | None, *, fix: bool
 ) -> list[_CheckResult]:
     """Check for stopped tasks with unfired post_stop hooks."""
     results: list[_CheckResult] = []
 
-    if project_id:
-        projects = [(project_id, load_project(project_id))]
+    if project_name:
+        projects = [(project_name, load_project(project_name))]
     else:
-        projects = [(p.id, p) for p in list_projects()]
+        projects = [(p.name, p) for p in list_projects()]
 
     for pid, project in projects:
         if not project.hook_post_stop:
@@ -331,14 +331,14 @@ def _check_unfired_hooks(
     return results
 
 
-def _check_shield_annotations(project_id: str | None, task_id: str | None) -> list[_CheckResult]:
+def _check_shield_annotations(project_name: str | None, task_id: str | None) -> list[_CheckResult]:
     """Check that every running task's container carries the expected shield annotation."""
     results: list[_CheckResult] = []
 
-    if project_id:
-        projects = [(project_id, load_project(project_id))]
+    if project_name:
+        projects = [(project_name, load_project(project_name))]
     else:
-        projects = [(p.id, p) for p in list_projects()]
+        projects = [(p.name, p) for p in list_projects()]
 
     for pid, project in projects:
         meta_dir = tasks_meta_dir(pid)
@@ -354,7 +354,7 @@ def _check_shield_annotations(project_id: str | None, task_id: str | None) -> li
 
 
 def _sanitize_id(value: str) -> str:
-    """Strip C0/C1 control characters from a project ID for safe terminal output."""
+    """Strip C0/C1 control characters from a project name for safe terminal output."""
     import unicodedata
 
     return "".join(
@@ -364,7 +364,7 @@ def _sanitize_id(value: str) -> str:
 
 
 def _abbreviate(ids: list[str], limit: int = 3) -> str:
-    """Join project IDs with a '+N more' suffix when the list is long."""
+    """Join project names with a '+N more' suffix when the list is long."""
     suffix = f" (+{len(ids) - limit} more)" if len(ids) > limit else ""
     return ", ".join(_sanitize_id(i) for i in ids[:limit]) + suffix
 
@@ -384,7 +384,7 @@ def _check_ssh_signer() -> _CheckResult:
     except Exception as exc:  # noqa: BLE001
         return ("warn", label, f"vault unreachable — {exc}")
 
-    unregistered = [p.id for p in projects if p.id not in assigned_scopes]
+    unregistered = [p.name for p in projects if p.name not in assigned_scopes]
     registered = len(projects) - len(unregistered)
     total = len(projects)
 
@@ -399,7 +399,7 @@ def _check_ssh_signer() -> _CheckResult:
 
 
 def _stream_containers(
-    project_id: str | None,
+    project_name: str | None,
     task_id: str | None,
     *,
     fix: bool,
@@ -412,19 +412,19 @@ def _stream_containers(
     — it emits an informational line for non-running containers, so we
     simply forward all tasks and let the orchestrator decide.
     """
-    if project_id and task_id:
-        ContainerDoctor(project_id, task_id).run(
+    if project_name and task_id:
+        ContainerDoctor(project_name, task_id).run(
             fix=fix,
             reporter=reporter,
-            label_prefix=f"Task {project_id}/{task_id}: ",
+            label_prefix=f"Task {project_name}/{task_id}: ",
         )
         return
 
     # Project or global scope — iterate all known tasks
-    if project_id:
-        projects = [(project_id, load_project(project_id))]
+    if project_name:
+        projects = [(project_name, load_project(project_name))]
     else:
-        projects = [(p.id, p) for p in list_projects()]
+        projects = [(p.name, p) for p in list_projects()]
 
     for pid, _project in projects:
         meta_dir = tasks_meta_dir(pid)
@@ -598,7 +598,7 @@ rows and the output looks broken.
 
 
 def _cmd_sickbay(
-    project_id: str | None = None,
+    project_name: str | None = None,
     task_id: str | None = None,
     fix: bool = False,
 ) -> None:
@@ -615,19 +615,19 @@ def _cmd_sickbay(
         # blank line between stage groups.
         print()
 
-    for status, label, detail in _check_unfired_hooks(project_id, task_id, fix=fix):
+    for status, label, detail in _check_unfired_hooks(project_name, task_id, fix=fix):
         reporter.emit(status, label, detail)
-    for status, label, detail in _check_shield_annotations(project_id, task_id):
+    for status, label, detail in _check_shield_annotations(project_name, task_id):
         reporter.emit(status, label, detail)
 
-    _stream_containers(project_id, task_id, fix=fix, reporter=reporter)
+    _stream_containers(project_name, task_id, fix=fix, reporter=reporter)
 
     # Single-task summary: ``ok (consistent)`` iff every check for this
     # task came back clean.  Globals aren't run in the ``task_id`` scope,
     # so the reporter's worst-status at this point covers exactly the
     # three task-scoped check sets.
     if task_id and reporter.worst_status == "ok":
-        reporter.emit("ok", f"Task {project_id}/{task_id}", "consistent")
+        reporter.emit("ok", f"Task {project_name}/{task_id}", "consistent")
 
     if reporter.worst_status == "error":
         sys.exit(2)

--- a/src/terok/cli/commands/task.py
+++ b/src/terok/cli/commands/task.py
@@ -36,16 +36,16 @@ from ...lib.api import (
 )
 from ...lib.core.config import get_logs_partial_streaming as _get_logs_partial_streaming
 from ...lib.orchestration.tasks import resolve_task_id
-from ._completers import add_project_id, add_task_id, complete_preset_names, set_completer
+from ._completers import add_project_name, add_task_id, complete_preset_names, set_completer
 
 
 def _add_project_arg(parser: argparse.ArgumentParser, **kwargs: object) -> None:
-    """Add a ``project_id`` positional with project-ID completion."""
-    add_project_id(parser, **kwargs)
+    """Add a ``project_name`` positional with project name completion."""
+    add_project_name(parser, **kwargs)
 
 
 def _add_project_task_args(parser: argparse.ArgumentParser) -> None:
-    """Add ``project_id`` and ``task_id`` positionals with completers.
+    """Add ``project_name`` and ``task_id`` positionals with completers.
 
     The ``task_id`` positional is ``nargs="?"`` so the same parser
     accepts both forms — ``terok task <verb> proj task`` (two
@@ -57,12 +57,12 @@ def _add_project_task_args(parser: argparse.ArgumentParser) -> None:
     the slash form into the canonical pair before any verb-specific
     handling.
     """
-    add_project_id(parser)
+    add_project_name(parser)
     add_task_id(parser, nargs="?", default=None)
 
 
 def _normalize_pt(args: argparse.Namespace) -> None:
-    """If ``project_id`` is ``"<p>/<t>"`` and ``task_id`` is unset, split it.
+    """If ``project_name`` is ``"<p>/<t>"`` and ``task_id`` is unset, split it.
 
     Idempotent — calling twice has the same effect.  Inputs without
     ``/`` or with ``task_id`` already set pass through untouched.
@@ -77,13 +77,13 @@ def _normalize_pt(args: argparse.Namespace) -> None:
     ``/`` (covers nested segments like ``"proj/a/b"`` where the tail
     ``"a/b"`` would otherwise reach the filesystem helpers verbatim).
     """
-    pid = getattr(args, "project_id", None)
+    pid = getattr(args, "project_name", None)
     if isinstance(pid, str) and "/" in pid and getattr(args, "task_id", None) is None:
         project, _, task = pid.partition("/")
-        for part, label in ((project, "project_id"), (task, "task_id")):
+        for part, label in ((project, "project_name"), (task, "task_id")):
             if not part or part in (".", "..") or part.startswith("..") or "/" in part:
                 raise SystemExit(f"Invalid slash-form {label}: {part!r}")
-        args.project_id = project
+        args.project_name = project
         args.task_id = task or None
 
 
@@ -143,7 +143,7 @@ def register(
         "run",
         help="Create a new task and run it (mode selects the runtime)",
     )
-    _add_project_arg(t_run, help="Project ID")
+    _add_project_arg(t_run, help="Project name")
     t_run.add_argument(
         "--mode",
         choices=("cli", "toad", "headless"),
@@ -381,8 +381,8 @@ def dispatch(args: argparse.Namespace) -> bool:
     """Handle task-related commands.  Returns True if handled."""
     _normalize_pt(args)
     if args.cmd == "login":
-        tid = resolve_task_id(args.project_id, args.task_id)
-        task_login(args.project_id, tid)
+        tid = resolve_task_id(args.project_name, args.task_id)
+        task_login(args.project_name, tid)
         return True
     if args.cmd == "task":
         return _dispatch_task_sub(args)
@@ -494,7 +494,7 @@ def _cmd_task_run_interactive(args: argparse.Namespace, *, runner: Any, attach: 
     URL + token and returns; CLI under *attach* execs into ``task_login``
     once the container reports ready.
     """
-    pid = args.project_id
+    pid = args.project_name
     _ensure_project_image(pid)
     tid = task_new(pid, name=getattr(args, "name", None))
     runner(
@@ -521,11 +521,11 @@ def _cmd_task_run_headless(args: argparse.Namespace) -> None:
 
     instructions_text = _read_instructions(getattr(args, "instructions", None))
 
-    _ensure_project_image(args.project_id)
+    _ensure_project_image(args.project_name)
 
     task_run_headless(
         HeadlessRunRequest(
-            project_id=args.project_id,
+            project_name=args.project_name,
             prompt=prompt,
             config_path=getattr(args, "agent_config", None),
             model=getattr(args, "model", None),
@@ -554,27 +554,27 @@ def _resolve_attach(args: argparse.Namespace) -> bool:
     return sys.stdin.isatty() and sys.stdout.isatty()
 
 
-def _ensure_project_image(project_id: str) -> None:
+def _ensure_project_image(project_name: str) -> None:
     """Ensure the project's L2 image exists, offering to build it when missing.
 
     TTY → interactive ``Build now? [Y/n]`` prompt, then ``build_images()``
     inline.  Non-TTY → exit with a hint so scripts stay deterministic.
     """
-    require_project_exists(project_id)
+    require_project_exists(project_name)
 
-    if project_image_exists(project_id):
+    if project_image_exists(project_name):
         return
 
     hint = (
-        f"Image for project {project_id!r} is not present. "
-        f"Build it first: terok project build {project_id}"
+        f"Image for project {project_name!r} is not present. "
+        f"Build it first: terok project build {project_name}"
     )
     if not (sys.stdin.isatty() and sys.stdout.isatty()):
         raise SystemExit(hint)
 
     try:
         answer = (
-            input(f"Image for project {project_id!r} is missing. Build now? [Y/n]: ")
+            input(f"Image for project {project_name!r} is missing. Build now? [Y/n]: ")
             .strip()
             .lower()
         )
@@ -590,7 +590,7 @@ def _ensure_project_image(project_id: str) -> None:
     if answer in ("n", "no"):
         raise SystemExit(hint)
 
-    build_images(project_id)
+    build_images(project_name)
 
 
 def _read_instructions(instructions_path: str | None) -> str | None:
@@ -610,7 +610,7 @@ def _read_instructions(instructions_path: str | None) -> str | None:
         raise SystemExit(f"Failed to read instructions file {instructions_path}: {exc}") from exc
 
 
-def _cmd_task_revoke_credentials(project_id: str, task_id: str) -> None:
+def _cmd_task_revoke_credentials(project_name: str, task_id: str) -> None:
     """Run ``terok task revoke-credentials`` — DB-side phantom-token nuke.
 
     Leaves the container alive so the operator can inspect forensic
@@ -624,15 +624,15 @@ def _cmd_task_revoke_credentials(project_id: str, task_id: str) -> None:
     """
     from ...lib.domain.task_credentials import revoke_credentials
 
-    count = revoke_credentials(project_id, task_id)
+    count = revoke_credentials(project_name, task_id)
     if count == 0:
-        print(f"No phantom tokens found for {project_id}/{task_id}.")
+        print(f"No phantom tokens found for {project_name}/{task_id}.")
     else:
         suffix = "" if count == 1 else "s"
-        print(f"Revoked {count} phantom token{suffix} for {project_id}/{task_id}.")
+        print(f"Revoked {count} phantom token{suffix} for {project_name}/{task_id}.")
 
 
-def _cmd_task_audit_credentials(project_id: str, task_id: str, args: argparse.Namespace) -> None:
+def _cmd_task_audit_credentials(project_name: str, task_id: str, args: argparse.Namespace) -> None:
     """Run ``terok task audit-credentials`` — filtered tail of the broker's audit JSONL."""
     from datetime import datetime
 
@@ -652,7 +652,7 @@ def _cmd_task_audit_credentials(project_id: str, task_id: str, args: argparse.Na
             )
 
     entries = audit_credentials(
-        project_id,
+        project_name,
         task_id,
         provider=getattr(args, "provider", None),
         since=since,
@@ -666,7 +666,7 @@ def _cmd_task_audit_credentials(project_id: str, task_id: str, args: argparse.Na
 
     rows = list(entries)
     if not rows:
-        print(f"No credential-audit entries for {project_id}/{task_id}.")
+        print(f"No credential-audit entries for {project_name}/{task_id}.")
         return
     for row in rows:
         ts = row.get("ts", "?")
@@ -688,10 +688,10 @@ def _dispatch_task_sub(args: argparse.Namespace) -> bool:
 
     # ``task new`` (terokctl scripting surface) — same: no task_id yet.
     if args.task_cmd == "new":
-        task_new(args.project_id, name=getattr(args, "name", None))
+        task_new(args.project_name, name=getattr(args, "name", None))
         return True
 
-    pid = args.project_id
+    pid = args.project_name
     require_project_exists(pid)
     tid = resolve_task_id(pid, args.task_id) if hasattr(args, "task_id") else ""
     if args.task_cmd == "list":
@@ -767,13 +767,13 @@ def _dispatch_task_sub(args: argparse.Namespace) -> bool:
 def _dispatch_archive_sub(args: argparse.Namespace) -> bool:
     """Dispatch ``task archive <subcommand>``."""
     if args.archive_cmd == "list":
-        task_archive_list(args.project_id)
+        task_archive_list(args.project_name)
     elif args.archive_cmd == "logs":
-        log_file = task_archive_logs(args.project_id, args.archive_id)
+        log_file = task_archive_logs(args.project_name, args.archive_id)
         if log_file is None:
             raise SystemExit(
                 f"No archived logs found for prefix {args.archive_id!r}. "
-                f"Use 'terok task archive list {args.project_id}' to see available archives."
+                f"Use 'terok task archive list {args.project_name}' to see available archives."
             )
         with log_file.open("r", encoding="utf-8", errors="replace") as f:
             for line in f:

--- a/src/terok/cli/main.py
+++ b/src/terok/cli/main.py
@@ -118,7 +118,7 @@ def main(prog: str = "terok") -> None:
             f"  1. Bootstrap:  {prog} setup                       (install host services)\n"
             f"  2. Auth:       {prog} auth claude                 (host-wide auth — no project needed)\n"
             f"  3. Project:    {prog} project wizard              (create a project)\n"
-            f"  4. Work:       {prog} task run <project_id>       (attach into a new CLI task)\n"
+            f"  4. Work:       {prog} task run <project_name>       (attach into a new CLI task)\n"
             "\n"
             f"Bare {prog} auth opens an interactive menu for multiple providers.\n"
             "\n"

--- a/src/terok/cli/tree.py
+++ b/src/terok/cli/tree.py
@@ -90,7 +90,7 @@ def inject_pt_resolver(
 
     For each ``(path, kwarg)`` entry, wraps the handler at *path* so
     that, if the named keyword argument is a string containing ``/``,
-    it's split on the first slash, treated as ``(project_id,
+    it's split on the first slash, treated as ``(project_name,
     task_id)``, and resolved to the task's current container name via
     [`lookup_container_by_pt`][terok.lib.orchestration.tasks.query.lookup_container_by_pt].
     Inputs without ``/`` (raw container ids) pass through untouched —

--- a/src/terok/lib/core/images.py
+++ b/src/terok/lib/core/images.py
@@ -41,14 +41,14 @@ def agent_cli_image(base_image: str) -> str:
     return f"terok-l1-cli:{_base_tag(base_image)}"
 
 
-def project_cli_image(project_id: str) -> str:
-    """Return the L2 CLI project image tag for *project_id*."""
-    return f"{project_id}:l2-cli"
+def project_cli_image(project_name: str) -> str:
+    """Return the L2 CLI project image tag for *project_name*."""
+    return f"{project_name}:l2-cli"
 
 
-def project_dev_image(project_id: str) -> str:
-    """Return the L2 dev project image tag for *project_id*."""
-    return f"{project_id}:l2-dev"
+def project_dev_image(project_name: str) -> str:
+    """Return the L2 dev project image tag for *project_name*."""
+    return f"{project_name}:l2-dev"
 
 
 @lru_cache(maxsize=64)
@@ -106,8 +106,8 @@ def require_agent_installed(project: ProjectConfig, name: str, *, noun: str = "A
     available = ", ".join(sorted(installed_agents(image))) or "(none)"
     raise SystemExit(
         f"{noun} {name!r} is not installed in the L1 image for "
-        f"project {project.id!r} ({image}).\n"
+        f"project {project.name!r} ({image}).\n"
         f"Installed: {available}\n"
         f"Add it to image.agents and rebuild: "
-        f"terok project build --agents {name} {project.id}"
+        f"terok project build --agents {name} {project.name}"
     )

--- a/src/terok/lib/core/paths.py
+++ b/src/terok/lib/core/paths.py
@@ -95,17 +95,17 @@ def core_state_dir() -> Path:
 # ── Vault ──────────────────────────────────────────────────────────────
 
 
-def _acp_runtime_path(project_id: str, task_id: str, *, suffix: str) -> Path:
+def _acp_runtime_path(project_name: str, task_id: str, *, suffix: str) -> Path:
     """Per-task ACP runtime artefact path with the given file suffix.
 
     All ACP daemon files (socket, bound-agent sidecar, future log /
     pid files) live under ``runtime_dir() / "acp" / <project>`` with
     the same ``<task_id><suffix>`` shape, so they move together.
     """
-    return runtime_dir() / _ACP_RUNTIME_SUBDIR / project_id / f"{task_id}{suffix}"
+    return runtime_dir() / _ACP_RUNTIME_SUBDIR / project_name / f"{task_id}{suffix}"
 
 
-def acp_socket_path(project_id: str, task_id: str) -> Path:
+def acp_socket_path(project_name: str, task_id: str) -> Path:
     """Return the per-task ACP listener socket path on the host.
 
     The proxy daemon binds this Unix socket on first
@@ -114,20 +114,20 @@ def acp_socket_path(project_id: str, task_id: str) -> Path:
     (``runtime_dir() / <subdir> / …``) so all transient sockets live
     under a single XDG-compliant root.
     """
-    return _acp_runtime_path(project_id, task_id, suffix=".sock")
+    return _acp_runtime_path(project_name, task_id, suffix=".sock")
 
 
-def acp_bound_path(project_id: str, task_id: str) -> Path:
+def acp_bound_path(project_name: str, task_id: str) -> Path:
     """Return the per-task ACP "bound agent" sidecar JSON path.
 
     Written atomically by the proxy daemon when an agent is bound to a
     session; read by the host-side discovery surface to surface the
     bound-agent name in ``acp list`` output.
     """
-    return _acp_runtime_path(project_id, task_id, suffix=".bound")
+    return _acp_runtime_path(project_name, task_id, suffix=".bound")
 
 
-def acp_log_path(project_id: str, task_id: str) -> Path:
+def acp_log_path(project_name: str, task_id: str) -> Path:
     """Return the per-task ACP daemon stderr log path.
 
     ``terok acp connect`` redirects the spawned daemon's stderr here
@@ -136,7 +136,7 @@ def acp_log_path(project_id: str, task_id: str) -> Path:
     session, and the user would see a bare Python stack trace from
     the bridge with no hint at the underlying cause.
     """
-    return _acp_runtime_path(project_id, task_id, suffix=".log")
+    return _acp_runtime_path(project_name, task_id, suffix=".log")
 
 
 def vault_root() -> Path:

--- a/src/terok/lib/core/project_model.py
+++ b/src/terok/lib/core/project_model.py
@@ -30,7 +30,9 @@ class ProjectConfig(BaseModel):
 
     model_config = ConfigDict(frozen=True)
 
-    id: str
+    name: str
+    description: str | None = None
+    """Free-text, human-readable project description (optional; display only)."""
     security_class: str  # "online" | "gatekeeping"
     isolation: str = "shared"  # "shared" | "sealed"
     upstream_url: str | None
@@ -59,7 +61,7 @@ class ProjectConfig(BaseModel):
     credentials_scope: Literal["shared", "project"] = "shared"
     """Credentials isolation: ``shared`` reuses the host-wide bucket;
     ``project`` carves out a private set under ``<root>/mounts`` and
-    reads/writes the vault DB under set ``<id>`` instead of
+    reads/writes the vault DB under set ``<name>`` instead of
     ``"default"``.  Computed via ``credential_set`` and
     ``project_mounts_dir`` on this class."""
     shutdown_timeout: int = 10
@@ -135,11 +137,11 @@ class ProjectConfig(BaseModel):
 
         ``"default"`` for shared-credential projects (the host-wide bucket
         every project sees by default).  When ``credentials_scope`` is
-        ``"project"``, the project's id is used as the set name so its
-        logins live in their own row keyed by ``(project.id, provider)``
+        ``"project"``, the project's name is used as the set name so its
+        logins live in their own row keyed by ``(project.name, provider)``
         and never collide with another project's tokens.
         """
-        return self.id if self.credentials_scope == "project" else "default"
+        return self.name if self.credentials_scope == "project" else "default"
 
     @property
     def project_mounts_dir(self) -> Path:
@@ -163,45 +165,45 @@ class PresetInfo:
     path: Path
 
 
-_PROJECT_ID_RE = re.compile(r"[a-z0-9][a-z0-9_-]*")
+_PROJECT_NAME_RE = re.compile(r"[a-z0-9][a-z0-9_-]*")
 
-#: Reserved IDs that would collide with vault namespace conventions.
+#: Reserved names that would collide with vault namespace conventions.
 #: ``"default"`` is the shared credential bucket every project starts on;
 #: a project literally named ``default`` with ``credentials_scope: project``
 #: would silently overwrite the host-wide row.
-_RESERVED_PROJECT_IDS: frozenset[str] = frozenset({"default"})
+_RESERVED_PROJECT_NAMES: frozenset[str] = frozenset({"default"})
 
 
-def is_valid_project_id(project_id: str) -> bool:
-    """Return whether *project_id* matches the ``[a-z0-9][a-z0-9_-]*`` contract.
+def is_valid_project_name(project_name: str) -> bool:
+    """Return whether *project_name* matches the ``[a-z0-9][a-z0-9_-]*`` contract.
 
     Pattern-only — this is the structural/path-safety predicate used by
     discovery and task-path guards.  Reserved-name policy (e.g.
-    ``"default"``) lives in [`validate_project_id`][terok.lib.core.project_model.validate_project_id]
+    ``"default"``) lives in [`validate_project_name`][terok.lib.core.project_model.validate_project_name]
     instead: a legacy on-disk project named ``default`` must still be
     *discoverable* so [`discover_projects`][terok.lib.core.projects.discover_projects]
     can surface it as broken (with a rename hint) rather than silently
     dropping it from the listing.
     """
-    return bool(project_id) and _PROJECT_ID_RE.fullmatch(project_id) is not None
+    return bool(project_name) and _PROJECT_NAME_RE.fullmatch(project_name) is not None
 
 
-def validate_project_id(project_id: str) -> None:
-    """Ensure a project ID is safe for use as a directory and OCI image name.
+def validate_project_name(project_name: str) -> None:
+    """Ensure a project name is safe for use as a directory and OCI image name.
 
-    Raises SystemExit if the ID is empty, contains uppercase letters, path
+    Raises SystemExit if the name is empty, contains uppercase letters, path
     separators or traversal sequences, uses characters outside
     ``[a-z0-9_-]``, or collides with a reserved name (currently only
     ``"default"`` — the shared vault credential bucket).
     """
-    if not project_id or _PROJECT_ID_RE.fullmatch(project_id) is None:
+    if not project_name or _PROJECT_NAME_RE.fullmatch(project_name) is None:
         raise SystemExit(
-            f"Invalid project ID '{project_id}': "
+            f"Invalid project name '{project_name}': "
             "must start with a lowercase letter or digit, followed by lowercase letters, "
             "digits, hyphens, or underscores"
         )
-    if project_id in _RESERVED_PROJECT_IDS:
+    if project_name in _RESERVED_PROJECT_NAMES:
         raise SystemExit(
-            f"Project ID '{project_id}' is reserved (it collides with the shared "
+            f"Project name '{project_name}' is reserved (it collides with the shared "
             "credential bucket).  Pick a different name."
         )

--- a/src/terok/lib/core/projects.py
+++ b/src/terok/lib/core/projects.py
@@ -452,22 +452,16 @@ def _rewrite_project_identity(cfg: dict[str, Any], project_name: str) -> None:
     project_section = _project_section_for_write(cfg)
     legacy_slug = project_section.pop("id", None)
     previous_name = project_section.get("name")
-    if (
-        legacy_slug is not None
-        and previous_name is not None
-        and project_section.get("description") is None
-    ):
-        project_section["description"] = previous_name
-    elif (
-        legacy_slug is None
-        and isinstance(previous_name, str)
+    old_name_is_display_label = legacy_slug is not None or (
+        isinstance(previous_name, str)
         and previous_name != project_name
-        and project_section.get("description") is None
         and not is_valid_project_name(previous_name)
+    )
+    if (
+        previous_name is not None
+        and project_section.get("description") is None
+        and old_name_is_display_label
     ):
-        # Old configs could omit ``id`` and use ``name`` only as a display
-        # label while the directory provided the slug.  If that display
-        # string is not a valid slug, preserve it while normalising.
         project_section["description"] = previous_name
     project_section["name"] = project_name
 

--- a/src/terok/lib/core/projects.py
+++ b/src/terok/lib/core/projects.py
@@ -475,12 +475,11 @@ def _rewrite_project_identity(cfg: dict[str, Any], project_name: str) -> None:
 def normalize_project_name(project_name: str) -> Path:
     """Rewrite ``project.yml`` so ``project.name`` matches its directory.
 
-    This is the explicit quick fix for
-    [`_validate_project_name_matches_directory`][terok.lib.core.projects._validate_project_name_matches_directory]:
-    directory names are the local project identity, and the config file is
-    normalised to declare the same name.  Legacy ``project.id`` is removed
-    and any old display-only ``project.name`` is preserved as
-    ``project.description`` when safe.
+    This is the explicit quick fix for project-name mismatches: directory
+    names are the local project identity, and the config file is normalised
+    to declare the same name.  Legacy ``project.id`` is removed and any old
+    display-only ``project.name`` is preserved as ``project.description``
+    when safe.
     """
     validate_project_name(project_name)
     cfg_path = _find_project_root(project_name) / _PROJECT_YML

--- a/src/terok/lib/core/projects.py
+++ b/src/terok/lib/core/projects.py
@@ -184,6 +184,7 @@ def _build_project_config(
     project_name: str,
 ) -> ProjectConfig:
     """Transform a validated raw YAML model + resolved identity into a flat ProjectConfig."""
+    _validate_project_name_matches_directory(raw.project.name, project_name, root / _PROJECT_YML)
     pid = raw.project.name or project_name
     validate_project_name(pid)
     sec = raw.project.security_class
@@ -375,11 +376,7 @@ def derive_project(source_id: str, new_id: str) -> Path:
 
     source_cfg = _yaml_load((source.root / _PROJECT_YML).read_text(encoding="utf-8")) or {}
 
-    project_section = source_cfg.setdefault("project", {})
-    project_section["name"] = new_id
-    project_section.pop(
-        "id", None
-    )  # drop any legacy slug key so it can't shadow ``name`` on reload
+    _rewrite_project_identity(source_cfg, new_id)
     source_cfg.pop("agent", None)
     _pin_shared_infra(source_cfg, source)
 
@@ -415,6 +412,87 @@ def _find_project_root(project_name: str) -> Path:
     if (sys_root / _PROJECT_YML).is_file():
         return sys_root
     raise SystemExit(f"Project '{project_name}' not found in {user_root} or {sys_root}")
+
+
+def _validate_project_name_matches_directory(
+    declared_name: str | None, directory_name: str, cfg_path: Path
+) -> None:
+    """Reject a ``project.yml`` name/id that disagrees with its directory name."""
+    if declared_name is None or declared_name == directory_name:
+        return
+    raise SystemExit(
+        "Project name mismatch:\n"
+        f"  directory name: {directory_name!r}\n"
+        f"  project.yml name: {declared_name!r}\n"
+        f"  config file: {cfg_path}\n\n"
+        "Terok treats the directory name as the local project identity and "
+        "requires project.name (or legacy project.id) to match it.\n"
+        "Fix the file by hand, or run:\n\n"
+        f"  terok project normalize-name {directory_name}\n"
+    )
+
+
+def _project_section_for_write(cfg: dict[str, Any]) -> dict[str, Any]:
+    """Return a mutable ``project`` section, replacing invalid section shapes."""
+    section = cfg.setdefault("project", {})
+    if not isinstance(section, dict):
+        section = {}
+        cfg["project"] = section
+    return section
+
+
+def _rewrite_project_identity(cfg: dict[str, Any], project_name: str) -> None:
+    """Rewrite ``cfg`` so its ``project`` section declares *project_name*.
+
+    Handles both the new shape (``project.name`` is the slug) and the
+    legacy shape (``project.id`` was the slug, ``project.name`` was a
+    display label).  Legacy display labels are preserved as
+    ``project.description`` when possible.
+    """
+    project_section = _project_section_for_write(cfg)
+    legacy_slug = project_section.pop("id", None)
+    previous_name = project_section.get("name")
+    if (
+        legacy_slug is not None
+        and previous_name is not None
+        and project_section.get("description") is None
+    ):
+        project_section["description"] = previous_name
+    elif (
+        legacy_slug is None
+        and isinstance(previous_name, str)
+        and previous_name != project_name
+        and project_section.get("description") is None
+        and not is_valid_project_name(previous_name)
+    ):
+        # Old configs could omit ``id`` and use ``name`` only as a display
+        # label while the directory provided the slug.  If that display
+        # string is not a valid slug, preserve it while normalising.
+        project_section["description"] = previous_name
+    project_section["name"] = project_name
+
+
+def normalize_project_name(project_name: str) -> Path:
+    """Rewrite ``project.yml`` so ``project.name`` matches its directory.
+
+    This is the explicit quick fix for
+    [`_validate_project_name_matches_directory`][terok.lib.core.projects._validate_project_name_matches_directory]:
+    directory names are the local project identity, and the config file is
+    normalised to declare the same name.  Legacy ``project.id`` is removed
+    and any old display-only ``project.name`` is preserved as
+    ``project.description`` when safe.
+    """
+    validate_project_name(project_name)
+    cfg_path = _find_project_root(project_name) / _PROJECT_YML
+    try:
+        cfg = _yaml_load(cfg_path.read_text(encoding="utf-8")) or {}
+    except (OSError, UnicodeDecodeError, YAMLError) as exc:
+        raise SystemExit(f"Failed to read {cfg_path}: {exc}") from exc
+    if not isinstance(cfg, dict):
+        raise SystemExit(f"Invalid {_PROJECT_YML} ({cfg_path}): expected a mapping")
+    _rewrite_project_identity(cfg, project_name)
+    cfg_path.write_text(_yaml_dump(cfg), encoding="utf-8")
+    return cfg_path
 
 
 def require_project_exists(project_name: str) -> None:

--- a/src/terok/lib/core/projects.py
+++ b/src/terok/lib/core/projects.py
@@ -39,8 +39,8 @@ from .config import (
 from .project_model import (  # noqa: F401 — re-exported public API
     PresetInfo,
     ProjectConfig,
-    is_valid_project_id,
-    validate_project_id,
+    is_valid_project_name,
+    validate_project_name,
 )
 from .yaml_schema import RawGlobalGitSection, RawProjectYaml
 
@@ -181,11 +181,11 @@ def _build_project_config(
     raw: RawProjectYaml,
     identity: dict[str, str | None],
     root: Path,
-    project_id: str,
+    project_name: str,
 ) -> ProjectConfig:
     """Transform a validated raw YAML model + resolved identity into a flat ProjectConfig."""
-    pid = raw.project.id or project_id
-    validate_project_id(pid)
+    pid = raw.project.name or project_name
+    validate_project_name(pid)
     sec = raw.project.security_class
     tasks_root = Path(raw.tasks.root or (sandbox_live_dir() / "tasks" / pid)).resolve()
     gate_path = Path(raw.gate.path or (gate_repos_dir() / f"{pid}.git")).resolve()
@@ -223,7 +223,8 @@ def _build_project_config(
     hook_pre, hook_post, hook_ready, hook_stop = _resolve_hooks(raw)
 
     return ProjectConfig(
-        id=pid,
+        name=pid,
+        description=raw.project.description,
         security_class=sec,
         isolation=raw.project.isolation,
         # Normalise "" → None so downstream ``is None`` checks and truthy
@@ -303,13 +304,13 @@ def find_preset_path(project: ProjectConfig, preset_name: str) -> Path | None:
     return None
 
 
-def list_presets(project_id: str) -> list[PresetInfo]:
+def list_presets(project_name: str) -> list[PresetInfo]:
     """Return sorted preset info for a project.
 
     Search tiers (higher priority overwrites lower):
     bundled (shipped with terok) → global (user-wide) → project.
     """
-    project = load_project(project_id)
+    project = load_project(project_name)
 
     seen: dict[str, PresetInfo] = {}
     # Higher-priority tiers overwrite lower ones
@@ -325,16 +326,16 @@ def list_presets(project_id: str) -> list[PresetInfo]:
     return sorted(seen.values(), key=lambda info: info.name)
 
 
-def load_preset(project_id: str, preset_name: str) -> tuple[dict[str, Any], Path]:
+def load_preset(project_name: str, preset_name: str) -> tuple[dict[str, Any], Path]:
     """Load a preset file and return ``(data, path)``.
 
     Search order: project → global → bundled.
     Raises SystemExit if the preset is not found.
     """
-    project = load_project(project_id)
+    project = load_project(project_name)
     path = find_preset_path(project, preset_name)
     if path is None:
-        available = list_presets(project_id)
+        available = list_presets(project_name)
         names = ", ".join(info.name for info in available)
         hint = f"  Available: {names}" if available else "  No presets found."
         raise SystemExit(f"Preset '{preset_name}' not found.\n{hint}")
@@ -349,7 +350,7 @@ def derive_project(source_id: str, new_id: str) -> Path:
     """Create a new project config that *shares infrastructure* with an existing one.
 
     The derived project points at the same git-gate mirror and the same SSH
-    keypair as the source — only ``project.id`` and the ``agent:`` section
+    keypair as the source — only ``project.name`` and the ``agent:`` section
     differ.  This is the "sibling project" use case: rerun the same repo
     through a different image or agent without re-provisioning keys or
     re-cloning the mirror.  The source's ``instructions.md``, if present, is
@@ -360,21 +361,25 @@ def derive_project(source_id: str, new_id: str) -> Path:
 
     Raises SystemExit if the source project is not found or the target already exists.
     """
-    validate_project_id(new_id)
+    validate_project_name(new_id)
     source = load_project(source_id)
     projects_root = user_projects_dir().resolve()
     target_root = (projects_root / new_id).resolve()
 
     # Guard against directory traversal (belt-and-suspenders with the regex above)
     if not target_root.is_relative_to(projects_root):
-        raise SystemExit(f"Invalid project ID '{new_id}': path escapes projects directory")
+        raise SystemExit(f"Invalid project name '{new_id}': path escapes projects directory")
 
     if target_root.exists():
         raise SystemExit(f"Project '{new_id}' already exists at {target_root}")
 
     source_cfg = _yaml_load((source.root / _PROJECT_YML).read_text(encoding="utf-8")) or {}
 
-    source_cfg.setdefault("project", {})["id"] = new_id
+    project_section = source_cfg.setdefault("project", {})
+    project_section["name"] = new_id
+    project_section.pop(
+        "id", None
+    )  # drop any legacy slug key so it can't shadow ``name`` on reload
     source_cfg.pop("agent", None)
     _pin_shared_infra(source_cfg, source)
 
@@ -401,19 +406,19 @@ def _pin_shared_infra(cfg: dict, source: ProjectConfig) -> None:
     cfg.setdefault("gate", {})["path"] = str(source.gate_path)
 
 
-def _find_project_root(project_id: str) -> Path:
-    """Return the root directory for *project_id*, preferring user over system."""
-    user_root = user_projects_dir() / project_id
-    sys_root = projects_dir() / project_id
+def _find_project_root(project_name: str) -> Path:
+    """Return the root directory for *project_name*, preferring user over system."""
+    user_root = user_projects_dir() / project_name
+    sys_root = projects_dir() / project_name
     if (user_root / _PROJECT_YML).is_file():
         return user_root
     if (sys_root / _PROJECT_YML).is_file():
         return sys_root
-    raise SystemExit(f"Project '{project_id}' not found in {user_root} or {sys_root}")
+    raise SystemExit(f"Project '{project_name}' not found in {user_root} or {sys_root}")
 
 
-def require_project_exists(project_id: str) -> None:
-    """Raise [`SystemExit`][SystemExit] unless *project_id* names a known project.
+def require_project_exists(project_name: str) -> None:
+    """Raise [`SystemExit`][SystemExit] unless *project_name* names a known project.
 
     Cheap stat-based check — no YAML parse, no pydantic validation.  Use
     this in CLI entry points that want to fail before any user-visible
@@ -421,7 +426,7 @@ def require_project_exists(project_id: str) -> None:
     The downstream [`load_project`][terok.lib.core.projects.load_project]
     call still catches malformed YAML.
     """
-    _find_project_root(project_id)
+    _find_project_root(project_name)
 
 
 # ---------- Project listing ----------
@@ -436,7 +441,7 @@ class BrokenProject:
     re-run the failing ``load_project`` to rediscover the message.
     """
 
-    id: str
+    name: str
     config_path: Path
     error: str
 
@@ -458,7 +463,7 @@ def discover_projects() -> tuple[list[ProjectConfig], list[BrokenProject]]:
             valid.append(load_project(pid))
         except SystemExit as exc:
             msg = _sanitize_for_tty(str(exc))
-            broken.append(BrokenProject(id=pid, config_path=paths_by_id[pid], error=msg))
+            broken.append(BrokenProject(name=pid, config_path=paths_by_id[pid], error=msg))
     return valid, broken
 
 
@@ -477,13 +482,13 @@ def list_projects() -> list[ProjectConfig]:
         # embedded newlines would split across records and could be read
         # as injected log lines.  stderr print keeps newlines so pydantic's
         # multi-line validation output is readable on the console.
-        logger.warning("Skipping broken project '%s': %s", bp.id, bp.error.replace("\n", "\\n"))
-        print(f"warning: skipping broken project '{bp.id}': {bp.error}", file=sys.stderr)
+        logger.warning("Skipping broken project '%s': %s", bp.name, bp.error.replace("\n", "\\n"))
+        print(f"warning: skipping broken project '{bp.name}': {bp.error}", file=sys.stderr)
     return valid
 
 
 def _discover_project_paths() -> dict[str, Path]:
-    """Map each on-disk project ID to its ``project.yml`` path.
+    """Map each on-disk project name to its ``project.yml`` path.
 
     User scope wins over system scope for collisions — matches how
     [`load_project`][terok.lib.core.projects.load_project] resolves the effective config.  Returning the
@@ -498,7 +503,7 @@ def _discover_project_paths() -> dict[str, Path]:
             if not d.is_dir() or d.name in paths:
                 continue
             yml = d / _PROJECT_YML
-            if yml.is_file() and is_valid_project_id(d.name):
+            if yml.is_file() and is_valid_project_name(d.name):
                 paths[d.name] = yml
     return paths
 
@@ -535,9 +540,9 @@ def _validated_global_git_section() -> dict[str, Any]:
         return {}
 
 
-def load_project(project_id: str) -> ProjectConfig:
-    """Load and return a fully resolved [`ProjectConfig`][terok.cli.commands.sickbay.ProjectConfig] from *project_id*."""
-    root = _find_project_root(project_id)
+def load_project(project_name: str) -> ProjectConfig:
+    """Load and return a fully resolved [`ProjectConfig`][terok.cli.commands.sickbay.ProjectConfig] from *project_name*."""
+    root = _find_project_root(project_name)
     cfg_path = root / _PROJECT_YML
     if not cfg_path.is_file():
         raise SystemExit(f"Missing {_PROJECT_YML} in {root}")
@@ -553,7 +558,7 @@ def load_project(project_id: str) -> ProjectConfig:
     identity = identity_stack.resolve()
 
     try:
-        return _build_project_config(raw, identity, root, project_id)
+        return _build_project_config(raw, identity, root, project_name)
     except ValidationError as exc:
         # Identity values come from merged sources (git config, global config,
         # project.yml).  Include provenance in the error so the user knows
@@ -564,7 +569,7 @@ def load_project(project_id: str) -> ProjectConfig:
         )
 
 
-def set_project_image_agents(project_id: str, selection: str) -> Path:
+def set_project_image_agents(project_name: str, selection: str) -> Path:
     """Write *selection* into the project's ``project.yml`` under ``image.agents``.
 
     Caller validates *selection* up-front; on success returns the
@@ -572,6 +577,6 @@ def set_project_image_agents(project_id: str, selection: str) -> Path:
     """
     from terok.lib.integrations.sandbox import yaml_update_section
 
-    cfg_path = _find_project_root(project_id) / _PROJECT_YML
+    cfg_path = _find_project_root(project_name) / _PROJECT_YML
     yaml_update_section(cfg_path, "image", {"agents": selection})
     return cfg_path

--- a/src/terok/lib/core/task_state.py
+++ b/src/terok/lib/core/task_state.py
@@ -93,9 +93,9 @@ CONTAINER_MODES = ("cli", "web", "run", "toad")
 """All valid container mode suffixes used in container naming."""
 
 
-def container_name(project_id: str, mode: str, task_id: str) -> str:
+def container_name(project_name: str, mode: str, task_id: str) -> str:
     """Return the canonical container name for a task."""
-    return f"{project_id}-{mode}-{task_id}"
+    return f"{project_name}-{mode}-{task_id}"
 
 
 # ── Project queries ────────────────────────────────────────────────────

--- a/src/terok/lib/core/yaml_schema.py
+++ b/src/terok/lib/core/yaml_schema.py
@@ -86,10 +86,12 @@ class RawProjectSection(BaseModel):
 
     model_config = ConfigDict(extra="forbid")
 
-    id: str | None = Field(
-        default=None, description="Unique project identifier (lowercase, ``[a-z0-9_-]``)"
+    name: str | None = Field(
+        default=None, description="Unique project name / slug (lowercase, ``[a-z0-9_-]``)"
     )
-    name: str | None = Field(default=None, description="Human-readable project name (display only)")
+    description: str | None = Field(
+        default=None, description="Free-text, human-readable project description (display only)"
+    )
     security_class: str = Field(
         default="gatekeeping",
         description="Security mode: ``gatekeeping`` (gated mirror, default) or ``online`` (direct push)",
@@ -98,10 +100,29 @@ class RawProjectSection(BaseModel):
         default="shared", description="shared (bind mounts) or sealed (no mounts)"
     )
 
-    @field_validator("id")
+    @model_validator(mode="before")
     @classmethod
-    def _validate_id(cls, v: str | None) -> str | None:
-        """Validate project ID format when explicitly set."""
+    def _accept_legacy_keys(cls, data: Any) -> Any:
+        """Read pre-rename ``id`` / ``name`` keys from older ``project.yml`` files.
+
+        Before the rename, ``id`` was the slug and ``name`` a free-text display
+        label.  Now ``name`` is the slug and ``description`` the label.  When the
+        legacy ``id`` key is present we treat the file as pre-rename: its ``id``
+        becomes ``name`` and any old ``name`` becomes ``description``.  New files
+        (no ``id`` key) pass through untouched.
+        """
+        if isinstance(data, dict) and "id" in data:
+            data = dict(data)
+            legacy_slug = data.pop("id")
+            if data.get("name") is not None and data.get("description") is None:
+                data["description"] = data["name"]
+            data["name"] = legacy_slug
+        return data
+
+    @field_validator("name")
+    @classmethod
+    def _validate_name(cls, v: str | None) -> str | None:
+        """Validate project name / slug format when explicitly set."""
         if v is None:
             return None
         import re

--- a/src/terok/lib/core/yaml_schema.py
+++ b/src/terok/lib/core/yaml_schema.py
@@ -119,20 +119,6 @@ class RawProjectSection(BaseModel):
             data["name"] = legacy_slug
         return data
 
-    @field_validator("name")
-    @classmethod
-    def _validate_name(cls, v: str | None) -> str | None:
-        """Validate project name / slug format when explicitly set."""
-        if v is None:
-            return None
-        import re
-
-        if not re.fullmatch(r"[a-z0-9][a-z0-9_-]*", v):
-            raise ValueError(
-                f"must match [a-z0-9][a-z0-9_-]* (lowercase, no path separators), got {v!r}"
-            )
-        return v
-
     @field_validator("security_class")
     @classmethod
     def _validate_security_class(cls, v: str) -> str:

--- a/src/terok/lib/domain/auth.py
+++ b/src/terok/lib/domain/auth.py
@@ -53,17 +53,17 @@ def resolve_auth_provider(name: str) -> str:
     return auth_provider_aliases().get(name, name)
 
 
-def resolve_credential_routing(project_id: str | None) -> tuple[Path, str]:
+def resolve_credential_routing(project_name: str | None) -> tuple[Path, str]:
     """Resolve ``(mounts_dir, credential_set)`` for an auth flow.
 
     The single source of truth for credential routing, shared by the CLI
     [`authenticate`][terok.lib.domain.auth.authenticate] flow and the
     TUI's native auth path so the two can't drift.
 
-    Host-wide auth (``project_id is None``) and ``shared``-scope projects
+    Host-wide auth (``project_name is None``) and ``shared``-scope projects
     land in the host-wide mount tree + the ``"default"`` vault set.  A
     ``project``-scoped project gets its private subtree + a vault set
-    keyed by the project id.
+    keyed by the project name.
 
     Side effect: for a ``project``-scoped project the per-project mount
     tree is created (mode ``0o700``) if absent — the OAuth post-capture
@@ -75,10 +75,10 @@ def resolve_credential_routing(project_id: str | None) -> tuple[Path, str]:
     from ..core.projects import load_project
     from ..orchestration.environment import project_mounts_dir
 
-    if project_id is None:
+    if project_name is None:
         return sandbox_live_mounts_dir(), "default"
 
-    project = load_project(project_id)
+    project = load_project(project_name)
     mounts_dir = project_mounts_dir(project)
     if project.credentials_scope == "project":
         mounts_dir.mkdir(parents=True, exist_ok=True, mode=0o700)
@@ -86,10 +86,10 @@ def resolve_credential_routing(project_id: str | None) -> tuple[Path, str]:
     return mounts_dir, project.credential_set
 
 
-def authenticate(provider: str, project_id: str | None = None) -> None:
+def authenticate(provider: str, project_name: str | None = None) -> None:
     """Run the auth flow for *provider*, host-wide by default.
 
-    When *project_id* is given, the project's L2 CLI image is reused — the
+    When *project_name* is given, the project's L2 CLI image is reused — the
     escape hatch for users who want project-scoped credentials or happen to
     have a project image handy.  When omitted, terok resolves an L1 image
     (shared across projects that build on the same base) and offers to
@@ -105,7 +105,7 @@ def authenticate(provider: str, project_id: str | None = None) -> None:
     ``"shared"`` (default) writes to the host-wide bucket every project
     sees, ``"project"`` carves out a private set under the project's id
     and stores the agent-config files under the project's own mount
-    tree.  When *project_id* is ``None``, both default to the host-wide
+    tree.  When *project_name* is ``None``, both default to the host-wide
     bucket — no project context exists to override them.
 
     Providers that declare a headless device-code login (``device_auth`` in
@@ -128,12 +128,12 @@ def authenticate(provider: str, project_id: str | None = None) -> None:
     )
 
     image: str | Callable[[], str]
-    if project_id is None:
+    if project_name is None:
         image = lambda: _resolve_host_auth_image(provider)  # noqa: E731 — lazy by design
     else:
-        image = project_cli_image(project_id)
+        image = project_cli_image(project_name)
 
-    mounts_dir, credential_set = resolve_credential_routing(project_id)
+    mounts_dir, credential_set = resolve_credential_routing(project_name)
 
     # The roster declares which auth modes a provider supports; terok's
     # config can disable the OAuth path (experimental flag + per-provider
@@ -141,7 +141,7 @@ def authenticate(provider: str, project_id: str | None = None) -> None:
     # the same gate into the executor's auth flow so the per-provider
     # prompt agrees.
     Authenticator(provider).run(
-        project_id,
+        project_name,
         mounts_dir=mounts_dir,
         image=image,
         expose_token=expose,

--- a/src/terok/lib/domain/auth.py
+++ b/src/terok/lib/domain/auth.py
@@ -103,7 +103,7 @@ def authenticate(provider: str, project_name: str | None = None) -> None:
     Credential routing follows the named project's
     [`credentials_scope`][terok.lib.core.project_model.ProjectConfig.credentials_scope]:
     ``"shared"`` (default) writes to the host-wide bucket every project
-    sees, ``"project"`` carves out a private set under the project's id
+    sees, ``"project"`` carves out a private set under the project's name
     and stores the agent-config files under the project's own mount
     tree.  When *project_name* is ``None``, both default to the host-wide
     bucket — no project context exists to override them.
@@ -233,7 +233,7 @@ def _resolve_host_auth_image(provider: str) -> str:
     hint = (
         "No agent image present.  Build one with: terok image build "
         "(or terok project build <project>), "
-        "or pass --project <id> to reuse an existing project's image."
+        "or pass --project <name> to reuse an existing project's image."
     )
     if not (sys.stdin.isatty() and sys.stdout.isatty()):
         raise SystemExit(hint)

--- a/src/terok/lib/domain/image_cleanup.py
+++ b/src/terok/lib/domain/image_cleanup.py
@@ -47,7 +47,7 @@ class ImageInfo:
 
         Podman labels every locally-built image with a ``localhost/`` registry
         prefix.  terok's classification (global vs L2) and project lookups key
-        off bare project ids, so callers compare against this property rather
+        off bare project names, so callers compare against this property rather
         than the raw [`repository`][terok.lib.domain.image_cleanup.ImageInfo.repository] string.
         """
         return self.repository.removeprefix("localhost/")
@@ -73,15 +73,15 @@ class CleanupResult:
     dry_run: bool
 
 
-def _known_project_ids() -> set[str] | None:
-    """Return the set of currently configured project IDs, or None on failure.
+def _known_project_names() -> set[str] | None:
+    """Return the set of currently configured project names, or None on failure.
 
     Returning None (rather than an empty set) lets callers distinguish
     "no projects configured" from "project discovery failed", preventing
     accidental deletion of valid L2 images.
     """
     try:
-        return {p.id for p in list_projects()}
+        return {p.name for p in list_projects()}
     except Exception as exc:
         from ..util.logging_utils import log_warning
 
@@ -106,11 +106,11 @@ def _is_terok_image(repo: str, tag: str) -> bool:
     return _is_terok_l2_image(repo, tag)
 
 
-def list_images(project_id: str | None = None) -> list[ImageInfo]:
+def list_images(project_name: str | None = None) -> list[ImageInfo]:
     """List terok-managed images, optionally filtered by project.
 
     Args:
-        project_id: If given, only show images for this project.
+        project_name: If given, only show images for this project.
 
     Returns:
         List of ImageInfo objects for matching images.
@@ -120,9 +120,9 @@ def list_images(project_id: str | None = None) -> list[ImageInfo]:
         repo = image.repository.removeprefix("localhost/")
         if not _is_terok_image(repo, image.tag):
             continue
-        if project_id is not None:
+        if project_name is not None:
             # Filter: L2 images must match the project; L0/L1 always shown
-            if _is_terok_l2_image(repo, image.tag) and repo != project_id:
+            if _is_terok_l2_image(repo, image.tag) and repo != project_name:
                 continue
         images.append(ImageInfo.from_image(image))
     return images
@@ -135,7 +135,7 @@ def find_orphaned_images() -> list[ImageInfo]:
     - Dangling images (``<none>:<none>``) from terok layer rebuilds
     - L2 project images whose project no longer exists in the config
     """
-    known_ids = _known_project_ids()
+    known_ids = _known_project_names()
 
     # Dangling images that descended from terok base layers
     dangling = _find_dangling_terok_images()

--- a/src/terok/lib/domain/panic.py
+++ b/src/terok/lib/domain/panic.py
@@ -62,7 +62,7 @@ logger = logging.getLogger(__name__)
 _LOCK_FILENAME = "panic.lock"
 _PHASE2_TIMEOUT_S = 15
 
-# (project_id, task_id, mode, cname, task_dir)
+# (project_name, task_id, mode, cname, task_dir)
 type _Target = tuple[str, str, str, str, Path]
 
 
@@ -248,19 +248,19 @@ def _discover_targets() -> list[_Target]:
     targets: list[_Target] = []
     for cfg in list_projects():
         try:
-            tasks = get_tasks(cfg.id)
+            tasks = get_tasks(cfg.name)
             if not tasks:
                 continue
-            states = get_all_task_states(cfg.id, tasks)
+            states = get_all_task_states(cfg.name, tasks)
         except Exception:
-            logger.debug("panic: failed to list tasks for %s", cfg.id, exc_info=True)
+            logger.debug("panic: failed to list tasks for %s", cfg.name, exc_info=True)
             continue
         targets.extend(
             (
-                cfg.id,
+                cfg.name,
                 t.task_id,
                 t.mode,
-                container_name(cfg.id, t.mode, t.task_id),
+                container_name(cfg.name, t.mode, t.task_id),
                 cfg.tasks_root / str(t.task_id),
             )
             for t in tasks

--- a/src/terok/lib/domain/project.py
+++ b/src/terok/lib/domain/project.py
@@ -137,32 +137,32 @@ def find_projects_sharing_gate(
 
     Args:
         gate_path: The gate path to check for
-        exclude_project: Project ID to exclude from results (usually the current project)
+        exclude_project: Project name to exclude from results (usually the current project)
 
     Returns:
-        List of (project_id, upstream_url) tuples for projects sharing this gate
+        List of (project_name, upstream_url) tuples for projects sharing this gate
     """
     from ..core.projects import list_projects as _list_projects
 
     gate_path = gate_path.resolve()
     return [
-        (project.id, project.upstream_url)
+        (project.name, project.upstream_url)
         for project in _list_projects()
-        if project.id != exclude_project and project.gate_path.resolve() == gate_path
+        if project.name != exclude_project and project.gate_path.resolve() == gate_path
     ]
 
 
-def validate_gate_upstream_match(project_id: str) -> None:
+def validate_gate_upstream_match(project_name: str) -> None:
     """Validate that no other project uses the same gate with a different upstream.
 
     Raises SystemExit if another project uses the same gate path but has a
     different upstream_url configured.
 
     Args:
-        project_id: The project to validate
+        project_name: The project to validate
     """
-    project = load_project(project_id)
-    sharing = find_projects_sharing_gate(project.gate_path, exclude_project=project_id)
+    project = load_project(project_name)
+    sharing = find_projects_sharing_gate(project.gate_path, exclude_project=project_name)
 
     for other_id, other_url in sharing:
         if other_url is None or project.upstream_url is None or other_url != project.upstream_url:
@@ -181,7 +181,7 @@ def validate_gate_upstream_match(project_id: str) -> None:
                 f"\n"
                 f"  Gate path: {project.gate_path}\n"
                 f"\n"
-                f"  This project ({project_id}):\n"
+                f"  This project ({project_name}):\n"
                 f"    upstream_url: {this_display}\n"
                 f"\n"
                 f"  Conflicting project ({other_id}):\n"
@@ -204,7 +204,7 @@ def make_git_gate(config: ProjectConfig, *, use_personal_ssh: bool | None = None
     """
     effective = use_personal_ssh if use_personal_ssh is not None else config.ssh_use_personal
     return GitGate(
-        scope=config.id,
+        scope=config.name,
         gate_path=config.gate_path,
         upstream_url=config.upstream_url,
         default_branch=config.default_branch,
@@ -221,7 +221,7 @@ def make_ssh_manager(config: ProjectConfig) -> SSHManager:
     the DB connection closes on exit.
     """
     return SSHManager.open_for_config(
-        scope=config.id, cfg=make_sandbox_config(), prompt_on_tty=True
+        scope=config.name, cfg=make_sandbox_config(), prompt_on_tty=True
     )
 
 
@@ -232,14 +232,14 @@ def make_ssh_manager(config: ProjectConfig) -> SSHManager:
 # ---------------------------------------------------------------------------
 
 
-def get_project(project_id: str) -> Project:
+def get_project(project_name: str) -> Project:
     """Load a project by ID and return a rich [`Project`][terok.lib.domain.project.Project] aggregate."""
-    return Project(load_project(project_id))
+    return Project(load_project(project_name))
 
 
-def project_image_exists(project_id: str) -> bool:
+def project_image_exists(project_name: str) -> bool:
     """Return ``True`` when the project's L2 CLI image is present locally."""
-    return image_exists(project_cli_image(project_id))
+    return image_exists(project_cli_image(project_name))
 
 
 def list_projects() -> list[Project]:
@@ -284,7 +284,7 @@ class ACPEndpoint:
     probe or open the socket.
     """
 
-    project_id: str
+    project_name: str
     """The owning project's id."""
 
     task_id: str
@@ -305,7 +305,7 @@ class ACPEndpoint:
     agent for the open session; ``None`` otherwise."""
 
 
-def _read_bound_agent(project_id: str, task_id: str) -> str | None:
+def _read_bound_agent(project_name: str, task_id: str) -> str | None:
     """Read the bound-agent name from the proxy daemon's sidecar JSON.
 
     The daemon writes ``{"agent": "<name>"}`` atomically (via os.replace)
@@ -313,7 +313,7 @@ def _read_bound_agent(project_id: str, task_id: str) -> str | None:
     error path collapses to ``None`` so the listing surface keeps
     working when the daemon is mid-update or the file is absent.
     """
-    path = acp_bound_path(project_id, task_id)
+    path = acp_bound_path(project_name, task_id)
     try:
         payload = json.loads(path.read_text("utf-8"))
     except (OSError, json.JSONDecodeError):
@@ -323,7 +323,7 @@ def _read_bound_agent(project_id: str, task_id: str) -> str | None:
 
 
 def _task_has_any_authed_agent(
-    project_id: str,
+    project_name: str,
     task: Task,
     authed: set[str],
     *,
@@ -343,13 +343,13 @@ def _task_has_any_authed_agent(
     or N sandbox constructions.
     """
     image_agents = _image_agents_for_task(
-        project_id, task, sandbox=sandbox, label_cache=label_cache
+        project_name, task, sandbox=sandbox, label_cache=label_cache
     )
     return bool(image_agents & authed) if image_agents else False
 
 
 def _image_agents_for_task(
-    project_id: str,
+    project_name: str,
     task: Task,
     *,
     sandbox: Any,
@@ -367,7 +367,7 @@ def _image_agents_for_task(
     if task.mode is None:
         return set()
     try:
-        cname = container_name(project_id, task.mode, task.id)
+        cname = container_name(project_name, task.mode, task.id)
         container = sandbox.runtime.container(cname)
         image = container.image
         if image is None:
@@ -384,7 +384,7 @@ def _image_agents_for_task(
     return parsed
 
 
-def _archive_project(project_id: str) -> str | None:
+def _archive_project(project_name: str) -> str | None:
     """Create a compressed archive of project data before deletion.
 
     Collects project config, task metadata, task archives, and build
@@ -397,8 +397,8 @@ def _archive_project(project_id: str) -> str | None:
     Returns the archive file path as a string, or ``None`` on failure.
     """
     try:
-        project = load_project(project_id)
-        pid = project.id
+        project = load_project(project_name)
+        pid = project.name
 
         archive_root = archive_dir()
         ts = archive_timestamp()
@@ -453,7 +453,7 @@ def _archive_project(project_id: str) -> str | None:
         _logger.debug("_archive_project: archived %s to %s", pid, archive_path)
         return str(archive_path)
     except Exception as exc:
-        _logger.warning("_archive_project: failed to archive %s: %s", project_id, exc)
+        _logger.warning("_archive_project: failed to archive %s: %s", project_name, exc)
         return None
 
 
@@ -502,21 +502,21 @@ def _rmtree_managed(path: Path, label: str, deleted: list[str], skipped: list[st
     deleted.append(str(path))
 
 
-def delete_project(project_id: str) -> DeleteProjectResult:
+def delete_project(project_name: str) -> DeleteProjectResult:
     """Delete a project and all its associated data.
 
     Removes task workspaces, task metadata, build artifacts, SSH credentials,
     the git gate (if not shared with other projects), and the project config
     directory.
     """
-    archive_path = _archive_project(project_id)
+    archive_path = _archive_project(project_name)
     if archive_path is None:
         raise SystemExit(
-            f"Project archiving failed for '{project_id}'; aborting deletion to prevent data loss."
+            f"Project archiving failed for '{project_name}'; aborting deletion to prevent data loss."
         )
 
-    project = load_project(project_id)
-    pid = project.id
+    project = load_project(project_name)
+    pid = project.name
     deleted: list[str] = []
     skipped: list[str] = []
 
@@ -588,7 +588,7 @@ class AgentManager:
     ) -> dict[str, Any]:
         """Return the merged agent config dict."""
         return resolve_agent_config(
-            self._config.id,
+            self._config.name,
             agent_config=self._config.agent_config,
             project_root=self._config.root,
             preset=preset,
@@ -618,7 +618,7 @@ class Project:
         task.stop()
         project.gate.sync()
 
-    **Identity** is based on ``project.id`` — two ``Project`` instances with
+    **Identity** is based on ``project.name`` — two ``Project`` instances with
     the same ID compare equal and hash identically, so they work correctly
     in sets and dicts.
 
@@ -645,9 +645,14 @@ class Project:
     # --- Identity (delegates to ProjectConfig) ---
 
     @property
-    def id(self) -> str:
-        """Return the project ID."""
-        return self._config.id
+    def name(self) -> str:
+        """Return the project name (slug)."""
+        return self._config.name
+
+    @property
+    def description(self) -> str | None:
+        """Return the optional free-text project description, if set."""
+        return self._config.description
 
     @property
     def config(self) -> ProjectConfig:
@@ -660,24 +665,24 @@ class Project:
         return self._config.security_class
 
     def __eq__(self, other: object) -> bool:
-        """Two projects are equal iff they share the same ID."""
-        return isinstance(other, Project) and self.id == other.id
+        """Two projects are equal iff they share the same name."""
+        return isinstance(other, Project) and self.name == other.name
 
     def __hash__(self) -> int:
-        """Hash by project ID for use in sets and dicts."""
-        return hash(self.id)
+        """Hash by project name for use in sets and dicts."""
+        return hash(self.name)
 
     # --- Task containment (Factory Method) ---
 
     def create_task(self, *, name: str | None = None) -> Task:
         """Create a new task and return a rich Task entity."""
-        task_id = task_new(self._config.id, name=name)
-        meta = get_task_meta(self._config.id, task_id)
+        task_id = task_new(self._config.name, name=name)
+        meta = get_task_meta(self._config.name, task_id)
         return Task(self._config, meta)
 
     def get_task(self, task_id: str) -> Task:
         """Return a rich Task entity for an existing task."""
-        meta = get_task_meta(self._config.id, task_id)
+        meta = get_task_meta(self._config.name, task_id)
         return Task(self._config, meta)
 
     @property
@@ -687,11 +692,11 @@ class Project:
 
     def list_tasks(self, *, status: str | None = None, mode: str | None = None) -> list[Task]:
         """Return all tasks, optionally filtered by status or mode."""
-        metas = get_tasks(self._config.id)
+        metas = get_tasks(self._config.name)
         if mode:
             metas = [m for m in metas if m.mode == mode]
         # Hydrate live container state so status filtering is accurate
-        live_states = get_all_task_states(self._config.id, metas)
+        live_states = get_all_task_states(self._config.name, metas)
         for m in metas:
             m.container_state = live_states.get(m.task_id)
         if status:
@@ -728,20 +733,20 @@ class Project:
         label_cache: dict[str, set[str]] = {}
         out: list[ACPEndpoint] = []
         for task in running:
-            sock = acp_socket_path(self._config.id, task.id)
+            sock = acp_socket_path(self._config.name, task.id)
             sock_exists = sock.exists()
-            bound = _read_bound_agent(self._config.id, task.id) if sock_exists else None
+            bound = _read_bound_agent(self._config.name, task.id) if sock_exists else None
             if sock_exists:
                 status = ACPEndpointStatus.ACTIVE
             elif _task_has_any_authed_agent(
-                self._config.id, task, authed, sandbox=sandbox, label_cache=label_cache
+                self._config.name, task, authed, sandbox=sandbox, label_cache=label_cache
             ):
                 status = ACPEndpointStatus.READY
             else:
                 status = ACPEndpointStatus.UNSUPPORTED
             out.append(
                 ACPEndpoint(
-                    project_id=self._config.id,
+                    project_name=self._config.name,
                     task_id=task.id,
                     socket_path=sock,
                     status=status,
@@ -753,33 +758,33 @@ class Project:
     def run_headless(self, request: HeadlessRunRequest) -> Task:
         """Create and run a headless task atomically.  Returns the Task."""
         task_id = task_run_headless(request)
-        meta = get_task_meta(self._config.id, task_id)
+        meta = get_task_meta(self._config.name, task_id)
         return Task(self._config, meta)
 
     def followup_headless(self, task_id: str, prompt: str, follow: bool = True) -> None:
         """Send a follow-up prompt to a completed headless task."""
         from ..orchestration.task_runners import task_followup_headless
 
-        task_followup_headless(self._config.id, task_id, prompt, follow=follow)
+        task_followup_headless(self._config.name, task_id, prompt, follow=follow)
 
     # --- Project lifecycle ---
 
     def delete(self) -> DeleteProjectResult:
         """Delete the project and all associated data."""
-        return delete_project(self._config.id)
+        return delete_project(self._config.name)
 
     # --- Infrastructure ---
 
     def generate_dockerfiles(self) -> None:
         """Render and write Dockerfiles for this project."""
-        generate_dockerfiles(self._config.id)
+        generate_dockerfiles(self._config.name)
 
     def build_images(
         self, *, include_dev: bool = False, refresh_agents: bool = False, full: bool = False
     ) -> None:
         """Build container images for this project."""
         build_images(
-            self._config.id,
+            self._config.name,
             include_dev=include_dev,
             refresh_agents=refresh_agents,
             full_rebuild=full,
@@ -789,21 +794,21 @@ class Project:
         """Return the project's infrastructure state snapshot.
 
         *gate_commit_provider* is an optional callable that, given a
-        project id, returns the last gate commit dict (or ``None``).
+        project name, returns the last gate commit dict (or ``None``).
         Used by the TUI to inject the live gate manager's ``last_commit``
         lookup without reaching for it from inside the helper.
         """
         from .project_state import get_project_state
 
         return get_project_state(
-            self._config.id, gate_commit_provider=gate_commit_provider, project=self._config
+            self._config.name, gate_commit_provider=gate_commit_provider, project=self._config
         )
 
     def storage_detail(self) -> ProjectDetail:
         """Return a detailed view of this project's on-disk footprint."""
         from .storage import get_project_storage_detail
 
-        return get_project_storage_detail(self._config.id)
+        return get_project_storage_detail(self._config.name)
 
     # --- Security setup ---
 
@@ -847,7 +852,7 @@ class Project:
     def register_ssh_key(self, key_id: int) -> None:
         """Bind an already-minted *key_id* to this project (idempotent)."""
         with vault_db() as db:
-            db.assign_ssh_key(self._config.id, key_id)
+            db.assign_ssh_key(self._config.name, key_id)
 
     @property
     def needs_ssh_key_registration(self) -> bool:
@@ -882,8 +887,8 @@ class Project:
 
     def list_presets(self) -> list[PresetInfo]:
         """Return available presets for this project."""
-        return list_presets(self._config.id)
+        return list_presets(self._config.name)
 
     def __repr__(self) -> str:
         """Return a developer-friendly string representation."""
-        return f"Project(id={self.id!r}, security={self.security_class!r})"
+        return f"Project(name={self.name!r}, security={self.security_class!r})"

--- a/src/terok/lib/domain/project.py
+++ b/src/terok/lib/domain/project.py
@@ -233,7 +233,7 @@ def make_ssh_manager(config: ProjectConfig) -> SSHManager:
 
 
 def get_project(project_name: str) -> Project:
-    """Load a project by ID and return a rich [`Project`][terok.lib.domain.project.Project] aggregate."""
+    """Load a project by name and return a rich [`Project`][terok.lib.domain.project.Project] aggregate."""
     return Project(load_project(project_name))
 
 
@@ -285,7 +285,7 @@ class ACPEndpoint:
     """
 
     project_name: str
-    """The owning project's id."""
+    """The owning project's name."""
 
     task_id: str
     """The task this endpoint serves."""
@@ -619,7 +619,7 @@ class Project:
         project.gate.sync()
 
     **Identity** is based on ``project.name`` — two ``Project`` instances with
-    the same ID compare equal and hash identically, so they work correctly
+    the same name compare equal and hash identically, so they work correctly
     in sets and dicts.
 
     **Subsystem access** (``gate``, ``ssh``, ``agents``) uses lazy

--- a/src/terok/lib/domain/project.py
+++ b/src/terok/lib/domain/project.py
@@ -650,11 +650,6 @@ class Project:
         return self._config.name
 
     @property
-    def description(self) -> str | None:
-        """Return the optional free-text project description, if set."""
-        return self._config.description
-
-    @property
     def config(self) -> ProjectConfig:
         """Return the underlying configuration value object."""
         return self._config

--- a/src/terok/lib/domain/project_state.py
+++ b/src/terok/lib/domain/project_state.py
@@ -41,7 +41,7 @@ if TYPE_CHECKING:
 
 
 def get_project_state(
-    project_id: str,
+    project_name: str,
     gate_commit_provider: Callable[[str], dict | None] | None = None,
     *,
     project: "ProjectConfig | None" = None,
@@ -60,15 +60,15 @@ def get_project_state(
     - ``gate_last_commit`` - Dict with commit info if gate exists, None otherwise.
 
     Args:
-        project_id: The project to inspect.
+        project_name: The project to inspect.
         gate_commit_provider: Optional callback to retrieve the last gate commit.
         project: Pre-loaded project config; avoids redundant ``load_project``.
     """
 
-    project = project or load_project(project_id)
+    project = project or load_project(project_name)
 
     # Dockerfiles: look in the same location generate_dockerfiles writes to.
-    stage_dir = build_dir() / project.id
+    stage_dir = build_dir() / project.name
     dockerfiles = [
         stage_dir / "L0.Dockerfile",
         stage_dir / "L1.cli.Dockerfile",
@@ -80,7 +80,7 @@ def get_project_state(
     # existence is runtime-agnostic — podman's image store is the
     # same regardless of which OCI runtime ends up booting them — so
     # PodmanRuntime directly is the right cheap path here.
-    required_tags = [project_cli_image(project.id)]
+    required_tags = [project_cli_image(project.name)]
     runtime = PodmanRuntime()
     has_images = all(runtime.image(tag).exists() for tag in required_tags)
 
@@ -101,7 +101,7 @@ def get_project_state(
             except Exception as exc:
                 from ..util.logging_utils import log_warning
 
-                log_warning(f"Template comparison failed for {project_id}: {exc}")
+                log_warning(f"Template comparison failed for {project_name}: {exc}")
                 dockerfiles_old = False
 
     images_old = False
@@ -116,7 +116,7 @@ def get_project_state(
 
     # SSH: consider SSH "ready" when the scope has at least one assigned key
     # in the vault DB.  The old on-disk SSH directory no longer exists.
-    has_ssh = _scope_has_vault_key(project.id)
+    has_ssh = _scope_has_vault_key(project.name)
 
     # Gate: a mirror bare repo initialized by sync_project_gate(). We
     # treat existence of the directory as "gate present".
@@ -127,11 +127,11 @@ def get_project_state(
     gate_last_commit = None
     if has_gate and gate_commit_provider is not None:
         try:
-            gate_last_commit = gate_commit_provider(project_id)
+            gate_last_commit = gate_commit_provider(project_name)
         except Exception as exc:
             from ..util.logging_utils import log_warning
 
-            log_warning(f"Gate commit lookup failed for {project_id}: {exc}")
+            log_warning(f"Gate commit lookup failed for {project_name}: {exc}")
             gate_last_commit = None
 
     return {
@@ -168,7 +168,7 @@ def _detect_stale_layers(project: "ProjectConfig", rendered: dict[str, str] | No
             "l1": l1_content_hash(rendered),
             "l2": l2_content_hash(rendered),
         }
-        manifest = read_build_manifest(project.id)
+        manifest = read_build_manifest(project.name)
     except (ImportError, OSError, ValueError, KeyError):
         return ["l0", "l1", "l2"]
 
@@ -187,25 +187,25 @@ def _detect_stale_layers(project: "ProjectConfig", rendered: dict[str, str] | No
     return stale
 
 
-def is_task_image_old(project_id: str | None, task: Any) -> bool | None:
+def is_task_image_old(project_name: str | None, task: Any) -> bool | None:
     """Check if the image used by a task's container is outdated.
 
     Compares the build context hash label on the running container's image
     against the current build context hash for the project.
 
     Args:
-        project_id: The project ID, or None.
+        project_name: The project name, or None.
         task: A TaskMeta instance with task_id and mode attributes.
 
     Returns:
         True if the image is old, False if current, None if unable to determine.
     """
-    if project_id is None:
+    if project_name is None:
         return None
     if task.mode != "cli":
         return None
 
-    cname = _container_name(project_id, task.mode, task.task_id)
+    cname = _container_name(project_name, task.mode, task.task_id)
     # State + image probes are runtime-agnostic (``podman inspect``
     # returns the same shape regardless of OCI runtime), so reach for
     # ``PodmanRuntime`` directly — avoids a redundant ``load_project``
@@ -220,7 +220,7 @@ def is_task_image_old(project_id: str | None, task: Any) -> bool | None:
     try:
         from ..orchestration.image import render_all_dockerfiles
 
-        project = load_project(project_id)
+        project = load_project(project_name)
         rendered = render_all_dockerfiles(project)
         stale = _detect_stale_layers(project, rendered)
     except Exception:
@@ -228,7 +228,7 @@ def is_task_image_old(project_id: str | None, task: Any) -> bool | None:
         try:
             from ..orchestration.image import build_context_hash
 
-            current_hash = build_context_hash(project_id)
+            current_hash = build_context_hash(project_name)
         except Exception:
             return None
         label = image.labels().get("terok.build_context_hash")

--- a/src/terok/lib/domain/storage.py
+++ b/src/terok/lib/domain/storage.py
@@ -84,11 +84,11 @@ def format_bytes(n: int) -> str:
 
 _GLOBAL_PREFIXES = ("terok-l0", "terok-l1-cli")
 
-ORPHAN_PROJECT_ID = "(orphans)"
-"""Synthetic project id for the overview row that collects L2 images whose
+ORPHAN_PROJECT_NAME = "(orphans)"
+"""Synthetic project name for the overview row that collects L2 images whose
 project no longer exists in the config.
 
-Parentheses are forbidden in real project ids (validated against
+Parentheses are forbidden in real project names (validated against
 ``[a-z0-9][a-z0-9_-]*`` in ``project_model``), so this value can never
 collide with a configured project."""
 
@@ -100,8 +100,8 @@ def _is_global_image(img: ImageInfo) -> bool:
     return img.project_key.startswith(_GLOBAL_PREFIXES)
 
 
-def _image_project_id(img: ImageInfo) -> str | None:
-    """Extract the project ID from an L2 image, or None for global images."""
+def _image_project_name(img: ImageInfo) -> str | None:
+    """Extract the project name from an L2 image, or None for global images."""
     if _is_global_image(img):
         return None
     if img.tag in ("l2-cli", "l2-dev"):
@@ -118,7 +118,7 @@ def _image_project_id(img: ImageInfo) -> str | None:
 class ProjectSummary:
     """One-line digest of a project's storage footprint."""
 
-    project_id: str
+    project_name: str
     image_bytes: int
     workspace_bytes: int
     task_count: int
@@ -172,7 +172,7 @@ class StorageOverview:
 class ProjectDetail:
     """Full per-task storage breakdown for a single project."""
 
-    project_id: str
+    project_name: str
     images: list[ImageInfo]
     tasks: list[TaskStorageInfo]
     overlays: dict[str, int]
@@ -227,7 +227,7 @@ def get_storage_overview() -> StorageOverview:
     projects_conf = list_projects()
     project_image_bytes: dict[str, int] = {}
     for img in all_images:
-        pid = _image_project_id(img)
+        pid = _image_project_name(img)
         if pid:
             project_image_bytes[pid] = project_image_bytes.get(pid, 0) + parse_image_size(img.size)
 
@@ -245,8 +245,8 @@ def get_storage_overview() -> StorageOverview:
             )
         summaries.append(
             ProjectSummary(
-                project_id=proj.id,
-                image_bytes=project_image_bytes.get(proj.id, 0),
+                project_name=proj.name,
+                image_bytes=project_image_bytes.get(proj.name, 0),
                 workspace_bytes=sum(t.workspace_bytes for t in tasks),
                 task_count=len(tasks),
                 credential_mounts_bytes=cred_mounts_bytes,
@@ -255,12 +255,12 @@ def get_storage_overview() -> StorageOverview:
 
     # Surface L2 images whose project is no longer configured so they roll up
     # into the grand total instead of vanishing from the overview.
-    known_ids = {p.id for p in projects_conf}
+    known_ids = {p.name for p in projects_conf}
     orphan_bytes = sum(b for pid, b in project_image_bytes.items() if pid not in known_ids)
     if orphan_bytes:
         summaries.append(
             ProjectSummary(
-                project_id=ORPHAN_PROJECT_ID,
+                project_name=ORPHAN_PROJECT_NAME,
                 image_bytes=orphan_bytes,
                 workspace_bytes=0,
                 task_count=0,
@@ -274,7 +274,7 @@ def get_storage_overview() -> StorageOverview:
     )
 
 
-def get_project_storage_detail(project_id: str) -> ProjectDetail:
+def get_project_storage_detail(project_name: str) -> ProjectDetail:
     """Detailed view for one project, including overlay sizes.
 
     This triggers ``podman ps --size`` for the project's containers —
@@ -283,13 +283,13 @@ def get_project_storage_detail(project_id: str) -> ProjectDetail:
     from ..core import runtime as _rt
     from ..core.projects import load_project
 
-    project = load_project(project_id)
-    project_images = [img for img in list_images(project_id) if not _is_global_image(img)]
+    project = load_project(project_name)
+    project_images = [img for img in list_images(project_name) if not _is_global_image(img)]
     tasks = TaskStorageInfo.measure_all(project.tasks_root)
     runtime = _rt.resolve_runtime(project)
     # ``container_rw_sizes`` is podman-specific; not every backend exposes it.
     overlays = (
-        runtime.container_rw_sizes(project_id) if hasattr(runtime, "container_rw_sizes") else {}
+        runtime.container_rw_sizes(project_name) if hasattr(runtime, "container_rw_sizes") else {}
     )
 
     # Per-project credential mounts (only present when scope=project).
@@ -302,7 +302,7 @@ def get_project_storage_detail(project_id: str) -> ProjectDetail:
         )
 
     return ProjectDetail(
-        project_id=project_id,
+        project_name=project_name,
         images=project_images,
         tasks=tasks,
         overlays=overlays,

--- a/src/terok/lib/domain/task.py
+++ b/src/terok/lib/domain/task.py
@@ -58,7 +58,7 @@ class Task:
     """Rich task entity — DDD Entity with identity and lifecycle behavior.
 
     Each task has a unique identity within its project, defined by the tuple
-    ``(project_id, task_id)``.  Two ``Task`` instances are equal iff they
+    ``(project_name, task_id)``.  Two ``Task`` instances are equal iff they
     share this identity, regardless of metadata differences.
 
     Obtained via [`get_task`][terok.lib.domain.project.Project.get_task],
@@ -116,56 +116,58 @@ class Task:
     def __eq__(self, other: object) -> bool:
         """Two tasks are equal iff they belong to the same project and share the same ID."""
         return (
-            isinstance(other, Task) and self._config.id == other._config.id and self.id == other.id
+            isinstance(other, Task)
+            and self._config.name == other._config.name
+            and self.id == other.id
         )
 
     def __hash__(self) -> int:
-        """Hash by (project_id, task_id) for use in sets and dicts."""
-        return hash((self._config.id, self.id))
+        """Hash by (project_name, task_id) for use in sets and dicts."""
+        return hash((self._config.name, self.id))
 
     # --- Lifecycle ---
 
     def run_cli(self, *, preset: str | None = None) -> None:
         """Launch a CLI-mode task container."""
-        task_run_cli(self._config.id, self.id, preset=preset)
+        task_run_cli(self._config.name, self.id, preset=preset)
 
     def stop(self, *, timeout: int | None = None) -> None:
         """Gracefully stop the task container."""
-        task_stop(self._config.id, self.id, timeout=timeout)
+        task_stop(self._config.name, self.id, timeout=timeout)
 
     def restart(self) -> None:
         """Restart the task container."""
-        task_restart(self._config.id, self.id)
+        task_restart(self._config.name, self.id)
 
     def delete(self) -> None:
         """Delete the task (workspace, metadata, containers)."""
-        task_delete(self._config.id, self.id)
+        task_delete(self._config.name, self.id)
 
     def rename(self, new_name: str) -> None:
         """Rename the task."""
-        task_rename(self._config.id, self.id, new_name)
+        task_rename(self._config.name, self.id, new_name)
 
     def followup(self, prompt: str, follow: bool = True) -> None:
         """Send a follow-up prompt to a completed headless task."""
-        task_followup_headless(self._config.id, self.id, prompt, follow=follow)
+        task_followup_headless(self._config.name, self.id, prompt, follow=follow)
 
     # --- Observation ---
 
     def logs(self, options: LogViewOptions | None = None) -> None:
         """View task logs."""
-        task_logs(self._config.id, self.id, options or LogViewOptions())
+        task_logs(self._config.name, self.id, options or LogViewOptions())
 
     def login(self) -> None:
         """Open an interactive shell in the task container."""
-        task_login(self._config.id, self.id)
+        task_login(self._config.name, self.id)
 
     def get_login_command(self) -> list[str]:
         """Return the podman exec command for login."""
-        return get_login_command(self._config.id, self.id)
+        return get_login_command(self._config.name, self.id)
 
     def get_workspace_diff(self, against: str = "HEAD") -> str | None:
         """Get git diff from the task's workspace."""
-        return get_workspace_git_diff(self._config.id, self.id, against=against)
+        return get_workspace_git_diff(self._config.name, self.id, against=against)
 
     def show_status(self) -> None:
         """Print live task status with container state diagnostics.
@@ -175,7 +177,7 @@ class Task:
         """
         from ..orchestration.tasks import task_status
 
-        task_status(self._config.id, self.id)
+        task_status(self._config.name, self.id)
 
     def wait_for_exit(self, *, timeout: int = 7200) -> tuple[int | None, str | None]:
         """Wait for this task's container to exit; record exit code in metadata.
@@ -189,8 +191,8 @@ class Task:
 
         if not self._meta.mode:
             raise RuntimeError(f"Task {self.id} has no mode — never started")
-        cname = container_name(self._config.id, self._meta.mode, self.id)
-        return wait_for_container_exit(cname, self._config.id, self.id, timeout=timeout)
+        cname = container_name(self._config.name, self._meta.mode, self.id)
+        return wait_for_container_exit(cname, self._config.name, self.id, timeout=timeout)
 
     def capture_logs(self) -> Path | None:
         """Capture this task's container logs to disk; return the log path.
@@ -215,7 +217,7 @@ class Task:
         """
         from .project_state import is_task_image_old
 
-        return is_task_image_old(self._config.id, self._meta)
+        return is_task_image_old(self._config.name, self._meta)
 
     # --- Diagnostics ---
 
@@ -235,7 +237,7 @@ class Task:
         """
         from ..orchestration.container_doctor import ContainerDoctor
 
-        return ContainerDoctor(self._config.id, self.id).run(
+        return ContainerDoctor(self._config.name, self.id).run(
             fix=fix,
             reporter=reporter,  # type: ignore[arg-type]
             label_prefix=label_prefix,

--- a/src/terok/lib/domain/task_credentials.py
+++ b/src/terok/lib/domain/task_credentials.py
@@ -19,7 +19,7 @@ Two verbs ride alongside the rest of ``terok task ...``:
 
 Both translate the operator's project/task identifiers into the opaque
 ``(scope, subject)`` pair the sandbox actually keys on.  ``scope`` is
-the project id; ``subject`` is the task id.  The mapping lives here
+the project name; ``subject`` is the task id.  The mapping lives here
 rather than in ``terok-sandbox`` because the sandbox makes no claim
 about what those labels identify.
 """
@@ -35,8 +35,8 @@ if TYPE_CHECKING:
     from datetime import datetime
 
 
-def revoke_credentials(project_id: str, task_id: str) -> int:
-    """Revoke every phantom token bound to ``(project_id, task_id)``.
+def revoke_credentials(project_name: str, task_id: str) -> int:
+    """Revoke every phantom token bound to ``(project_name, task_id)``.
 
     The DB-side delete takes effect on the next request the agent
     issues — the broker has no in-memory token cache, so an in-flight
@@ -46,7 +46,7 @@ def revoke_credentials(project_id: str, task_id: str) -> int:
     block further use, don't kill in-flight TCP.
 
     Args:
-        project_id: Project id (becomes the token's ``scope``).
+        project_name: Project id (becomes the token's ``scope``).
         task_id: Task id (becomes the token's ``subject``).
 
     Returns:
@@ -56,18 +56,18 @@ def revoke_credentials(project_id: str, task_id: str) -> int:
     from .vault import vault_db
 
     with vault_db() as db:
-        return db.revoke_tokens(project_id, task_id)
+        return db.revoke_tokens(project_name, task_id)
 
 
 def audit_credentials(
-    project_id: str,
+    project_name: str,
     task_id: str,
     *,
     provider: str | None = None,
     since: datetime | None = None,
     tail: int | None = None,
 ) -> Iterator[dict]:
-    """Yield audit lines for ``(project_id, task_id)`` after filtering.
+    """Yield audit lines for ``(project_name, task_id)`` after filtering.
 
     Reads the broker's
     [`credential_audit_log_path`][terok_sandbox.SandboxConfig.credential_audit_log_path]
@@ -76,7 +76,7 @@ def audit_credentials(
     keeps only the last ``tail`` survivors when set.
 
     Args:
-        project_id: Project id (matched against the line's ``scope``).
+        project_name: Project id (matched against the line's ``scope``).
         task_id: Task id (matched against the line's ``subject``).
         provider: When set, drop lines whose ``provider`` field differs.
         since: When set, drop lines whose ``ts`` parses earlier than
@@ -93,7 +93,7 @@ def audit_credentials(
 
     audit_path = make_sandbox_config().credential_audit_log_path
     matches: Iterable[dict] = _filtered_lines(
-        audit_path, project_id, task_id, provider=provider, since=since
+        audit_path, project_name, task_id, provider=provider, since=since
     )
     if tail is not None and tail > 0:
         # Materialise to slice from the tail; full-history scans rarely
@@ -104,7 +104,7 @@ def audit_credentials(
 
 def _filtered_lines(
     audit_path: Path,
-    project_id: str,
+    project_name: str,
     task_id: str,
     *,
     provider: str | None,
@@ -125,7 +125,7 @@ def _filtered_lines(
             entry = _parse_line(raw)
             if entry is None:
                 continue
-            if entry.get("scope") != project_id or entry.get("subject") != task_id:
+            if entry.get("scope") != project_name or entry.get("subject") != task_id:
                 continue
             if provider is not None and entry.get("provider") != provider:
                 continue

--- a/src/terok/lib/domain/task_logs.py
+++ b/src/terok/lib/domain/task_logs.py
@@ -60,7 +60,7 @@ class LogViewOptions:
 
 
 def task_logs(
-    project_id: str,
+    project_name: str,
     task_id: str,
     options: LogViewOptions | None = None,
 ) -> None:
@@ -69,7 +69,7 @@ def task_logs(
     Works on both running and exited containers (podman logs supports both).
 
     Args:
-        project_id: The project ID.
+        project_name: The project name.
         task_id: The task ID.
         options: Display options (follow, raw, tail, streaming).
     """
@@ -78,8 +78,8 @@ def task_logs(
     import select
     import signal
 
-    project = load_project(project_id)
-    meta_dir = tasks_meta_dir(project.id)
+    project = load_project(project_name)
+    meta_dir = tasks_meta_dir(project.name)
     meta = read_task_meta(meta_dir, task_id)
     if meta is None:
         raise SystemExit(f"Unknown task {task_id}")
@@ -88,15 +88,15 @@ def task_logs(
     if not mode:
         raise SystemExit(
             f"Task {task_id} has never been run (no mode set).\n"
-            f"  Start a fresh task: terok task run {project_id}\n"
-            f"  Or run this stub:   terokctl task attach {project_id} {task_id} --mode cli"
+            f"  Start a fresh task: terok task run {project_name}\n"
+            f"  Or run this stub:   terokctl task attach {project_name} {task_id} --mode cli"
         )
 
     # Validate --tail early so both live and persisted paths behave consistently
     if options.tail is not None and options.tail < 0:
         raise SystemExit("--tail must be >= 0")
 
-    cname = container_name(project.id, mode, task_id)
+    cname = container_name(project.name, mode, task_id)
 
     # Verify container exists (running or exited)
     state = _rt.resolve_runtime(project).container(cname).state
@@ -115,7 +115,7 @@ def task_logs(
             return
         raise SystemExit(
             f"Container {cname} does not exist and no persisted logs found. "
-            f"Run 'terok task restart {project_id} {task_id}' first."
+            f"Run 'terok task restart {project_name} {task_id}' first."
         )
 
     runner = AgentRunner()

--- a/src/terok/lib/domain/wizards/new_project.py
+++ b/src/terok/lib/domain/wizards/new_project.py
@@ -326,7 +326,7 @@ QUESTIONS: tuple[Question, ...] = (
             "creates an isolated set: agent logins, OAuth tokens, and shared "
             "config files live under this project's own state directory and "
             "have to be authenticated from scratch via "
-            "``terok auth --project <id>``."
+            "``terok auth --project <name>``."
         ),
         choices=(
             Choice("shared", "Use shared host-wide credentials (recommended)"),

--- a/src/terok/lib/domain/wizards/new_project.py
+++ b/src/terok/lib/domain/wizards/new_project.py
@@ -38,7 +38,7 @@ from terok.lib.integrations.sandbox import check_gpu_available
 from terok.ui_utils.editor import open_in_editor
 
 from ...core.config import user_projects_dir
-from ...core.project_model import validate_project_id
+from ...core.project_model import validate_project_name
 
 # ── Vocabulary ────────────────────────────────────────────────────────
 
@@ -178,12 +178,12 @@ class Question:
         return self.choices_loader() if self.choices_loader is not None else self.choices
 
 
-def _validate_project_id(project_id: str) -> str | None:
-    """Return an error message if *project_id* is invalid, else ``None``."""
-    if not project_id:
-        return "Project ID cannot be empty."
+def _validate_project_name(project_name: str) -> str | None:
+    """Return an error message if *project_name* is invalid, else ``None``."""
+    if not project_name:
+        return "Project name cannot be empty."
     try:
-        validate_project_id(project_id)
+        validate_project_name(project_name)
     except SystemExit as exc:
         return str(exc)
     return None
@@ -193,12 +193,12 @@ _SLUG_ALLOWED = re.compile(r"[a-z0-9_-]+")
 _SLUG_RUNS = re.compile(r"-{2,}")
 
 
-def _slugify_project_id(raw: str) -> str:
-    """Best-effort-normalise *raw* into a valid project ID.
+def _slugify_project_name(raw: str) -> str:
+    """Best-effort-normalise *raw* into a valid project name.
 
     Meets users halfway: ``"terok pages"`` → ``"terok-pages"`` rather than
     bouncing them back with a regex error.  Drops characters outside the
-    project-ID alphabet (``[a-z0-9_-]``), collapses runs of hyphens, and
+    project name alphabet (``[a-z0-9_-]``), collapses runs of hyphens, and
     strips leading/trailing punctuation.  When the input is already
     hopeless (e.g. ``"!!!"``) the result is empty and validation gives
     the user the usual "must start with a lowercase letter…" message.
@@ -282,12 +282,12 @@ QUESTIONS: tuple[Question, ...] = (
         required=True,
     ),
     Question(
-        key="project_id",
+        key="project_name",
         kind="text",
-        prompt="Project ID",
+        prompt="Project name",
         required=True,
-        transform=_slugify_project_id,
-        validate=_validate_project_id,
+        transform=_slugify_project_name,
+        validate=_validate_project_name,
         placeholder="lowercase; letters, digits, hyphens, underscores",
     ),
     Question(
@@ -587,7 +587,7 @@ def generate_config(values: dict) -> Path:
     """
     rendered = render_project_yaml(values)
 
-    project_dir = user_projects_dir() / values["project_id"]
+    project_dir = user_projects_dir() / values["project_name"]
     ensure_dir_writable(project_dir, "Project")
 
     config_path = project_dir / "project.yml"
@@ -597,7 +597,7 @@ def generate_config(values: dict) -> Path:
             while True:
                 answer = (
                     input(
-                        f"Configuration for project '{values['project_id']}' already exists "
+                        f"Configuration for project '{values['project_name']}' already exists "
                         f"at {config_path}. Overwrite? [y/N]: "
                     )
                     .strip()
@@ -620,7 +620,7 @@ def generate_config(values: dict) -> Path:
 def render_project_yaml(values: dict) -> str:
     """Render ``project.yml`` without writing it — used by the TUI review screen."""
     variables = {
-        "PROJECT_ID": values["project_id"],
+        "PROJECT_NAME": values["project_name"],
         "UPSTREAM_URL": values["upstream_url"],
         "DEFAULT_BRANCH": values["default_branch"],
         "USER_SNIPPET": values["user_snippet"],
@@ -651,14 +651,14 @@ def render_project_yaml(values: dict) -> str:
         return env.get_template(template_path.name).render(**variables)
 
 
-def write_project_yaml(project_id: str, rendered: str, *, overwrite: bool = False) -> Path:
-    """Write *rendered* YAML to ``<user_projects_dir>/<project_id>/project.yml``.
+def write_project_yaml(project_name: str, rendered: str, *, overwrite: bool = False) -> Path:
+    """Write *rendered* YAML to ``<user_projects_dir>/<project_name>/project.yml``.
 
     The TUI reviews YAML in a ``TextArea`` before writing, so this is the
     write half of [`generate_config`][terok.lib.domain.wizards.new_project.generate_config] — kept separate so the TUI can
     pass tweaked content without re-rendering the template.
     """
-    project_dir = user_projects_dir() / project_id
+    project_dir = user_projects_dir() / project_name
     ensure_dir_writable(project_dir, "Project")
     config_path = project_dir / "project.yml"
     if config_path.exists() and not overwrite:
@@ -672,7 +672,7 @@ def write_project_yaml(project_id: str, rendered: str, *, overwrite: bool = Fals
 
 def offer_edit_then_init(
     config_path: Path,
-    project_id: str,
+    project_name: str,
     init_fn: Callable[[str], None] | None,
 ) -> None:
     """Interactively review and commission a newly-created project configuration.
@@ -693,19 +693,19 @@ def offer_edit_then_init(
         if init_fn is not None:
             init_answer = input("Run project initialization? [Y/n]: ").strip().lower()
             if init_answer not in ("n", "no"):
-                init_fn(project_id)
-                print(f"\nProject '{project_id}' is ready.")
+                init_fn(project_name)
+                print(f"\nProject '{project_name}' is ready.")
                 return
 
-        print(f"Next step: terok project init {project_id}")
+        print(f"Next step: terok project init {project_name}")
     except (KeyboardInterrupt, EOFError):
-        print(f"\nSkipped. Run manually: terok project init {project_id}")
+        print(f"\nSkipped. Run manually: terok project init {project_name}")
 
 
 def run_wizard(init_fn: Callable[[str], None] | None = None) -> Path | None:
     """Top-level wizard entry point called by the CLI.
 
-    *init_fn* is an optional callable accepting a project ID string that
+    *init_fn* is an optional callable accepting a project name string that
     performs project initialisation (ssh-init, generate, build, gate-sync).
     When ``None`` (the default), no automatic initialisation is offered.
 
@@ -717,11 +717,11 @@ def run_wizard(init_fn: Callable[[str], None] | None = None) -> Path | None:
         return None
 
     config_path = generate_config(values)
-    project_id = values["project_id"]
+    project_name = values["project_name"]
     print(f"\nProject configuration created: {config_path}")
 
     _maybe_print_global_agents_hint(values)
-    offer_edit_then_init(config_path, project_id, init_fn)
+    offer_edit_then_init(config_path, project_name, init_fn)
     return config_path
 
 

--- a/src/terok/lib/orchestration/agent_config.py
+++ b/src/terok/lib/orchestration/agent_config.py
@@ -35,7 +35,7 @@ def _preset_scope_label(preset_path: Path) -> str:
 
 
 def build_agent_config_stack(
-    project_id: str,
+    project_name: str,
     *,
     agent_config: dict[str, Any] | None = None,
     project_root: Path | None = None,
@@ -45,7 +45,7 @@ def build_agent_config_stack(
     """Build config stack: global → project → preset → CLI overrides.
 
     Args:
-        project_id: Project identifier (needed for preset resolution).
+        project_name: Project identifier (needed for preset resolution).
         agent_config: Project-level agent config dict (from ``project.agent_config``).
         project_root: Project root path (for provenance display).
         preset: Optional preset name.
@@ -70,7 +70,7 @@ def build_agent_config_stack(
     if preset:
         from terok.lib.core.projects import load_preset
 
-        preset_data, preset_path = load_preset(project_id, preset)
+        preset_data, preset_path = load_preset(project_name, preset)
         # Skip empty presets – they contribute nothing to the merge and would
         # only add noise to provenance output from ``config resolved``.
         if preset_data:
@@ -85,7 +85,7 @@ def build_agent_config_stack(
 
 
 def resolve_agent_config(
-    project_id: str,
+    project_name: str,
     *,
     agent_config: dict[str, Any] | None = None,
     project_root: Path | None = None,
@@ -98,7 +98,7 @@ def resolve_agent_config(
     that only need the final resolved dict (e.g. task runners).
     """
     return build_agent_config_stack(
-        project_id,
+        project_name,
         agent_config=agent_config,
         project_root=project_root,
         preset=preset,

--- a/src/terok/lib/orchestration/container_doctor.py
+++ b/src/terok/lib/orchestration/container_doctor.py
@@ -4,7 +4,7 @@
 """In-container health checks via the layered doctor protocol.
 
 Entry point: [`ContainerDoctor`][terok.lib.orchestration.container_doctor.ContainerDoctor].
-``ContainerDoctor(project_id, task_id).run(...)`` collects checks from
+``ContainerDoctor(project_name, task_id).run(...)`` collects checks from
 ``terok_sandbox.doctor`` (network, shield),
 ``terok_executor.doctor`` (bridges, credentials, env), and adds
 terok-level checks (git identity, remote URL).  It executes probes
@@ -233,7 +233,7 @@ def _port_drift_check(env_var: str, label: str, expected: int) -> DoctorCheck:
 
 
 def _terok_doctor_checks(
-    project_id: str,
+    project_name: str,
     token_broker_port: int | None,
     ssh_signer_port: int | None,
 ) -> list[DoctorCheck]:
@@ -244,7 +244,7 @@ def _terok_doctor_checks(
     doesn't bake a ``TEROK_*_PORT`` env into the container in that mode,
     so there is no value to drift from.
     """
-    project = load_project(project_id)
+    project = load_project(project_name)
 
     checks: list[DoctorCheck] = []
 
@@ -401,7 +401,7 @@ def _check_per_container_services(cname: str) -> list[_CheckResult]:
 
 
 def _collect_all_checks(
-    project_id: str,
+    project_name: str,
     task_dir: Path,
 ) -> list[DoctorCheck]:
     """Gather health checks from sandbox, agent, and terok layers.
@@ -441,7 +441,7 @@ def _collect_all_checks(
         )
     )
     checks.extend(AgentRoster.shared().doctor_checks(token_broker_port=token_broker_port))
-    checks.extend(_terok_doctor_checks(project_id, token_broker_port, ssh_signer_port))
+    checks.extend(_terok_doctor_checks(project_name, token_broker_port, ssh_signer_port))
     return checks
 
 
@@ -478,23 +478,23 @@ def _apply_fix(runtime: ContainerRuntime, cname: str, check: DoctorCheck) -> _Ch
 
 
 def _resolve_running_container(
-    project_id: str, task_id: str
+    project_name: str, task_id: str
 ) -> tuple[str, Path, list[_CheckResult]]:
     """Resolve a task to its running container name and task directory.
 
     Returns ``(cname, task_dir, [])`` on success.  If the task cannot be
     checked, *cname* is empty and the list holds the skip/warning result.
     """
-    label = f"Task {project_id}/{task_id}"
-    if not task_exists(project_id, task_id):
+    label = f"Task {project_name}/{task_id}"
+    if not task_exists(project_name, task_id):
         return ("", Path(), [("warn", label, "metadata not found")])
 
-    meta, _ = load_task_meta(project_id, task_id)
+    meta, _ = load_task_meta(project_name, task_id)
     mode = meta.get("mode")
     if not mode:
         return ("", Path(), [("warn", label, "never started (no mode)")])
 
-    cname = container_name(project_id, mode, task_id)
+    cname = container_name(project_name, mode, task_id)
     # State probe is runtime-agnostic — ``podman inspect`` returns
     # the same shape whether the container booted under crun or krun
     # — so the early reachability check goes through PodmanRuntime
@@ -506,7 +506,7 @@ def _resolve_running_container(
     if state != "running":
         return ("", Path(), [("info", label, f"not running ({state}) — skipped")])
 
-    task_dir = load_project(project_id).tasks_root / str(task_id)
+    task_dir = load_project(project_name).tasks_root / str(task_id)
     return (cname, task_dir, [])
 
 
@@ -535,16 +535,16 @@ def _dispatch_host_side(check: DoctorCheck, task_dir: Path, cname: str) -> _Chec
 class ContainerDoctor:
     """Layered in-container health-check orchestrator for one task.
 
-    Construct with ``ContainerDoctor(project_id, task_id)`` and call
+    Construct with ``ContainerDoctor(project_name, task_id)`` and call
     :meth:`run` to execute every probe in sandbox / agent / terok
     layers against the running container.
 
-    The instance carries the ``(project_id, task_id)`` pair that names
+    The instance carries the ``(project_name, task_id)`` pair that names
     the target task; runtime resolution happens inside :meth:`run` so
     the cheap construction is free of subprocess work.
     """
 
-    project_id: str
+    project_name: str
     """Project the task belongs to."""
 
     task_id: str
@@ -573,7 +573,7 @@ class ContainerDoctor:
         the sickbay command to tag multi-task runs with ``"Task
         pid/tid: "``.
         """
-        cname, task_dir, early = _resolve_running_container(self.project_id, self.task_id)
+        cname, task_dir, early = _resolve_running_container(self.project_name, self.task_id)
         if early:
             if reporter is not None:
                 for status, label, detail in early:
@@ -585,8 +585,8 @@ class ContainerDoctor:
         # reaches the container through the same backend that booted it
         # (under krun: SSH over a passt-forwarded TCP port; under crun:
         # podman exec).
-        runtime = _rt.resolve_runtime(load_project(self.project_id))
-        checks = list(_collect_all_checks(self.project_id, task_dir))
+        runtime = _rt.resolve_runtime(load_project(self.project_name))
+        checks = list(_collect_all_checks(self.project_name, task_dir))
 
         # Per-container vault + gate reachability — host-side, best-effort.
         # Emitted after the layered probes so they read as a closing
@@ -617,7 +617,7 @@ class ContainerDoctor:
 
 
 def run_container_doctor(
-    project_id: str,
+    project_name: str,
     task_id: str,
     *,
     fix: bool = False,
@@ -625,7 +625,7 @@ def run_container_doctor(
     label_prefix: str = "",
 ) -> list[_CheckResult]:
     """Shim around :meth:`ContainerDoctor.run` for back-compat callers."""
-    return ContainerDoctor(project_id, task_id).run(
+    return ContainerDoctor(project_name, task_id).run(
         fix=fix, reporter=reporter, label_prefix=label_prefix
     )
 

--- a/src/terok/lib/orchestration/container_exec.py
+++ b/src/terok/lib/orchestration/container_exec.py
@@ -17,7 +17,7 @@ from ..util.logging_utils import _log_debug
 
 
 def container_git_diff(
-    project_id: str,
+    project_name: str,
     task_id: str,
     mode: str,
     *args: str,
@@ -26,7 +26,7 @@ def container_git_diff(
     """Run ``git diff`` inside a task container and return stdout.
 
     Args:
-        project_id: Project identifier.
+        project_name: Project identifier.
         task_id: Task identifier.
         mode: Container mode (``"cli"``, ``"web"``, ``"run"``, ``"toad"``).
         *args: Additional arguments passed to ``git diff`` (e.g.
@@ -41,9 +41,9 @@ def container_git_diff(
     ``/workspace`` path — the host ``workspace-dangerous`` path is never
     passed to any subprocess.
     """
-    project = load_project(project_id)
+    project = load_project(project_name)
     runtime = _rt.resolve_runtime(project)
-    cname = _container_name(project_id, mode, task_id)
+    cname = _container_name(project_name, mode, task_id)
     container = runtime.container(cname)
     state = container.state
 

--- a/src/terok/lib/orchestration/environment.py
+++ b/src/terok/lib/orchestration/environment.py
@@ -75,7 +75,7 @@ def _check_project_credentials_present(project: ProjectConfig) -> None:
     a project that opted into ``credentials_scope: project`` has just
     explicitly *isolated* its bucket: silent fallback would defeat the
     isolation, and an empty bucket is almost always a user oversight
-    (they edited project.yml but forgot ``terok auth --project <id>``).
+    (they edited project.yml but forgot ``terok auth --project <name>``).
     Surface it before the container starts so the error message names
     the recovery command instead of bubbling up from inside the agent.
     """

--- a/src/terok/lib/orchestration/environment.py
+++ b/src/terok/lib/orchestration/environment.py
@@ -89,10 +89,10 @@ def _check_project_credentials_present(project: ProjectConfig) -> None:
 
     agent = project.default_agent or "claude"
     raise SystemExit(
-        f"Project '{project.id}' is configured for per-project credentials "
+        f"Project '{project.name}' is configured for per-project credentials "
         f"(credentials.scope: project) but its vault bucket is empty.\n"
         f"Authenticate before launching tasks:\n\n"
-        f"  terok auth {agent} --project {project.id}\n"
+        f"  terok auth {agent} --project {project.name}\n"
     )
 
 
@@ -157,9 +157,9 @@ def _gatekeeping_repo_env(
     gate_repo = project.gate_path
     if not gate_repo.exists():
         raise SystemExit(
-            f"Git gate missing for project '{project.id}'.\n"
+            f"Git gate missing for project '{project.name}'.\n"
             f"Expected at: {gate_repo}\n"
-            f"Run 'terok project gate-sync {project.id}' to create/update the local mirror."
+            f"Run 'terok project gate-sync {project.name}' to create/update the local mirror."
         )
     token = mint_gate_token()
     gate_url = _gate_url(gate_repo, gate_base, gate_port, token)
@@ -437,7 +437,7 @@ def _warn_leaked_credentials(mounts_dir: Path) -> None:
 # ---------- Clone-cache workspace seeding ----------
 
 
-def _seed_workspace_cache(repo_dir: Path, project_id: str, code_repo: str | None) -> None:
+def _seed_workspace_cache(repo_dir: Path, project_name: str, code_repo: str | None) -> None:
     """Pre-populate *repo_dir* from the clone cache (best-effort).
 
     Only acts when the workspace has a ``.new-task-marker`` (new task)
@@ -454,12 +454,12 @@ def _seed_workspace_cache(repo_dir: Path, project_id: str, code_repo: str | None
 
     try:
         seed_workspace_from_clone_cache(
-            repo_dir, project_id, origin_url=code_repo, cfg=make_sandbox_config()
+            repo_dir, project_name, origin_url=code_repo, cfg=make_sandbox_config()
         )
     except Exception:
         _logger.warning(
             "seed_workspace_from_clone_cache failed for project %s at %s",
-            project_id,
+            project_name,
             repo_dir,
             exc_info=True,
         )
@@ -504,7 +504,7 @@ class TaskEnvironment:
         Delegates shared config mounts, base env vars, workspace volume,
         git identity, and OpenCode provider env to
         [`terok_executor.assemble_container_env`][terok_executor.assemble_container_env],
-        then layers terok-specific concerns: ``PROJECT_ID``, gate
+        then layers terok-specific concerns: ``PROJECT_NAME``, gate
         server URLs, and the full vault (OAuth, socket transport, SSH
         agent).
         """
@@ -531,7 +531,7 @@ class TaskEnvironment:
         # Only for new tasks (marker present, no .git yet).  The in-container
         # init script then does fetch+reset instead of a full git clone.
         # In sealed mode the seeded dir is podman-cp'd into the container.
-        _seed_workspace_cache(repo_dir, project.id, sec_env.get("CODE_REPO"))
+        _seed_workspace_cache(repo_dir, project.name, sec_env.get("CODE_REPO"))
 
         # Pre-resolve git identity using terok's authorship logic so the
         # container has correct GIT_AUTHOR_*/GIT_COMMITTER_* from launch.
@@ -578,7 +578,7 @@ class TaskEnvironment:
                 authorship=project.git_authorship,
                 human_name=project.human_name or "Nobody",
                 human_email=project.human_email or "nobody@localhost",
-                credential_scope=project.id,
+                credential_scope=project.name,
                 credential_set=project.credential_set,
                 vault_transport=vault_transport,
                 vault_required=not vault_bypass,
@@ -599,7 +599,7 @@ class TaskEnvironment:
         volumes: list[VolumeSpec] = [*result.volumes, *sec_volumes]
 
         # terok-specific env vars not covered by the shared assembly
-        env["PROJECT_ID"] = project.id
+        env["PROJECT_NAME"] = project.name
         env["GIT_RESET_MODE"] = os.environ.get("TEROK_GIT_RESET_MODE", "none")
         # Forward every sec_env key the spec didn't already consume.  Inverted
         # from a closed allowlist after a leak: each new gate env var added

--- a/src/terok/lib/orchestration/hooks.py
+++ b/src/terok/lib/orchestration/hooks.py
@@ -27,7 +27,7 @@ HOOK_NAMES = ("pre_start", "post_start", "post_ready", "post_stop")
 
 
 def _build_hook_env(
-    project_id: str,
+    project_name: str,
     task_id: str,
     mode: str,
     cname: str,
@@ -40,7 +40,7 @@ def _build_hook_env(
     env = {
         **os.environ,
         "TEROK_HOOK": hook_name,
-        "TEROK_PROJECT_ID": project_id,
+        "TEROK_PROJECT_NAME": project_name,
         "TEROK_TASK_ID": str(task_id),
         "TEROK_TASK_MODE": mode,
         "TEROK_CONTAINER_NAME": cname,
@@ -127,7 +127,7 @@ def run_hook(
     hook_name: str,
     command: str | None,
     *,
-    project_id: str,
+    project_name: str,
     task_id: str,
     mode: str,
     cname: str,
@@ -153,7 +153,7 @@ def run_hook(
         return
 
     env = _build_hook_env(
-        project_id,
+        project_name,
         task_id,
         mode,
         cname,

--- a/src/terok/lib/orchestration/image.py
+++ b/src/terok/lib/orchestration/image.py
@@ -4,7 +4,7 @@
 """Dockerfile generation, image building, and build-context hashing.
 
 [`ProjectImage`][terok.lib.orchestration.image.ProjectImage] is the
-entry point: instantiate from a project id or
+entry point: instantiate from a project name or
 [`ProjectConfig`][terok.lib.core.project_model.ProjectConfig] and call
 [`build`][terok.lib.orchestration.image.ProjectImage.build] /
 [`generate_dockerfiles`][terok.lib.orchestration.image.ProjectImage.generate_dockerfiles].
@@ -66,9 +66,9 @@ class ProjectImage:
     """Resolved project configuration."""
 
     @classmethod
-    def load(cls, project_id: str) -> ProjectImage:
-        """Construct from *project_id* via [`load_project`][terok.lib.core.projects.load_project]."""
-        return cls(load_project(project_id))
+    def load(cls, project_name: str) -> ProjectImage:
+        """Construct from *project_name* via [`load_project`][terok.lib.core.projects.load_project]."""
+        return cls(load_project(project_name))
 
     # ── Family + rendered Dockerfiles ────────────────
 
@@ -119,7 +119,7 @@ class ProjectImage:
     @property
     def stage_dir(self) -> Path:
         """Build-context directory for this project (``build_dir()/<id>``)."""
-        return build_dir() / self.project.id
+        return build_dir() / self.project.name
 
     def generate_dockerfiles(self) -> None:
         """Render and write Dockerfiles and auxiliary scripts to the stage dir.
@@ -151,7 +151,7 @@ class ProjectImage:
     @property
     def manifest_path(self) -> Path:
         """Path to the on-disk build manifest for this project."""
-        return build_dir() / self.project.id / "build_manifest.json"
+        return build_dir() / self.project.name / "build_manifest.json"
 
     def read_manifest(self) -> dict[str, Any] | None:
         """Load the build manifest, or ``None`` if absent/corrupt."""
@@ -211,8 +211,8 @@ class ProjectImage:
 
         l1_cli_image = base_images.l1
         l0_image = base_images.l0
-        l2_cli_image = project_cli_image(self.project.id)
-        l2_dev_image = project_dev_image(self.project.id)
+        l2_cli_image = project_cli_image(self.project.name)
+        l2_dev_image = project_dev_image(self.project.name)
 
         # Generate L2 build context (Dockerfile + staged resources).
         self.generate_dockerfiles()
@@ -313,7 +313,7 @@ class ProjectImage:
             if not us_path.is_file():
                 raise SystemExit(
                     f"image.user_snippet_file not found: {us_path}\n"
-                    f"  (configured in project '{self.project.id}')"
+                    f"  (configured in project '{self.project.name}')"
                 )
             try:
                 parts.append(us_path.read_text(encoding="utf-8"))
@@ -431,43 +431,43 @@ def build_context_hash_from_rendered(project: ProjectConfig, rendered: dict[str,
     )
 
 
-def build_context_hash(project_id: str) -> str:
+def build_context_hash(project_name: str) -> str:
     """Shim around [`ProjectImage.context_hash`][terok.lib.orchestration.image.ProjectImage.context_hash]."""
-    return ProjectImage.load(project_id).context_hash
+    return ProjectImage.load(project_name).context_hash
 
 
-def _write_build_manifest(project_id: str, manifest: dict[str, Any]) -> None:
+def _write_build_manifest(project_name: str, manifest: dict[str, Any]) -> None:
     """Shim around [`ProjectImage._write_manifest`][terok.lib.orchestration.image.ProjectImage._write_manifest]."""
-    ProjectImage.load(project_id)._write_manifest(manifest)
+    ProjectImage.load(project_name)._write_manifest(manifest)
 
 
-def _manifest_path(project_id: str) -> Path:
+def _manifest_path(project_name: str) -> Path:
     """Shim around [`ProjectImage.manifest_path`][terok.lib.orchestration.image.ProjectImage.manifest_path]."""
-    return ProjectImage.load(project_id).manifest_path
+    return ProjectImage.load(project_name).manifest_path
 
 
-def read_build_manifest(project_id: str) -> dict[str, Any] | None:
+def read_build_manifest(project_name: str) -> dict[str, Any] | None:
     """Shim around [`ProjectImage.read_manifest`][terok.lib.orchestration.image.ProjectImage.read_manifest]."""
-    return ProjectImage.load(project_id).read_manifest()
+    return ProjectImage.load(project_name).read_manifest()
 
 
-def generate_dockerfiles(project_id: str, *, family: str | None = None) -> None:
+def generate_dockerfiles(project_name: str, *, family: str | None = None) -> None:
     """Shim around [`ProjectImage.generate_dockerfiles`][terok.lib.orchestration.image.ProjectImage.generate_dockerfiles]."""
-    image = ProjectImage.load(project_id)
+    image = ProjectImage.load(project_name)
     if family is not None:
         object.__setattr__(image, "family", family)
     image.generate_dockerfiles()
 
 
 def build_images(
-    project_id: str,
+    project_name: str,
     include_dev: bool = False,
     refresh_agents: bool = False,
     full_rebuild: bool = False,
     agents: str | None = None,
 ) -> None:
     """Shim around [`ProjectImage.build`][terok.lib.orchestration.image.ProjectImage.build]."""
-    ProjectImage.load(project_id).build(
+    ProjectImage.load(project_name).build(
         include_dev=include_dev,
         refresh_agents=refresh_agents,
         full_rebuild=full_rebuild,

--- a/src/terok/lib/orchestration/ports.py
+++ b/src/terok/lib/orchestration/ports.py
@@ -11,15 +11,15 @@ users on shared hosts.
 from terok.lib.integrations.sandbox import claim_port, release_port
 
 
-def assign_web_port(project_id: str, task_id: str, preferred: int | None = None) -> int:
+def assign_web_port(project_name: str, task_id: str, preferred: int | None = None) -> int:
     """Claim a web port for a task via the shared registry.
 
     When *preferred* is set (e.g. from persisted task metadata), tries
     that port first before scanning.
     """
-    return claim_port(f"web:{project_id}/{task_id}", preferred=preferred)
+    return claim_port(f"web:{project_name}/{task_id}", preferred=preferred)
 
 
-def release_web_port(project_id: str, task_id: str) -> None:
+def release_web_port(project_name: str, task_id: str) -> None:
     """Release a previously claimed web port for a task."""
-    release_port(f"web:{project_id}/{task_id}")
+    release_port(f"web:{project_name}/{task_id}")

--- a/src/terok/lib/orchestration/task_runners/cli.py
+++ b/src/terok/lib/orchestration/task_runners/cli.py
@@ -38,7 +38,7 @@ from .shield import _apply_shield_policy
 
 
 def task_run_cli(
-    project_id: str,
+    project_name: str,
     task_id: str,
     preset: str | None = None,
     unrestricted: bool | None = None,
@@ -49,10 +49,10 @@ def task_run_cli(
     CLI access.  After the container reports ready the task metadata is
     marked ``running`` and the user is shown login instructions.
     """
-    project = load_project(project_id)
-    meta, meta_path = load_task_meta(project.id, task_id, "cli")
+    project = load_project(project_name)
+    meta, meta_path = load_task_meta(project.name, task_id, "cli")
 
-    cname = container_name(project.id, "cli", task_id)
+    cname = container_name(project.name, "cli", task_id)
     container_state = _rt.resolve_runtime(project).container(cname).state
 
     # If container already exists, handle it
@@ -60,7 +60,7 @@ def task_run_cli(
         color_enabled = _supports_color()
         if container_state == "running":
             print(f"Container {_green(cname, color_enabled)} is already running.")
-            _print_login_instructions(project.id, task_id, cname, color_enabled)
+            _print_login_instructions(project.name, task_id, cname, color_enabled)
             return
         # Container exists but is stopped/exited - start it
         print(f"Starting existing container {_green(cname, color_enabled)}...")
@@ -70,7 +70,7 @@ def task_run_cli(
         run_hook(
             "post_start",
             project.hook_post_start,
-            project_id=project.id,
+            project_name=project.name,
             task_id=task_id,
             mode="cli",
             cname=cname,
@@ -82,19 +82,19 @@ def task_run_cli(
         meta["ready_at"] = datetime.now(UTC).isoformat()
         write_task_meta(meta_path, meta)
         print("Container started.")
-        _print_login_instructions(project.id, task_id, cname, color_enabled)
+        _print_login_instructions(project.name, task_id, cname, color_enabled)
         return
 
     env, volumes = build_task_env_and_volumes(project, task_id)
 
     # Resolve layered agent config (global → project → preset → CLI overrides)
-    agent_config_dir = _prepare_agent_config(project, project_id, task_id, preset)
+    agent_config_dir = _prepare_agent_config(project, project_name, task_id, preset)
     volumes.append(VolumeSpec(agent_config_dir, CONTAINER_TEROK_CONFIG, sharing=Sharing.PRIVATE))
 
     # Resolve unrestricted mode: CLI flag → config → default (True)
     if unrestricted is None:
         _effective = resolve_agent_config(
-            project_id,
+            project_name,
             agent_config=project.agent_config,
             project_root=project.root,
             preset=preset,
@@ -113,7 +113,7 @@ def task_run_cli(
     run_hook(
         "pre_start",
         project.hook_pre_start,
-        project_id=project.id,
+        project_name=project.name,
         task_id=task_id,
         mode="cli",
         cname=cname,
@@ -122,7 +122,7 @@ def task_run_cli(
     )
     _run_container(
         cname=cname,
-        image=project_cli_image(project.id),
+        image=project_cli_image(project.name),
         env=env,
         volumes=volumes,
         project=project,
@@ -136,7 +136,7 @@ def task_run_cli(
     run_hook(
         "post_start",
         project.hook_post_start,
-        project_id=project.id,
+        project_name=project.name,
         task_id=task_id,
         mode="cli",
         cname=cname,
@@ -155,7 +155,7 @@ def task_run_cli(
     run_hook(
         "post_ready",
         project.hook_post_ready,
-        project_id=project.id,
+        project_name=project.name,
         task_id=task_id,
         mode="cli",
         cname=cname,
@@ -174,7 +174,7 @@ def task_run_cli(
     print(
         f"\nCLI container is running in the background.\n- Name:     {_green(cname, color_enabled)}"
     )
-    _print_login_instructions(project.id, task_id, cname, color_enabled)
+    _print_login_instructions(project.name, task_id, cname, color_enabled)
     print(f"- To stop:  {_red(f'podman stop {cname}', color_enabled)}\n")
 
 

--- a/src/terok/lib/orchestration/task_runners/config.py
+++ b/src/terok/lib/orchestration/task_runners/config.py
@@ -61,7 +61,7 @@ def _apply_unrestricted_env(env: dict[str, str]) -> None:
 
 def _prepare_agent_config(
     project: ProjectConfig,
-    project_id: str,
+    project_name: str,
     task_id: str,
     preset: str | None,
     *,
@@ -74,7 +74,7 @@ def _prepare_agent_config(
     (e.g. explicit agent selection).
     """
     effective = resolve_agent_config(
-        project_id,
+        project_name,
         agent_config=project.agent_config,
         project_root=project.root,
         preset=preset,

--- a/src/terok/lib/orchestration/task_runners/container.py
+++ b/src/terok/lib/orchestration/task_runners/container.py
@@ -63,16 +63,16 @@ def _assert_running(project: ProjectConfig, cname: str) -> None:
         )
 
 
-def _print_login_instructions(project_id: str, task_id: str, cname: str, color: bool) -> None:
+def _print_login_instructions(project_name: str, task_id: str, cname: str, color: bool) -> None:
     """Print how to log into a CLI container; warn if the vault recovery key is unconfirmed.
 
-    Resolves the runtime per *project_id* so the printed raw-command
+    Resolves the runtime per *project_name* so the printed raw-command
     line matches what the operator's about to invoke — under crun
     that's ``podman exec``; under krun it's
     ``ssh -p <host_port> -i <key> … dev@127.0.0.1``.
     """
-    project = load_project(project_id)
-    login_cmd = f"terok login {project_id} {task_id}"
+    project = load_project(project_name)
+    login_cmd = f"terok login {project_name} {task_id}"
     raw_cmd = shlex.join(
         _rt.resolve_runtime(project).container(cname).login_command(command=("bash",))
     )
@@ -179,7 +179,7 @@ def _run_container(
     # the pointed-at JSON file as ``ClearanceEvent.dossier`` on every
     # event.  The JSON file IS the wire dossier — wire-shape keys, no
     # projection, no snapshot — so one annotation is enough.
-    task_dossier_path = dossier_path(tasks_meta_dir(project.id), task_id)
+    task_dossier_path = dossier_path(tasks_meta_dir(project.name), task_id)
     annotations = {"dossier.meta_path": str(task_dossier_path)}
     merged_args = list(extra_args or ()) + _project_runtime_flags(project, cname=cname)
     if project.runtime == "krun":
@@ -212,7 +212,7 @@ def _run_container(
             runtime=project.runtime,
             hostname=cname,
             annotations=annotations,
-            project_id=project.id,
+            project_id=project.name,  # executor API kwarg is ``project_id``; value is the project name
             task_id=task_id,
             dossier_path=task_dossier_path,
         )

--- a/src/terok/lib/orchestration/task_runners/headless.py
+++ b/src/terok/lib/orchestration/task_runners/headless.py
@@ -62,7 +62,7 @@ _PROMPT_HISTORY_FILENAME = "prompt-history.txt"
 class HeadlessRunRequest:
     """Groups all parameters for a headless (unattended) agent run."""
 
-    project_id: str
+    project_name: str
     prompt: str
     config_path: str | None = None
     model: str | None = None
@@ -103,13 +103,13 @@ def _print_detached_summary(summary: DetachedSummary) -> None:
     )
 
 
-def _print_run_summary(project_id: str, task_id: str, mode: str, workspace: Path) -> None:
+def _print_run_summary(project_name: str, task_id: str, mode: str, workspace: Path) -> None:
     """Print a summary of changes made by the headless agent.
 
     Runs ``git diff --stat`` **inside** the task container to avoid executing
     potentially poisoned git hooks on the host.
     """
-    diff_stat = container_git_diff(project_id, task_id, mode, "--stat", "HEAD@{1}..HEAD")
+    diff_stat = container_git_diff(project_name, task_id, mode, "--stat", "HEAD@{1}..HEAD")
     if diff_stat is not None:
         stripped = diff_stat.strip()
         if stripped:
@@ -136,7 +136,7 @@ def _build_cli_overrides(config_path: str | None) -> dict:
 
 def _report_headless_result(
     *,
-    project_id: str,
+    project_name: str,
     task_id: str,
     cname: str,
     task_dir: Path,
@@ -151,9 +151,9 @@ def _report_headless_result(
     """
     color_enabled = _supports_color()
     if follow:
-        exit_code = _rt.resolve_runtime(load_project(project_id)).container(cname).wait()
-        _print_run_summary(project_id, task_id, "run", task_dir / WORKSPACE_DANGEROUS_DIRNAME)
-        update_task_exit_code(project_id, task_id, exit_code)
+        exit_code = _rt.resolve_runtime(load_project(project_name)).container(cname).wait()
+        _print_run_summary(project_name, task_id, "run", task_dir / WORKSPACE_DANGEROUS_DIRNAME)
+        update_task_exit_code(project_name, task_id, exit_code)
         if exit_code != 0:
             print(f"\n{label} exited with code {_red(str(exit_code), color_enabled)}")
     else:
@@ -186,14 +186,14 @@ def task_run_headless(request: HeadlessRunRequest) -> str:
         get_agent,
     )
 
-    project = load_project(request.project_id)
+    project = load_project(request.project_name)
     resolved = get_agent(request.agent, default_agent=project.default_agent)
     require_agent_installed(project, resolved.name)
 
     # Resolve layered agent config (global → project → preset → CLI overrides)
     cli_overrides = _build_cli_overrides(request.config_path)
     effective = resolve_agent_config(
-        request.project_id,
+        request.project_name,
         agent_config=project.agent_config,
         project_root=project.root,
         preset=request.preset,
@@ -230,7 +230,7 @@ def task_run_headless(request: HeadlessRunRequest) -> str:
         effective_prompt = f"{request.prompt}\n\n{pcfg.prompt_extra}"
 
     # Create a new task
-    task_id = task_new(request.project_id, name=request.name)
+    task_id = task_new(request.project_name, name=request.name)
 
     # Prepare agent-config dir with wrapper, prompt.txt, instructions.md
     task_dir = project.tasks_root / str(task_id)
@@ -270,13 +270,13 @@ def task_run_headless(request: HeadlessRunRequest) -> str:
     )
 
     # Build podman command (DETACHED)
-    cname = container_name(project.id, "run", task_id)
+    cname = container_name(project.name, "run", task_id)
 
-    meta, meta_path = load_task_meta(project.id, task_id)
+    meta, meta_path = load_task_meta(project.name, task_id)
     run_hook(
         "pre_start",
         project.hook_pre_start,
-        project_id=project.id,
+        project_name=project.name,
         task_id=task_id,
         mode="run",
         cname=cname,
@@ -285,7 +285,7 @@ def task_run_headless(request: HeadlessRunRequest) -> str:
     )
     _run_container(
         cname=cname,
-        image=project_cli_image(project.id),
+        image=project_cli_image(project.name),
         env=env,
         volumes=volumes,
         project=project,
@@ -297,7 +297,7 @@ def task_run_headless(request: HeadlessRunRequest) -> str:
     run_hook(
         "post_start",
         project.hook_post_start,
-        project_id=project.id,
+        project_name=project.name,
         task_id=task_id,
         mode="run",
         cname=cname,
@@ -317,7 +317,7 @@ def task_run_headless(request: HeadlessRunRequest) -> str:
     write_task_meta(meta_path, meta)
 
     _report_headless_result(
-        project_id=project.id,
+        project_name=project.name,
         task_id=task_id,
         cname=cname,
         task_dir=task_dir,
@@ -355,7 +355,7 @@ def _inject_followup_prompt(
 
 
 def task_followup_headless(
-    project_id: str,
+    project_name: str,
     task_id: str,
     prompt: str,
     follow: bool = True,
@@ -384,8 +384,8 @@ def task_followup_headless(
     """
     from terok.lib.integrations.executor import AGENTS
 
-    project = load_project(project_id)
-    meta, meta_path = load_task_meta(project.id, task_id)
+    project = load_project(project_name)
+    meta, meta_path = load_task_meta(project.name, task_id)
 
     mode = meta.get("mode")
     if mode != "run":
@@ -394,7 +394,7 @@ def task_followup_headless(
             f"Follow-up is only supported for unattended (mode='run') tasks."
         )
 
-    cname = container_name(project.id, "run", task_id)
+    cname = container_name(project.name, "run", task_id)
     container_state = _rt.resolve_runtime(project).container(cname).state
     if container_state == "running":
         raise SystemExit(
@@ -439,7 +439,7 @@ def task_followup_headless(
     run_hook(
         "post_start",
         project.hook_post_start,
-        project_id=project.id,
+        project_name=project.name,
         task_id=task_id,
         mode="run",
         cname=cname,
@@ -453,7 +453,7 @@ def task_followup_headless(
     write_task_meta(meta_path, meta)
 
     _report_headless_result(
-        project_id=project.id,
+        project_name=project.name,
         task_id=task_id,
         cname=cname,
         task_dir=task_dir,

--- a/src/terok/lib/orchestration/task_runners/restart.py
+++ b/src/terok/lib/orchestration/task_runners/restart.py
@@ -45,11 +45,11 @@ def _validate_restart_preconditions(
     """
     web_port = meta.get("web_port")
     if isinstance(web_port, int):
-        actual = assign_web_port(project.id, task_id, preferred=web_port)
+        actual = assign_web_port(project.name, task_id, preferred=web_port)
         if actual != web_port:
-            release_web_port(project.id, task_id)
+            release_web_port(project.name, task_id)
             raise SystemExit(
-                f"Port {web_port} for {project.id}/{task_id} is no longer available "
+                f"Port {web_port} for {project.name}/{task_id} is no longer available "
                 f"(got {actual}).  Re-create the task to use the new port."
             )
     if mode == "toad":
@@ -69,7 +69,7 @@ def _stop_running_container(
     run_hook(
         "post_stop",
         project.hook_post_stop,
-        project_id=project.id,
+        project_name=project.name,
         task_id=task_id,
         mode=mode,
         cname=cname,
@@ -88,7 +88,7 @@ def _start_and_report_restart(
     run_hook(
         "post_start",
         project.hook_post_start,
-        project_id=project.id,
+        project_name=project.name,
         task_id=task_id,
         mode=mode,
         cname=cname,
@@ -100,7 +100,7 @@ def _start_and_report_restart(
     color_enabled = _supports_color()
     print(f"Restarted task {task_id}: {_green(cname, color_enabled)}")
     if mode == "cli":
-        _print_login_instructions(project.id, task_id, cname, color_enabled)
+        _print_login_instructions(project.name, task_id, cname, color_enabled)
     elif mode == "toad":
         port = meta.get("web_port")
         token = meta.get("web_token")
@@ -109,7 +109,7 @@ def _start_and_report_restart(
             print(f"Toad: {_hyperlink(_blue(url, color_enabled), url, enabled=color_enabled)}")
 
 
-def task_restart(project_id: str, task_id: str) -> None:
+def task_restart(project_name: str, task_id: str) -> None:
     """Restart a task's container.
 
     Semantics: stop the container if running, then start it.  If the
@@ -117,17 +117,17 @@ def task_restart(project_id: str, task_id: str) -> None:
     raise ``SystemExit`` with an actionable pointer to ``terok task run``
     — "restart" only means restart, not re-run.
     """
-    project = load_project(project_id)
-    meta, meta_path = load_task_meta(project.id, task_id)
+    project = load_project(project_name)
+    meta, meta_path = load_task_meta(project.name, task_id)
 
     mode = meta.get("mode")
     if not mode:
         raise SystemExit(f"Task {task_id} has never been run (no mode set)")
 
-    cname = container_name(project.id, mode, task_id)
+    cname = container_name(project.name, mode, task_id)
     container_state = _rt.resolve_runtime(project).container(cname).state
 
-    print(f"Restarting task {project_id}/{task_id} ({mode})...")
+    print(f"Restarting task {project_name}/{task_id} ({mode})...")
 
     if container_state is None:
         # Container is gone — restart can't recreate it.  User must start
@@ -135,7 +135,7 @@ def task_restart(project_id: str, task_id: str) -> None:
         raise SystemExit(
             f"Container {cname} no longer exists.  Restart requires a running "
             f"or stopped container.  Create a new task with:\n"
-            f"  terok task run {project_id}"
+            f"  terok task run {project_name}"
             + (' "<prompt>" --mode headless' if mode == "run" else "")
         )
 

--- a/src/terok/lib/orchestration/task_runners/toad.py
+++ b/src/terok/lib/orchestration/task_runners/toad.py
@@ -141,13 +141,13 @@ def _resume_toad_container(
     saved_port = meta.get("web_port")
     if not isinstance(saved_port, int):
         raise SystemExit(f"Existing toad container {cname} has no saved web_port in metadata.")
-    actual = assign_web_port(project.id, task_id, preferred=saved_port)
+    actual = assign_web_port(project.name, task_id, preferred=saved_port)
     if actual != saved_port:
         # The registry handed us a fallback port — release it so the task
         # doesn't leak a claim we'll never publish.
-        release_web_port(project.id, task_id)
+        release_web_port(project.name, task_id)
         raise SystemExit(
-            f"Port {saved_port} for {project.id}/{task_id} is no longer available "
+            f"Port {saved_port} for {project.name}/{task_id} is no longer available "
             f"(got {actual}).  Re-create the task to use the new port."
         )
     saved_token = _rehydrate_toad_token(project, task_id, meta, cname)
@@ -164,7 +164,7 @@ def _resume_toad_container(
     run_hook(
         "post_start",
         project.hook_post_start,
-        project_id=project.id,
+        project_name=project.name,
         task_id=task_id,
         mode="toad",
         cname=cname,
@@ -178,7 +178,7 @@ def _resume_toad_container(
 
 
 def task_run_toad(
-    project_id: str,
+    project_name: str,
     task_id: str,
     preset: str | None = None,
     unrestricted: bool | None = None,
@@ -191,10 +191,10 @@ def task_run_toad(
     listening.  Caddy enforces the per-task token (see
     `_ensure_toad_token`) on every request.
     """
-    project = load_project(project_id)
-    meta, meta_path = load_task_meta(project.id, task_id, "toad")
+    project = load_project(project_name)
+    meta, meta_path = load_task_meta(project.name, task_id, "toad")
 
-    cname = container_name(project.id, "toad", task_id)
+    cname = container_name(project.name, "toad", task_id)
     container_state = _rt.resolve_runtime(project).container(cname).state
 
     pub_host = get_public_host()
@@ -212,12 +212,12 @@ def task_run_toad(
         return
 
     # New container — allocate a fresh port.
-    port = assign_web_port(project.id, task_id)
+    port = assign_web_port(project.name, task_id)
     meta["web_port"] = port
 
     env, volumes = build_task_env_and_volumes(project, task_id)
 
-    agent_config_dir = _prepare_agent_config(project, project_id, task_id, preset)
+    agent_config_dir = _prepare_agent_config(project, project_name, task_id, preset)
     volumes.append(VolumeSpec(agent_config_dir, CONTAINER_TEROK_CONFIG, sharing=Sharing.PRIVATE))
 
     token = _ensure_toad_token(agent_config_dir)
@@ -229,7 +229,7 @@ def task_run_toad(
     # Resolve unrestricted mode: CLI flag → config → default (True)
     if unrestricted is None:
         _effective = resolve_agent_config(
-            project_id,
+            project_name,
             agent_config=project.agent_config,
             project_root=project.root,
             preset=preset,
@@ -266,7 +266,7 @@ def task_run_toad(
     run_hook(
         "pre_start",
         project.hook_pre_start,
-        project_id=project.id,
+        project_name=project.name,
         task_id=task_id,
         mode="toad",
         cname=cname,
@@ -276,7 +276,7 @@ def task_run_toad(
     )
     _run_container(
         cname=cname,
-        image=project_cli_image(project.id),
+        image=project_cli_image(project.name),
         env=env,
         volumes=volumes,
         project=project,
@@ -289,7 +289,7 @@ def task_run_toad(
     run_hook(
         "post_start",
         project.hook_post_start,
-        project_id=project.id,
+        project_name=project.name,
         task_id=task_id,
         mode="toad",
         cname=cname,
@@ -315,7 +315,7 @@ def task_run_toad(
     run_hook(
         "post_ready",
         project.hook_post_ready,
-        project_id=project.id,
+        project_name=project.name,
         task_id=task_id,
         mode="toad",
         cname=cname,

--- a/src/terok/lib/orchestration/tasks/archive.py
+++ b/src/terok/lib/orchestration/tasks/archive.py
@@ -37,9 +37,9 @@ def _load_archived_task_meta(entry: Path) -> dict | None:
         return None
 
 
-def list_archived_tasks(project_id: str) -> list[ArchivedTask]:
-    """Return archived tasks for *project_id*, sorted newest-first."""
-    archive_root = tasks_archive_dir(project_id)
+def list_archived_tasks(project_name: str) -> list[ArchivedTask]:
+    """Return archived tasks for *project_name*, sorted newest-first."""
+    archive_root = tasks_archive_dir(project_name)
     if not archive_root.is_dir():
         return []
     results: list[ArchivedTask] = []
@@ -65,9 +65,9 @@ def list_archived_tasks(project_id: str) -> list[ArchivedTask]:
     return results
 
 
-def task_archive_list(project_id: str) -> None:
-    """Print archived tasks for *project_id*."""
-    archived = list_archived_tasks(project_id)
+def task_archive_list(project_name: str) -> None:
+    """Print archived tasks for *project_name*."""
+    archived = list_archived_tasks(project_name)
     if not archived:
         print("No archived tasks found")
         return
@@ -81,13 +81,13 @@ def task_archive_list(project_id: str) -> None:
         print(f"- {a.archived_at} #{a.task_id}: {a.name}{extra_s}")
 
 
-def task_archive_logs(project_id: str, archive_id: str) -> Path | None:
+def task_archive_logs(project_name: str, archive_id: str) -> Path | None:
     """Return the log file path for an archived task identified by *archive_id*.
 
     *archive_id* is matched against archive directory names (prefix match).
     Returns the log file path if found, or ``None``.
     """
-    archive_root = tasks_archive_dir(project_id)
+    archive_root = tasks_archive_dir(project_name)
     if not archive_root.is_dir():
         return None
     for entry in sorted(archive_root.iterdir(), reverse=True):

--- a/src/terok/lib/orchestration/tasks/identity.py
+++ b/src/terok/lib/orchestration/tasks/identity.py
@@ -106,7 +106,7 @@ def _validate_task_id_prefix(prefix: str) -> None:
     )
 
 
-def resolve_task_id(project_id: str, prefix: str) -> str:
+def resolve_task_id(project_name: str, prefix: str) -> str:
     """Resolve a (possibly partial) task ID to its full form.
 
     The *prefix* is first run through [`normalize_task_id_input`][terok.lib.orchestration.tasks.normalize_task_id_input],
@@ -129,16 +129,16 @@ def resolve_task_id(project_id: str, prefix: str) -> str:
         )
     prefix = stripped.translate(_TASK_ID_INPUT_TRANSLATE)
     _validate_task_id_prefix(prefix)
-    meta_dir = tasks_meta_dir(project_id)
+    meta_dir = tasks_meta_dir(project_name)
     if not meta_dir.is_dir():
-        raise SystemExit(f"No tasks found for project {project_id}")
-    if task_exists(project_id, prefix):
+        raise SystemExit(f"No tasks found for project {project_name}")
+    if task_exists(project_name, prefix):
         return prefix
     matches = [tid for tid in iter_task_ids(meta_dir) if is_task_id(tid) and tid.startswith(prefix)]
     if len(matches) == 1:
         return matches[0]
     if not matches:
-        raise SystemExit(f"No task matching '{prefix}' in project {project_id}")
+        raise SystemExit(f"No task matching '{prefix}' in project {project_name}")
     raise SystemExit(f"Ambiguous task ID '{prefix}' — matches: {', '.join(sorted(matches))}")
 
 

--- a/src/terok/lib/orchestration/tasks/lifecycle.py
+++ b/src/terok/lib/orchestration/tasks/lifecycle.py
@@ -83,10 +83,10 @@ def _task_new(project: ProjectConfig, *, name: str | None = None) -> str:
         if err:
             raise SystemExit(f"Invalid task name: {err}")
     else:
-        task_name = generate_task_name(project.id)
+        task_name = generate_task_name(project.name)
     tasks_root = project.tasks_root
     ensure_dir(tasks_root)
-    meta_dir = tasks_meta_dir(project.id)
+    meta_dir = tasks_meta_dir(project.name)
     ensure_dir(meta_dir)
 
     existing = set(iter_task_ids(meta_dir))
@@ -110,7 +110,7 @@ def _task_new(project: ProjectConfig, *, name: str | None = None) -> str:
     _write_task_readme(ws)
 
     meta = {
-        "project_id": project.id,
+        "project_name": project.name,
         "task_id": next_id,
         "name": task_name,
         "mode": None,
@@ -123,11 +123,11 @@ def _task_new(project: ProjectConfig, *, name: str | None = None) -> str:
     return next_id
 
 
-def task_new(project_id: str, *, name: str | None = None) -> str:
+def task_new(project_name: str, *, name: str | None = None) -> str:
     """Create a new task with a fresh workspace for a project.
 
     Args:
-        project_id: The project to create the task under.
+        project_name: The project to create the task under.
         name: Optional human-readable name.  Allowed characters are
             lowercase letters, digits, hyphens, and underscores.
             If ``None``, a random slug-style name is generated via
@@ -155,12 +155,12 @@ def task_new(project_id: str, *, name: str | None = None) -> str:
     - Stale workspace from incompletely deleted previous task with same ID
     - Ensuring new tasks always start with latest code
     """
-    return _task_new(load_project(project_id), name=name)
+    return _task_new(load_project(project_name), name=name)
 
 
 def _task_rename(project: ProjectConfig, task_id: str, new_name: str) -> None:
     """Rename a task by updating its metadata file."""
-    meta_dir = tasks_meta_dir(project.id)
+    meta_dir = tasks_meta_dir(project.name)
     meta = read_task_meta(meta_dir, task_id)
     if meta is None:
         raise SystemExit(f"Unknown task {task_id}")
@@ -175,13 +175,13 @@ def _task_rename(project: ProjectConfig, task_id: str, new_name: str) -> None:
     print(f"Renamed task {task_id} to {sanitized}")
 
 
-def task_rename(project_id: str, task_id: str, new_name: str) -> None:
+def task_rename(project_name: str, task_id: str, new_name: str) -> None:
     """Rename a task by updating its metadata file.
 
     Sanitizes *new_name* and writes the result to the task's metadata file.
     Raises ``SystemExit`` if the task is unknown or the sanitized name is invalid.
     """
-    _task_rename(load_project(project_id), task_id, new_name)
+    _task_rename(load_project(project_name), task_id, new_name)
 
 
 def capture_task_logs(project: ProjectConfig | str, task_id: str, mode: str) -> Path | None:
@@ -192,7 +192,7 @@ def capture_task_logs(project: ProjectConfig | str, task_id: str, mode: str) -> 
     path on success, or ``None`` if the container doesn't exist or podman
     fails.
 
-    *project* may be a [`ProjectConfig`][terok.cli.commands.sickbay.ProjectConfig] or a project-ID string
+    *project* may be a [`ProjectConfig`][terok.cli.commands.sickbay.ProjectConfig] or a project name string
     (the string form loads the config internally for backward compat).
     """
     if isinstance(project, str):
@@ -202,7 +202,7 @@ def capture_task_logs(project: ProjectConfig | str, task_id: str, mode: str) -> 
     ensure_dir(logs_dir)
     log_file = logs_dir / "container.log"
 
-    cname = container_name(project.id, mode, task_id)
+    cname = container_name(project.name, mode, task_id)
     if AgentRunner().capture_logs(cname, log_file, timestamps=True, timeout=60.0):
         return log_file
     return None
@@ -211,7 +211,7 @@ def capture_task_logs(project: ProjectConfig | str, task_id: str, mode: str) -> 
 def _archive_task(project: ProjectConfig, task_id: str, meta: dict) -> Path | None:
     """Archive task metadata and logs before deletion.
 
-    Creates an entry at ``archive/<project_id>/tasks/<ts>_<task_id>[_<name>]/``
+    Creates an entry at ``archive/<project_name>/tasks/<ts>_<task_id>[_<name>]/``
     containing the task metadata YAML and any captured logs.  The archival
     timestamp is the primary identifier because task numbers and names can
     be reused after deletion.
@@ -226,7 +226,7 @@ def _archive_task(project: ProjectConfig, task_id: str, meta: dict) -> Path | No
         if task_name:
             dir_name = f"{dir_name}_{task_name}"
 
-        archive_root = tasks_archive_dir(project.id)
+        archive_root = tasks_archive_dir(project.name)
         archive_dir = create_archive_dir(archive_root, dir_name)
 
         # Save the *merged* meta as a single self-contained JSON snapshot.
@@ -267,15 +267,15 @@ class TaskDeleteResult:
     warnings: list[str]
 
 
-def _remove_task_containers(project_id: str, task_id: str, warnings: list[str]) -> bool:
+def _remove_task_containers(project_name: str, task_id: str, warnings: list[str]) -> bool:
     """Force-remove every mode's container for the task.
 
     Returns ``True`` only when every container was removed cleanly;
     a raised error or per-container failure is collected into *warnings*
     and yields ``False``.
     """
-    names = [container_name(project_id, mode, str(task_id)) for mode in CONTAINER_MODES]
-    project = load_project(project_id)
+    names = [container_name(project_name, mode, str(task_id)) for mode in CONTAINER_MODES]
+    project = load_project(project_name)
     runtime = _rt.resolve_runtime(project)
     try:
         rm_results = runtime.force_remove([runtime.container(n) for n in names])
@@ -327,7 +327,7 @@ def _remove_meta_files(paths: tuple[Path, ...], warnings: list[str]) -> None:
 
 
 def _release_task_web_port(
-    project_id: str, task_id: str, containers_removed: bool, warnings: list[str]
+    project_name: str, task_id: str, containers_removed: bool, warnings: list[str]
 ) -> None:
     """Release the task's claimed web port — only safe once its containers are gone."""
     if not containers_removed:
@@ -337,7 +337,7 @@ def _release_task_web_port(
     try:
         from ..ports import release_web_port
 
-        release_web_port(project_id, task_id)
+        release_web_port(project_name, task_id)
     except Exception as exc:  # noqa: BLE001 — best-effort cleanup
         _log_debug(f"task_delete: web port release failed: {exc}")
         warnings.append(f"Web port release failed: {exc}")
@@ -350,11 +350,11 @@ def _task_delete(project: ProjectConfig, task_id: str) -> TaskDeleteResult:
     collecting any failure into the returned warnings rather than
     aborting the rest of the teardown.
     """
-    _log_debug(f"task_delete: start project_id={project.id} task_id={task_id}")
+    _log_debug(f"task_delete: start project_name={project.name} task_id={task_id}")
     warnings: list[str] = []
 
     workspace = project.tasks_root / str(task_id)
-    meta_dir = tasks_meta_dir(project.id)
+    meta_dir = tasks_meta_dir(project.name)
     dossier_file = dossier_path(meta_dir, task_id)
     meta_file = meta_path(meta_dir, task_id)
     _log_debug(
@@ -375,7 +375,7 @@ def _task_delete(project: ProjectConfig, task_id: str) -> TaskDeleteResult:
     # and dies with the supervisor when the container is removed.
     # *Successful* removal below is therefore what invalidates the token.
     _log_debug("task_delete: removing task containers")
-    containers_removed = _remove_task_containers(project.id, task_id, warnings)
+    containers_removed = _remove_task_containers(project.name, task_id, warnings)
     if not containers_removed:
         # Removal failed, so the supervisor — and the in-memory gate token it
         # holds — may still be live even as the rest of the delete proceeds.
@@ -394,32 +394,32 @@ def _task_delete(project: ProjectConfig, task_id: str) -> TaskDeleteResult:
         run_hook(
             "post_stop",
             project.hook_post_stop,
-            project_id=project.id,
+            project_name=project.name,
             task_id=task_id,
             mode=mode,
-            cname=container_name(project.id, mode, task_id),
+            cname=container_name(project.name, mode, task_id),
             task_dir=workspace,
             meta_path=meta_file,
         )
 
     _remove_workspace(workspace, warnings)
     _remove_meta_files((dossier_file, meta_file), warnings)
-    _release_task_web_port(project.id, task_id, containers_removed, warnings)
+    _release_task_web_port(project.name, task_id, containers_removed, warnings)
 
     _log_debug("task_delete: finished")
     return TaskDeleteResult(task_id=task_id, warnings=warnings)
 
 
-def task_delete(project_id: str, task_id: str) -> TaskDeleteResult:
+def task_delete(project_name: str, task_id: str) -> TaskDeleteResult:
     """Delete a task's workspace, metadata, and any associated containers.
 
     Before removal, captures container logs and archives the task metadata
-    and logs to ``archive/<project_id>/tasks/``.  Containers are stopped
-    best-effort via podman using the ``<project.id>-<mode>-<task_id>``
+    and logs to ``archive/<project_name>/tasks/``.  Containers are stopped
+    best-effort via podman using the ``<project.name>-<mode>-<task_id>``
     naming scheme.  Returns a [`TaskDeleteResult`][terok.lib.orchestration.tasks.TaskDeleteResult] so the caller can
     present any warnings from cleanup steps that failed.
     """
-    return _task_delete(load_project(project_id), task_id)
+    return _task_delete(load_project(project_name), task_id)
 
 
 def _validate_login(project: ProjectConfig, task_id: str) -> tuple[str, str]:
@@ -428,7 +428,7 @@ def _validate_login(project: ProjectConfig, task_id: str) -> tuple[str, str]:
     Returns ``(container_name, mode)`` on success.
     Raises ``SystemExit`` with actionable messages on failure.
     """
-    meta_dir = tasks_meta_dir(project.id)
+    meta_dir = tasks_meta_dir(project.name)
     meta = read_task_meta(meta_dir, task_id)
     if meta is None:
         raise SystemExit(f"Unknown task {task_id}")
@@ -437,21 +437,21 @@ def _validate_login(project: ProjectConfig, task_id: str) -> tuple[str, str]:
     if not mode:
         raise SystemExit(
             f"Task {task_id} has never been run (no mode set).\n"
-            f"  Start a fresh task: terok task run {project.id}\n"
-            f"  Or run this stub:   terokctl task attach {project.id} {task_id} --mode cli"
+            f"  Start a fresh task: terok task run {project.name}\n"
+            f"  Or run this stub:   terokctl task attach {project.name} {task_id} --mode cli"
         )
 
-    cname = container_name(project.id, mode, task_id)
+    cname = container_name(project.name, mode, task_id)
     state = _rt.resolve_runtime(project).container(cname).state
     if state is None:
         raise SystemExit(
             f"Container {cname} does not exist. "
-            f"Run 'terok task restart {project.id} {task_id}' first."
+            f"Run 'terok task restart {project.name} {task_id}' first."
         )
     if state != "running":
         raise SystemExit(
             f"Container {cname} is not running (state: {state}). "
-            f"Run 'terok task restart {project.id} {task_id}' first."
+            f"Run 'terok task restart {project.name} {task_id}' first."
         )
     return cname, mode
 
@@ -484,7 +484,7 @@ def _task_login(project: ProjectConfig, task_id: str) -> None:
 def _task_stop(project: ProjectConfig, task_id: str, *, timeout: int | None = None) -> None:
     """Gracefully stop a running task container."""
     effective_timeout = timeout if timeout is not None else project.shutdown_timeout
-    meta_dir = tasks_meta_dir(project.id)
+    meta_dir = tasks_meta_dir(project.name)
     meta = read_task_meta(meta_dir, task_id)
     if meta is None:
         raise SystemExit(f"Unknown task {task_id}")
@@ -494,7 +494,7 @@ def _task_stop(project: ProjectConfig, task_id: str, *, timeout: int | None = No
     if not mode:
         raise SystemExit(f"Task {task_id} has never been run (no mode set)")
 
-    cname = container_name(project.id, mode, task_id)
+    cname = container_name(project.name, mode, task_id)
     runtime = _rt.resolve_runtime(project)
 
     state = runtime.container(cname).state
@@ -513,7 +513,7 @@ def _task_stop(project: ProjectConfig, task_id: str, *, timeout: int | None = No
     try:
         from ..ports import release_web_port
 
-        release_web_port(project.id, task_id)
+        release_web_port(project.name, task_id)
     except Exception:  # noqa: BLE001 — best-effort; container is already stopped
         pass
 
@@ -522,7 +522,7 @@ def _task_stop(project: ProjectConfig, task_id: str, *, timeout: int | None = No
     run_hook(
         "post_stop",
         project.hook_post_stop,
-        project_id=project.id,
+        project_name=project.name,
         task_id=task_id,
         mode=mode,
         cname=cname,
@@ -532,33 +532,33 @@ def _task_stop(project: ProjectConfig, task_id: str, *, timeout: int | None = No
 
     color_enabled = _supports_color()
     print(f"Stopped task {task_id}: {_green(cname, color_enabled)}")
-    print(f"Restart with: terok task restart {project.id} {task_id}")
+    print(f"Restart with: terok task restart {project.name} {task_id}")
 
 
-def get_login_command(project_id: str, task_id: str) -> list[str]:
+def get_login_command(project_name: str, task_id: str) -> list[str]:
     """Return the podman exec command to log into a task container."""
-    return _get_login_command(load_project(project_id), task_id)
+    return _get_login_command(load_project(project_name), task_id)
 
 
-def task_login(project_id: str, task_id: str) -> None:
+def task_login(project_name: str, task_id: str) -> None:
     """Open an interactive shell in a running task container."""
-    _task_login(load_project(project_id), task_id)
+    _task_login(load_project(project_name), task_id)
 
 
-def task_stop(project_id: str, task_id: str, *, timeout: int | None = None) -> None:
+def task_stop(project_name: str, task_id: str, *, timeout: int | None = None) -> None:
     """Gracefully stop a running task container.
 
     Uses ``podman stop --time <N>`` to give the container *timeout* seconds
     before SIGKILL.  When *timeout* is ``None`` the project's
     ``run.shutdown_timeout`` setting is used (default 10 s).
     """
-    _task_stop(load_project(project_id), task_id, timeout=timeout)
+    _task_stop(load_project(project_name), task_id, timeout=timeout)
 
 
-def task_status(project_id: str, task_id: str) -> None:
+def task_status(project_name: str, task_id: str) -> None:
     """Show live task status with container state diagnostics."""
-    project = load_project(project_id)
-    meta_dir = tasks_meta_dir(project.id)
+    project = load_project(project_name)
+    meta_dir = tasks_meta_dir(project.name)
     meta = read_task_meta(meta_dir, task_id)
     if meta is None:
         raise SystemExit(f"Unknown task {task_id}")
@@ -573,7 +573,7 @@ def task_status(project_id: str, task_id: str) -> None:
     cname = None
     cs = None
     if mode:
-        cname = container_name(project.id, mode, task_id)
+        cname = container_name(project.name, mode, task_id)
         cs = _rt.resolve_runtime(project).container(cname).state
 
     # Build TaskMeta for effective_status / mode_emoji computation
@@ -630,7 +630,7 @@ def task_status(project_id: str, task_id: str) -> None:
 
 def wait_for_container_exit(
     container_name: str,
-    project_id: str,
+    project_name: str,
     task_id: str,
     timeout: int = 7200,
 ) -> tuple[int | None, str | None]:
@@ -651,7 +651,7 @@ def wait_for_container_exit(
     except Exception as e:
         return None, str(e)
 
-    update_task_exit_code(project_id, task_id, exit_code)
+    update_task_exit_code(project_name, task_id, exit_code)
     return exit_code, None
 
 

--- a/src/terok/lib/orchestration/tasks/meta.py
+++ b/src/terok/lib/orchestration/tasks/meta.py
@@ -17,7 +17,7 @@ filename says "meta" and its audience is terok-internal; ruamel keeps
 comments and round-trip ergonomics cheap.
 
 The split is reconciled at the I/O boundary: ``read_task_meta``
-returns one merged dict in internal-storage shape (``project_id``,
+returns one merged dict in internal-storage shape (``project_name``,
 ``task_id``, …), ``write_task_meta`` splits a single dict back to
 both files atomically.
 """
@@ -43,8 +43,8 @@ _META_SUFFIX = "_meta.yml"
 # Subset of in-memory meta keys that belong on the wire (and thus in
 # the JSON dossier file).  Stored under internal names — translated
 # at the I/O boundary by ``_DOSSIER_TO_WIRE`` / ``_DOSSIER_FROM_WIRE``.
-_DOSSIER_INTERNAL_KEYS = ("project_id", "task_id", "name")
-_DOSSIER_TO_WIRE = {"project_id": "project", "task_id": "task", "name": "name"}
+_DOSSIER_INTERNAL_KEYS = ("project_name", "task_id", "name")
+_DOSSIER_TO_WIRE = {"project_name": "project", "task_id": "task", "name": "name"}
 _DOSSIER_FROM_WIRE = {v: k for k, v in _DOSSIER_TO_WIRE.items()}
 
 CONTAINER_TEROK_CONFIG = "/home/dev/.terok"
@@ -236,46 +236,46 @@ def _task_id_from_filename(name: str) -> str:
     return ""
 
 
-def task_exists(project_id: str, task_id: str) -> bool:
-    """Return ``True`` if any task-meta file exists for ``(project_id, task_id)``."""
-    meta_dir = tasks_meta_dir(project_id)
+def task_exists(project_name: str, task_id: str) -> bool:
+    """Return ``True`` if any task-meta file exists for ``(project_name, task_id)``."""
+    meta_dir = tasks_meta_dir(project_name)
     return dossier_path(meta_dir, task_id).is_file() or meta_path(meta_dir, task_id).is_file()
 
 
-def tasks_meta_dir(project_id: str) -> Path:
-    """Return the directory containing task metadata files for *project_id*."""
-    _reject_unsafe_id(project_id, "project_id")
-    return core_state_dir() / "projects" / project_id / "tasks"
+def tasks_meta_dir(project_name: str) -> Path:
+    """Return the directory containing task metadata files for *project_name*."""
+    _reject_unsafe_id(project_name, "project_name")
+    return core_state_dir() / "projects" / project_name / "tasks"
 
 
-def agent_config_dir(project_id: str, task_id: str) -> Path:
+def agent_config_dir(project_name: str, task_id: str) -> Path:
     """Host path of the agent-config dir bind-mounted at `CONTAINER_TEROK_CONFIG`."""
-    _reject_unsafe_id(project_id, "project_id")
+    _reject_unsafe_id(project_name, "project_name")
     _reject_unsafe_id(task_id, "task_id")
-    return load_project(project_id).tasks_root / str(task_id) / "agent-config"
+    return load_project(project_name).tasks_root / str(task_id) / "agent-config"
 
 
-def tasks_archive_dir(project_id: str) -> Path:
-    """Return the directory containing archived task data for *project_id*.
+def tasks_archive_dir(project_name: str) -> Path:
+    """Return the directory containing archived task data for *project_name*.
 
     Lives under the namespace archive tree (``archive/<pid>/tasks/``) so
     operators can find all archived data in one location.  On project
     deletion the entire ``archive/<pid>/`` subtree is bundled into the
     project snapshot and removed.
     """
-    _reject_unsafe_id(project_id, "project_id")
-    return archive_dir() / project_id / "tasks"
+    _reject_unsafe_id(project_name, "project_name")
+    return archive_dir() / project_name / "tasks"
 
 
-def update_task_exit_code(project_id: str, task_id: str, exit_code: int | None) -> None:
+def update_task_exit_code(project_name: str, task_id: str, exit_code: int | None) -> None:
     """Update task metadata with exit code and final status.
 
     Args:
-        project_id: The project ID
+        project_name: The project name
         task_id: The task ID
         exit_code: The exit code from the task, or None if unknown/failed
     """
-    meta_dir = tasks_meta_dir(project_id)
+    meta_dir = tasks_meta_dir(project_name)
     meta = read_task_meta(meta_dir, task_id)
     if meta is None:
         return
@@ -291,17 +291,17 @@ def _check_mode(meta: dict, expected: str) -> None:
 
 
 def load_task_meta(
-    project_id: str, task_id: str, expected_mode: str | None = None
+    project_name: str, task_id: str, expected_mode: str | None = None
 ) -> tuple[dict, Path]:
     """Load task metadata and optionally validate mode.
 
     Returns ``(meta, dossier_path)``: the merged in-memory dict (in
-    its internal storage shape — ``project_id`` / ``task_id`` / …)
+    its internal storage shape — ``project_name`` / ``task_id`` / …)
     plus the canonical dossier-file handle for write-back via
     ``write_task_meta(dossier_path, meta)``.  Raises SystemExit if
     the task is unknown or its mode conflicts with *expected_mode*.
     """
-    meta_dir = tasks_meta_dir(project_id)
+    meta_dir = tasks_meta_dir(project_name)
     meta = read_task_meta(meta_dir, task_id)
     if meta is None:
         raise SystemExit(f"Unknown task {task_id}")
@@ -310,17 +310,17 @@ def load_task_meta(
     return meta, dossier_path(meta_dir, task_id)
 
 
-def mark_task_deleting(project_id: str, task_id: str) -> None:
+def mark_task_deleting(project_name: str, task_id: str) -> None:
     """Persist ``deleting: true`` to the task's metadata file."""
     try:
-        meta_dir = tasks_meta_dir(project_id)
+        meta_dir = tasks_meta_dir(project_name)
         meta = read_task_meta(meta_dir, task_id)
         if meta is None:
             return
         meta["deleting"] = True
         write_task_meta(dossier_path(meta_dir, task_id), meta)
     except Exception as e:
-        _log_debug(f"mark_task_deleting: failed project_id={project_id} task_id={task_id}: {e}")
+        _log_debug(f"mark_task_deleting: failed project_name={project_name} task_id={task_id}: {e}")
 
 
 __all__ = [

--- a/src/terok/lib/orchestration/tasks/naming.py
+++ b/src/terok/lib/orchestration/tasks/naming.py
@@ -45,26 +45,26 @@ def validate_task_name(sanitized: str) -> str | None:
     return None
 
 
-def generate_task_name(project_id: str | None = None) -> str:
+def generate_task_name(project_name: str | None = None) -> str:
     """Generate a random human-readable task name (e.g. ``talented-toucan``).
 
-    When *project_id* is given, name categories are resolved from config:
+    When *project_name* is given, name categories are resolved from config:
     project ``tasks.name_categories`` → global ``tasks.name_categories``
-    → deterministic 3-category selection based on project ID hash.
+    → deterministic 3-category selection based on project name hash.
     """
     import namer
 
-    categories = _resolve_name_categories(project_id) if project_id else None
+    categories = _resolve_name_categories(project_name) if project_name else None
     return namer.generate(separator="-", category=categories)
 
 
-def _resolve_name_categories(project_id: str) -> list[str] | None:
+def _resolve_name_categories(project_name: str) -> list[str] | None:
     """Resolve task-name categories: project config → global config → hash default."""
     from ...core.config import get_task_name_categories
 
     # 1. Per-project override
     try:
-        project = load_project(project_id)
+        project = load_project(project_name)
         if project.task_name_categories:
             return project.task_name_categories
     except SystemExit:
@@ -75,19 +75,19 @@ def _resolve_name_categories(project_id: str) -> list[str] | None:
     if global_cats:
         return global_cats
 
-    # 3. Hash-based default: pick 3 categories deterministically from project ID
-    return _default_categories_for_project(project_id)
+    # 3. Hash-based default: pick 3 categories deterministically from project name
+    return _default_categories_for_project(project_name)
 
 
-def _default_categories_for_project(project_id: str) -> list[str]:
-    """Pick 3 categories deterministically based on a hash of the project ID."""
+def _default_categories_for_project(project_name: str) -> list[str]:
+    """Pick 3 categories deterministically based on a hash of the project name."""
     import hashlib
     import random
 
     import namer
 
     categories = sorted(namer.list_categories())
-    seed = int(hashlib.md5(project_id.encode(), usedforsecurity=False).hexdigest(), 16)
+    seed = int(hashlib.md5(project_name.encode(), usedforsecurity=False).hexdigest(), 16)
     rng = random.Random(seed)
     return rng.sample(categories, min(3, len(categories)))
 

--- a/src/terok/lib/orchestration/tasks/query.py
+++ b/src/terok/lib/orchestration/tasks/query.py
@@ -342,8 +342,8 @@ class ContainerEventStream(Protocol):
         ...
 
 
-def container_event_stream(project_id: str) -> ContainerEventStream | None:
-    """Subscribe to live podman container events for *project_id*, or ``None``.
+def container_event_stream(project_name: str) -> ContainerEventStream | None:
+    """Subscribe to live podman container events for *project_name*, or ``None``.
 
     The push-based companion to
     [`get_all_task_states`][terok.lib.orchestration.tasks.query.get_all_task_states]:
@@ -356,7 +356,8 @@ def container_event_stream(project_id: str) -> ContainerEventStream | None:
     from terok.lib.integrations.sandbox import PodmanRuntime
 
     try:
-        return PodmanRuntime().events(project_id)
+        events = getattr(PodmanRuntime(), "events", None)
+        return events(project_name) if callable(events) else None
     except Exception:  # noqa: BLE001 — podman absent / subscribe failed; resync covers it
         return None
 

--- a/src/terok/lib/orchestration/tasks/query.py
+++ b/src/terok/lib/orchestration/tasks/query.py
@@ -11,7 +11,7 @@ from collections.abc import Iterator
 from dataclasses import dataclass
 from typing import Any, Protocol
 
-from ...core.project_model import is_valid_project_id
+from ...core.project_model import is_valid_project_name
 from ...core.projects import load_project
 from ...core.task_state import TaskState, container_name, effective_status
 from ...core.work_status import read_work_status
@@ -20,7 +20,7 @@ from .identity import is_task_id
 from .meta import _is_safe_id_segment, iter_task_ids, read_task_meta, tasks_meta_dir
 
 
-def get_task_container_state(project_id: str, task_id: str, mode: str | None) -> str | None:
+def get_task_container_state(project_name: str, task_id: str, mode: str | None) -> str | None:
     """Get actual container state for a task (TUI helper).
 
     Container state queries are runtime-agnostic — ``podman inspect``
@@ -33,11 +33,11 @@ def get_task_container_state(project_id: str, task_id: str, mode: str | None) ->
         return None
     from terok.lib.integrations.sandbox import PodmanRuntime
 
-    cname = container_name(project_id, mode, task_id)
+    cname = container_name(project_name, mode, task_id)
     return PodmanRuntime().container(cname).state
 
 
-def lookup_container_by_pt(project_id: str, task_id: str) -> str | None:
+def lookup_container_by_pt(project_name: str, task_id: str) -> str | None:
     """Resolve a `project/task` pair to the current container name, or `None`.
 
     Powers the slash-form identity acceptance on per-container
@@ -50,16 +50,16 @@ def lookup_container_by_pt(project_id: str, task_id: str) -> str | None:
     verbatim" (raw container id) or "fail with an actionable error"
     (unknown project/task).
     """
-    if not is_valid_project_id(project_id) or not _is_safe_id_segment(task_id):
+    if not is_valid_project_name(project_name) or not _is_safe_id_segment(task_id):
         return None
-    meta_dir = tasks_meta_dir(project_id)
+    meta_dir = tasks_meta_dir(project_name)
     raw = read_task_meta(meta_dir, task_id)
     if raw is None:
         return None
     mode = raw.get("mode")
     if not mode:
         return None
-    return container_name(project_id, mode, task_id)
+    return container_name(project_name, mode, task_id)
 
 
 @dataclass(kw_only=True)
@@ -71,7 +71,7 @@ class TaskMeta(TaskState):
     """
 
     task_id: str
-    project_id: str = ""
+    project_name: str = ""
     """Project the task belongs to.
 
     Carried in the meta JSON so consumers that don't already know the
@@ -120,7 +120,7 @@ class TaskMeta(TaskState):
         self.web_port = fresh.web_port
 
     @classmethod
-    def load(cls, project_id: str, task_id: str) -> TaskMeta:
+    def load(cls, project_name: str, task_id: str) -> TaskMeta:
         """Load a TaskMeta from disk, with live container state hydrated.
 
         Raises ``SystemExit`` if the task metadata file is not found.
@@ -129,7 +129,7 @@ class TaskMeta(TaskState):
         kept as the canonical entry point so callers reach the class
         through its own factory.
         """
-        return get_task_meta(project_id, task_id)
+        return get_task_meta(project_name, task_id)
 
 
 def _is_initialized(meta: dict) -> bool:
@@ -137,14 +137,14 @@ def _is_initialized(meta: dict) -> bool:
     return "ready_at" in meta
 
 
-def get_task_meta(project_id: str, task_id: str) -> TaskMeta:
+def get_task_meta(project_name: str, task_id: str) -> TaskMeta:
     """Return metadata for a single task with live container state.
 
     Hydrates ``container_state`` from the running container so that
     ``TaskMeta.status`` reflects current reality rather than stale YAML.
     Raises ``SystemExit`` if the task metadata file is not found.
     """
-    meta_dir = tasks_meta_dir(project_id)
+    meta_dir = tasks_meta_dir(project_name)
     raw = read_task_meta(meta_dir, task_id)
     if raw is None:
         raise SystemExit(f"Unknown task {task_id}")
@@ -159,7 +159,7 @@ def get_task_meta(project_id: str, task_id: str) -> TaskMeta:
         try:
             from terok.lib.integrations.sandbox import PodmanRuntime
 
-            cname = container_name(project_id, mode, task_id)
+            cname = container_name(project_name, mode, task_id)
             live_state = PodmanRuntime().container(cname).state
         except Exception:
             pass
@@ -167,7 +167,7 @@ def get_task_meta(project_id: str, task_id: str) -> TaskMeta:
     ws_status: str | None = None
     ws_message: str | None = None
     if tid:
-        project = load_project(project_id)
+        project = load_project(project_name)
         try:
             agent_cfg = project.tasks_root / tid / "agent-config"
             ws = read_work_status(agent_cfg)
@@ -178,8 +178,8 @@ def get_task_meta(project_id: str, task_id: str) -> TaskMeta:
     return TaskMeta(
         task_id=tid,
         # ``or`` (not the dict default) so a migrated record carrying an
-        # empty string still falls back to the path-derived project_id.
-        project_id=raw.get("project_id") or project_id,
+        # empty string still falls back to the path-derived project_name.
+        project_name=raw.get("project_name") or project_name,
         mode=mode,
         workspace=raw.get("workspace", ""),
         web_port=raw.get("web_port"),
@@ -199,14 +199,14 @@ def get_task_meta(project_id: str, task_id: str) -> TaskMeta:
     )
 
 
-def get_workspace_git_diff(project_id: str, task_id: str, against: str = "HEAD") -> str | None:
+def get_workspace_git_diff(project_name: str, task_id: str, against: str = "HEAD") -> str | None:
     """Get git diff from a task's workspace via container exec.
 
     Runs ``git diff`` **inside** the task container rather than on the host,
     so that even poisoned git hooks only execute within the container sandbox.
 
     Args:
-        project_id: The project ID
+        project_name: The project name
         task_id: The task ID
         against: What to diff against (``"HEAD"`` or ``"PREV"``)
 
@@ -214,8 +214,8 @@ def get_workspace_git_diff(project_id: str, task_id: str, against: str = "HEAD")
         The git diff output as a string, or ``None`` if failed
     """
     try:
-        load_project(project_id)  # validate project exists
-        meta_dir = tasks_meta_dir(project_id)
+        load_project(project_name)  # validate project exists
+        meta_dir = tasks_meta_dir(project_name)
         meta = read_task_meta(meta_dir, task_id)
         if meta is None:
             return None
@@ -224,21 +224,21 @@ def get_workspace_git_diff(project_id: str, task_id: str, against: str = "HEAD")
             return None
 
         if against == "PREV":
-            return container_git_diff(project_id, task_id, mode, "HEAD~1", "HEAD")
-        return container_git_diff(project_id, task_id, mode, "HEAD")
+            return container_git_diff(project_name, task_id, mode, "HEAD~1", "HEAD")
+        return container_git_diff(project_name, task_id, mode, "HEAD")
 
     except (Exception, SystemExit):
         return None
 
 
-def _get_tasks(project_id: str, reverse: bool = False) -> list[TaskMeta]:
-    """Return all task metadata for *project_id*, sorted by task ID."""
-    meta_dir = tasks_meta_dir(project_id)
+def _get_tasks(project_name: str, reverse: bool = False) -> list[TaskMeta]:
+    """Return all task metadata for *project_name*, sorted by task ID."""
+    meta_dir = tasks_meta_dir(project_name)
     tasks: list[TaskMeta] = []
     if not meta_dir.is_dir():
         return tasks
     try:
-        project = load_project(project_id)
+        project = load_project(project_name)
         tasks_root = project.tasks_root
     except SystemExit:
         tasks_root = None
@@ -263,7 +263,7 @@ def _get_tasks(project_id: str, reverse: bool = False) -> list[TaskMeta]:
             tasks.append(
                 TaskMeta(
                     task_id=tid,
-                    project_id=meta.get("project_id") or project_id,
+                    project_name=meta.get("project_name") or project_name,
                     mode=mode,
                     workspace=meta.get("workspace", ""),
                     web_port=meta.get("web_port"),
@@ -291,19 +291,19 @@ def _get_tasks(project_id: str, reverse: bool = False) -> list[TaskMeta]:
     return tasks
 
 
-def get_tasks(project_id: str, reverse: bool = False) -> list[TaskMeta]:
-    """Return all task metadata for *project_id*, sorted by task ID."""
-    return _get_tasks(project_id, reverse=reverse)
+def get_tasks(project_name: str, reverse: bool = False) -> list[TaskMeta]:
+    """Return all task metadata for *project_name*, sorted by task ID."""
+    return _get_tasks(project_name, reverse=reverse)
 
 
 def get_all_task_states(
-    project_id: str,
+    project_name: str,
     tasks: list[TaskMeta],
 ) -> dict[str, str | None]:
     """Map each task to its live container state via a single batch query.
 
     Args:
-        project_id: The project whose containers to query.
+        project_name: The project whose containers to query.
         tasks: List of ``TaskMeta`` instances (must have ``task_id`` and ``mode``).
 
     Returns:
@@ -313,11 +313,11 @@ def get_all_task_states(
     # doesn't differ across OCI runtimes.
     from terok.lib.integrations.sandbox import PodmanRuntime
 
-    container_states = PodmanRuntime().container_states(project_id)
+    container_states = PodmanRuntime().container_states(project_name)
     result: dict[str, str | None] = {}
     for t in tasks:
         if t.mode:
-            cname = container_name(project_id, t.mode, str(t.task_id))
+            cname = container_name(project_name, t.mode, str(t.task_id))
             result[str(t.task_id)] = container_states.get(cname)
         else:
             result[str(t.task_id)] = None
@@ -362,7 +362,7 @@ def container_event_stream(project_id: str) -> ContainerEventStream | None:
 
 
 def task_list(
-    project_id: str,
+    project_name: str,
     *,
     status: str | None = None,
     mode: str | None = None,
@@ -372,7 +372,7 @@ def task_list(
 
     Status is computed live from podman container state + task metadata.
     """
-    tasks = get_tasks(project_id)
+    tasks = get_tasks(project_name)
 
     # Pre-filter by mode/agent before the podman query to reduce work
     if mode:
@@ -385,7 +385,7 @@ def task_list(
         return
 
     # Batch-query podman for all container states in one call
-    live_states = get_all_task_states(project_id, tasks)
+    live_states = get_all_task_states(project_name, tasks)
     for t in tasks:
         t.container_state = live_states.get(t.task_id)
 

--- a/src/terok/resources/templates/projects/project.yml.template
+++ b/src/terok/resources/templates/projects/project.yml.template
@@ -8,7 +8,7 @@
 {%- endif %}
 
 project:
-  id: "{{PROJECT_ID}}"
+  name: "{{PROJECT_NAME}}"
   security_class: "{{SECURITY_CLASS}}"
 
 git:
@@ -29,7 +29,7 @@ image:
 {%- else %}
   # agents: "all"    # uncomment to override the global default — see
   #                  # `terok agents set` (global) or
-  #                  # `terok project agents set {{PROJECT_ID}}` (per-project).
+  #                  # `terok project agents set {{PROJECT_NAME}}` (per-project).
 {%- endif %}
   # Optional: extra Dockerfile commands injected into the project image.
   # Use user_snippet_file to point to an external .dockerinclude file.

--- a/src/terok/tui/app.py
+++ b/src/terok/tui/app.py
@@ -98,7 +98,7 @@ if _HAS_TEXTUAL:
     class ProjectStateResult:
         """Result of loading project infrastructure state in a background thread."""
 
-        project_id: str
+        project_name: str
         project: ProjectConfig | None = None
         state: dict | None = None
         staleness: GateStalenessInfo | None = None
@@ -290,11 +290,11 @@ if _HAS_TEXTUAL:
             # only — forgotten when the app closes.
             self.console_logs = ConsoleLogRegistry()
 
-            self.current_project_id: str | None = None
+            self.current_project_name: str | None = None
             self.current_task: TaskMeta | None = None
             self._projects_by_id: dict[str, ProjectConfig] = {}
             self._broken_by_id: dict[str, BrokenProject] = {}
-            # Tracks which broken-project IDs have already been toasted so
+            # Tracks which broken-project names have already been toasted so
             # repeated ``refresh_projects`` calls don't re-notify the same
             # set on every action (#565).  Resets when all breakages clear,
             # so a later regression toasts again.
@@ -303,7 +303,7 @@ if _HAS_TEXTUAL:
             # Upstream polling state
             self._staleness_info: GateStalenessInfo | None = None
             self._polling_timer = None
-            self._polling_project_id: str | None = None  # Project ID the timer was started for
+            self._polling_project_name: str | None = None  # Project name the timer was started for
             self._last_notified_stale: bool = False  # Track if we already notified about staleness
             self._auto_sync_cooldown: dict[str, float] = {}  # Per-project cooldown timestamps
             # Container status tracking: inotify watch + podman event stream,
@@ -319,7 +319,7 @@ if _HAS_TEXTUAL:
             self._last_image_old: bool | None = None
             # Selection persistence
             self._last_selected_project: str | None = None
-            self._last_selected_tasks: dict[str, str] = {}  # project_id -> task_id
+            self._last_selected_tasks: dict[str, str] = {}  # project_name -> task_id
             # First-run nudge marker — flipped when the wizard has auto-opened
             # once, so subsequent empty-install starts don't nag.
             self._first_run_dismissed: bool = False
@@ -744,7 +744,7 @@ if _HAS_TEXTUAL:
                 state_path = self._config.core_state_dir / "terok-state.json"
                 state_path.parent.mkdir(parents=True, exist_ok=True)
                 state = {
-                    "last_project": self.current_project_id,
+                    "last_project": self.current_project_name,
                     "last_tasks": self._last_selected_tasks,
                     "first_run_dismissed": getattr(self, "_first_run_dismissed", False),
                 }
@@ -759,8 +759,8 @@ if _HAS_TEXTUAL:
         async def refresh_projects(self) -> None:
             """Reload projects from disk and rebuild every dependent pane."""
             projects, broken = discover_projects()
-            self._projects_by_id = {p.id: p for p in projects}
-            self._broken_by_id = {bp.id: bp for bp in broken}
+            self._projects_by_id = {p.name: p for p in projects}
+            self._broken_by_id = {bp.name: bp for bp in broken}
 
             proj_widget = self.query_one("#project-list", ProjectList)
             proj_widget.set_projects(projects, broken)
@@ -774,22 +774,22 @@ if _HAS_TEXTUAL:
             self._last_project_state = None
             self._last_image_old = None
 
-            if self.current_project_id in self._broken_by_id:
+            if self.current_project_name in self._broken_by_id:
                 # Broken projects have no loadable config; ``refresh_tasks`` and
                 # the polling loop would raise inside ``load_project``.
-                self._render_broken_selection(self.current_project_id)
+                self._render_broken_selection(self.current_project_name)
             else:
                 await self.refresh_tasks()
                 self._start_upstream_polling()
 
         def _announce_newly_broken(self, broken: list[BrokenProject]) -> None:
-            """Toast once when the set of broken-project IDs changes.
+            """Toast once when the set of broken-project names changes.
 
             Users upgrading across a schema change need to see the breakage
             immediately — but only once per distinct set, so repeated
             ``refresh_projects`` calls don't spam (#565).
             """
-            current_ids = {bp.id for bp in broken}
+            current_ids = {bp.name for bp in broken}
             if not current_ids:
                 # Breakages cleared — forget announced so a regression re-fires.
                 self._announced_broken_ids = set()
@@ -797,7 +797,7 @@ if _HAS_TEXTUAL:
             if current_ids == self._announced_broken_ids:
                 return
             first = broken[0]
-            summary = f"{first.id}: {first.error.splitlines()[0]}"
+            summary = f"{first.name}: {first.error.splitlines()[0]}"
             extra = f" (+{len(broken) - 1} more)" if len(broken) > 1 else ""
             self.notify(
                 f"Broken project config detected — {summary}{extra}",
@@ -813,43 +813,43 @@ if _HAS_TEXTUAL:
             broken: list[BrokenProject],
         ) -> None:
             """Restore the previously-selected project, or fall back to the first row."""
-            candidate_ids = [bp.id for bp in broken] + [p.id for p in projects]
+            candidate_ids = [bp.name for bp in broken] + [p.name for p in projects]
             last_project = self._last_selected_project
             if last_project and last_project in candidate_ids:
-                self.current_project_id = last_project
-                proj_widget.select_project(self.current_project_id)
-            elif self.current_project_id is None:
-                self.current_project_id = candidate_ids[0]
-                proj_widget.select_project(self.current_project_id)
+                self.current_project_name = last_project
+                proj_widget.select_project(self.current_project_name)
+            elif self.current_project_name is None:
+                self.current_project_name = candidate_ids[0]
+                proj_widget.select_project(self.current_project_name)
 
         def _render_empty_project_state(self) -> None:
             """Clear every pane when no projects exist on disk at all."""
-            self.current_project_id = None
+            self.current_project_name = None
             self._last_project_state = None
             self._last_image_old = None
             self.query_one("#task-list", TaskList).set_tasks("", [])
             self.query_one("#task-details", TaskDetails).set_task(None)
             self.query_one("#project-state", ProjectState).set_state(None, None, None)
 
-        def _render_broken_selection(self, project_id: str) -> None:
+        def _render_broken_selection(self, project_name: str) -> None:
             """Render a broken project's error and clear the task/details panes."""
-            bp = self._broken_by_id.get(project_id)
+            bp = self._broken_by_id.get(project_name)
             state_widget = self.query_one("#project-state", ProjectState)
             if bp is None:
                 state_widget.set_state(None, None, None)
                 return
             state_widget.set_broken(bp)
             task_list = self.query_one("#task-list", TaskList)
-            task_list.set_tasks(project_id, [])
+            task_list.set_tasks(project_name, [])
             task_details = self.query_one("#task-details", TaskDetails)
             task_details.set_task(None)
             self.current_task = None
 
         async def refresh_tasks(self) -> None:
             """Reload tasks for the current project and update the task list."""
-            if not self.current_project_id:
+            if not self.current_project_name:
                 return
-            pid = self.current_project_id
+            pid = self.current_project_name
             tasks_meta = get_tasks(pid, reverse=True)
             # Set the launching flag before ``set_tasks`` so the first
             # label render is already correct — avoids reformatting every
@@ -861,7 +861,7 @@ if _HAS_TEXTUAL:
 
             if task_list.tasks:
                 # Try to restore last selected task for this project
-                last_task_id = self._last_selected_tasks.get(self.current_project_id)
+                last_task_id = self._last_selected_tasks.get(self.current_project_name)
                 desired_idx = 0
                 if last_task_id:
                     for idx, task in enumerate(task_list.tasks):
@@ -923,13 +923,13 @@ if _HAS_TEXTUAL:
                 return
             details.set_task(self.current_task)
             if not self.current_task.deleting:
-                self._queue_task_image_status(self.current_project_id, self.current_task)
+                self._queue_task_image_status(self.current_project_name, self.current_task)
 
         # ---------- Launch tracking ----------
 
         def _apply_launching_to_tasks(self) -> None:
             """Mirror ``_launching_tasks`` onto current ``TaskMeta`` instances and repaint."""
-            pid = self.current_project_id
+            pid = self.current_project_name
             if pid is None:
                 return
             task_list = self.query_one("#task-list", TaskList)
@@ -943,22 +943,22 @@ if _HAS_TEXTUAL:
                 ) in self._launching_tasks
                 self.query_one("#task-details", TaskDetails).set_task(self.current_task)
 
-        def _mark_launching(self, project_id: str, task_id: str) -> None:
+        def _mark_launching(self, project_name: str, task_id: str) -> None:
             """Flag a task as currently being launched.  Triggers a repaint."""
-            key = (project_id, task_id)
+            key = (project_name, task_id)
             if key in self._launching_tasks:
                 return
             self._launching_tasks.add(key)
-            if project_id == self.current_project_id:
+            if project_name == self.current_project_name:
                 self._apply_launching_to_tasks()
 
-        def _unmark_launching(self, project_id: str, task_id: str) -> None:
+        def _unmark_launching(self, project_name: str, task_id: str) -> None:
             """Clear the launching flag once the worker has reached a terminal state."""
-            key = (project_id, task_id)
+            key = (project_name, task_id)
             if key not in self._launching_tasks:
                 return
             self._launching_tasks.discard(key)
-            if project_id == self.current_project_id:
+            if project_name == self.current_project_name:
                 self._apply_launching_to_tasks()
 
         # ---------- Status / notifications ----------
@@ -971,32 +971,32 @@ if _HAS_TEXTUAL:
             """
             state_widget = self.query_one("#project-state", ProjectState)
 
-            if not self.current_project_id:
+            if not self.current_project_name:
                 state_widget.set_state(None, None, None)
                 return
             if task_count is not None:
                 self._last_task_count = task_count
 
-            project_id = self.current_project_id
-            project = self._projects_by_id.get(project_id)
+            project_name = self.current_project_name
+            project = self._projects_by_id.get(project_name)
             if project is not None:
                 state_widget.show_loading(project, self._last_task_count)
             else:
                 state_widget.update("Loading project details...")
 
             self.run_worker(
-                lambda: self._load_project_state(project_id),
-                name=f"project-state:{project_id}",
+                lambda: self._load_project_state(project_name),
+                name=f"project-state:{project_name}",
                 group="project-state",
                 exclusive=True,
                 thread=True,
                 exit_on_error=False,
             )
 
-        def _load_project_state(self, project_id: str) -> ProjectStateResult:
+        def _load_project_state(self, project_name: str) -> ProjectStateResult:
             """Load project infrastructure state in a background thread."""
             try:
-                project = load_project(project_id)
+                project = load_project(project_name)
                 gate = make_git_gate(project)
 
                 def _gate_commit_provider(_pid: str) -> dict | None:
@@ -1015,28 +1015,28 @@ if _HAS_TEXTUAL:
                 except Exception:
                     shield_env = None
                 return ProjectStateResult(
-                    project_id,
+                    project_name,
                     project,
                     state,
                     staleness,
                     shield_env=shield_env,
                 )
             except SystemExit as e:
-                return ProjectStateResult(project_id, error=str(e))
+                return ProjectStateResult(project_name, error=str(e))
             except Exception as e:
-                return ProjectStateResult(project_id, error=str(e))
+                return ProjectStateResult(project_name, error=str(e))
 
-        def _queue_task_image_status(self, project_id: str | None, task: TaskMeta | None) -> None:
+        def _queue_task_image_status(self, project_name: str | None, task: TaskMeta | None) -> None:
             """Schedule a background check for whether the task's image is outdated."""
-            if not project_id or task is None:
+            if not project_name or task is None:
                 return
             if task.deleting:
                 return
 
             task_id = task.task_id
             self.run_worker(
-                lambda: self._load_task_image_status(project_id, task),
-                name=f"task-image:{project_id}:{task_id}",
+                lambda: self._load_task_image_status(project_name, task),
+                name=f"task-image:{project_name}:{task_id}",
                 group="task-image",
                 exclusive=True,
                 thread=True,
@@ -1044,20 +1044,20 @@ if _HAS_TEXTUAL:
             )
 
         def _load_task_image_status(
-            self, project_id: str, task: TaskMeta
+            self, project_name: str, task: TaskMeta
         ) -> tuple[str, str, bool | None]:
             """Check whether a task's container image is outdated (runs in thread)."""
-            image_old = Task(load_project(project_id), task).image_is_old()
-            return project_id, task.task_id, image_old
+            image_old = Task(load_project(project_name), task).image_is_old()
+            return project_name, task.task_id, image_old
 
-        def _query_shield_state(self, project_id: str, task: TaskMeta) -> None:
+        def _query_shield_state(self, project_name: str, task: TaskMeta) -> None:
             """Schedule a background worker to query shield state for a task."""
             if not task.mode:
                 return
             tid = task.task_id
             self.run_worker(
-                lambda: self._load_shield_state(project_id, task),
-                name=f"shield-state:{project_id}:{tid}",
+                lambda: self._load_shield_state(project_name, task),
+                name=f"shield-state:{project_name}:{tid}",
                 group="shield-state",
                 exclusive=True,
                 thread=True,
@@ -1065,31 +1065,31 @@ if _HAS_TEXTUAL:
             )
 
         @staticmethod
-        def _load_shield_state(project_id: str, task: TaskMeta) -> tuple[str, str, str | None]:
+        def _load_shield_state(project_name: str, task: TaskMeta) -> tuple[str, str, str | None]:
             """Query shield state for a task (runs in thread)."""
             try:
-                project = load_project(project_id)
+                project = load_project(project_name)
                 mode = task.mode or "cli"
-                cname = container_name(project_id, mode, task.task_id)
+                cname = container_name(project_name, mode, task.task_id)
                 task_dir = project.tasks_root / str(task.task_id)
                 st = ShieldManager(task_dir).state(cname)
                 # ``ShieldManager.state`` returns an Any-annotated
                 # ShieldState (importlinter keeps terok_shield out of
                 # this layer); the runtime value is an enum whose
                 # ``.name`` is the display string.
-                return project_id, task.task_id, st.name
+                return project_name, task.task_id, st.name
             except Exception:
-                return project_id, task.task_id, None
+                return project_name, task.task_id, None
 
         # ---------- Selection handlers (from widgets) ----------
 
         @on(ProjectList.ProjectSelected)
         async def handle_project_selected(self, message: ProjectList.ProjectSelected) -> None:
             """Called when user selects a project in the list."""
-            self.current_project_id = message.project_id
+            self.current_project_name = message.project_name
             self._last_project_state = None
             # Save the project selection
-            self._last_selected_project = self.current_project_id
+            self._last_selected_project = self.current_project_name
             self._save_selection_state()
 
             # Broken projects have no loadable config, so the usual task /
@@ -1099,7 +1099,7 @@ if _HAS_TEXTUAL:
             if message.is_broken:
                 self._stop_upstream_polling()
                 self._stop_container_status_polling()
-                self._render_broken_selection(message.project_id)
+                self._render_broken_selection(message.project_name)
                 return
 
             await self.refresh_tasks()
@@ -1110,21 +1110,21 @@ if _HAS_TEXTUAL:
         @on(TaskList.TaskSelected)
         async def handle_task_selected(self, message: TaskList.TaskSelected) -> None:
             """Called when user selects a task in the list."""
-            self.current_project_id = message.project_id
+            self.current_project_name = message.project_name
             self.current_task = message.task
             self._last_image_old = None
 
             # Save the task selection for this project
-            if self.current_project_id and self.current_task:
-                self._last_selected_tasks[self.current_project_id] = self.current_task.task_id
+            if self.current_project_name and self.current_task:
+                self._last_selected_tasks[self.current_project_name] = self.current_task.task_id
                 self._save_selection_state()
 
             self._update_task_details()
 
             # Immediately check container state when task is selected
             if self.current_task and self.current_task.mode:
-                self._queue_container_state_check(message.project_id)
-                self._query_shield_state(message.project_id, self.current_task)
+                self._queue_container_state_check(message.project_name)
+                self._query_shield_state(message.project_name, self.current_task)
 
         @on(Worker.StateChanged)
         async def handle_worker_state_changed(self, event: Worker.StateChanged) -> None:
@@ -1141,7 +1141,7 @@ if _HAS_TEXTUAL:
                 if not result:
                     return
                 psr: ProjectStateResult = result
-                if psr.project_id != self.current_project_id:
+                if psr.project_name != self.current_project_name:
                     return
                 state_widget = self.query_one("#project-state", ProjectState)
                 if psr.error:
@@ -1150,7 +1150,7 @@ if _HAS_TEXTUAL:
                 if psr.project is None or psr.state is None:
                     state_widget.set_state(None, None, None)
                     return
-                self._projects_by_id[psr.project_id] = psr.project
+                self._projects_by_id[psr.project_name] = psr.project
                 self._staleness_info = psr.staleness
                 self._last_project_state = psr.state
                 self._last_shield_env = psr.shield_env
@@ -1167,8 +1167,8 @@ if _HAS_TEXTUAL:
                 result = worker.result
                 if not result:
                     return
-                project_id, task_id, image_old = result
-                if project_id != self.current_project_id:
+                project_name, task_id, image_old = result
+                if project_name != self.current_project_name:
                     return
                 if not self.current_task or self.current_task.task_id != task_id:
                     return
@@ -1181,8 +1181,8 @@ if _HAS_TEXTUAL:
                 result = worker.result
                 if not result:
                     return
-                project_id, metas = result
-                if project_id != self.current_project_id:
+                project_name, metas = result
+                if project_name != self.current_project_name:
                     return
                 task_list = self.query_one("#task-list", TaskList)
                 # The batch query re-reads the on-disk task set every tick, so
@@ -1222,24 +1222,24 @@ if _HAS_TEXTUAL:
                 result = worker.result
                 if not result:
                     return
-                project_id, task_id, task_name, error, warnings = result
-                self._deleting_tasks.discard((project_id, task_id))
-                task_label = f"{project_id} {task_id}" + (f" {task_name}" if task_name else "")
+                project_name, task_id, task_name, error, warnings = result
+                self._deleting_tasks.discard((project_name, task_id))
+                task_label = f"{project_name} {task_id}" + (f" {task_name}" if task_name else "")
                 if error:
                     self.notify(f"Delete error for task {task_label}: {error}")
                 elif warnings:
                     detail = "; ".join(warnings)
                     self.notify(
                         f"Deleted task {task_label} with warnings:\n{detail}\n"
-                        f"Archive: terok task archive list {project_id}",
+                        f"Archive: terok task archive list {project_name}",
                     )
                 else:
                     self.notify(
                         f"Deleted task {task_label}.\n"
-                        f"Archive: terok task archive list {project_id}",
+                        f"Archive: terok task archive list {project_name}",
                     )
 
-                if project_id != self.current_project_id:
+                if project_name != self.current_project_name:
                     return
                 await self.refresh_tasks()
 
@@ -1247,14 +1247,14 @@ if _HAS_TEXTUAL:
                 result = worker.result
                 if not result:
                     return
-                project_id, task_id, error = result
+                project_name, task_id, error = result
                 if error:
                     self.notify(f"Unattended error: {error}")
                 elif task_id:
-                    self._focus_task_after_creation(project_id, task_id)
-                    self.notify(f"Unattended task {task_id} started for {project_id}")
-                    self._start_unattended_watcher(project_id, task_id)
-                if project_id == self.current_project_id:
+                    self._focus_task_after_creation(project_name, task_id)
+                    self.notify(f"Unattended task {task_id} started for {project_name}")
+                    self._start_unattended_watcher(project_name, task_id)
+                if project_name == self.current_project_name:
                     await self.refresh_tasks()
                 return
 
@@ -1262,14 +1262,14 @@ if _HAS_TEXTUAL:
                 result = worker.result
                 if not result:
                     return
-                project_id, task_id, exit_code, error = result
+                project_name, task_id, exit_code, error = result
                 if error:
                     self.notify(f"Unattended watcher error for task {task_id}: {error}")
                 elif exit_code == 0:
                     self.notify(f"Unattended task {task_id} completed successfully")
                 else:
                     self.notify(f"Unattended task {task_id} failed (exit {exit_code})")
-                if project_id == self.current_project_id:
+                if project_name == self.current_project_name:
                     await self.refresh_tasks()
                 return
 
@@ -1277,13 +1277,13 @@ if _HAS_TEXTUAL:
                 result = worker.result
                 if not result:
                     return
-                project_id, task_id, error = result
+                project_name, task_id, error = result
                 if error:
                     self.notify(f"Follow-up error: {error}")
                 else:
                     self.notify(f"Follow-up started for task {task_id}")
-                    self._start_unattended_watcher(project_id, task_id)
-                if project_id == self.current_project_id:
+                    self._start_unattended_watcher(project_name, task_id)
+                if project_name == self.current_project_name:
                     await self.refresh_tasks()
                 return
 
@@ -1291,7 +1291,7 @@ if _HAS_TEXTUAL:
                 result = worker.result
                 if not result:
                     return
-                project_id, task_id, error = result
+                project_name, task_id, error = result
                 if error:
                     self.notify(f"Shield action failed: {error}")
                 else:
@@ -1308,17 +1308,17 @@ if _HAS_TEXTUAL:
                 if (
                     self.current_task
                     and self.current_task.task_id == task_id
-                    and project_id == self.current_project_id
+                    and project_name == self.current_project_name
                 ):
-                    self._query_shield_state(project_id, self.current_task)
+                    self._query_shield_state(project_name, self.current_task)
                 return
 
             if worker.group == "shield-state":
                 result = worker.result
                 if not result:
                     return
-                project_id, task_id, shield_st = result
-                if project_id != self.current_project_id:
+                project_name, task_id, shield_st = result
+                if project_name != self.current_project_name:
                     return
                 if not self.current_task or self.current_task.task_id != task_id:
                     return
@@ -1462,18 +1462,18 @@ if _HAS_TEXTUAL:
 
         async def action_show_project_actions(self) -> None:
             """Show detail screen with project info and actions."""
-            if not self.current_project_id:
+            if not self.current_project_name:
                 self.notify("No project selected.")
                 return
-            if self.current_project_id in self._broken_by_id:
-                bp = self._broken_by_id[self.current_project_id]
+            if self.current_project_name in self._broken_by_id:
+                bp = self._broken_by_id[self.current_project_name]
                 self.notify(
-                    f"Cannot act on broken project '{bp.id}'. Fix {bp.config_path} first.",
+                    f"Cannot act on broken project '{bp.name}'. Fix {bp.config_path} first.",
                     severity="warning",
                     timeout=10,
                 )
                 return
-            project = self._projects_by_id.get(self.current_project_id)
+            project = self._projects_by_id.get(self.current_project_name)
             if not project:
                 self.notify("Project data not loaded yet.")
                 return
@@ -1489,7 +1489,7 @@ if _HAS_TEXTUAL:
 
         async def action_show_task_actions(self) -> None:
             """Show detail screen with task info and actions."""
-            if not self.current_project_id:
+            if not self.current_project_name:
                 self.notify("No project selected.")
                 return
             try:
@@ -1501,7 +1501,7 @@ if _HAS_TEXTUAL:
                 TaskDetailsScreen(
                     self.current_task,
                     has_tasks,
-                    self.current_project_id,
+                    self.current_project_name,
                     self._last_image_old,
                 ),
                 self._on_task_action_screen_result,
@@ -1594,7 +1594,7 @@ if _HAS_TEXTUAL:
             """Open the host-wide ``Authenticate agents and tools`` modal.
 
             Reuses [`AuthActionsScreen`][terok.tui.screens.AuthActionsScreen], but the result handler
-            forces a host-wide auth flow (``project_id=None``) regardless
+            forces a host-wide auth flow (``project_name=None``) regardless
             of what's selected in the main pane — the per-project entry
             lives on the project-details screen.
             """
@@ -1606,7 +1606,7 @@ if _HAS_TEXTUAL:
             """Route the host-wide auth modal's selection.
 
             ``auth_<provider>`` lands in `_action_auth_host_wide`
-            (forced ``project_id=None``); ``import_opencode_config``
+            (forced ``project_name=None``); ``import_opencode_config``
             shares the project-screen handler since the import is
             project-agnostic anyway.
             """

--- a/src/terok/tui/log_viewer.py
+++ b/src/terok/tui/log_viewer.py
@@ -330,7 +330,7 @@ class _PlainTextTuiFormatter:
 class TaskContainerRef:
     """Identifies a task's container for log viewing."""
 
-    project_id: str
+    project_name: str
     task_id: str
     mode: str
     container_name: str
@@ -384,7 +384,7 @@ class LogViewerScreen(screen.Screen[None]):
             follow: If True, stream logs in real-time with auto-scroll.
         """
         super().__init__()
-        self.project_id = ref.project_id
+        self.project_name = ref.project_name
         self.task_id = ref.task_id
         self.mode = ref.mode
         self.container_name = ref.container_name

--- a/src/terok/tui/polling.py
+++ b/src/terok/tui/polling.py
@@ -128,8 +128,8 @@ class PollingMixin(_MixinBase):
         self._stop_container_status_polling()
         if not self.current_project_name:
             return
-        self._start_task_watcher(self.current_project_id)
-        self._start_container_event_worker(self.current_project_id)
+        self._start_task_watcher(self.current_project_name)
+        self._start_container_event_worker(self.current_project_name)
         # Seed after both push sources are armed, so a change in the startup
         # window can't slip past unseen between snapshot and first event.
         self._poll_container_status()
@@ -149,8 +149,8 @@ class PollingMixin(_MixinBase):
 
     # ---------- inotify watch (host-side task files) ----------
 
-    def _start_task_watcher(self, project_id: str) -> bool:
-        """Arm an inotify watch on *project_id*'s task + agent-config dirs.
+    def _start_task_watcher(self, project_name: str) -> bool:
+        """Arm an inotify watch on *project_name*'s task + agent-config dirs.
 
         Returns ``True`` once the watch fd is registered on the event loop;
         ``False`` (the resync carries the project alone) if inotify is
@@ -165,7 +165,7 @@ class PollingMixin(_MixinBase):
         except Exception as e:  # noqa: BLE001 — watch is best-effort; resync covers it
             self._log_debug(f"task watcher init error: {e}")
             return False
-        if not watcher.start(self._task_watch_paths(project_id)):
+        if not watcher.start(self._task_watch_paths(project_name)):
             return False
         try:
             asyncio.get_running_loop().add_reader(watcher.fileno, self._on_task_dir_changed)
@@ -176,7 +176,7 @@ class PollingMixin(_MixinBase):
         self._task_watcher = watcher
         return True
 
-    def _task_watch_paths(self, project_id: str) -> list[Path]:
+    def _task_watch_paths(self, project_name: str) -> list[Path]:
         """The directories to watch: the metadata dir plus each task's config dir.
 
         The metadata dir reveals membership and lifecycle (``ready_at``,
@@ -189,23 +189,23 @@ class PollingMixin(_MixinBase):
 
         paths: list[Path] = []
         try:
-            paths.append(tasks_meta_dir(project_id))
-            tasks = get_tasks(project_id)
-        except Exception as e:  # noqa: BLE001 — a bad id just means no metadata watch
+            paths.append(tasks_meta_dir(project_name))
+            tasks = get_tasks(project_name)
+        except Exception as e:  # noqa: BLE001 — a bad project name just means no metadata watch
             self._log_debug(f"task watch path error: {e}")
             return paths
         for task in tasks:
             try:
-                paths.append(agent_config_dir(project_id, task.task_id))
+                paths.append(agent_config_dir(project_name, task.task_id))
             except Exception:  # noqa: BLE001 # nosec B112 — skip tasks whose config dir won't resolve
                 continue
         return paths
 
     def _resync_task_watches(self) -> None:
         """Re-point the inotify watch at the current task set (new/removed dirs)."""
-        if self._task_watcher is None or not self.current_project_id:
+        if self._task_watcher is None or not self.current_project_name:
             return
-        self._task_watcher.sync(self._task_watch_paths(self.current_project_id))
+        self._task_watcher.sync(self._task_watch_paths(self.current_project_name))
 
     def _stop_task_watcher(self) -> None:
         """Detach and close the inotify watch and any pending debounce."""
@@ -231,7 +231,7 @@ class PollingMixin(_MixinBase):
 
     # ---------- podman event stream (container up/down) ----------
 
-    def _start_container_event_worker(self, project_id: str) -> None:
+    def _start_container_event_worker(self, project_name: str) -> None:
         """Subscribe to podman container events and reconcile on each.
 
         Opens the stream on the UI thread (so the handle is held synchronously
@@ -243,19 +243,19 @@ class PollingMixin(_MixinBase):
 
         from ..lib.api import container_event_stream
 
-        stream = container_event_stream(project_id)
+        stream = container_event_stream(project_name)
         if stream is None:
             return
         self._container_event_stream = stream
         self.run_worker(
-            functools.partial(self._drain_container_events, stream, project_id),
-            name=f"container-events:{project_id}",
+            functools.partial(self._drain_container_events, stream, project_name),
+            name=f"container-events:{project_name}",
             group="container-events",
             thread=True,
             exclusive=True,
         )
 
-    def _drain_container_events(self, stream: "ContainerEventStream", project_id: str) -> None:
+    def _drain_container_events(self, stream: "ContainerEventStream", project_name: str) -> None:
         """Worker thread: reconcile on each container event until the stream closes.
 
         Teardown closes the stream, which unblocks the parked ``readline`` and
@@ -264,13 +264,13 @@ class PollingMixin(_MixinBase):
         """
         try:
             for _event in stream:
-                self.call_from_thread(self._on_container_event, project_id)
+                self.call_from_thread(self._on_container_event, project_name)
         except Exception as e:  # noqa: BLE001 — stream died; resync covers the gap
             self._log_debug(f"container event stream ended: {e}")
 
-    def _on_container_event(self, project_id: str) -> None:
+    def _on_container_event(self, project_name: str) -> None:
         """UI thread: debounce a reconcile for a container event (current project)."""
-        if project_id == self.current_project_id:
+        if project_name == self.current_project_name:
             self._schedule_reconcile()
 
     def _stop_container_event_stream(self) -> None:

--- a/src/terok/tui/polling.py
+++ b/src/terok/tui/polling.py
@@ -52,7 +52,7 @@ class PollingMixin(_MixinBase):
         current_task: "TaskMeta | None"
         _staleness_info: "GateStalenessInfo | None"
         _polling_timer: "Timer | None"
-        _polling_project_id: str | None
+        _polling_project_name: str | None
         _last_notified_stale: bool
         _auto_sync_cooldown: dict[str, float]
         _container_status_timer: "Timer | None"
@@ -61,7 +61,7 @@ class PollingMixin(_MixinBase):
         _watch_debounce: "Timer | None"
 
         # TerokTUI helpers (not on textual.App).
-        current_project_id: str | None
+        current_project_name: str | None
 
         def _log_debug(self, message: str) -> None: ...
         def _refresh_project_state(self) -> None: ...
@@ -79,11 +79,11 @@ class PollingMixin(_MixinBase):
         self._staleness_info = None
         self._last_notified_stale = False
 
-        if not self.current_project_id:
+        if not self.current_project_name:
             return
 
         try:
-            project = load_project(self.current_project_id)
+            project = load_project(self.current_project_name)
         except SystemExit:
             return
 
@@ -96,7 +96,7 @@ class PollingMixin(_MixinBase):
             return
 
         interval_seconds = project.upstream_polling_interval_minutes * 60
-        self._polling_project_id = self.current_project_id
+        self._polling_project_name = self.current_project_name
 
         # Perform initial poll immediately (in background worker)
         self._poll_upstream()
@@ -111,7 +111,7 @@ class PollingMixin(_MixinBase):
         if self._polling_timer is not None:
             self._polling_timer.stop()
             self._polling_timer = None
-        self._polling_project_id = None
+        self._polling_project_name = None
 
     def _start_container_status_polling(self) -> None:
         """Track container status from events, with a slow resync as insurance.
@@ -126,7 +126,7 @@ class PollingMixin(_MixinBase):
         from ..lib.core.config import get_tui_container_resync_seconds
 
         self._stop_container_status_polling()
-        if not self.current_project_id:
+        if not self.current_project_name:
             return
         self._start_task_watcher(self.current_project_id)
         self._start_container_event_worker(self.current_project_id)
@@ -291,20 +291,20 @@ class PollingMixin(_MixinBase):
 
     def _poll_container_status(self) -> None:
         """Check container status for all visible tasks via a single batch query."""
-        if not self.current_project_id:
+        if not self.current_project_name:
             return
-        self._queue_container_state_check(self.current_project_id)
+        self._queue_container_state_check(self.current_project_name)
 
-    def _queue_container_state_check(self, project_id: str) -> None:
+    def _queue_container_state_check(self, project_name: str) -> None:
         """Queue a background batch check for all task container states."""
         self.run_worker(
-            self._load_container_state_worker(project_id),
-            name=f"container-state:{project_id}",
+            self._load_container_state_worker(project_name),
+            name=f"container-state:{project_name}",
             group="container-state",
             exclusive=True,
         )
 
-    async def _load_container_state_worker(self, project_id: str) -> tuple[str, list["TaskMeta"]]:
+    async def _load_container_state_worker(self, project_name: str) -> tuple[str, list["TaskMeta"]]:
         """Batch-snapshot every task for a project with live container state.
 
         Returns fresh ``TaskMeta`` instances — the task set on disk plus each
@@ -317,38 +317,38 @@ class PollingMixin(_MixinBase):
         from ..lib.api import get_all_task_states, get_tasks
 
         def _snapshot() -> list["TaskMeta"]:
-            tasks = get_tasks(project_id)
-            states = get_all_task_states(project_id, tasks)
+            tasks = get_tasks(project_name)
+            states = get_all_task_states(project_name, tasks)
             for task in tasks:
                 task.container_state = states.get(task.task_id)
             return tasks
 
         try:
             tasks = await asyncio.get_event_loop().run_in_executor(None, _snapshot)
-            return (project_id, tasks)
+            return (project_name, tasks)
         except (Exception, SystemExit) as e:  # noqa: BLE001 — background worker; must not crash TUI
             self._log_debug(f"container state batch check error: {e}")
-            return (project_id, [])
+            return (project_name, [])
 
     def _poll_upstream(self) -> None:
         """Check upstream for changes and update staleness info.
 
         Runs the actual comparison in a background worker to avoid blocking the UI.
         """
-        project_id = self._polling_project_id
-        if not project_id or project_id != self.current_project_id:
+        project_name = self._polling_project_name
+        if not project_name or project_name != self.current_project_name:
             # Project changed since timer was started, skip this poll
             return
 
-        self._log_debug(f"polling upstream for {project_id}")
+        self._log_debug(f"polling upstream for {project_name}")
         # Run blocking git operation in background worker
         self.run_worker(
-            self._poll_upstream_worker(project_id),
+            self._poll_upstream_worker(project_name),
             name="poll_upstream",
             exclusive=True,  # Cancel any previous poll still running
         )
 
-    async def _poll_upstream_worker(self, project_id: str) -> None:
+    async def _poll_upstream_worker(self, project_name: str) -> None:
         """Background worker to check upstream (runs in thread pool)."""
         import asyncio
 
@@ -357,22 +357,22 @@ class PollingMixin(_MixinBase):
         try:
             # Run blocking call in thread pool
             staleness = await asyncio.get_event_loop().run_in_executor(
-                None, lambda: make_git_gate(load_project(project_id)).compare_vs_upstream()
+                None, lambda: make_git_gate(load_project(project_name)).compare_vs_upstream()
             )
 
             # Validate project hasn't changed while we were polling
-            if project_id != self.current_project_id:
+            if project_name != self.current_project_name:
                 return
 
-            self._on_staleness_updated(project_id, staleness)
+            self._on_staleness_updated(project_name, staleness)
 
         except (Exception, SystemExit) as e:  # noqa: BLE001 — background worker; must not crash TUI
             self._log_debug(f"upstream poll error: {e}")
 
-    def _on_staleness_updated(self, project_id: str, staleness: "GateStalenessInfo") -> None:
+    def _on_staleness_updated(self, project_name: str, staleness: "GateStalenessInfo") -> None:
         """Handle updated staleness info."""
         # Double-check project hasn't changed
-        if project_id != self.current_project_id:
+        if project_name != self.current_project_name:
             return
 
         self._staleness_info = staleness
@@ -389,7 +389,7 @@ class PollingMixin(_MixinBase):
             self._last_notified_stale = True
 
             # Trigger auto-sync if enabled (with cooldown check)
-            self._maybe_auto_sync(project_id)
+            self._maybe_auto_sync(project_name)
         elif not staleness.is_stale:
             # Only reset when we have confirmed up-to-date status
             self._last_notified_stale = False
@@ -397,7 +397,7 @@ class PollingMixin(_MixinBase):
         # Refresh the project state display
         self._refresh_project_state()
 
-    def _maybe_auto_sync(self, project_id: str) -> None:
+    def _maybe_auto_sync(self, project_name: str) -> None:
         """Trigger auto-sync if enabled for this project.
 
         Runs sync in background worker to avoid blocking UI.
@@ -407,31 +407,31 @@ class PollingMixin(_MixinBase):
 
         from ..lib.api import load_project
 
-        if not project_id or project_id != self.current_project_id:
+        if not project_name or project_name != self.current_project_name:
             return
 
         # Check cooldown (5 minute minimum between auto-syncs per project)
         now = time.time()
-        cooldown_until = self._auto_sync_cooldown.get(project_id, 0)
+        cooldown_until = self._auto_sync_cooldown.get(project_name, 0)
         if now < cooldown_until:
             self._log_debug("auto-sync skipped: cooldown active")
             return
 
         try:
-            project = load_project(project_id)
+            project = load_project(project_name)
             if not project.auto_sync_enabled:
                 return
 
             # Set cooldown before starting sync (5 minutes)
-            self._auto_sync_cooldown[project_id] = now + 300
+            self._auto_sync_cooldown[project_name] = now + 300
 
-            self._log_debug(f"auto-syncing gate for {project_id}")
+            self._log_debug(f"auto-syncing gate for {project_name}")
             self.notify("Auto-syncing gate from upstream...")
 
             # Run sync in background worker
             branches = project.auto_sync_branches or None
             self.run_worker(
-                self._sync_worker(project_id, branches, is_auto=True),
+                self._sync_worker(project_name, branches, is_auto=True),
                 name="auto_sync",
                 exclusive=True,
             )
@@ -440,7 +440,7 @@ class PollingMixin(_MixinBase):
             self._log_debug(f"auto-sync error: {e}")
 
     async def _sync_worker(
-        self, project_id: str, branches: list[str] | None = None, is_auto: bool = False
+        self, project_name: str, branches: list[str] | None = None, is_auto: bool = False
     ) -> None:
         """Background worker to sync gate from upstream."""
         import asyncio
@@ -450,11 +450,11 @@ class PollingMixin(_MixinBase):
         try:
             # Run blocking sync in thread pool
             result = await asyncio.get_event_loop().run_in_executor(
-                None, lambda: make_git_gate(load_project(project_id)).sync_branches(branches)
+                None, lambda: make_git_gate(load_project(project_name)).sync_branches(branches)
             )
 
             # Validate project hasn't changed
-            if project_id != self.current_project_id:
+            if project_name != self.current_project_name:
                 return
 
             if result["success"]:
@@ -463,10 +463,10 @@ class PollingMixin(_MixinBase):
 
                 # Re-check staleness after sync
                 staleness = await asyncio.get_event_loop().run_in_executor(
-                    None, lambda: make_git_gate(load_project(project_id)).compare_vs_upstream()
+                    None, lambda: make_git_gate(load_project(project_name)).compare_vs_upstream()
                 )
 
-                if project_id == self.current_project_id:
+                if project_name == self.current_project_name:
                     self._staleness_info = staleness
                     # Only reset notification flag if we're actually up-to-date now
                     if not staleness.is_stale and not staleness.error:

--- a/src/terok/tui/project_actions.py
+++ b/src/terok/tui/project_actions.py
@@ -54,7 +54,7 @@ class ProjectActionsMixin(_MixinBase):
 
     if TYPE_CHECKING:
         # TerokTUI-specific state and helpers (not on textual.App).
-        current_project_id: str | None
+        current_project_name: str | None
 
         async def refresh_projects(self) -> None: ...
         async def refresh_tasks(self) -> None: ...
@@ -158,10 +158,10 @@ class ProjectActionsMixin(_MixinBase):
 
     async def action_generate_dockerfiles(self) -> None:
         """Generate Dockerfiles for the current project."""
-        if not self.current_project_id:
+        if not self.current_project_name:
             self.notify("No project selected.")
             return
-        pid = self.current_project_id
+        pid = self.current_project_name
         self._run_console_action(
             "terok.tui.worker_actions:generate",
             pid,
@@ -170,10 +170,10 @@ class ProjectActionsMixin(_MixinBase):
 
     async def action_build_images(self) -> None:
         """Build only L2 project images (reuses existing L0/L1)."""
-        if not self.current_project_id:
+        if not self.current_project_name:
             self.notify("No project selected.")
             return
-        pid = self.current_project_id
+        pid = self.current_project_name
         self._run_console_action(
             "terok.tui.worker_actions:build",
             pid,
@@ -183,10 +183,10 @@ class ProjectActionsMixin(_MixinBase):
 
     async def action_init_ssh(self) -> None:
         """Mint a fresh vault-backed SSH keypair for the current project."""
-        if not self.current_project_id:
+        if not self.current_project_name:
             self.notify("No project selected.")
             return
-        pid = self.current_project_id
+        pid = self.current_project_name
         self._run_console_action(
             "terok.tui.worker_actions:init_ssh",
             pid,
@@ -195,10 +195,10 @@ class ProjectActionsMixin(_MixinBase):
 
     async def _action_build_agents(self) -> None:
         """Rebuild from L0 with fresh agents."""
-        if not self.current_project_id:
+        if not self.current_project_name:
             self.notify("No project selected.")
             return
-        pid = self.current_project_id
+        pid = self.current_project_name
         self._run_console_action(
             "terok.tui.worker_actions:build_agents",
             pid,
@@ -208,10 +208,10 @@ class ProjectActionsMixin(_MixinBase):
 
     async def _action_build_full(self) -> None:
         """Rebuild from L0 (no cache)."""
-        if not self.current_project_id:
+        if not self.current_project_name:
             self.notify("No project selected.")
             return
-        pid = self.current_project_id
+        pid = self.current_project_name
         self._run_console_action(
             "terok.tui.worker_actions:build_full",
             pid,
@@ -243,7 +243,7 @@ class ProjectActionsMixin(_MixinBase):
         registered upstream and hang on a long timeout — so a single
         captured child process is the wrong shape for this action.
         """
-        if not self.current_project_id:
+        if not self.current_project_name:
             self.notify("No project selected.")
             return
         from .wizard_screens import InitProgressScreen
@@ -252,7 +252,7 @@ class ProjectActionsMixin(_MixinBase):
             self._invalidate_image_caches()
             self._refresh_project_state()
 
-        await self.push_screen(InitProgressScreen(self.current_project_id), _on_init_done)
+        await self.push_screen(InitProgressScreen(self.current_project_name), _on_init_done)
 
     # ---------- Authentication actions ----------
 
@@ -262,13 +262,13 @@ class ProjectActionsMixin(_MixinBase):
         Reached from the project-details screen, where a project is
         always selected.  The top-level "Authenticate agents and tools"
         entry uses ``_action_auth_host_wide`` instead — it bypasses
-        ``current_project_id`` so a stray selection in the main pane
+        ``current_project_name`` so a stray selection in the main pane
         doesn't silently scope a host-wide intent to one project.
         """
-        if not self.current_project_id:
+        if not self.current_project_name:
             self.notify("No project selected.")
             return
-        self._run_auth_flow(provider, self.current_project_id)
+        self._run_auth_flow(provider, self.current_project_name)
 
     async def _action_auth_host_wide(self, provider: str) -> None:
         """Run the host-wide auth flow for *provider* — no project context.
@@ -280,7 +280,7 @@ class ProjectActionsMixin(_MixinBase):
         self._run_auth_flow(provider, None)
 
     @work(exclusive=False, group="auth-flow", exit_on_error=False)
-    async def _run_auth_flow(self, provider: str, project_id: str | None) -> None:
+    async def _run_auth_flow(self, provider: str, project_name: str | None) -> None:
         """Drive the Textual-native auth flow in a worker.
 
         Thin ``@work`` wrapper around
@@ -290,9 +290,9 @@ class ProjectActionsMixin(_MixinBase):
         is unit-testable without a running worker (mirrors the wizard's
         ``_run_wizard_flow`` / ``_run_wizard_flow_body`` pair).
         """
-        await self._run_auth_flow_body(provider, project_id)
+        await self._run_auth_flow_body(provider, project_name)
 
-    async def _run_auth_flow_body(self, provider: str, project_id: str | None) -> None:
+    async def _run_auth_flow_body(self, provider: str, project_name: str | None) -> None:
         """Pick the auth mode for *provider* and dispatch to the matching flow.
 
         Replaces the previous ``worker_actions:auth`` subprocess dispatch,
@@ -331,11 +331,11 @@ class ProjectActionsMixin(_MixinBase):
             return
 
         if mode == "api_key":
-            await self._auth_via_api_key(provider, project_id=project_id)
+            await self._auth_via_api_key(provider, project_name=project_name)
         else:
-            await self._auth_via_oauth(provider, project_id=project_id)
+            await self._auth_via_oauth(provider, project_name=project_name)
 
-    async def _auth_via_api_key(self, provider: str, *, project_id: str | None) -> None:
+    async def _auth_via_api_key(self, provider: str, *, project_name: str | None) -> None:
         """Collect an API key via a Textual modal and store it in the vault."""
         from ..lib.api import resolve_credential_routing, store_api_key
         from .screens import ApiKeyEntryScreen
@@ -345,7 +345,7 @@ class ProjectActionsMixin(_MixinBase):
             return
         # Per-project projects store under their own vault set; shared/host-wide
         # land in "default".  Same routing the CLI uses (see domain.auth).
-        _mounts_dir, credential_set = resolve_credential_routing(project_id)
+        _mounts_dir, credential_set = resolve_credential_routing(project_name)
         try:
             store_api_key(provider, key, credential_set=credential_set)
         except Exception as exc:  # noqa: BLE001 — surface every storage failure
@@ -357,7 +357,7 @@ class ProjectActionsMixin(_MixinBase):
             return
         self.notify(f"API key stored for {provider}.")
 
-    async def _auth_via_oauth(self, provider: str, *, project_id: str | None) -> None:
+    async def _auth_via_oauth(self, provider: str, *, project_name: str | None) -> None:
         """Prepare an OAuth auth container session and hand it to the launcher."""
         from ..lib.api import Authenticator, find_host_auth_image, resolve_credential_routing
         from ..lib.core.config import (
@@ -366,7 +366,7 @@ class ProjectActionsMixin(_MixinBase):
         )
         from ..lib.core.images import project_cli_image
 
-        if project_id is None:
+        if project_name is None:
             image = find_host_auth_image(provider)
             if image is None:
                 self.notify(
@@ -377,7 +377,7 @@ class ProjectActionsMixin(_MixinBase):
                 )
                 return
         else:
-            image = project_cli_image(project_id)
+            image = project_cli_image(project_name)
 
         expose = (provider == "claude" and is_claude_oauth_exposed()) or (
             provider == "codex" and is_codex_oauth_exposed()
@@ -385,14 +385,14 @@ class ProjectActionsMixin(_MixinBase):
         # Per-project projects capture into their own mount tree + vault set;
         # shared/host-wide use the global tree + "default" (same routing the
         # CLI uses, see domain.auth.resolve_credential_routing).
-        mounts_dir, credential_set = resolve_credential_routing(project_id)
+        mounts_dir, credential_set = resolve_credential_routing(project_name)
         # ``prepare_oauth`` raises ``SystemExit`` only for an unknown or
         # non-OAuth provider — both already excluded by ``_run_auth_flow``
         # before we get here, so no defensive catch is needed.  An
         # unexpected raise surfaces through the ``@work`` harness instead
         # of tearing down the app.
         session = Authenticator(provider).prepare_oauth(
-            project_id,
+            project_name,
             mounts_dir=mounts_dir,
             image=image,
             expose_token=expose,
@@ -516,10 +516,10 @@ class ProjectActionsMixin(_MixinBase):
 
     async def _action_sync_gate(self) -> None:
         """Sync gate (init if doesn't exist, sync if exists)."""
-        if not self.current_project_id:
+        if not self.current_project_name:
             self.notify("No project selected.")
             return
-        pid = self.current_project_id
+        pid = self.current_project_name
         self._run_console_action(
             "terok.tui.worker_actions:sync_gate",
             pid,
@@ -583,10 +583,10 @@ class ProjectActionsMixin(_MixinBase):
 
     async def _action_edit_instructions(self) -> None:
         """Edit the current project's instructions.md in ``$EDITOR`` or the integrated editor."""
-        if not self.current_project_id:
+        if not self.current_project_name:
             self.notify("No project selected.")
             return
-        pid = self.current_project_id
+        pid = self.current_project_name
         instr_path = load_project(pid).root / "instructions.md"
         await self._edit_instructions_file(
             instr_path,
@@ -596,10 +596,10 @@ class ProjectActionsMixin(_MixinBase):
 
     async def _action_toggle_instructions_inherit(self) -> None:
         """Toggle YAML instructions between inherit and override mode."""
-        if not self.current_project_id:
+        if not self.current_project_name:
             self.notify("No project selected.")
             return
-        pid = self.current_project_id
+        pid = self.current_project_name
 
         try:
             from ..lib.util.yaml import dump as _yaml_dump, load as _yaml_load
@@ -645,10 +645,10 @@ class ProjectActionsMixin(_MixinBase):
 
     async def _action_show_resolved_instructions(self) -> None:
         """Display fully resolved instructions as a task would receive them."""
-        if not self.current_project_id:
+        if not self.current_project_name:
             self.notify("No project selected.")
             return
-        pid = self.current_project_id
+        pid = self.current_project_name
 
         from terok.lib.api.agents import get_agent, resolve_instructions
 
@@ -753,7 +753,7 @@ class ProjectActionsMixin(_MixinBase):
 
             rendered = render_project_yaml(values)
             review_result = await self.push_screen_wait(
-                ProjectReviewScreen(values["project_id"], rendered)
+                ProjectReviewScreen(values["project_name"], rendered)
             )
             if review_result is None:
                 return  # Escape on the review screen — abandon
@@ -767,12 +767,12 @@ class ProjectActionsMixin(_MixinBase):
             final_yaml = review_result
             break
 
-        project_id = str(values["project_id"])
-        outcome = await self.push_screen_wait(InitProgressScreen(project_id, final_yaml))
+        project_name = str(values["project_name"])
+        outcome = await self.push_screen_wait(InitProgressScreen(project_name, final_yaml))
 
         match outcome:
             case InitOutcome.SUCCESS:
-                self.notify(f"Project '{project_id}' is ready.")
+                self.notify(f"Project '{project_name}' is ready.")
                 self._maybe_nudge_global_agents(values)
             case InitOutcome.DECLINED:
                 # User chose to keep the existing project.yml — benign
@@ -784,14 +784,14 @@ class ProjectActionsMixin(_MixinBase):
                 # written and early steps may have partially run; point
                 # them at the CLI to resume rather than guessing.
                 self.notify(
-                    f"Wizard cancelled. If '{values['project_id']}' was partially "
+                    f"Wizard cancelled. If '{values['project_name']}' was partially "
                     "initialized, finish it with `terok project init` from the CLI.",
                     severity="warning",
                     timeout=10,
                 )
             case InitOutcome.FAILED:
                 self.notify(
-                    f"Project '{values['project_id']}' created but init did not complete. "
+                    f"Project '{values['project_name']}' created but init did not complete. "
                     "Fix any issues and run `terok project init` from the CLI.",
                     severity="warning",
                     timeout=10,
@@ -827,11 +827,11 @@ class ProjectActionsMixin(_MixinBase):
 
     async def _action_delete_project(self) -> None:
         """Delete the current project after confirmation."""
-        if not self.current_project_id:
+        if not self.current_project_name:
             self.notify("No project selected.")
             return
 
-        pid = self.current_project_id
+        pid = self.current_project_name
         try:
             project = load_project(pid)
         except (SystemExit, Exception) as e:
@@ -871,10 +871,10 @@ class ProjectActionsMixin(_MixinBase):
 
     async def _on_delete_project_confirmed(self, confirmed: bool | None) -> None:
         """Handle the result of the delete confirmation dialog."""
-        if not confirmed or not self.current_project_id:
+        if not confirmed or not self.current_project_name:
             return
 
-        pid = self.current_project_id
+        pid = self.current_project_name
         try:
             result = delete_project(pid)
         except (SystemExit, Exception) as e:
@@ -888,7 +888,7 @@ class ProjectActionsMixin(_MixinBase):
             msg += f" ({len(result['skipped'])} item(s) skipped)"
         self.notify(msg)
 
-        self.current_project_id = None
+        self.current_project_name = None
         await self.refresh_projects()
 
     # ---------- Shield actions ----------

--- a/src/terok/tui/screens.py
+++ b/src/terok/tui/screens.py
@@ -171,7 +171,7 @@ class ProjectDetailsScreen(screen.Screen[str | None]):
     def compose(self) -> ComposeResult:
         """Build the detail pane and categorized action list for a project."""
         detail_pane = Static(id="detail-content")
-        detail_pane.border_title = f"Project: {self._project.id}"
+        detail_pane.border_title = f"Project: {self._project.name}"
         detail_pane.border_subtitle = "Esc to close"
         yield detail_pane
 
@@ -238,7 +238,7 @@ class ProjectDetailsScreen(screen.Screen[str | None]):
         self.app.push_screen(
             AgentsSelectScreen(
                 initial=self._project.agents,
-                title=f"Agents for {self._project.id}",
+                title=f"Agents for {self._project.name}",
             ),
             self._on_agents_modal_result,
         )
@@ -249,7 +249,7 @@ class ProjectDetailsScreen(screen.Screen[str | None]):
             return
         from terok.lib.api import set_project_image_agents
 
-        path = set_project_image_agents(self._project.id, selection)
+        path = set_project_image_agents(self._project.name, selection)
         # Keep the cached config in sync so a re-open of the modal in
         # this same screen instance seeds from the freshly-saved value.
         # ``ProjectConfig`` is frozen, hence the model_copy.
@@ -1246,7 +1246,7 @@ else:  # pragma: no cover - stub TextArea in test envs
 class TaskLaunchScreen(screen.ModalScreen["tuple[str, str, str, str, str, str | None] | None"]):
     """Post-creation modal for CLI tasks: agent selection + optional prompt.
 
-    Dismisses with ``(project_id, task_id, task_name, container_name,
+    Dismisses with ``(project_name, task_id, task_name, container_name,
     agent, prompt)`` on Login, or ``None`` on Dismiss.  The full launch
     context is captured at creation time so the callback is immune to
     selection changes.
@@ -1298,7 +1298,7 @@ class TaskLaunchScreen(screen.ModalScreen["tuple[str, str, str, str, str, str | 
     def __init__(
         self,
         container_name: str,
-        project_id: str,
+        project_name: str,
         task_id: str,
         task_name: str | None = "",
         default_shell: str = "bash",
@@ -1318,7 +1318,7 @@ class TaskLaunchScreen(screen.ModalScreen["tuple[str, str, str, str, str, str | 
         """
         super().__init__()
         self._container_name = container_name
-        self._project_id = project_id
+        self._project_name = project_name
         self._task_id = task_id
         self._task_name = task_name or task_id
         self._default_shell = default_shell
@@ -1447,11 +1447,13 @@ class TaskLaunchScreen(screen.ModalScreen["tuple[str, str, str, str, str, str | 
         has_mode = False
         if state == "running":
             try:
-                has_mode = get_task_meta(self._project_id, self._task_id).mode is not None
+                has_mode = get_task_meta(self._project_name, self._task_id).mode is not None
             except (SystemExit, Exception) as exc:
                 from ..lib.util.logging_utils import _log_debug
 
-                _log_debug(f"Task meta fetch failed for {self._project_id}/{self._task_id}: {exc}")
+                _log_debug(
+                    f"Task meta fetch failed for {self._project_name}/{self._task_id}: {exc}"
+                )
                 has_mode = False
         return state, has_mode
 
@@ -1531,7 +1533,7 @@ class TaskLaunchScreen(screen.ModalScreen["tuple[str, str, str, str, str, str | 
         prompt = prompt_input.text.strip() or None
         self.dismiss(
             (
-                self._project_id,
+                self._project_name,
                 self._task_id,
                 self._task_name,
                 self._container_name,
@@ -1659,14 +1661,14 @@ class TaskDetailsScreen(screen.Screen[str | None]):
         self,
         task: TaskMeta | None,
         has_tasks: bool,
-        project_id: str,
+        project_name: str,
         image_old: bool | None = None,
     ) -> None:
         """Store task data and context for rendering when the screen mounts."""
         super().__init__()
         self._task_meta = task
         self._has_tasks = has_tasks
-        self._project_id = project_id
+        self._project_name = project_name
         self._image_old = image_old
 
     def compose(self) -> ComposeResult:
@@ -1744,7 +1746,7 @@ class TaskDetailsScreen(screen.Screen[str | None]):
         self._last_render_width = width
         rendered = render_task_details(
             self._task_meta,
-            project_id=self._project_id,
+            project_name=self._project_name,
             image_old=self._image_old,
             empty_message="No task selected.",
             width=width,

--- a/src/terok/tui/task_actions.py
+++ b/src/terok/tui/task_actions.py
@@ -61,17 +61,17 @@ else:
 _INITIAL_PROMPT_FILENAME = "initial-prompt.txt"
 
 
-def _save_initial_prompt(project_id: str, task_id: str, prompt: str | None) -> None:
+def _save_initial_prompt(project_name: str, task_id: str, prompt: str | None) -> None:
     """Persist the user's initial prompt to the task's mounted agent-config dir."""
     if not prompt:
         return
-    path = agent_config_dir(project_id, task_id) / _INITIAL_PROMPT_FILENAME
+    path = agent_config_dir(project_name, task_id) / _INITIAL_PROMPT_FILENAME
     path.write_text(prompt + "\n", encoding="utf-8")
 
 
-def _login_title(project_id: str, task_id: str, task_name: str) -> str:
+def _login_title(project_name: str, task_id: str, task_name: str) -> str:
     """Build a unified terminal/tmux title for task login sessions."""
-    return f"{project_id}:{task_id}:{task_name}"
+    return f"{project_name}:{task_id}:{task_name}"
 
 
 def _shield_up(cname: str, task_dir: Path) -> None:
@@ -109,7 +109,7 @@ class TaskActionsMixin(_MixinBase):
 
     if TYPE_CHECKING:
         # TerokTUI-specific state and helpers (not on textual.App).
-        current_project_id: str | None
+        current_project_name: str | None
         current_task: Any
         _last_selected_tasks: dict[str, str]
         _deleting_tasks: set[tuple[str, str]]
@@ -136,50 +136,50 @@ class TaskActionsMixin(_MixinBase):
         def _launch_terminal_session(self, *args: Any, **kwargs: Any) -> Any: ...
         def _save_selection_state(self) -> None: ...
         def _update_task_details(self) -> None: ...
-        def _mark_launching(self, project_id: str, task_id: str) -> None: ...
-        def _unmark_launching(self, project_id: str, task_id: str) -> None: ...
+        def _mark_launching(self, project_name: str, task_id: str) -> None: ...
+        def _unmark_launching(self, project_name: str, task_id: str) -> None: ...
 
     # ---------- Helpers ----------
 
-    def _focus_task_after_creation(self, project_id: str, task_id: str) -> None:
+    def _focus_task_after_creation(self, project_name: str, task_id: str) -> None:
         """Persist selection so the newly created task is focused after refresh."""
-        self._last_selected_tasks[project_id] = task_id
+        self._last_selected_tasks[project_name] = task_id
         self._save_selection_state()
 
     # ---------- Worker helpers ----------
 
-    def _queue_task_delete(self, project_id: str, task_id: str, task_name: str) -> None:
+    def _queue_task_delete(self, project_name: str, task_id: str, task_name: str) -> None:
         """Schedule a background worker to delete a task."""
-        self._deleting_tasks.add((project_id, task_id))
+        self._deleting_tasks.add((project_name, task_id))
         self.run_worker(
-            lambda: self._delete_task(project_id, task_id, task_name),
-            name=f"task-delete:{project_id}:{task_id}",
+            lambda: self._delete_task(project_name, task_id, task_name),
+            name=f"task-delete:{project_name}:{task_id}",
             group="task-delete",
             thread=True,
             exit_on_error=False,
         )
 
     def _delete_task(
-        self, project_id: str, task_id: str, task_name: str
+        self, project_name: str, task_id: str, task_name: str
     ) -> tuple[str, str, str, str | None, list[str]]:
-        """Delete a task and return ``(project_id, task_id, task_name, error, warnings)``."""
+        """Delete a task and return ``(project_name, task_id, task_name, error, warnings)``."""
         try:
-            result = task_delete(project_id, task_id)
-            return project_id, task_id, task_name, None, result.warnings
+            result = task_delete(project_name, task_id)
+            return project_name, task_id, task_name, None, result.warnings
         except SystemExit as e:
-            return project_id, task_id, task_name, str(e), []
+            return project_name, task_id, task_name, str(e), []
         except Exception as e:
-            return project_id, task_id, task_name, str(e), []
+            return project_name, task_id, task_name, str(e), []
 
     # ---------- Task lifecycle actions ----------
 
     async def _action_task_start_cli(self) -> None:
         """Create a new task and immediately run CLI agent."""
-        if not self.current_project_id:
+        if not self.current_project_name:
             self.notify("No project selected.")
             return
 
-        default_name = generate_task_name(self.current_project_id)
+        default_name = generate_task_name(self.current_project_name)
         await self.push_screen(
             TaskNameScreen(default_name=default_name),
             self._on_task_start_cli_name,
@@ -187,7 +187,7 @@ class TaskActionsMixin(_MixinBase):
 
     async def _on_task_start_cli_name(self, name: str | None) -> None:
         """Handle name result from TaskNameScreen for CLI task start."""
-        if name is None or not self.current_project_id:
+        if name is None or not self.current_project_name:
             return
         await self._start_cli_task_background(name)
 
@@ -203,7 +203,7 @@ class TaskActionsMixin(_MixinBase):
         runs in a worker and fills the dropdown when it returns.  This
         keeps the prompt TextArea instantly typeable.
         """
-        pid = self.current_project_id
+        pid = self.current_project_name
         if not pid:
             return
         try:
@@ -250,7 +250,7 @@ class TaskActionsMixin(_MixinBase):
 
         launch_screen = TaskLaunchScreen(
             container_name=cname,
-            project_id=pid,
+            project_name=pid,
             task_id=task_id,
             task_name=name,
             default_shell=default_shell,
@@ -329,11 +329,11 @@ class TaskActionsMixin(_MixinBase):
 
     async def _action_task_start_toad(self) -> None:
         """Create a new task and immediately run Toad serve."""
-        if not self.current_project_id:
+        if not self.current_project_name:
             self.notify("No project selected.")
             return
 
-        default_name = generate_task_name(self.current_project_id)
+        default_name = generate_task_name(self.current_project_name)
         await self.push_screen(
             TaskNameScreen(default_name=default_name),
             self._on_task_start_toad_name,
@@ -341,7 +341,7 @@ class TaskActionsMixin(_MixinBase):
 
     async def _on_task_start_toad_name(self, name: str | None) -> None:
         """Handle name result from TaskNameScreen for Toad task start."""
-        if name is None or not self.current_project_id:
+        if name is None or not self.current_project_name:
             return
         await self._start_toad_task_background(name)
 
@@ -351,7 +351,7 @@ class TaskActionsMixin(_MixinBase):
         The container start runs as a captured ConsoleLog entry \u2014 view
         it from the ``Console output`` command if it needs inspecting.
         """
-        pid = self.current_project_id
+        pid = self.current_project_name
         if not pid:
             return
         try:
@@ -386,12 +386,12 @@ class TaskActionsMixin(_MixinBase):
 
     async def _action_task_start_unattended(self) -> None:
         """Create a new task and run Claude headlessly (unattended)."""
-        if not self.current_project_id:
+        if not self.current_project_name:
             self.notify("No project selected.")
             return
 
         # Show name input screen first, then prompt
-        default_name = generate_task_name(self.current_project_id)
+        default_name = generate_task_name(self.current_project_name)
         await self.push_screen(
             TaskNameScreen(default_name=default_name),
             self._on_unattended_name_result,
@@ -401,10 +401,10 @@ class TaskActionsMixin(_MixinBase):
 
     async def _on_unattended_name_result(self, name: str | None) -> None:
         """Handle the name returned from TaskNameScreen for unattended."""
-        if name is None or not self.current_project_id:
+        if name is None or not self.current_project_name:
             return
 
-        pid = self.current_project_id
+        pid = self.current_project_name
 
         # Store the name and show agent selection screen
         self._unattended_pending_name = name
@@ -468,9 +468,9 @@ class TaskActionsMixin(_MixinBase):
 
     async def _launch_unattended(self, prompt: str, agent: str | None = None) -> None:
         """Launch a headless unattended task in a background worker."""
-        if not self.current_project_id:
+        if not self.current_project_name:
             return
-        pid = self.current_project_id
+        pid = self.current_project_name
         name = getattr(self, "_unattended_pending_name", None)
         self._unattended_pending_name = None
         self.notify(f"Starting unattended task for {pid}...")
@@ -484,7 +484,7 @@ class TaskActionsMixin(_MixinBase):
 
     def _run_headless_worker(
         self,
-        project_id: str,
+        project_name: str,
         prompt: str,
         name: str | None = None,
         agent: str | None = None,
@@ -493,43 +493,43 @@ class TaskActionsMixin(_MixinBase):
         try:
             task_id = task_run_headless(
                 HeadlessRunRequest(
-                    project_id=project_id,
+                    project_name=project_name,
                     prompt=prompt,
                     follow=False,
                     name=name,
                     agent=agent,
                 )
             )
-            return project_id, task_id, None
+            return project_name, task_id, None
         except SystemExit as e:
-            return project_id, "", str(e)
+            return project_name, "", str(e)
         except Exception as e:
-            return project_id, "", str(e)
+            return project_name, "", str(e)
 
-    def _start_unattended_watcher(self, project_id: str, task_id: str) -> None:
+    def _start_unattended_watcher(self, project_name: str, task_id: str) -> None:
         """Spawn a background worker that waits for the container to finish
         and updates task metadata with the exit code."""
-        cname = container_name(project_id, "run", task_id)
+        cname = container_name(project_name, "run", task_id)
         self.run_worker(
-            lambda: self._unattended_wait_worker(project_id, task_id, cname),
-            name=f"unattended-wait:{project_id}:{task_id}",
+            lambda: self._unattended_wait_worker(project_name, task_id, cname),
+            name=f"unattended-wait:{project_name}:{task_id}",
             group="unattended-wait",
             thread=True,
             exit_on_error=False,
         )
 
     def _unattended_wait_worker(
-        self, project_id: str, task_id: str, cname: str
+        self, project_name: str, task_id: str, cname: str
     ) -> tuple[str, str, int | None, str | None]:
         """Background worker: wait for the container to exit and update metadata."""
-        exit_code, error = wait_for_container_exit(cname, project_id, task_id)
-        return project_id, task_id, exit_code, error
+        exit_code, error = wait_for_container_exit(cname, project_name, task_id)
+        return project_name, task_id, exit_code, error
 
     # ── Follow-up on completed/failed unattended tasks ──
 
     async def _action_task_followup(self) -> None:
         """Follow up on a completed/failed unattended task with a new prompt."""
-        if not self.current_project_id or not self.current_task:
+        if not self.current_project_name or not self.current_task:
             self.notify("No task selected.")
             return
         task = self.current_task
@@ -544,9 +544,9 @@ class TaskActionsMixin(_MixinBase):
 
     async def _on_followup_prompt_result(self, prompt: str | None) -> None:
         """Handle the prompt returned from follow-up prompt screen."""
-        if not prompt or not self.current_project_id or not self.current_task:
+        if not prompt or not self.current_project_name or not self.current_task:
             return
-        pid = self.current_project_id
+        pid = self.current_project_name
         tid = self.current_task.task_id
         self.notify(f"Sending follow-up to task {tid}...")
         self.run_worker(
@@ -558,20 +558,20 @@ class TaskActionsMixin(_MixinBase):
         )
 
     def _run_followup_worker(
-        self, project_id: str, task_id: str, prompt: str
+        self, project_name: str, task_id: str, prompt: str
     ) -> tuple[str, str, str | None]:
         """Background worker: call task_followup_headless and return result."""
         try:
-            task_followup_headless(project_id, task_id, prompt, follow=False)
-            return project_id, task_id, None
+            task_followup_headless(project_name, task_id, prompt, follow=False)
+            return project_name, task_id, None
         except SystemExit as e:
-            return project_id, task_id, str(e)
+            return project_name, task_id, str(e)
         except Exception as e:
-            return project_id, task_id, str(e)
+            return project_name, task_id, str(e)
 
     async def _action_follow_logs(self) -> None:
         """View logs for a task in the integrated log viewer."""
-        if not self.current_project_id or not self.current_task:
+        if not self.current_project_name or not self.current_task:
             self.notify("No task selected.")
             return
         task = self.current_task
@@ -579,7 +579,7 @@ class TaskActionsMixin(_MixinBase):
             self.notify("Task has no mode set (never started).")
             return
 
-        pid = self.current_project_id
+        pid = self.current_project_name
         tid = task.task_id
         cname = container_name(pid, task.mode, tid)
 
@@ -595,7 +595,7 @@ class TaskActionsMixin(_MixinBase):
         await self.push_screen(
             LogViewerScreen(
                 TaskContainerRef(
-                    project_id=pid,
+                    project_name=pid,
                     task_id=tid,
                     mode=task.mode,
                     container_name=cname,
@@ -607,10 +607,10 @@ class TaskActionsMixin(_MixinBase):
 
     async def _action_restart_task(self) -> None:
         """Restart a task container (stops it first if running)."""
-        if not self.current_project_id or not self.current_task:
+        if not self.current_project_name or not self.current_task:
             self.notify("No task selected.")
             return
-        pid = self.current_project_id
+        pid = self.current_project_name
         tid = self.current_task.task_id
         self._run_console_action(
             "terok.tui.worker_actions:task_restart",
@@ -622,10 +622,10 @@ class TaskActionsMixin(_MixinBase):
 
     async def _action_stop_task(self) -> None:
         """Stop a running task container."""
-        if not self.current_project_id or not self.current_task:
+        if not self.current_project_name or not self.current_task:
             self.notify("No task selected.")
             return
-        pid = self.current_project_id
+        pid = self.current_project_name
         tid = self.current_task.task_id
         self._run_console_action(
             "terok.tui.worker_actions:task_stop",
@@ -644,7 +644,7 @@ class TaskActionsMixin(_MixinBase):
         error notification pointing at the toad-mode alternative (its
         browser URL works without a host shell).
         """
-        if not self.current_project_id or not self.current_task:
+        if not self.current_project_name or not self.current_task:
             self.notify("No task selected.")
             return
         if self.is_web:
@@ -656,7 +656,7 @@ class TaskActionsMixin(_MixinBase):
                 timeout=12,
             )
             return
-        pid = self.current_project_id
+        pid = self.current_project_name
         tid = self.current_task.task_id
         try:
             cmd = get_login_command(pid, tid)
@@ -675,13 +675,13 @@ class TaskActionsMixin(_MixinBase):
 
     async def action_delete_task(self) -> None:
         """Delete the currently selected task and its containers."""
-        if not self.current_project_id or not self.current_task:
+        if not self.current_project_name or not self.current_task:
             self.notify("No task selected.")
             return
 
         tid = self.current_task.task_id
         tname = self.current_task.name or ""
-        pid = self.current_project_id
+        pid = self.current_project_name
         task_label = f"{pid} {tid}" + (f" {tname}" if tname else "")
         # Guard on the live in-flight set, not the on-disk ``deleting`` flag:
         # a flag left behind by a crashed session is stale and must stay
@@ -690,7 +690,7 @@ class TaskActionsMixin(_MixinBase):
             self.notify(f"Task {task_label} is already being deleted.")
             return
 
-        self._log_debug(f"delete: start project_id={pid} task_id={tid}")
+        self._log_debug(f"delete: start project_name={pid} task_id={tid}")
         self.notify(f"Deleting task {task_label}...")
 
         self.current_task.deleting = True
@@ -703,7 +703,7 @@ class TaskActionsMixin(_MixinBase):
 
     async def _action_rename_task(self) -> None:
         """Rename the currently selected task."""
-        if not self.current_project_id or not self.current_task:
+        if not self.current_project_name or not self.current_task:
             self.notify("No task selected.")
             return
         current_name = self.current_task.name or ""
@@ -714,9 +714,9 @@ class TaskActionsMixin(_MixinBase):
 
     async def _on_rename_task_result(self, name: str | None) -> None:
         """Handle name result from TaskNameScreen for rename."""
-        if name is None or not self.current_project_id or not self.current_task:
+        if name is None or not self.current_project_name or not self.current_task:
             return
-        pid = self.current_project_id
+        pid = self.current_project_name
         tid = self.current_task.task_id
         try:
             task_rename(pid, tid, name)
@@ -728,12 +728,12 @@ class TaskActionsMixin(_MixinBase):
 
     async def _copy_diff_to_clipboard(self, git_ref: str, label: str) -> None:
         """Common helper to copy a git diff to the clipboard."""
-        if not self.current_project_id or not self.current_task:
+        if not self.current_project_name or not self.current_task:
             self.notify("No task selected.")
             return
 
         task_id = self.current_task.task_id
-        diff = get_workspace_git_diff(self.current_project_id, task_id, git_ref)
+        diff = get_workspace_git_diff(self.current_project_name, task_id, git_ref)
 
         if diff is None:
             self.notify("Failed to get git diff. Is this a git repository?")
@@ -774,10 +774,10 @@ class TaskActionsMixin(_MixinBase):
         shield_fn: Callable[[str, Path], None],
     ) -> None:
         """Run a shield action (down/up) for the current task in a background worker."""
-        if not self.current_project_id or not self.current_task:
+        if not self.current_project_name or not self.current_task:
             self.notify("No task selected.")
             return
-        pid = self.current_project_id
+        pid = self.current_project_name
         task = self.current_task
         tid = task.task_id
         cname = container_name(pid, task.mode or "cli", tid)
@@ -906,10 +906,10 @@ class TaskActionsMixin(_MixinBase):
 
     async def action_create_task_from_main(self) -> None:
         """Show the task creation modal from the main screen."""
-        if not self.current_project_id:
+        if not self.current_project_name:
             self.notify("No project selected.")
             return
-        default_name = generate_task_name(self.current_project_id)
+        default_name = generate_task_name(self.current_project_name)
         await self.push_screen(
             TaskCreateScreen(default_name=default_name),
             self._on_create_task_result,

--- a/src/terok/tui/task_actions.py
+++ b/src/terok/tui/task_actions.py
@@ -277,7 +277,7 @@ class TaskActionsMixin(_MixinBase):
         except (SystemExit, Exception) as exc:
             self._log_debug(
                 f"_fill_installed_agents: agents lookup failed for project "
-                f"{getattr(project, 'id', '?')!r}; dropdown will show all. {exc}"
+                f"{getattr(project, 'name', '?')!r}; dropdown will show all. {exc}"
             )
             installed = frozenset()
         launch_screen.set_installed(installed)

--- a/src/terok/tui/widgets/project_list.py
+++ b/src/terok/tui/widgets/project_list.py
@@ -28,11 +28,11 @@ class ProjectListItem(ListItem):
     """List item that carries project metadata."""
 
     def __init__(
-        self, project_id: str, label: str, generation: int, *, is_broken: bool = False
+        self, project_name: str, label: str, generation: int, *, is_broken: bool = False
     ) -> None:
         """Create a project list item with its ID, label, and broken flag."""
         super().__init__(Static(label, markup=False))
-        self.project_id = project_id
+        self.project_name = project_name
         self.generation = generation
         self.is_broken = is_broken
 
@@ -52,10 +52,10 @@ class ProjectList(ListView):
     class ProjectSelected(Message):
         """Posted when a project is highlighted in the list."""
 
-        def __init__(self, project_id: str, *, is_broken: bool = False) -> None:
+        def __init__(self, project_name: str, *, is_broken: bool = False) -> None:
             """Create the message with the selected project's ID and broken flag."""
             super().__init__()
-            self.project_id = project_id
+            self.project_name = project_name
             self.is_broken = is_broken
 
     def __init__(self, **kwargs: Any) -> None:
@@ -85,26 +85,26 @@ class ProjectList(ListView):
         # attention, so putting it at the top makes the error indicator the
         # first thing the user sees.
         for bp in self.broken:
-            label = f"{render_emoji(_BROKEN_BADGE)} {bp.id} (broken)"
-            self.append(ProjectListItem(bp.id, label, self._generation, is_broken=True))
+            label = f"{render_emoji(_BROKEN_BADGE)} {bp.name} (broken)"
+            self.append(ProjectListItem(bp.name, label, self._generation, is_broken=True))
 
         for proj in projects:
             sec = SECURITY_CLASS_DISPLAY.get(proj.security_class, SECURITY_CLASS_DISPLAY["online"])
             gpu = GPU_DISPLAY[has_gpu(proj)]
-            label = f"{render_emoji(sec)}{render_emoji(gpu)} {proj.id}"
-            self.append(ProjectListItem(proj.id, label, self._generation))
+            label = f"{render_emoji(sec)}{render_emoji(gpu)} {proj.name}"
+            self.append(ProjectListItem(proj.name, label, self._generation))
 
-    def select_project(self, project_id: str) -> None:
+    def select_project(self, project_name: str) -> None:
         """Select a project by id (healthy or broken)."""
         # Broken rows are inserted before healthy ones; walk the combined
         # sequence in the same order they were appended.
         for idx, bp in enumerate(self.broken):
-            if bp.id == project_id:
+            if bp.name == project_name:
                 self.index = idx
                 return
         offset = len(self.broken)
         for idx, proj in enumerate(self.projects):
-            if proj.id == project_id:
+            if proj.name == project_name:
                 self.index = offset + idx
                 return
 
@@ -124,4 +124,4 @@ class ProjectList(ListView):
             return
         if item.generation != self._generation:
             return
-        self.post_message(self.ProjectSelected(item.project_id, is_broken=item.is_broken))
+        self.post_message(self.ProjectSelected(item.project_name, is_broken=item.is_broken))

--- a/src/terok/tui/widgets/project_state.py
+++ b/src/terok/tui/widgets/project_state.py
@@ -48,8 +48,10 @@ def render_project_loading(
         Text("Tasks:     loading") if task_count is None else Text(f"Tasks:     {task_count}")
     )
 
-    lines = [
-        Text(f"Project:   {project.id} {badges}"),
+    lines = [Text(f"Project:   {project.name} {badges}")]
+    if project.description:
+        lines.append(Text(f"Desc:      {project.description}", style=Style(dim=True)))
+    lines += [
         Text(upstream),
         Text(""),
         Text("Loading details..."),
@@ -68,7 +70,7 @@ def render_broken_project(bp: BrokenProject, css_variables: dict[str, str] | Non
     variables = css_variables or {}
     error_color = variables.get("error", "red")
     dim = Style(dim=True)
-    header = Text(f"Project:   {bp.id} ", style=Style(color=error_color, bold=True))
+    header = Text(f"Project:   {bp.name} ", style=Style(color=error_color, bold=True))
     header.append("(broken)", style=Style(color=error_color))
     lines = [
         header,
@@ -186,8 +188,10 @@ def render_project_details(
     else:
         shield_s = Text("unknown", style=Style(dim=True))
 
-    lines = [
-        Text(f"Project:   {project.id} {badges}"),
+    lines = [Text(f"Project:   {project.name} {badges}")]
+    if project.description:
+        lines.append(Text(f"Desc:      {project.description}", style=Style(dim=True)))
+    lines += [
         Text(upstream),
         Text(""),
         Text.assemble("Dockerfiles: ", docker_s),

--- a/src/terok/tui/widgets/task_detail.py
+++ b/src/terok/tui/widgets/task_detail.py
@@ -34,7 +34,7 @@ def _get_css_variables(widget: Static) -> dict[str, str]:
 
 def render_task_details(
     task: TaskMeta | None,
-    project_id: str | None = None,
+    project_name: str | None = None,
     image_old: bool | None = None,
     empty_message: str | None = None,
     css_variables: dict[str, str] | None = None,
@@ -104,11 +104,11 @@ def render_task_details(
         if not is_web:
             click_style = click_style + Style(link=link_url)
         lines.append(Text.assemble("Web URL:   ", Text(link_url, style=click_style)))
-    if task.mode == "cli" and project_id:
+    if task.mode == "cli" and project_name:
         lines.append(
             Text.assemble(
                 "Log in:    ",
-                Text(f"terok login {project_id} {task.task_id}", style=accent_style),
+                Text(f"terok login {project_name} {task.task_id}", style=accent_style),
             )
         )
     if task.unrestricted is not None:
@@ -163,12 +163,12 @@ def render_task_details(
     if task.mode == "run":
         if task.exit_code is not None:
             lines.append(Text(f"Exit code: {task.exit_code}"))
-        if project_id:
+        if project_name:
             lines.append(
                 Text.assemble(
                     "Logs:      ",
                     Text(
-                        f"terok task logs {project_id} {task.task_id} -f",
+                        f"terok task logs {project_name} {task.task_id} -f",
                         style=accent_style,
                     ),
                 )
@@ -183,7 +183,7 @@ class TaskDetails(Static):
     def __init__(self, **kwargs: Any) -> None:
         """Initialize the task details panel."""
         super().__init__(**kwargs)
-        self.current_project_id: str | None = None
+        self.current_project_name: str | None = None
         self._current_task: TaskMeta | None = None
         self._current_empty_message: str | None = None
         self._current_image_old: bool | None = None
@@ -201,11 +201,11 @@ class TaskDetails(Static):
     ) -> None:
         """Render and display details for the given task (or clear if None)."""
         if task is None:
-            self.current_project_id = None
+            self.current_project_name = None
         else:
-            # current_project_id lives on TerokTUI, not the base App[Any] type.
-            self.current_project_id = (
-                getattr(self.app, "current_project_id", None) if self.app else None
+            # current_project_name lives on TerokTUI, not the base App[Any] type.
+            self.current_project_name = (
+                getattr(self.app, "current_project_name", None) if self.app else None
             )
 
         self._current_task = task
@@ -246,7 +246,7 @@ class TaskDetails(Static):
 
         rendered = render_task_details(
             self._current_task,
-            self.current_project_id,
+            self.current_project_name,
             self._current_image_old,
             self._current_empty_message,
             _get_css_variables(self),

--- a/src/terok/tui/widgets/task_list.py
+++ b/src/terok/tui/widgets/task_list.py
@@ -17,10 +17,10 @@ from ...ui_utils.terminal import wrap_with_hanging_indent
 class TaskListItem(ListItem):
     """List item that carries task metadata."""
 
-    def __init__(self, project_id: str, task: TaskMeta, label: str, generation: int) -> None:
+    def __init__(self, project_name: str, task: TaskMeta, label: str, generation: int) -> None:
         """Create a task list item with its metadata and display label."""
         super().__init__(Static(label, markup=False))
-        self.project_id = project_id
+        self.project_name = project_name
         self.task_meta = task
         self.generation = generation
 
@@ -58,16 +58,16 @@ class TaskList(ListView):
     class TaskSelected(Message):
         """Posted when a task is highlighted in the list."""
 
-        def __init__(self, project_id: str, task: TaskMeta) -> None:
-            """Create the message with the owning project ID and task metadata."""
+        def __init__(self, project_name: str, task: TaskMeta) -> None:
+            """Create the message with the owning project name and task metadata."""
             super().__init__()
-            self.project_id = project_id
+            self.project_name = project_name
             self.task = task
 
     def __init__(self, **kwargs: Any) -> None:
         """Initialize the task list with empty state."""
         super().__init__(**kwargs)
-        self.project_id: str | None = None
+        self.project_name: str | None = None
         self.tasks: list[TaskMeta] = []
         self._generation = 0
         self._last_label_width = -1
@@ -118,14 +118,14 @@ class TaskList(ListView):
         self._last_label_width = width
         self.refresh_labels()
 
-    def set_tasks(self, project_id: str, tasks_meta: list[TaskMeta]) -> None:
+    def set_tasks(self, project_name: str, tasks_meta: list[TaskMeta]) -> None:
         """Populate the list from ``TaskMeta`` instances, newest first."""
         existing_states: dict[str, str | None] = {}
-        if self.project_id == project_id:
+        if self.project_name == project_name:
             for task in self.tasks:
                 existing_states[task.task_id] = task.container_state
 
-        self.project_id = project_id
+        self.project_name = project_name
         self.tasks = []
         self._generation += 1
         self.clear()
@@ -137,7 +137,7 @@ class TaskList(ListView):
             self.tasks.append(tm)
 
             label = self._format_task_label(tm, width)
-            self.append(TaskListItem(project_id, tm, label, self._generation))
+            self.append(TaskListItem(project_name, tm, label, self._generation))
 
     def mark_deleting(self, task_id: str) -> bool:
         """Mark a task as 'deleting' in the list and refresh its label."""
@@ -168,7 +168,7 @@ class TaskList(ListView):
 
     def _post_selected_task(self, item: ListItem | None = None) -> None:
         """Emit a TaskSelected message for the given or currently highlighted item."""
-        if self.project_id is None:
+        if self.project_name is None:
             return
         if item is None:
             item = self.highlighted_child
@@ -178,6 +178,6 @@ class TaskList(ListView):
             return
         if item.generation != self._generation:
             return
-        if item.project_id != self.project_id:
+        if item.project_name != self.project_name:
             return
-        self.post_message(self.TaskSelected(self.project_id, item.task_meta))
+        self.post_message(self.TaskSelected(self.project_name, item.task_meta))

--- a/src/terok/tui/wizard_screens.py
+++ b/src/terok/tui/wizard_screens.py
@@ -346,16 +346,16 @@ class ProjectReviewScreen(ModalScreen["str | object | None"]):
     }
     """
 
-    def __init__(self, project_id: str, rendered: str) -> None:
+    def __init__(self, project_name: str, rendered: str) -> None:
         """Create the review screen with the initial rendered YAML text."""
         super().__init__()
-        self._project_id = project_id
+        self._project_name = project_name
         self._rendered = rendered
 
     def compose(self) -> ComposeResult:
         """Build the editable YAML pane and Back/Initialize buttons."""
         dialog = Vertical(id="wizard-review-dialog")
-        dialog.border_title = f"Review project.yml — {self._project_id}"
+        dialog.border_title = f"Review project.yml — {self._project_name}"
         with dialog:
             yield TextArea.code_editor(
                 self._rendered,
@@ -564,7 +564,7 @@ class InitProgressScreen(ModalScreen[InitOutcome]):
         "gate": "Gate sync",
     }
 
-    def __init__(self, project_id: str, rendered_yaml: str | None = None) -> None:
+    def __init__(self, project_name: str, rendered_yaml: str | None = None) -> None:
         """Create the init screen.
 
         *rendered_yaml* is the ``project.yml`` content the new-project
@@ -574,7 +574,7 @@ class InitProgressScreen(ModalScreen[InitOutcome]):
         writing and confirming nothing.
         """
         super().__init__()
-        self._project_id = project_id
+        self._project_name = project_name
         self._rendered_yaml = rendered_yaml
         self._ssh_continue: Any = None  # an asyncio.Event, set when user clicks continue
         # Default pessimistic — the worker flips this to SUCCESS on a clean
@@ -585,7 +585,7 @@ class InitProgressScreen(ModalScreen[InitOutcome]):
     def compose(self) -> ComposeResult:
         """Build the per-step status list, log pane, and buttons."""
         dialog = Vertical(id="wizard-init-dialog")
-        dialog.border_title = f"Initializing project — {self._project_id}"
+        dialog.border_title = f"Initializing project — {self._project_name}"
         with dialog:
             with Vertical(id="wizard-init-steps"):
                 for key in self._STEP_KEYS:
@@ -632,7 +632,7 @@ class InitProgressScreen(ModalScreen[InitOutcome]):
     async def on_mount(self) -> None:
         """Confirm overwrite when needed, persist the YAML, then run init.
 
-        When a ``project.yml`` already exists for this project ID, the
+        When a ``project.yml`` already exists for this project name, the
         TUI mirrors the CLI's overwrite prompt via a modal confirm.
         The heavy lifting (confirm → write → worker) happens in a
         ``@work`` coroutine so ``push_screen_wait`` has the worker
@@ -676,9 +676,9 @@ class InitProgressScreen(ModalScreen[InitOutcome]):
                         self._outcome = InitOutcome.DECLINED
                         return
 
-                log.write(f"[dim]Writing project.yml for {self._project_id}…[/]")
+                log.write(f"[dim]Writing project.yml for {self._project_name}…[/]")
                 try:
-                    write_project_yaml(self._project_id, self._rendered_yaml, overwrite=True)
+                    write_project_yaml(self._project_name, self._rendered_yaml, overwrite=True)
                 except (OSError, SystemExit) as exc:
                     log.write(f"[red]Failed to write project.yml: {exc}[/]")
                     return
@@ -692,7 +692,7 @@ class InitProgressScreen(ModalScreen[InitOutcome]):
         """Return the on-disk ``project.yml`` path if it already exists, else None."""
         from ..lib.api import get_config
 
-        candidate = get_config().user_projects_dir / self._project_id / "project.yml"
+        candidate = get_config().user_projects_dir / self._project_name / "project.yml"
         return candidate if candidate.is_file() else None
 
     async def _confirm_overwrite(self, path: Path) -> bool:
@@ -703,10 +703,10 @@ class InitProgressScreen(ModalScreen[InitOutcome]):
         # invariant — Screen[bool] doesn't satisfy it. Stubs issue.
         screen_obj: Any = ConfirmDestructiveScreen(
             message=(
-                f"A configuration for project '{self._project_id}' already "
+                f"A configuration for project '{self._project_name}' already "
                 f"exists at:\n\n{path}\n\nOverwrite with the reviewed content?"
             ),
-            title=f"Overwrite project.yml — {self._project_id}",
+            title=f"Overwrite project.yml — {self._project_name}",
             confirm_label="Overwrite",
         )
         return bool(await self.app.push_screen_wait(screen_obj))
@@ -853,7 +853,7 @@ class InitProgressScreen(ModalScreen[InitOutcome]):
             summarize_ssh_init,
         )
 
-        project = get_project(self._project_id)
+        project = get_project(self._project_name)
         log = self.query_one("#wizard-init-log", RichLog)
         self._ssh_continue = asyncio.Event()
 
@@ -904,7 +904,7 @@ class InitProgressScreen(ModalScreen[InitOutcome]):
             # Step 2: Dockerfiles
             self._mark("generate", "running")
             with _log_capture(log):
-                await asyncio.to_thread(generate_dockerfiles, self._project_id)
+                await asyncio.to_thread(generate_dockerfiles, self._project_name)
             self._mark("generate", "done")
 
             # ``ProjectConfig`` is what the askpass + gate-enabled checks
@@ -921,9 +921,9 @@ class InitProgressScreen(ModalScreen[InitOutcome]):
             log.write("[dim]Building images — output follows.[/]")
             await self._run_dispatched_step(
                 "terok.tui.worker_actions:build",
-                self._project_id,
+                self._project_name,
                 log=log,
-                title=f"Building images for {self._project_id}",
+                title=f"Building images for {self._project_name}",
                 env=subprocess_env,
                 fail_msg="Image build failed",
             )
@@ -939,16 +939,16 @@ class InitProgressScreen(ModalScreen[InitOutcome]):
                 log.write("[dim]Syncing the git gate — output follows.[/]")
                 await self._run_dispatched_step(
                     "terok.tui.worker_actions:sync_gate",
-                    self._project_id,
+                    self._project_name,
                     log=log,
-                    title=f"Syncing gate for {self._project_id}",
+                    title=f"Syncing gate for {self._project_name}",
                     env=subprocess_env,
                     fail_msg="Gate sync failed",
                 )
                 self._mark("gate", "done")
 
             self._outcome = InitOutcome.SUCCESS
-            log.write(f"[green]Project '{self._project_id}' is ready.[/]")
+            log.write(f"[green]Project '{self._project_name}' is ready.[/]")
         except (Exception, SystemExit) as exc:
             # Many facade calls (``load_project``, etc.) signal user-
             # friendly errors with ``SystemExit`` which does *not*

--- a/src/terok/tui/worker_actions.py
+++ b/src/terok/tui/worker_actions.py
@@ -25,39 +25,39 @@ from __future__ import annotations
 # ── Project infrastructure ────────────────────────────────────────────
 
 
-def generate(project_id: str) -> None:
-    """Generate Dockerfiles for *project_id*."""
+def generate(project_name: str) -> None:
+    """Generate Dockerfiles for *project_name*."""
     from terok.lib.api import generate_dockerfiles
 
-    generate_dockerfiles(project_id)
+    generate_dockerfiles(project_name)
 
 
-def build(project_id: str) -> None:
-    """Build the L2 project images for *project_id* (reuses cached L0/L1)."""
+def build(project_name: str) -> None:
+    """Build the L2 project images for *project_name* (reuses cached L0/L1)."""
     from terok.lib.api import build_images
 
-    build_images(project_id)
+    build_images(project_name)
 
 
-def build_agents(project_id: str) -> None:
-    """Rebuild *project_id* from L0 with a fresh agent set."""
+def build_agents(project_name: str) -> None:
+    """Rebuild *project_name* from L0 with a fresh agent set."""
     from terok.lib.api import build_images
 
-    build_images(project_id, refresh_agents=True)
+    build_images(project_name, refresh_agents=True)
 
 
-def build_full(project_id: str) -> None:
-    """Rebuild *project_id* from L0 with no cache."""
+def build_full(project_name: str) -> None:
+    """Rebuild *project_name* from L0 with no cache."""
     from terok.lib.api import build_images
 
-    build_images(project_id, full_rebuild=True)
+    build_images(project_name, full_rebuild=True)
 
 
-def init_ssh(project_id: str) -> None:
-    """Mint a vault-backed SSH keypair for *project_id* and print its summary."""
+def init_ssh(project_name: str) -> None:
+    """Mint a vault-backed SSH keypair for *project_name* and print its summary."""
     from terok.lib.api import get_project, summarize_ssh_init
 
-    summarize_ssh_init(get_project(project_id).provision_ssh_key())
+    summarize_ssh_init(get_project(project_name).provision_ssh_key())
 
 
 # Full project setup ("Full setup" project-screen action) is *not* a
@@ -80,7 +80,7 @@ def _lookup_vault_pub_line(scope: str) -> str | None:
     return public_line_of(records[-1]) if records else None
 
 
-def _print_sync_gate_ssh_help(project_id: str) -> None:
+def _print_sync_gate_ssh_help(project_name: str) -> None:
     """Print SSH-specific troubleshooting for a gate-sync failure.
 
     Best-effort: a project that cannot be loaded just means no hint —
@@ -92,7 +92,7 @@ def _print_sync_gate_ssh_help(project_id: str) -> None:
     from terok.lib.api.setup import is_ssh_url
 
     try:
-        project = load_project(project_id)
+        project = load_project(project_name)
     except Exception:
         return
     if not is_ssh_url(project.upstream_url):
@@ -100,25 +100,25 @@ def _print_sync_gate_ssh_help(project_id: str) -> None:
 
     print("\nHint: this project uses an SSH upstream.")
     print("Gate sync failures are often a missing SSH key registration on the remote.")
-    pub_line = _lookup_vault_pub_line(project.id)
+    pub_line = _lookup_vault_pub_line(project.name)
     if pub_line is not None:
         print("Public key (register as a deploy key on the remote):")
         print(f"  {pub_line}")
     else:
-        print(f"No SSH key assigned to project (scope) {project.id!r} in the vault.")
-        print(f"Run 'terok project ssh-init {project_id}' to generate one,")
+        print(f"No SSH key assigned to project (scope) {project.name!r} in the vault.")
+        print(f"Run 'terok project ssh-init {project_name}' to generate one,")
         print("then register the printed public key as a deploy key upstream.")
 
 
-def sync_gate(project_id: str) -> None:
-    """Sync (creating if absent) the git gate for *project_id* from upstream."""
+def sync_gate(project_name: str) -> None:
+    """Sync (creating if absent) the git gate for *project_name* from upstream."""
     from terok.lib.api import load_project, make_git_gate
 
-    print(f"Syncing gate for {project_id}...")
+    print(f"Syncing gate for {project_name}...")
     try:
-        result = make_git_gate(load_project(project_id)).sync()
+        result = make_git_gate(load_project(project_name)).sync()
     except SystemExit as exc:
-        _print_sync_gate_ssh_help(project_id)
+        _print_sync_gate_ssh_help(project_name)
         raise SystemExit(f"Gate sync failed: {exc}") from exc
     if result["success"]:
         print(
@@ -127,7 +127,7 @@ def sync_gate(project_id: str) -> None:
             else "Gate synced from upstream."
         )
         return
-    _print_sync_gate_ssh_help(project_id)
+    _print_sync_gate_ssh_help(project_name)
     raise SystemExit(f"Gate sync failed: {', '.join(result['errors'])}")
 
 
@@ -234,29 +234,29 @@ def selinux_switch_to_tcp() -> None:
 # ── Task lifecycle ────────────────────────────────────────────────────
 
 
-def task_restart(project_id: str, task_id: str) -> None:
+def task_restart(project_name: str, task_id: str) -> None:
     """Restart *task_id*'s container (stopping it first if running)."""
     from terok.lib.api import task_restart as _task_restart
 
-    _task_restart(project_id, task_id)
+    _task_restart(project_name, task_id)
 
 
-def task_stop(project_id: str, task_id: str) -> None:
+def task_stop(project_name: str, task_id: str) -> None:
     """Stop *task_id*'s running container."""
     from terok.lib.api import task_stop as _task_stop
 
-    _task_stop(project_id, task_id)
+    _task_stop(project_name, task_id)
 
 
-def start_cli_container(project_id: str, task_id: str) -> None:
+def start_cli_container(project_name: str, task_id: str) -> None:
     """Start the CLI container for the already-created task *task_id*."""
     from terok.lib.api import task_run_cli
 
-    task_run_cli(project_id, task_id)
+    task_run_cli(project_name, task_id)
 
 
-def start_toad_container(project_id: str, task_id: str) -> None:
+def start_toad_container(project_name: str, task_id: str) -> None:
     """Start the Toad container for the already-created task *task_id*."""
     from terok.lib.api import task_run_toad
 
-    task_run_toad(project_id, task_id)
+    task_run_toad(project_name, task_id)

--- a/src/terok/tui/worker_log_screen.py
+++ b/src/terok/tui/worker_log_screen.py
@@ -48,8 +48,8 @@ class WorkerLogScreen(ModalScreen[None]):
 
         entry = app.dispatch_console_action(
             "terok.lib.api:build_images",
-            project_id,
-            title=f"Building images for {project_id}",
+            project_name,
+            title=f"Building images for {project_name}",
         )
         app.push_screen(WorkerLogScreen(entry))
 

--- a/tach.toml
+++ b/tach.toml
@@ -659,8 +659,8 @@ depends_on = []
 expose = [
     "ProjectConfig",
     "PresetInfo",
-    "is_valid_project_id",
-    "validate_project_id",
+    "is_valid_project_name",
+    "validate_project_name",
 ]
 from = ["terok.lib.core.project_model"]
 
@@ -678,7 +678,7 @@ expose = [
     "derive_project",
     "require_project_exists",
     "set_project_image_agents",
-    "validate_project_id",
+    "validate_project_name",
 ]
 from = ["terok.lib.core.projects"]
 
@@ -815,7 +815,7 @@ expose = ["list_images", "find_orphaned_images", "cleanup_images", "remove_image
 from = ["terok.lib.domain.image_cleanup"]
 
 [[interfaces]]
-expose = ["StorageOverview", "ProjectDetail", "ProjectSummary", "get_storage_overview", "get_project_storage_detail", "format_bytes", "parse_image_size", "ORPHAN_PROJECT_ID"]
+expose = ["StorageOverview", "ProjectDetail", "ProjectSummary", "get_storage_overview", "get_project_storage_detail", "format_bytes", "parse_image_size", "ORPHAN_PROJECT_NAME"]
 from = ["terok.lib.domain.storage"]
 
 [[interfaces]]

--- a/tach.toml
+++ b/tach.toml
@@ -675,6 +675,7 @@ expose = [
     "load_project",
     "load_preset",
     "list_presets",
+    "normalize_project_name",
     "derive_project",
     "require_project_exists",
     "set_project_image_agents",

--- a/tests/integration/cli/test_vault_unlock_story.py
+++ b/tests/integration/cli/test_vault_unlock_story.py
@@ -35,7 +35,7 @@ pytestmark = pytest.mark.needs_host_features
 
 _SOURCE_PROJECT = f"""
 project:
-  id: alpha
+  name: alpha
   security_class: online
 git:
   upstream_url: {TEST_UPSTREAM_URL}

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -111,6 +111,31 @@ hooks_unavailable = pytest.mark.skipif(
 )
 
 
+def _reset_layered_config_caches() -> None:
+    """Clear terok/sandbox config caches after tests rewrite config files."""
+    import terok_sandbox.config as _sandbox_config
+    from terok_util import paths as _util_paths
+
+    import terok.lib.core.config as _config
+
+    _util_paths._reset_config_caches_for_tests()
+    _config._validated_config_cache = None
+    _config._raw_config_cache = None
+    for name in (
+        "_credentials_section",
+        "_gate_server_section",
+        "_network_section",
+        "_paths_section",
+        "_services_section",
+        "_shield_section",
+        "_ssh_section",
+        "_vault_section",
+    ):
+        cache = getattr(_sandbox_config, name, None)
+        if cache is not None and hasattr(cache, "cache_clear"):
+            cache.cache_clear()
+
+
 # ── Mock shield CommandRunner ─────────────────────────────
 
 
@@ -352,13 +377,7 @@ def terok_env(
     request: pytest.FixtureRequest,
 ) -> TerokIntegrationEnv:
     """Return an isolated terok config/state environment for a test."""
-    from terok_util import paths as _util_paths
-
-    import terok.lib.core.config as _config
-
-    _util_paths._reset_config_caches_for_tests()
-    _config._validated_config_cache = None
-    _config._raw_config_cache = None
+    _reset_layered_config_caches()
 
     home_dir = tmp_path / HOME_DIR_NAME
     xdg_config_home = tmp_path / XDG_CONFIG_HOME_NAME
@@ -373,28 +392,20 @@ def terok_env(
     monkeypatch.setenv("TEROK_CONFIG_DIR", str(system_config_root))
     monkeypatch.setenv("TEROK_STATE_DIR", str(state_root))
 
-    # Write default global config with vault bypass — subprocess-based
-    # tests spawn a new CLI process that reads this file.  Tests that need the
-    # vault opt out via the needs_vault marker: skip the bypass so the
-    # subprocess CLI exercises the real per-container vault flow.
+    # Subprocess-based tests spawn a fresh CLI process, so expose the
+    # isolated test config through TEROK_CONFIG_FILE.  That keeps both terok
+    # and terok-sandbox away from the real /etc/user config stack and also
+    # avoids root/user-namespace path heuristics in nested CI containers.
+    config_dir = xdg_config_home / "terok"
+    config_dir.mkdir(parents=True, exist_ok=True)
+    config_file = config_dir / "config.yml"
+    config_lines = []
     if "needs_vault" not in {m.name for m in request.node.iter_markers()}:
-        (system_config_root / "config.yml").write_text(
-            "vault:\n  bypass_no_secret_protection: true\n",
-            encoding="utf-8",
-        )
-    # Sandbox reads ``credentials.passphrase`` from the user-tier
-    # config (``$XDG_CONFIG_HOME/terok/config.yml``) — system-tier
-    # paths point at ``/etc/terok`` on the real filesystem and won't
-    # see our tmp-rooted config.yml.  Seeding a deterministic
-    # passphrase makes the resolution chain hit the config tier and
-    # lets ``CredentialDB`` open the encrypted DB without a daemon,
-    # keyring, or interactive prompt — the realistic shape for
-    # subprocess-based integration tests.
-    (xdg_config_home / "terok").mkdir(parents=True, exist_ok=True)
-    (xdg_config_home / "terok" / "config.yml").write_text(
-        "credentials:\n  passphrase: integration-test-passphrase\n",
-        encoding="utf-8",
-    )
+        config_lines.extend(["vault:", "  bypass_no_secret_protection: true"])
+    config_lines.extend(["credentials:", "  passphrase: integration-test-passphrase"])
+    config_file.write_text("\n".join(config_lines) + "\n", encoding="utf-8")
+    monkeypatch.setenv("TEROK_CONFIG_FILE", str(config_file))
+    _reset_layered_config_caches()
 
     env = TerokIntegrationEnv(
         base_dir=tmp_path,

--- a/tests/integration/gate/test_sync.py
+++ b/tests/integration/gate/test_sync.py
@@ -22,7 +22,7 @@ pytestmark = pytest.mark.needs_host_features
 
 PROJECT_TEMPLATE = """
 project:
-  id: {project_id}
+  id: {project_name}
   security_class: gatekeeping
 git:
   upstream_url: {upstream_url}
@@ -47,7 +47,7 @@ class TestGateSync:
         terok_env.write_project(
             "demo",
             PROJECT_TEMPLATE.format(
-                project_id="demo",
+                project_name="demo",
                 upstream_url=file_repo_url(upstream),
                 gate_path=gate_path,
             ),
@@ -81,7 +81,7 @@ class TestGateSync:
         terok_env.write_project(
             "alpha",
             PROJECT_TEMPLATE.format(
-                project_id="alpha",
+                project_name="alpha",
                 upstream_url=file_repo_url(alpha_upstream),
                 gate_path=shared_gate,
             ),
@@ -91,7 +91,7 @@ class TestGateSync:
         terok_env.write_project(
             "beta",
             PROJECT_TEMPLATE.format(
-                project_id="beta",
+                project_name="beta",
                 upstream_url=file_repo_url(beta_upstream),
                 gate_path=shared_gate,
             ),

--- a/tests/integration/gate/test_sync.py
+++ b/tests/integration/gate/test_sync.py
@@ -22,7 +22,7 @@ pytestmark = pytest.mark.needs_host_features
 
 PROJECT_TEMPLATE = """
 project:
-  id: {project_name}
+  name: {project_name}
   security_class: gatekeeping
 git:
   upstream_url: {upstream_url}

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -154,47 +154,47 @@ class TerokIntegrationEnv:
 
     def write_project(
         self,
-        project_id: str,
+        project_name: str,
         yaml_text: str,
         *,
         scope: ProjectScope = "user",
     ) -> Path:
-        """Write ``project.yml`` for *project_id* under the requested scope."""
-        project_root = self._projects_root(scope) / project_id
+        """Write ``project.yml`` for *project_name* under the requested scope."""
+        project_root = self._projects_root(scope) / project_name
         project_root.mkdir(parents=True, exist_ok=True)
         content = textwrap.dedent(yaml_text).strip() + "\n"
         (project_root / PROJECT_FILENAME).write_text(content, encoding="utf-8")
         return project_root
 
-    def project_root(self, project_id: str, *, scope: ProjectScope = "user") -> Path:
-        """Return the project root path for *project_id* in the requested scope."""
-        return self._projects_root(scope) / project_id
+    def project_root(self, project_name: str, *, scope: ProjectScope = "user") -> Path:
+        """Return the project root path for *project_name* in the requested scope."""
+        return self._projects_root(scope) / project_name
 
-    def tasks_root(self, project_id: str) -> Path:
-        """Return the live task workspace root for *project_id*."""
-        return self.sandbox_live_root / "tasks" / project_id
+    def tasks_root(self, project_name: str) -> Path:
+        """Return the live task workspace root for *project_name*."""
+        return self.sandbox_live_root / "tasks" / project_name
 
-    def task_dir(self, project_id: str, task_id: str) -> Path:
+    def task_dir(self, project_name: str, task_id: str) -> Path:
         """Return the task directory for *task_id*."""
-        return self.tasks_root(project_id) / task_id
+        return self.tasks_root(project_name) / task_id
 
-    def task_workspace(self, project_id: str, task_id: str) -> Path:
+    def task_workspace(self, project_name: str, task_id: str) -> Path:
         """Return the task workspace directory for *task_id*."""
-        return self.task_dir(project_id, task_id) / WORKSPACE_DIRNAME
+        return self.task_dir(project_name, task_id) / WORKSPACE_DIRNAME
 
-    def task_meta_dir(self, project_id: str) -> Path:
+    def task_meta_dir(self, project_name: str) -> Path:
         """Return the metadata directory for project tasks."""
-        return self.state_root / "projects" / project_id / "tasks"
+        return self.state_root / "projects" / project_name / "tasks"
 
-    def task_meta_path(self, project_id: str, task_id: str) -> Path:
+    def task_meta_path(self, project_name: str, task_id: str) -> Path:
         """Return the metadata YAML path for *task_id*."""
-        return self.task_meta_dir(project_id) / f"{task_id}_meta.yml"
+        return self.task_meta_dir(project_name) / f"{task_id}_meta.yml"
 
-    def task_dossier_path(self, project_id: str, task_id: str) -> Path:
+    def task_dossier_path(self, project_name: str, task_id: str) -> Path:
         """Return the wire-dossier JSON path for *task_id*."""
-        return self.task_meta_dir(project_id) / f"{task_id}_dossier.json"
+        return self.task_meta_dir(project_name) / f"{task_id}_dossier.json"
 
-    def task_meta(self, project_id: str, task_id: str) -> dict:
+    def task_meta(self, project_name: str, task_id: str) -> dict:
         """Return the merged on-disk task meta — dossier (JSON) ∪ bookkeeping (YAML).
 
         Mirrors the in-memory shape ``read_task_meta`` produces for terok
@@ -205,26 +205,26 @@ class TerokIntegrationEnv:
         from ruamel.yaml import YAML
 
         result: dict = {}
-        yml = self.task_meta_path(project_id, task_id)
+        yml = self.task_meta_path(project_name, task_id)
         if yml.is_file():
             data = YAML(typ="rt").load(yml.read_text(encoding="utf-8")) or {}
             result.update({str(k): v for k, v in data.items()})
-        dossier = self.task_dossier_path(project_id, task_id)
+        dossier = self.task_dossier_path(project_name, task_id)
         if dossier.is_file():
             text = dossier.read_text(encoding="utf-8")
             wire = json.loads(text) if text.strip() else {}
-            for src, dst in (("project", "project_id"), ("task", "task_id"), ("name", "name")):
+            for src, dst in (("project", "project_name"), ("task", "task_id"), ("name", "name")):
                 if wire.get(src):
                     result[dst] = wire[src]
         return result
 
-    def task_archive_root(self, project_id: str) -> Path:
+    def task_archive_root(self, project_name: str) -> Path:
         """Return the archive root for deleted tasks."""
-        return self.base_dir / "archive" / project_id / "tasks"
+        return self.base_dir / "archive" / project_name / "tasks"
 
-    def gate_path(self, project_id: str) -> Path:
-        """Return the host-side gate mirror path for ``project_id``."""
-        return self.sandbox_state_root / "gate" / f"{project_id}.git"
+    def gate_path(self, project_name: str) -> Path:
+        """Return the host-side gate mirror path for ``project_name``."""
+        return self.sandbox_state_root / "gate" / f"{project_name}.git"
 
 
 def _hook_diagnostics(extra_args: list[str]) -> str:

--- a/tests/integration/launch/test_task_start.py
+++ b/tests/integration/launch/test_task_start.py
@@ -20,12 +20,12 @@ from ..helpers import TerokIntegrationEnv, write_fake_podman
 
 pytestmark = pytest.mark.needs_host_features
 
-PROJECT_ID = "demo"
+PROJECT_NAME = "demo"
 TOAD_PORT = 8080
 
 PROJECT_CONFIG = f"""
 project:
-  id: {PROJECT_ID}
+  id: {PROJECT_NAME}
   security_class: online
 git:
   upstream_url: {EXAMPLE_UPSTREAM_URL}
@@ -93,13 +93,13 @@ class TestLaunchWorkflows:
         self, terok_env: TerokIntegrationEnv, tmp_path: Path
     ) -> None:
         """`task run` (default --mode cli) should create a task and launch the CLI container."""
-        terok_env.write_project(PROJECT_ID, PROJECT_CONFIG)
+        terok_env.write_project(PROJECT_NAME, PROJECT_CONFIG)
         state_path, extra_env = _configure_fake_runtime(terok_env, tmp_path)
 
         result = terok_env.run_cli(
             "task",
             "run",
-            PROJECT_ID,
+            PROJECT_NAME,
             "--name",
             "Fix Login Bug",
             extra_env=extra_env,
@@ -107,8 +107,8 @@ class TestLaunchWorkflows:
 
         tid = _extract_task_id(result.stdout)
         assert_task_id(tid)
-        cli_container = f"{PROJECT_ID}-cli-{tid}"
-        meta = terok_env.task_meta(PROJECT_ID, tid)
+        cli_container = f"{PROJECT_NAME}-cli-{tid}"
+        meta = terok_env.task_meta(PROJECT_NAME, tid)
         state = _load_fake_podman_state(state_path)
         args = _container_args(state, cli_container)
 
@@ -118,7 +118,7 @@ class TestLaunchWorkflows:
         assert state["containers"][cli_container]["status"] == "running"
         assert state["containers"][cli_container]["marker"] == "__CLI_READY__"
         assert "--name" in args and args[args.index("--name") + 1] == cli_container
-        assert f"{PROJECT_ID}:l2-cli" in args
+        assert f"{PROJECT_NAME}:l2-cli" in args
         assert "-p" not in args
         assert meta["mode"] == "cli"
         assert meta["name"] == "fix-login-bug"
@@ -128,13 +128,13 @@ class TestLaunchWorkflows:
         self, terok_env: TerokIntegrationEnv, tmp_path: Path
     ) -> None:
         """`task run --mode toad` should launch the served Toad workflow."""
-        terok_env.write_project(PROJECT_ID, PROJECT_CONFIG)
+        terok_env.write_project(PROJECT_NAME, PROJECT_CONFIG)
         state_path, extra_env = _configure_fake_runtime(terok_env, tmp_path)
 
         result = terok_env.run_cli(
             "task",
             "run",
-            PROJECT_ID,
+            PROJECT_NAME,
             "--mode",
             "toad",
             extra_env=extra_env,
@@ -142,15 +142,15 @@ class TestLaunchWorkflows:
 
         tid = _extract_task_id(result.stdout)
         web_port = _extract_web_port(result.stdout)
-        toad_container = f"{PROJECT_ID}-toad-{tid}"
-        meta = terok_env.task_meta(PROJECT_ID, tid)
+        toad_container = f"{PROJECT_NAME}-toad-{tid}"
+        meta = terok_env.task_meta(PROJECT_NAME, tid)
         state = _load_fake_podman_state(state_path)
         args = _container_args(state, toad_container)
 
         assert "Toad is serving." in result.stdout
         assert state["containers"][toad_container]["marker"] == "TEROK_READY"
         assert args[args.index("-p") + 1] == f"{LOCALHOST}:{web_port}:{TOAD_PORT}"
-        assert f"{PROJECT_ID}:l2-cli" in args
+        assert f"{PROJECT_NAME}:l2-cli" in args
         # terok-toad-entry (in-container supervisor) starts Caddy + toad;
         # terok only forwards the public URL now.
         assert "terok-toad-entry" in args[-1]
@@ -167,18 +167,18 @@ class TestLaunchWorkflows:
         self, terok_env: TerokIntegrationEnv, tmp_path: Path
     ) -> None:
         """`task restart` should use `podman start` for an existing stopped container."""
-        terok_env.write_project(PROJECT_ID, PROJECT_CONFIG)
+        terok_env.write_project(PROJECT_NAME, PROJECT_CONFIG)
         state_path, extra_env = _configure_fake_runtime(terok_env, tmp_path)
 
-        start_result = terok_env.run_cli("task", "run", PROJECT_ID, extra_env=extra_env)
+        start_result = terok_env.run_cli("task", "run", PROJECT_NAME, extra_env=extra_env)
         tid = _extract_task_id(start_result.stdout)
-        cli_container = f"{PROJECT_ID}-cli-{tid}"
+        cli_container = f"{PROJECT_NAME}-cli-{tid}"
 
         state = _load_fake_podman_state(state_path)
         state["containers"][cli_container]["status"] = "exited"
         state_path.write_text(json.dumps(state, indent=2, sort_keys=True), encoding="utf-8")
 
-        result = terok_env.run_cli("task", "restart", PROJECT_ID, tid, extra_env=extra_env)
+        result = terok_env.run_cli("task", "restart", PROJECT_NAME, tid, extra_env=extra_env)
         restarted = _load_fake_podman_state(state_path)
 
         assert f"Restarting task demo/{tid} (cli)..." in result.stdout

--- a/tests/integration/launch/test_task_start.py
+++ b/tests/integration/launch/test_task_start.py
@@ -25,7 +25,7 @@ TOAD_PORT = 8080
 
 PROJECT_CONFIG = f"""
 project:
-  id: {PROJECT_NAME}
+  name: {PROJECT_NAME}
   security_class: online
 git:
   upstream_url: {EXAMPLE_UPSTREAM_URL}

--- a/tests/integration/projects/test_projects.py
+++ b/tests/integration/projects/test_projects.py
@@ -34,7 +34,7 @@ agent:
 COMMENTED_PROJECT = f"""
 # === Project identity ===
 project:
-  name: alpha
+  name: commented
   security_class: online  # keep this online for dev
 
 # --- Git configuration ---

--- a/tests/integration/projects/test_projects.py
+++ b/tests/integration/projects/test_projects.py
@@ -18,7 +18,7 @@ pytestmark = pytest.mark.needs_host_features
 
 SOURCE_PROJECT = f"""
 project:
-  id: alpha
+  name: alpha
   security_class: online
 git:
   upstream_url: {TEST_UPSTREAM_URL}
@@ -34,7 +34,7 @@ agent:
 COMMENTED_PROJECT = f"""
 # === Project identity ===
 project:
-  id: alpha
+  name: alpha
   security_class: online  # keep this online for dev
 
 # --- Git configuration ---
@@ -60,7 +60,7 @@ class TestProjects:
         terok_env.write_project("alpha", SOURCE_PROJECT)
         terok_env.write_project(
             "sysalpha",
-            SOURCE_PROJECT.replace("id: alpha", "id: sysalpha"),
+            SOURCE_PROJECT.replace("name: alpha", "name: sysalpha"),
             scope="system",
         )
 
@@ -95,7 +95,7 @@ class TestProjects:
         assert target.is_file()
 
         derived = yaml_load(target.read_text(encoding="utf-8"))
-        assert derived["project"]["id"] == "beta"
+        assert derived["project"]["name"] == "beta"
         assert "agent" not in derived
         assert derived["git"]["upstream_url"] == TEST_UPSTREAM_URL
 
@@ -123,7 +123,7 @@ class TestProjects:
         assert derived_instructions.read_text(encoding="utf-8") == instructions
 
         # Sibling without source instructions.md stays clean.
-        terok_env.write_project("gamma", SOURCE_PROJECT.replace("id: alpha", "id: gamma"))
+        terok_env.write_project("gamma", SOURCE_PROJECT.replace("name: alpha", "name: gamma"))
         terok_env.run_cli("project", "derive", "gamma", "delta")
         assert not (terok_env.project_root("delta") / "instructions.md").exists()
 
@@ -143,7 +143,7 @@ class TestProjects:
         derived = yaml_load(raw)
 
         # ── Structural correctness (same as the non-commented test) ──
-        assert derived["project"]["id"] == "derived"
+        assert derived["project"]["name"] == "derived"
         assert derived["git"]["upstream_url"] == TEST_UPSTREAM_URL
         assert derived["ssh"]["use_personal"] is False
         assert "agent" not in derived  # cleared by derive

--- a/tests/integration/setup/test_ssh_init.py
+++ b/tests/integration/setup/test_ssh_init.py
@@ -13,10 +13,10 @@ pytestmark = pytest.mark.needs_host_features
 
 PROJECT_TEMPLATE = """
 project:
-  id: {project_id}
+  id: {project_name}
   security_class: gatekeeping
 git:
-  upstream_url: https://example.com/{project_id}.git
+  upstream_url: https://example.com/{project_name}.git
 """
 
 
@@ -35,7 +35,7 @@ class TestSshInit:
         """
         terok_env.write_project(
             "demo",
-            PROJECT_TEMPLATE.format(project_id="demo"),
+            PROJECT_TEMPLATE.format(project_name="demo"),
         )
 
         first = terok_env.run_cli("project", "ssh-init", "demo")
@@ -52,7 +52,7 @@ class TestSshInit:
         """``--force`` rotates: scope ends up with a fresh key, distinct fingerprint."""
         terok_env.write_project(
             "rot",
-            PROJECT_TEMPLATE.format(project_id="rot"),
+            PROJECT_TEMPLATE.format(project_name="rot"),
         )
 
         initial = terok_env.run_cli("project", "ssh-init", "rot")
@@ -67,7 +67,7 @@ class TestSshInit:
         """``--comment`` lands verbatim in the printed public key line."""
         terok_env.write_project(
             "commented",
-            PROJECT_TEMPLATE.format(project_id="commented"),
+            PROJECT_TEMPLATE.format(project_name="commented"),
         )
 
         result = terok_env.run_cli(

--- a/tests/integration/setup/test_ssh_init.py
+++ b/tests/integration/setup/test_ssh_init.py
@@ -13,7 +13,7 @@ pytestmark = pytest.mark.needs_host_features
 
 PROJECT_TEMPLATE = """
 project:
-  id: {project_name}
+  name: {project_name}
   security_class: gatekeeping
 git:
   upstream_url: https://example.com/{project_name}.git

--- a/tests/integration/tasks/test_git_identity.py
+++ b/tests/integration/tasks/test_git_identity.py
@@ -76,7 +76,7 @@ _GIT_ENV_KEYS = (
 
 def _build_runner_env(
     terok_env: TerokIntegrationEnv,
-    project_id: str = "git-id-test",
+    project_name: str = "git-id-test",
 ) -> dict[str, str]:
     """Build the container env through the same path the production runners use.
 
@@ -88,7 +88,7 @@ def _build_runner_env(
     from terok.lib.core.projects import load_project
     from terok.lib.orchestration.environment import build_task_env_and_volumes
 
-    project = load_project(project_id)
+    project = load_project(project_name)
 
     from terok_executor.paths import mounts_dir
 

--- a/tests/integration/tasks/test_git_identity.py
+++ b/tests/integration/tasks/test_git_identity.py
@@ -37,7 +37,7 @@ pytestmark = pytest.mark.needs_host_features
 
 _BASE_PROJECT = f"""\
 project:
-  id: git-id-test
+  name: git-id-test
   security_class: online
 git:
   upstream_url: {EXAMPLE_UPSTREAM_URL}

--- a/tests/integration/tasks/test_lifecycle.py
+++ b/tests/integration/tasks/test_lifecycle.py
@@ -18,7 +18,7 @@ pytestmark = pytest.mark.needs_host_features
 
 PROJECT_CONFIG = f"""
 project:
-  id: demo
+  name: demo
   security_class: online
 git:
   upstream_url: {EXAMPLE_UPSTREAM_URL}

--- a/tests/integration/test_container_e2e.py
+++ b/tests/integration/test_container_e2e.py
@@ -117,17 +117,17 @@ def _find_free_port() -> int:
 def gate_env(tmp_path: Path) -> dict:
     """Set up a gate server with a test repo and return connection info."""
     # Create a bare repo
-    project_id = "e2e-test"
+    project_name = "e2e-test"
     base_path = tmp_path / "gate"
     base_path.mkdir()
-    repo_path = base_path / f"{project_id}.git"
+    repo_path = base_path / f"{project_name}.git"
     create_bare_repo_with_branches(repo_path, default_branch="main", other_branches=[])
 
     # Write token file
     token = uuid.uuid4().hex
     token_file = tmp_path / "tokens.json"
     token_file.write_text(
-        json.dumps({token: {"scope": project_id, "task": "1"}}),
+        json.dumps({token: {"scope": project_name, "task": "1"}}),
         encoding="utf-8",
     )
 
@@ -136,10 +136,10 @@ def gate_env(tmp_path: Path) -> dict:
     _start_gate_server(base_path, token_file, port)
 
     return {
-        "project_id": project_id,
+        "project_name": project_name,
         "token": token,
         "port": port,
-        "clone_url": f"http://{token}@host.containers.internal:{port}/{project_id}.git",
+        "clone_url": f"http://{token}@host.containers.internal:{port}/{project_name}.git",
     }
 
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -21,8 +21,8 @@ def mock_git_config():
     return unittest.mock.patch("terok.lib.core.projects._get_global_git_config", return_value=None)
 
 
-def write_project(root: Path, project_id: str, yaml_text: str) -> Path:
-    proj_dir = root / project_id
+def write_project(root: Path, project_name: str, yaml_text: str) -> Path:
+    proj_dir = root / project_name
     proj_dir.mkdir(parents=True, exist_ok=True)
     (proj_dir / "project.yml").write_text(yaml_text, encoding="utf-8")
     return proj_dir
@@ -40,7 +40,7 @@ def parse_meta_value(meta_text: str, key: str) -> str | None:
 def project_env(
     yaml_text: str,
     *,
-    project_id: str = "test-proj",
+    project_name: str = "test-proj",
     with_config_file: bool = False,
     with_gate: bool = False,
     extra_env: dict[str, str] | None = None,
@@ -58,7 +58,7 @@ def project_env(
         vault_dir = base / "vault"
         config_root.mkdir(parents=True, exist_ok=True)
 
-        write_project(config_root, project_id, yaml_text)
+        write_project(config_root, project_name, yaml_text)
 
         agent_state_dir = base / "agent"
         sandbox_live = base / "sandbox-live"
@@ -81,7 +81,7 @@ def project_env(
 
         gate_dir = None
         if with_gate:
-            gate_dir = sandbox_state / "gate" / f"{project_id}.git"
+            gate_dir = sandbox_state / "gate" / f"{project_name}.git"
             gate_dir.mkdir(parents=True, exist_ok=True)
 
         if extra_env:

--- a/tests/testfs.py
+++ b/tests/testfs.py
@@ -116,7 +116,7 @@ CONTAINER_CLAUDE_SESSION_PATH = CONTAINER_TEROK_DIR / "claude-session.txt"
 CONTAINER_TEROK_MOUNT_Z = f"{CONTAINER_TEROK_DIR}:Z"
 """Bind-mount fragment for the container terok directory with SELinux relabeling."""
 
-CONTAINER_CLAUDE_MEMORY_OVERRIDE = "/home/dev/.claude/projects/${PROJECT_ID}-workspace/memory"
+CONTAINER_CLAUDE_MEMORY_OVERRIDE = "/home/dev/.claude/projects/${PROJECT_NAME}-workspace/memory"
 """Literal shell path used in generated Claude wrapper memory override assertions."""
 
 WORKSPACE_ROOT = Path("/workspace")
@@ -137,6 +137,6 @@ STATE_ROOT_NAME = "state"
 """Temporary terok state root name used by integration fixtures."""
 
 
-def mock_wizard_project_file(project_id: str) -> Path:
-    """Return a fake wizard output path for ``project_id``."""
-    return FAKE_WIZARD_PROJECTS_DIR / project_id / "project.yml"
+def mock_wizard_project_file(project_name: str) -> Path:
+    """Return a fake wizard output path for ``project_name``."""
+    return FAKE_WIZARD_PROJECTS_DIR / project_name / "project.yml"

--- a/tests/testnet.py
+++ b/tests/testnet.py
@@ -73,11 +73,11 @@ def localhost_url(port: int) -> str:
 GATE_HOST = "localhost"
 
 
-def gate_repo_url(project_id: str, token: str, *, port: int = GATE_PORT) -> str:
+def gate_repo_url(project_name: str, token: str, *, port: int = GATE_PORT) -> str:
     """Build the authenticated in-container gate repository URL.
 
     The container always reaches the per-container gate through the fixed
     localhost socat bridge (``TCP-LISTEN:9418``) in both socket and TCP
     modes, so the URL points at ``localhost``.
     """
-    return f"http://{token}@{GATE_HOST}:{port}/{project_id}.git"
+    return f"http://{token}@{GATE_HOST}:{port}/{project_name}.git"

--- a/tests/unit/cli/test_cli_acp.py
+++ b/tests/unit/cli/test_cli_acp.py
@@ -254,7 +254,7 @@ class TestExperimentalAck:
 class TestCmdConnectResolvesTaskIdPrefix:
     """Regression for #761 — ``acp connect`` must resolve task-ID prefixes.
 
-    Every other CLI verb that takes ``<project_id> <task_id>``
+    Every other CLI verb that takes ``<project_name> <task_id>``
     (``task …``, ``shield …``, ``sickbay``) goes through
     [`resolve_task_id`][terok.lib.orchestration.tasks.identity.resolve_task_id]
     so users can type the shortest unambiguous prefix.  ``acp connect``
@@ -274,15 +274,15 @@ class TestCmdConnectResolvesTaskIdPrefix:
 
         monkeypatch.setattr(acp_mod, "_check_experimental_ack", lambda: calls.append(("ack", None)))
 
-        def _stub_resolve(project_id: str, prefix: str) -> str:
-            calls.append(("resolve", (project_id, prefix)))
+        def _stub_resolve(project_name: str, prefix: str) -> str:
+            calls.append(("resolve", (project_name, prefix)))
             return "42d1ca5e"
 
-        def _stub_socket_path(project_id: str, task_id: str) -> str:
-            calls.append(("socket_path", (project_id, task_id)))
+        def _stub_socket_path(project_name: str, task_id: str) -> str:
+            calls.append(("socket_path", (project_name, task_id)))
             return str(MOCK_BASE / "terok-testing" / "fake.sock")
 
-        def _stub_log_path(project_id: str, task_id: str) -> str:
+        def _stub_log_path(project_name: str, task_id: str) -> str:
             return str(MOCK_BASE / "terok-testing" / "fake.log")
 
         def _stub_socket_live(_path: str) -> bool:

--- a/tests/unit/cli/test_cli_acp.py
+++ b/tests/unit/cli/test_cli_acp.py
@@ -344,3 +344,90 @@ class TestFail:
         captured = capsys.readouterr()
         assert captured.out == ""
         assert "daemon won't start" in captured.err
+
+
+class TestProjectsToShow:
+    """``_projects_to_show`` resolves the filter to concrete Project objects."""
+
+    def test_explicit_filter_resolves_single_project(self) -> None:
+        from unittest import mock
+
+        with mock.patch("terok.lib.api.get_project", return_value="P") as gp:
+            assert acp_mod._projects_to_show("alpha") == ["P"]
+        gp.assert_called_once_with("alpha")
+
+    def test_no_filter_walks_every_known_project_by_name(self) -> None:
+        from types import SimpleNamespace
+        from unittest import mock
+
+        infos = [SimpleNamespace(name="alpha"), SimpleNamespace(name="beta")]
+        with (
+            mock.patch.object(acp_mod, "list_projects", return_value=infos),
+            mock.patch("terok.lib.api.get_project", side_effect=lambda n: f"proj:{n}") as gp,
+        ):
+            assert acp_mod._projects_to_show(None) == ["proj:alpha", "proj:beta"]
+        assert [c.args[0] for c in gp.call_args_list] == ["alpha", "beta"]
+
+
+class TestCmdList:
+    """``_cmd_list`` renders one row per running ACP endpoint."""
+
+    @staticmethod
+    def _endpoint(pid: str, tid: str):
+        from pathlib import Path
+        from types import SimpleNamespace
+
+        return SimpleNamespace(
+            project_name=pid,
+            task_id=tid,
+            status=SimpleNamespace(value="running"),
+            bound_agent="claude",
+            socket_path=Path("/run/acp.sock"),
+        )
+
+    def test_prints_placeholder_when_no_endpoints(self, capsys: pytest.CaptureFixture[str]) -> None:
+        from types import SimpleNamespace
+        from unittest import mock
+
+        empty_proj = SimpleNamespace(acp_endpoints=lambda: [])
+        with mock.patch.object(acp_mod, "_projects_to_show", return_value=[empty_proj]):
+            acp_mod._cmd_list(None)
+        assert "No ACP endpoints found" in capsys.readouterr().out
+
+    def test_renders_header_and_endpoint_rows(self, capsys: pytest.CaptureFixture[str]) -> None:
+        from types import SimpleNamespace
+        from unittest import mock
+
+        proj = SimpleNamespace(acp_endpoints=lambda: [self._endpoint("alpha", "t1")])
+        with mock.patch.object(acp_mod, "_projects_to_show", return_value=[proj]):
+            acp_mod._cmd_list(None)
+        out = capsys.readouterr().out
+        assert "PROJECT" in out and "STATUS" in out
+        assert "alpha" in out and "t1" in out and "running" in out and "claude" in out
+
+
+class TestDispatch:
+    """``dispatch`` routes acp subcommands and ignores foreign ones."""
+
+    def test_ignores_non_acp_command(self) -> None:
+        import argparse
+
+        assert acp_mod.dispatch(argparse.Namespace(cmd="task")) is False
+
+    def test_routes_list(self) -> None:
+        import argparse
+        from unittest import mock
+
+        args = argparse.Namespace(cmd="acp", acp_cmd="list", project_name="alpha")
+        with mock.patch.object(acp_mod, "_cmd_list") as m:
+            assert acp_mod.dispatch(args) is True
+        m.assert_called_once_with("alpha")
+
+    def test_routes_connect(self) -> None:
+        import argparse
+        from unittest import mock
+
+        args = argparse.Namespace(cmd="acp", acp_cmd="connect", project_name="alpha", task_id="t1")
+        with mock.patch.object(acp_mod, "_cmd_connect") as m:
+            assert acp_mod.dispatch(args) is True
+        m.assert_called_once_with("alpha", "t1")

--- a/tests/unit/cli/test_cli_auth.py
+++ b/tests/unit/cli/test_cli_auth.py
@@ -7,7 +7,7 @@ Three invocation shapes to verify:
 
 - ``terok auth``                           → interactive menu (no provider).
 - ``terok auth <p>``                       → host-wide auth.
-- ``terok auth <p> --project <id>``        → project-scoped auth.
+- ``terok auth <p> --project <name>``      → project-scoped auth.
 """
 
 from __future__ import annotations
@@ -109,7 +109,7 @@ def test_dispatch_host_wide_skips_project_loading() -> None:
 
 
 def test_dispatch_project_flag_runs_install_check() -> None:
-    """``auth <p> --project <id>`` loads the project and verifies the agent."""
+    """``auth <p> --project <name>`` loads the project and verifies the agent."""
     fake_project = SimpleNamespace(name="p1")
     args = argparse.Namespace(cmd="auth", provider="claude", project_flag="p1")
     with (

--- a/tests/unit/cli/test_cli_auth.py
+++ b/tests/unit/cli/test_cli_auth.py
@@ -110,7 +110,7 @@ def test_dispatch_host_wide_skips_project_loading() -> None:
 
 def test_dispatch_project_flag_runs_install_check() -> None:
     """``auth <p> --project <id>`` loads the project and verifies the agent."""
-    fake_project = SimpleNamespace(id="p1")
+    fake_project = SimpleNamespace(name="p1")
     args = argparse.Namespace(cmd="auth", provider="claude", project_flag="p1")
     with (
         patch("terok.cli.commands.auth.load_project", return_value=fake_project),
@@ -170,7 +170,7 @@ def test_run_interactive_cancels_on_empty_answer(capsys: pytest.CaptureFixture[s
         patch("sys.stdin", new=StringIO("\n")),
         patch("terok.cli.commands.auth._run_one") as mock_run,
     ):
-        _run_interactive(project_id=None)
+        _run_interactive(project_name=None)
     mock_run.assert_not_called()
 
 
@@ -181,7 +181,7 @@ def test_run_interactive_runs_each_selected_provider() -> None:
         patch("terok.cli.commands.auth.require_project_exists"),
         patch("terok.cli.commands.auth._run_one") as mock_run,
     ):
-        _run_interactive(project_id="myproj")
+        _run_interactive(project_name="myproj")
     assert [call.args for call in mock_run.call_args_list] == [
         ("claude", "myproj"),
         ("codex", "myproj"),
@@ -195,7 +195,7 @@ def test_run_interactive_hides_oauth_when_disabled(capsys: pytest.CaptureFixture
         patch("terok.cli.commands.auth.is_oauth_enabled_for", return_value=False),
         patch("terok.cli.commands.auth._run_one"),
     ):
-        _run_interactive(project_id=None)
+        _run_interactive(project_name=None)
     out = capsys.readouterr().out
     assert "oauth" not in out
     assert "api-key" in out
@@ -208,7 +208,7 @@ def test_run_interactive_shows_oauth_when_enabled(capsys: pytest.CaptureFixture[
         patch("terok.cli.commands.auth.is_oauth_enabled_for", return_value=True),
         patch("terok.cli.commands.auth._run_one"),
     ):
-        _run_interactive(project_id=None)
+        _run_interactive(project_name=None)
     out = capsys.readouterr().out
     assert "oauth" in out
 
@@ -222,20 +222,20 @@ def test_run_one_skips_install_check_when_host_wide() -> None:
         patch("terok.cli.commands.auth.load_project") as mock_load,
         patch("terok.cli.commands.auth.authenticate") as mock_auth,
     ):
-        _run_one("claude", project_id=None)
+        _run_one("claude", project_name=None)
     mock_load.assert_not_called()
     mock_auth.assert_called_once_with("claude", None)
 
 
 def test_run_one_resolves_alias_for_install_check() -> None:
     """``_run_one("openai", project)`` checks the *codex* agent is installed."""
-    fake_project = SimpleNamespace(id="p1")
+    fake_project = SimpleNamespace(name="p1")
     with (
         patch("terok.cli.commands.auth.load_project", return_value=fake_project),
         patch("terok.cli.commands.auth.require_agent_installed") as mock_check,
         patch("terok.cli.commands.auth.authenticate") as mock_auth,
     ):
-        _run_one("openai", project_id="p1")
+        _run_one("openai", project_name="p1")
     # the baked-agent lookup uses the resolved agent name, not the provider alias
     mock_check.assert_called_once_with(fake_project, "codex", noun="Provider")
     # authenticate gets the original token; it resolves the alias itself

--- a/tests/unit/cli/test_cli_config.py
+++ b/tests/unit/cli/test_cli_config.py
@@ -101,7 +101,7 @@ def patch_config_command(layout: SimpleNamespace) -> Iterator[None]:
         stack.enter_context(
             patch(
                 "terok.cli.commands.info.list_projects",
-                return_value=[SimpleNamespace(id="alpha", root=layout.project_root)],
+                return_value=[SimpleNamespace(name="alpha", root=layout.project_root)],
             )
         )
         stack.enter_context(
@@ -205,13 +205,13 @@ class TestConfigDispatch:
         mock.assert_called_once()
 
     def test_resolved_invokes_config_resolved(self) -> None:
-        """``config resolved`` forwards project_id and preset to the handler."""
+        """``config resolved`` forwards project_name and preset to the handler."""
         import argparse
 
         from terok.cli.commands.info import dispatch
 
         args = argparse.Namespace(
-            cmd="config", config_cmd="resolved", project_id="myproj", preset="team"
+            cmd="config", config_cmd="resolved", project_name="myproj", preset="team"
         )
         with patch("terok.cli.commands.info._cmd_config_resolved") as mock:
             assert dispatch(args) is True
@@ -223,7 +223,7 @@ class TestConfigDispatch:
 
         from terok.cli.commands.info import dispatch
 
-        args = argparse.Namespace(cmd="config", config_cmd="resolved", project_id="p")
+        args = argparse.Namespace(cmd="config", config_cmd="resolved", project_name="p")
         with patch("terok.cli.commands.info._cmd_config_resolved") as mock:
             assert dispatch(args) is True
         mock.assert_called_once_with("p", None)

--- a/tests/unit/cli/test_cli_image.py
+++ b/tests/unit/cli/test_cli_image.py
@@ -161,7 +161,7 @@ class TestImageDispatch:
 
         from terok.cli.commands.image import dispatch
 
-        args = argparse.Namespace(cmd="image", image_cmd="list", project_id="myproj")
+        args = argparse.Namespace(cmd="image", image_cmd="list", project_name="myproj")
         with patch("terok.cli.commands.image._cmd_list") as mock:
             assert dispatch(args) is True
         mock.assert_called_once_with("myproj")
@@ -199,7 +199,7 @@ class TestImageDispatch:
         )
         with patch("terok.cli.commands.image._cmd_usage") as mock:
             assert dispatch(args) is True
-        mock.assert_called_once_with(project_id="myproj", json_output=True)
+        mock.assert_called_once_with(project_name="myproj", json_output=True)
 
     def test_build_dispatch_forwards_flags(self) -> None:
         """``image build --rebuild --sidecar`` routes to the build helper."""
@@ -210,7 +210,7 @@ class TestImageDispatch:
         args = argparse.Namespace(
             cmd="image",
             image_cmd="build",
-            project_id=None,
+            project_name=None,
             base=None,
             agents=None,
             family=None,
@@ -221,7 +221,7 @@ class TestImageDispatch:
         with patch("terok.cli.commands.image._cmd_build") as mock:
             assert dispatch(args) is True
         mock.assert_called_once_with(
-            project_id=None,
+            project_name=None,
             base=None,
             agents=None,
             family=None,
@@ -264,7 +264,7 @@ class TestCmdBuild:
             patch("terok_executor.container.build.build_sidecar_image"),
         ):
             _cmd_build(
-                project_id=None,
+                project_name=None,
                 base=None,
                 agents=None,
                 family=None,
@@ -307,7 +307,7 @@ class TestCmdBuild:
             patch("terok_executor.container.build.build_sidecar_image"),
         ):
             _cmd_build(
-                project_id=None,
+                project_name=None,
                 base="ubuntu:24.04",
                 agents="claude,codex",
                 family="deb",
@@ -351,7 +351,7 @@ class TestCmdBuild:
             ) as mock_sidecar,
         ):
             _cmd_build(
-                project_id=None,
+                project_name=None,
                 base=None,
                 agents=None,
                 family=None,
@@ -363,7 +363,7 @@ class TestCmdBuild:
         mock_sidecar.assert_called_once()
         assert "terok-l1-sidecar:ubuntu-24.04" in capsys.readouterr().out
 
-    def test_project_id_drives_base_and_agents_from_project_config(self) -> None:
+    def test_project_name_drives_base_and_agents_from_project_config(self) -> None:
         """``image build <project>`` derives base + agents from the project, not globals."""
         from unittest.mock import MagicMock, sentinel
 
@@ -386,7 +386,7 @@ class TestCmdBuild:
             ) as mock_build,
         ):
             _cmd_build(
-                project_id="myproj",
+                project_name="myproj",
                 base=None,
                 agents=None,
                 family=None,
@@ -428,7 +428,7 @@ class TestCmdBuild:
         ):
             with pytest.raises(SystemExit, match="podman missing"):
                 _cmd_build(
-                    project_id=None,
+                    project_name=None,
                     base=None,
                     agents=None,
                     family=None,

--- a/tests/unit/cli/test_cli_image_usage.py
+++ b/tests/unit/cli/test_cli_image_usage.py
@@ -161,6 +161,23 @@ class TestOverviewOutput:
         assert data["projects"][0]["project_name"] == "proj1"
         assert "id" not in data["projects"][0]
 
+    @patch("terok.cli.commands._storage_view.supports_color", return_value=False)
+    def test_text_projects_render_project_names(self, _color, capsys):
+        """Overview text renders the project table with project names."""
+        overview = _make_overview(
+            global_images=[],
+            projects=[
+                ProjectSummary("proj1", 500_000_000, 200_000_000, 2),
+                ProjectSummary("longer-project", 100_000_000, 50_000_000, 1),
+            ],
+        )
+        with patch("terok.lib.domain.storage.get_storage_overview", return_value=overview):
+            cmd_overview(json_output=False)
+        output = capsys.readouterr().out
+        assert "Projects" in output
+        assert "proj1" in output
+        assert "longer-project" in output
+
 
 # ---------------------------------------------------------------------------
 # Detail output (render layer)

--- a/tests/unit/cli/test_cli_image_usage.py
+++ b/tests/unit/cli/test_cli_image_usage.py
@@ -150,6 +150,17 @@ class TestOverviewOutput:
         assert "projects" in data
         assert "grand_total_bytes" in data
 
+    def test_json_projects_use_project_name_key(self, capsys):
+        """Overview JSON uses the renamed project_name field consistently."""
+        with patch(
+            "terok.lib.domain.storage.get_storage_overview",
+            return_value=_make_overview(),
+        ):
+            cmd_overview(json_output=True)
+        data = json.loads(capsys.readouterr().out)
+        assert data["projects"][0]["project_name"] == "proj1"
+        assert "id" not in data["projects"][0]
+
 
 # ---------------------------------------------------------------------------
 # Detail output (render layer)

--- a/tests/unit/cli/test_cli_image_usage.py
+++ b/tests/unit/cli/test_cli_image_usage.py
@@ -47,7 +47,7 @@ def _make_overview(**kwargs) -> StorageOverview:
 def _make_detail(**kwargs) -> ProjectDetail:
     """Build a minimal ProjectDetail for testing."""
     defaults = {
-        "project_id": "myproject",
+        "project_name": "myproject",
         "images": [ImageInfo("myproject", "l2-cli", "id2", "3GB", "1d ago")],
         "tasks": [],
         "overlays": {},
@@ -195,6 +195,6 @@ class TestDetailOutput:
 
         cmd_detail("myproject", json_output=True)
         data = json.loads(capsys.readouterr().out)
-        assert data["project_id"] == "myproject"
+        assert data["project_name"] == "myproject"
         assert "images" in data
         assert "tasks" in data

--- a/tests/unit/cli/test_cli_project.py
+++ b/tests/unit/cli/test_cli_project.py
@@ -201,6 +201,21 @@ def test_list_formats_shared_dir_hint(capsys: pytest.CaptureFixture[str]) -> Non
     assert "shared=/shared/x" in capsys.readouterr().out
 
 
+def test_list_prints_description_when_set(capsys: pytest.CaptureFixture[str]) -> None:
+    """A project's optional description renders on its own indented line."""
+    proj = SimpleNamespace(
+        name="p",
+        description="My nice project",
+        security_class="online",
+        upstream_url=None,
+        shared_dir=None,
+        root="/r",
+    )
+    with patch("terok.cli.commands.project.list_projects", return_value=[proj]):
+        _cmd_project_list()
+    assert "My nice project" in capsys.readouterr().out
+
+
 # ---------------------------------------------------------------------------
 # _cmd_project_derive
 # ---------------------------------------------------------------------------

--- a/tests/unit/cli/test_cli_project.py
+++ b/tests/unit/cli/test_cli_project.py
@@ -47,21 +47,21 @@ from terok.cli.commands.project import (
         ),
         pytest.param(
             "delete",
-            {"project_id": "p1", "force": False},
+            {"project_name": "p1", "force": False},
             "terok.cli.commands.project._cmd_project_delete",
             {"positional": ("p1",), "kwargs": {"force": False}},
             id="delete",
         ),
         pytest.param(
             "init",
-            {"project_id": "p1"},
+            {"project_name": "p1"},
             "terok.cli.commands.project.cmd_project_init",
             {"positional": ("p1",)},
             id="init",
         ),
         pytest.param(
             "generate",
-            {"project_id": "p1"},
+            {"project_name": "p1"},
             "terok.cli.commands.project.generate_dockerfiles",
             {"positional": ("p1",)},
             id="generate",
@@ -69,7 +69,7 @@ from terok.cli.commands.project import (
         pytest.param(
             "build",
             {
-                "project_id": "p1",
+                "project_name": "p1",
                 "dev": True,
                 "refresh_agents": False,
                 "full_rebuild": False,
@@ -89,35 +89,35 @@ from terok.cli.commands.project import (
         ),
         pytest.param(
             "ssh-init",
-            {"project_id": "p1"},
+            {"project_name": "p1"},
             "terok.cli.commands.project._cmd_ssh_init",
             {"positional_is_args": True},
             id="ssh-init",
         ),
         pytest.param(
             "gate-path",
-            {"project_id": "p1"},
+            {"project_name": "p1"},
             "terok.cli.commands.project._cmd_gate_path",
             {"positional": ("p1",)},
             id="gate-path",
         ),
         pytest.param(
             "gate-sync",
-            {"project_id": "p1"},
+            {"project_name": "p1"},
             "terok.cli.commands.project._cmd_gate_sync",
             {"positional_is_args": True},
             id="gate-sync",
         ),
         pytest.param(
             "presets",
-            {"presets_cmd": "list", "project_id": "p1"},
+            {"presets_cmd": "list", "project_name": "p1"},
             "terok.cli.commands.project._cmd_presets",
             {"positional": ("p1",)},
             id="presets-list",
         ),
         pytest.param(
             "agents",
-            {"agents_cmd": "set", "project_id": "p1", "selection": "claude,vibe"},
+            {"agents_cmd": "set", "project_name": "p1", "selection": "claude,vibe"},
             "terok.cli.commands.project._cmd_agents_set",
             {"positional": ("p1", "claude,vibe")},
             id="agents-set",
@@ -169,7 +169,8 @@ def test_list_empty_prints_placeholder(capsys: pytest.CaptureFixture[str]) -> No
 def test_list_prints_each_project(capsys: pytest.CaptureFixture[str]) -> None:
     """Each project renders with id, security_class, upstream, config_root."""
     proj = SimpleNamespace(
-        id="myproj",
+        name="myproj",
+        description=None,
         security_class="online",
         upstream_url="git@github.com:org/repo.git",
         shared_dir=None,
@@ -188,7 +189,12 @@ def test_list_prints_each_project(capsys: pytest.CaptureFixture[str]) -> None:
 def test_list_formats_shared_dir_hint(capsys: pytest.CaptureFixture[str]) -> None:
     """Projects with a shared_dir show the ``shared=`` segment."""
     proj = SimpleNamespace(
-        id="p", security_class="online", upstream_url=None, shared_dir="/shared/x", root="/r"
+        name="p",
+        description=None,
+        security_class="online",
+        upstream_url=None,
+        shared_dir="/shared/x",
+        root="/r",
     )
     with patch("terok.cli.commands.project.list_projects", return_value=[proj]):
         _cmd_project_list()
@@ -227,7 +233,7 @@ def test_derive_calls_downstream_and_offers_edit(capsys: pytest.CaptureFixture[s
 def fake_project_for_delete() -> SimpleNamespace:
     """Minimal project namespace to exercise the delete flow."""
     return SimpleNamespace(
-        id="doomed",
+        name="doomed",
         root="/root",
         security_class="online",
         upstream_url=None,
@@ -261,7 +267,7 @@ def test_delete_force_skips_prompt(
 
 
 def test_delete_confirm_matches_proceeds(fake_project_for_delete: SimpleNamespace) -> None:
-    """Typing the project id at the prompt proceeds with deletion."""
+    """Typing the project name at the prompt proceeds with deletion."""
     patches = _patch_delete_flow(fake_project_for_delete)
     with patches[0], patches[1], patches[2], patches[3] as mock_delete:
         with patch("builtins.input", return_value="doomed"):
@@ -300,7 +306,7 @@ def test_delete_prints_upstream_when_set(
 ) -> None:
     """Projects with an upstream_url surface it in the deletion header."""
     proj = SimpleNamespace(
-        id="doomed",
+        name="doomed",
         root="/root",
         security_class="online",
         upstream_url="git@github.com:org/repo.git",
@@ -387,7 +393,7 @@ def test_gate_sync_success_prints_summary(capsys: pytest.CaptureFixture[str]) ->
         "created": False,
         "cache_refreshed": True,
     }
-    args = argparse.Namespace(project_id="p1", force_reinit=False)
+    args = argparse.Namespace(project_name="p1", force_reinit=False)
     with (
         patch(
             "terok.cli.commands.project.load_project",
@@ -412,7 +418,7 @@ def test_gate_sync_renders_remoteless_upstream_label(capsys: pytest.CaptureFixtu
         "created": True,
         "cache_refreshed": False,
     }
-    args = argparse.Namespace(project_id="scratch", force_reinit=False)
+    args = argparse.Namespace(project_name="scratch", force_reinit=False)
     with (
         patch(
             "terok.cli.commands.project.load_project",
@@ -429,7 +435,7 @@ def test_gate_sync_failure_raises(capsys: pytest.CaptureFixture[str]) -> None:
     """A failure verdict turns into a SystemExit carrying the error detail."""
     fake_gate = MagicMock()
     fake_gate.sync.return_value = {"success": False, "errors": ["clone timed out"]}
-    args = argparse.Namespace(project_id="broken", force_reinit=False)
+    args = argparse.Namespace(project_name="broken", force_reinit=False)
     with (
         patch(
             "terok.cli.commands.project.load_project",
@@ -443,11 +449,13 @@ def test_gate_sync_failure_raises(capsys: pytest.CaptureFixture[str]) -> None:
 
 def test_gate_sync_refuses_when_gate_disabled() -> None:
     """``gate.enabled: false`` rejects at the CLI rather than touching sandbox."""
-    args = argparse.Namespace(project_id="noproj", force_reinit=False)
+    args = argparse.Namespace(project_name="noproj", force_reinit=False)
+    no_gate = MagicMock(gate_enabled=False)
+    no_gate.name = "noproj"
     with (
         patch(
             "terok.cli.commands.project.load_project",
-            return_value=MagicMock(id="noproj", gate_enabled=False),
+            return_value=no_gate,
         ),
         patch("terok.cli.commands.project.make_git_gate") as mock_make,
         pytest.raises(SystemExit, match="gate.enabled: false"),

--- a/tests/unit/cli/test_cli_project.py
+++ b/tests/unit/cli/test_cli_project.py
@@ -18,6 +18,7 @@ from terok.cli.commands.project import (
     _cmd_project_delete,
     _cmd_project_derive,
     _cmd_project_list,
+    _cmd_project_normalize_name,
     cmd_project_init,
     dispatch,
 )
@@ -44,6 +45,13 @@ from terok.cli.commands.project import (
             "terok.cli.commands.project._cmd_project_derive",
             {"positional": ("src", "dst")},
             id="derive",
+        ),
+        pytest.param(
+            "normalize-name",
+            {"project_name": "p1"},
+            "terok.cli.commands.project._cmd_project_normalize_name",
+            {"positional": ("p1",)},
+            id="normalize-name",
         ),
         pytest.param(
             "delete",
@@ -237,6 +245,20 @@ def test_derive_calls_downstream_and_offers_edit(capsys: pytest.CaptureFixture[s
     mock_derive.assert_called_once_with("alpha", "beta")
     mock_offer.assert_called_once()
     assert "beta" in capsys.readouterr().out
+
+
+def test_normalize_name_prints_updated_path(capsys: pytest.CaptureFixture[str]) -> None:
+    """The quick-fix command reports the rewritten config file."""
+    from pathlib import Path
+
+    target = Path("/tmp/terok-testing/projects/p1/project.yml")
+    with patch("terok.cli.commands.project.normalize_project_name", return_value=target) as mock:
+        _cmd_project_normalize_name("p1")
+
+    mock.assert_called_once_with("p1")
+    out = capsys.readouterr().out
+    assert str(target) in out
+    assert "project.name = 'p1'" in out
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/cli/test_cli_shield.py
+++ b/tests/unit/cli/test_cli_shield.py
@@ -44,14 +44,14 @@ def _stub_resolve_task_id() -> object:
         pytest.param(["shield", "status"], {"shield_cmd": "status"}, id="status-no-task"),
         pytest.param(
             ["shield", "status", "proj", "1"],
-            {"shield_cmd": "status", "project_id": "proj", "task_id": "1"},
+            {"shield_cmd": "status", "project_name": "proj", "task_id": "1"},
             id="status-with-task",
         ),
         pytest.param(
             ["shield", "allow", "proj", "task1", "example.com"],
             {
                 "shield_cmd": "allow",
-                "project_id": "proj",
+                "project_name": "proj",
                 "task_id": "task1",
                 "target": "example.com",
             },
@@ -61,7 +61,7 @@ def _stub_resolve_task_id() -> object:
             ["shield", "deny", "proj", "task1", "example.com"],
             {
                 "shield_cmd": "deny",
-                "project_id": "proj",
+                "project_name": "proj",
                 "task_id": "task1",
                 "target": "example.com",
             },
@@ -71,7 +71,7 @@ def _stub_resolve_task_id() -> object:
             ["shield", "down", "proj", "task1", "--all"],
             {
                 "shield_cmd": "down",
-                "project_id": "proj",
+                "project_name": "proj",
                 "task_id": "task1",
                 "allow_all": True,
             },
@@ -79,17 +79,17 @@ def _stub_resolve_task_id() -> object:
         ),
         pytest.param(
             ["shield", "up", "proj", "task1"],
-            {"shield_cmd": "up", "project_id": "proj", "task_id": "task1"},
+            {"shield_cmd": "up", "project_name": "proj", "task_id": "task1"},
             id="up",
         ),
         pytest.param(
             ["shield", "rules", "proj", "task1"],
-            {"shield_cmd": "rules", "project_id": "proj", "task_id": "task1"},
+            {"shield_cmd": "rules", "project_name": "proj", "task_id": "task1"},
             id="rules",
         ),
         pytest.param(
             ["shield", "profiles"],
-            {"shield_cmd": "profiles", "project_id": MISSING},
+            {"shield_cmd": "profiles", "project_name": MISSING},
             id="profiles",
         ),
         pytest.param(
@@ -99,22 +99,22 @@ def _stub_resolve_task_id() -> object:
         ),
         pytest.param(
             ["shield", "watch", "proj", "task1"],
-            {"shield_cmd": "watch", "project_id": "proj", "task_id": "task1"},
+            {"shield_cmd": "watch", "project_name": "proj", "task_id": "task1"},
             id="watch",
         ),
         pytest.param(
             ["shield", "simple-clearance", "proj", "task1"],
-            {"shield_cmd": "simple-clearance", "project_id": "proj", "task_id": "task1"},
+            {"shield_cmd": "simple-clearance", "project_name": "proj", "task_id": "task1"},
             id="simple-clearance",
         ),
         pytest.param(
             ["shield", "logs", "proj", "task1"],
-            {"shield_cmd": "logs", "project_id": "proj", "task_id": "task1", "n": 50},
+            {"shield_cmd": "logs", "project_name": "proj", "task_id": "task1", "n": 50},
             id="logs",
         ),
         pytest.param(
             ["shield", "logs", "proj", "task1", "-n", "10"],
-            {"shield_cmd": "logs", "project_id": "proj", "task_id": "task1", "n": 10},
+            {"shield_cmd": "logs", "project_name": "proj", "task_id": "task1", "n": 10},
             id="logs-custom-n",
         ),
     ],
@@ -169,7 +169,7 @@ def test_dispatch_status_without_task(mock_mgr_cls: MagicMock) -> None:
 
 def test_dispatch_partial_task_selector_exits() -> None:
     """Providing only one half of the project/task selector exits cleanly."""
-    args = argparse.Namespace(cmd="shield", shield_cmd="status", project_id="proj", task_id=None)
+    args = argparse.Namespace(cmd="shield", shield_cmd="status", project_name="proj", task_id=None)
     with (
         patch("sys.stderr", new_callable=StringIO) as err,
         pytest.raises(SystemExit) as exc_info,
@@ -201,7 +201,7 @@ def test_dispatch_task_scoped_commands(
     getattr(mock_shield, shield_method).return_value = shield_result
     mock_mgr_cls.return_value.shield = mock_shield
 
-    args = argparse.Namespace(cmd="shield", shield_cmd=shield_cmd, project_id="proj", task_id="1")
+    args = argparse.Namespace(cmd="shield", shield_cmd=shield_cmd, project_name="proj", task_id="1")
     with patch("sys.stdout", new_callable=StringIO) as out:
         assert dispatch(args)
 
@@ -238,7 +238,7 @@ def test_dispatch_exec_error_surfaces_details(
     mock_shield.state.side_effect = ExecError(["nft", "list"], 1, "no such process")
     mock_mgr_cls.return_value.shield = mock_shield
 
-    args = argparse.Namespace(cmd="shield", shield_cmd="status", project_id="proj", task_id="1")
+    args = argparse.Namespace(cmd="shield", shield_cmd="status", project_name="proj", task_id="1")
     with (
         patch("sys.stderr", new_callable=StringIO) as err,
         pytest.raises(SystemExit) as exc_info,
@@ -264,7 +264,7 @@ def test_dispatch_runtime_error_prints_message(
     args = argparse.Namespace(
         cmd="shield",
         shield_cmd="allow",
-        project_id="proj",
+        project_name="proj",
         task_id="1",
         target="example.com",
     )
@@ -299,7 +299,7 @@ def test_dispatch_simple_clearance(
     mock_mgr_cls.return_value.shield = mock_shield
 
     args = argparse.Namespace(
-        cmd="shield", shield_cmd="simple-clearance", project_id="proj", task_id="1"
+        cmd="shield", shield_cmd="simple-clearance", project_name="proj", task_id="1"
     )
     assert dispatch(args)
     mock_run.assert_called_once_with(mock_shield.config.state_dir, "proj-cli-1")
@@ -318,7 +318,7 @@ def test_dispatch_watch(
     mock_shield.config.state_dir = MOCK_TASK_DIR_1 / "shield"
     mock_mgr_cls.return_value.shield = mock_shield
 
-    args = argparse.Namespace(cmd="shield", shield_cmd="watch", project_id="proj", task_id="1")
+    args = argparse.Namespace(cmd="shield", shield_cmd="watch", project_name="proj", task_id="1")
     assert dispatch(args)
     mock_run.assert_called_once_with(mock_shield.config.state_dir, "proj-cli-1")
 
@@ -330,7 +330,8 @@ def test_resolve_task_errors(
     _meta: MagicMock,
 ) -> None:
     """Task resolution rejects tasks that have never been run."""
-    mock_project.return_value = MagicMock(id="proj")
+    mock_project.return_value = MagicMock()
+    mock_project.return_value.name = "proj"
     with pytest.raises(ValueError, match="has never been run"):
         _resolve_task("proj", "1")
 
@@ -395,7 +396,7 @@ class TestPersistDesiredState:
         mock_shield = MagicMock()
         mock_mgr_cls.return_value.shield = mock_shield
 
-        args = argparse.Namespace(cmd="shield", shield_cmd="up", project_id="proj", task_id="1")
+        args = argparse.Namespace(cmd="shield", shield_cmd="up", project_name="proj", task_id="1")
         assert dispatch(args)
         mock_shield.up.assert_called_once()
         assert (tmp_path / "shield_desired_state").read_text().strip() == "up"
@@ -419,7 +420,7 @@ class TestPersistDesiredState:
         mock_mgr_cls.return_value.shield = mock_shield
 
         args = argparse.Namespace(
-            cmd="shield", shield_cmd="down", project_id="proj", task_id="1", allow_all=False
+            cmd="shield", shield_cmd="down", project_name="proj", task_id="1", allow_all=False
         )
         assert dispatch(args)
         mock_shield.down.assert_called_once()

--- a/tests/unit/cli/test_cli_task_dispatch.py
+++ b/tests/unit/cli/test_cli_task_dispatch.py
@@ -1,0 +1,140 @@
+# SPDX-FileCopyrightText: 2026 Jiri Vyskocil
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for ``terok task`` subcommand dispatch and credential handlers.
+
+These pin the CLI command table — every task-scoped subcommand must forward the
+*project name* (slug) and resolved task id to its service function — and exercise
+the phantom-token / audit handlers' output branches.
+"""
+
+from __future__ import annotations
+
+import argparse
+from unittest import mock
+
+import pytest
+
+from terok.cli.commands import task as task_mod
+
+_PROJ = "demoproj"
+_TID = "swift-otter"
+
+
+def _ns(**kw: object) -> argparse.Namespace:
+    return argparse.Namespace(**kw)
+
+
+# (task_cmd, extra args, patched symbol, expected call) — task-scoped routing.
+_ROUTES = [
+    (
+        "new",
+        {"name": "fresh"},
+        "task_new",
+        mock.call(_PROJ, name="fresh"),
+    ),
+    ("delete", {}, "task_delete", mock.call(_PROJ, _TID)),
+    ("stop", {"timeout": 9}, "task_stop", mock.call(_PROJ, _TID, timeout=9)),
+    ("rename", {"name": "renamed"}, "task_rename", mock.call(_PROJ, _TID, "renamed")),
+    ("status", {}, "task_status", mock.call(_PROJ, _TID)),
+]
+
+
+@pytest.mark.parametrize(("cmd", "extra", "symbol", "expected"), _ROUTES)
+def test_task_subcommand_routes_with_project_name(cmd, extra, symbol, expected) -> None:  # type: ignore[no-untyped-def]
+    """Each task subcommand forwards the project name (+ task id) to its service."""
+    args = _ns(task_cmd=cmd, project_name=_PROJ, task_id=_TID, **extra)
+    with (
+        mock.patch.object(task_mod, "require_project_exists"),
+        mock.patch.object(task_mod, "resolve_task_id", return_value=_TID),
+        mock.patch.object(task_mod, "task_delete", return_value=mock.Mock(warnings=[])),
+        mock.patch.object(task_mod, symbol) as target,
+    ):
+        assert task_mod._dispatch_task_sub(args) is True
+    if symbol != "task_delete":  # delete is pre-patched above for its result.warnings access
+        assert target.call_args == expected
+
+
+def test_new_skips_task_id_resolution() -> None:
+    """``task new`` creates without resolving a task id (none exists yet)."""
+    args = _ns(task_cmd="new", project_name=_PROJ, name=None)
+    with (
+        mock.patch.object(task_mod, "resolve_task_id") as resolve,
+        mock.patch.object(task_mod, "task_new") as new,
+    ):
+        assert task_mod._dispatch_task_sub(args) is True
+    new.assert_called_once_with(_PROJ, name=None)
+    resolve.assert_not_called()
+
+
+def test_archive_routes_to_archive_dispatch() -> None:
+    args = _ns(task_cmd="archive", project_name=_PROJ, task_id=_TID, archive_cmd="list")
+    with (
+        mock.patch.object(task_mod, "require_project_exists"),
+        mock.patch.object(task_mod, "resolve_task_id", return_value=_TID),
+        mock.patch.object(task_mod, "task_archive_list") as lister,
+    ):
+        assert task_mod._dispatch_task_sub(args) is True
+    lister.assert_called_once_with(_PROJ)
+
+
+class TestArchiveDispatch:
+    """``task archive`` subcommands forward the project name."""
+
+    def test_list(self) -> None:
+        args = _ns(archive_cmd="list", project_name=_PROJ)
+        with mock.patch.object(task_mod, "task_archive_list") as m:
+            assert task_mod._dispatch_archive_sub(args) is True
+        m.assert_called_once_with(_PROJ)
+
+    def test_logs_streams_resolved_file(self, tmp_path, capsys: pytest.CaptureFixture[str]) -> None:
+        log = tmp_path / "archive.log"
+        log.write_text("hello from archive\n", encoding="utf-8")
+        args = _ns(archive_cmd="logs", project_name=_PROJ, archive_id="42")
+        with mock.patch.object(task_mod, "task_archive_logs", return_value=log) as m:
+            assert task_mod._dispatch_archive_sub(args) is True
+        m.assert_called_once_with(_PROJ, "42")
+        assert "hello from archive" in capsys.readouterr().out
+
+    def test_logs_missing_archive_exits(self) -> None:
+        args = _ns(archive_cmd="logs", project_name=_PROJ, archive_id="42")
+        with mock.patch.object(task_mod, "task_archive_logs", return_value=None):
+            with pytest.raises(SystemExit, match="No archived logs"):
+                task_mod._dispatch_archive_sub(args)
+
+
+class TestRevokeCredentials:
+    """``task revoke-credentials`` reports the phantom-token count."""
+
+    def test_no_tokens(self, capsys: pytest.CaptureFixture[str]) -> None:
+        with mock.patch("terok.lib.domain.task_credentials.revoke_credentials", return_value=0):
+            task_mod._cmd_task_revoke_credentials(_PROJ, _TID)
+        assert "No phantom tokens" in capsys.readouterr().out
+
+    def test_pluralizes_count(self, capsys: pytest.CaptureFixture[str]) -> None:
+        with mock.patch("terok.lib.domain.task_credentials.revoke_credentials", return_value=2):
+            task_mod._cmd_task_revoke_credentials(_PROJ, _TID)
+        out = capsys.readouterr().out
+        assert "Revoked 2 phantom tokens" in out and f"{_PROJ}/{_TID}" in out
+
+
+class TestAuditCredentials:
+    """``task audit-credentials`` renders or JSON-dumps broker audit rows."""
+
+    def test_empty_prints_placeholder(self, capsys: pytest.CaptureFixture[str]) -> None:
+        with mock.patch("terok.lib.domain.task_credentials.audit_credentials", return_value=[]):
+            task_mod._cmd_task_audit_credentials(_PROJ, _TID, _ns(json_output=False))
+        assert "No credential-audit entries" in capsys.readouterr().out
+
+    def test_table_renders_rows(self, capsys: pytest.CaptureFixture[str]) -> None:
+        row = {"ts": "2026-01-01", "provider": "claude", "method": "lookup", "path": "/x"}
+        with mock.patch("terok.lib.domain.task_credentials.audit_credentials", return_value=[row]):
+            task_mod._cmd_task_audit_credentials(_PROJ, _TID, _ns(json_output=False))
+        out = capsys.readouterr().out
+        assert "claude" in out and "lookup" in out
+
+    def test_rejects_naive_since(self) -> None:
+        with pytest.raises(SystemExit, match="naive"):
+            task_mod._cmd_task_audit_credentials(
+                _PROJ, _TID, _ns(json_output=False, since="2026-01-01T00:00:00")
+            )

--- a/tests/unit/cli/test_cli_unattended.py
+++ b/tests/unit/cli/test_cli_unattended.py
@@ -70,7 +70,7 @@ def test_run_dispatches_to_task_run_headless() -> None:
         "3600",
     )
 
-    assert request.project_id == "myproject"
+    assert request.project_name == "myproject"
     assert request.prompt == "Fix the auth bug"
     assert request.config_path is None
     assert request.model == "opus"

--- a/tests/unit/cli/test_cli_workflows.py
+++ b/tests/unit/cli/test_cli_workflows.py
@@ -191,7 +191,7 @@ class TestCliSshInit:
         args = argparse.Namespace(
             cmd="project",
             project_cmd="ssh-init",
-            project_id="proj",
+            project_name="proj",
             key_type="ed25519",
             comment=None,
             force=False,
@@ -288,9 +288,9 @@ class TestTaskRunInteractive:
             unittest.mock.patch(runner_path) as mock_runner,
         ):
             run_main(argv)
-        project_id, expected_task_id, kwargs = expected_call
-        mock_new.assert_called_once_with(project_id, name=None)
-        mock_runner.assert_called_once_with(project_id, expected_task_id, **kwargs)
+        project_name, expected_task_id, kwargs = expected_call
+        mock_new.assert_called_once_with(project_name, name=None)
+        mock_runner.assert_called_once_with(project_name, expected_task_id, **kwargs)
         # --no-attach must suppress the login exec in every interactive mode.
         mock_task_login.assert_not_called()
 

--- a/tests/unit/cli/test_completers.py
+++ b/tests/unit/cli/test_completers.py
@@ -12,10 +12,10 @@ from unittest.mock import patch
 import pytest
 
 from terok.cli.commands._completers import (
-    add_project_id,
+    add_project_name,
     add_task_id,
     complete_preset_names,
-    complete_project_ids,
+    complete_project_names,
     complete_task_ids,
     set_completer,
 )
@@ -26,22 +26,22 @@ from terok.cli.commands._completers import (
 
 
 class TestCompleteProjectIds:
-    """``complete_project_ids`` returns project IDs matching the prefix."""
+    """``complete_project_names`` returns project names matching the prefix."""
 
     def test_lists_all_ids_for_empty_prefix(self) -> None:
         with patch(
             "terok.cli.commands._completers.list_projects",
-            return_value=[SimpleNamespace(id="alpha"), SimpleNamespace(id="beta")],
+            return_value=[SimpleNamespace(name="alpha"), SimpleNamespace(name="beta")],
         ):
-            result = complete_project_ids("", argparse.Namespace())
+            result = complete_project_names("", argparse.Namespace())
         assert sorted(result) == ["alpha", "beta"]
 
     def test_filters_by_prefix(self) -> None:
         with patch(
             "terok.cli.commands._completers.list_projects",
-            return_value=[SimpleNamespace(id="alpha"), SimpleNamespace(id="ally")],
+            return_value=[SimpleNamespace(name="alpha"), SimpleNamespace(name="ally")],
         ):
-            result = complete_project_ids("al", argparse.Namespace())
+            result = complete_project_names("al", argparse.Namespace())
         assert sorted(result) == ["ally", "alpha"]
 
     def test_returns_empty_on_failure(self) -> None:
@@ -50,31 +50,31 @@ class TestCompleteProjectIds:
             "terok.cli.commands._completers.list_projects",
             side_effect=RuntimeError("boom"),
         ):
-            assert complete_project_ids("", argparse.Namespace()) == []
+            assert complete_project_names("", argparse.Namespace()) == []
 
 
 # ---------------------------------------------------------------------------
 
 
 class TestCompleteTaskIds:
-    """``complete_task_ids`` scopes to ``parsed_args.project_id``."""
+    """``complete_task_ids`` scopes to ``parsed_args.project_name``."""
 
     def test_empty_when_no_project_typed_yet(self) -> None:
-        """Without a project_id on parsed_args, no task suggestions."""
+        """Without a project_name on parsed_args, no task suggestions."""
         assert complete_task_ids("", argparse.Namespace()) == []
-        assert complete_task_ids("", argparse.Namespace(project_id=None)) == []
+        assert complete_task_ids("", argparse.Namespace(project_name=None)) == []
 
     def test_lists_tasks_for_project(self) -> None:
         tasks = [SimpleNamespace(task_id="k3v8h"), SimpleNamespace(task_id="p7fmn")]
         with patch("terok.cli.commands._completers.get_tasks", return_value=tasks) as mock:
-            result = complete_task_ids("", argparse.Namespace(project_id="myproj"))
+            result = complete_task_ids("", argparse.Namespace(project_name="myproj"))
         mock.assert_called_once_with("myproj")
         assert sorted(result) == ["k3v8h", "p7fmn"]
 
     def test_filters_by_prefix(self) -> None:
         tasks = [SimpleNamespace(task_id="k3v8h"), SimpleNamespace(task_id="p7fmn")]
         with patch("terok.cli.commands._completers.get_tasks", return_value=tasks):
-            result = complete_task_ids("k", argparse.Namespace(project_id="p"))
+            result = complete_task_ids("k", argparse.Namespace(project_name="p"))
         assert result == ["k3v8h"]
 
     @pytest.mark.parametrize(
@@ -96,14 +96,14 @@ class TestCompleteTaskIds:
             SimpleNamespace(task_id="p7fmn"),
         ]
         with patch("terok.cli.commands._completers.get_tasks", return_value=tasks):
-            result = complete_task_ids(typed, argparse.Namespace(project_id="p"))
+            result = complete_task_ids(typed, argparse.Namespace(project_name="p"))
         assert result == expected
 
     def test_skips_tasks_without_ids(self) -> None:
         """Tasks with a falsy ``task_id`` (defensive: shouldn't happen) are skipped."""
         tasks = [SimpleNamespace(task_id="k3v8h"), SimpleNamespace(task_id="")]
         with patch("terok.cli.commands._completers.get_tasks", return_value=tasks):
-            result = complete_task_ids("", argparse.Namespace(project_id="p"))
+            result = complete_task_ids("", argparse.Namespace(project_name="p"))
         assert result == ["k3v8h"]
 
     def test_returns_empty_on_failure(self) -> None:
@@ -111,19 +111,19 @@ class TestCompleteTaskIds:
             "terok.cli.commands._completers.get_tasks",
             side_effect=RuntimeError("boom"),
         ):
-            assert complete_task_ids("", argparse.Namespace(project_id="p")) == []
+            assert complete_task_ids("", argparse.Namespace(project_name="p")) == []
 
 
 # ---------------------------------------------------------------------------
 
 
 class TestCompletePresetNames:
-    """``complete_preset_names`` scopes to ``parsed_args.project_id``."""
+    """``complete_preset_names`` scopes to ``parsed_args.project_name``."""
 
     def test_empty_when_no_project(self) -> None:
-        """list_presets requires a project — silent when project_id absent."""
+        """list_presets requires a project — silent when project_name absent."""
         assert complete_preset_names("", argparse.Namespace()) == []
-        assert complete_preset_names("", argparse.Namespace(project_id=None)) == []
+        assert complete_preset_names("", argparse.Namespace(project_name=None)) == []
 
     def test_lists_presets_for_project(self) -> None:
         presets = [
@@ -132,14 +132,14 @@ class TestCompletePresetNames:
             SimpleNamespace(name="review"),
         ]
         with patch("terok.cli.commands._completers.list_presets", return_value=presets) as mock:
-            result = complete_preset_names("", argparse.Namespace(project_id="myproj"))
+            result = complete_preset_names("", argparse.Namespace(project_name="myproj"))
         mock.assert_called_once_with("myproj")
         assert sorted(result) == ["review", "solo", "team"]
 
     def test_filters_by_prefix(self) -> None:
         presets = [SimpleNamespace(name="solo"), SimpleNamespace(name="team")]
         with patch("terok.cli.commands._completers.list_presets", return_value=presets):
-            result = complete_preset_names("s", argparse.Namespace(project_id="p"))
+            result = complete_preset_names("s", argparse.Namespace(project_name="p"))
         assert result == ["solo"]
 
     def test_returns_empty_on_failure(self) -> None:
@@ -147,7 +147,7 @@ class TestCompletePresetNames:
             "terok.cli.commands._completers.list_presets",
             side_effect=RuntimeError("boom"),
         ):
-            assert complete_preset_names("", argparse.Namespace(project_id="p")) == []
+            assert complete_preset_names("", argparse.Namespace(project_name="p")) == []
 
 
 # ---------------------------------------------------------------------------
@@ -156,15 +156,15 @@ class TestCompletePresetNames:
 
 
 class TestParserAttachment:
-    """``add_project_id`` / ``add_task_id`` attach the right completer."""
+    """``add_project_name`` / ``add_task_id`` attach the right completer."""
 
-    def test_add_project_id_attaches_completer(self) -> None:
+    def test_add_project_name_attaches_completer(self) -> None:
         parser = argparse.ArgumentParser()
-        action = add_project_id(parser)
-        assert action.dest == "project_id"
+        action = add_project_name(parser)
+        assert action.dest == "project_name"
         # argcomplete reads the ``completer`` attribute — verify it's bound
         # to the right function (not just "something callable").
-        assert action.completer is complete_project_ids
+        assert action.completer is complete_project_names
 
     def test_add_task_id_attaches_completer(self) -> None:
         parser = argparse.ArgumentParser()
@@ -172,16 +172,16 @@ class TestParserAttachment:
         assert action.dest == "task_id"
         assert action.completer is complete_task_ids
 
-    def test_add_project_id_forwards_kwargs(self) -> None:
+    def test_add_project_name_forwards_kwargs(self) -> None:
         """Custom nargs / metavar / help must flow through to argparse."""
         parser = argparse.ArgumentParser()
-        action = add_project_id(parser, nargs="?", metavar="project", help="...")
+        action = add_project_name(parser, nargs="?", metavar="project", help="...")
         assert action.nargs == "?"
         assert action.metavar == "project"
 
 
 # ---------------------------------------------------------------------------
-# Coverage sweep — every parser that takes project_id/task_id has a completer
+# Coverage sweep — every parser that takes project_name/task_id has a completer
 # ---------------------------------------------------------------------------
 
 
@@ -204,11 +204,11 @@ def _walk_actions(parser: argparse.ArgumentParser, seen: set[int] | None = None)
 
 
 @pytest.mark.parametrize("prog", ["terok", "terokctl"])
-def test_every_project_id_and_task_id_has_completer(prog: str) -> None:
-    """Sweep the full parser tree — no ``project_id``/``task_id`` without a completer.
+def test_every_project_name_and_task_id_has_completer(prog: str) -> None:
+    """Sweep the full parser tree — no ``project_name``/``task_id`` without a completer.
 
-    Catches regressions where someone adds a new ``project_id`` positional
-    but forgets ``add_project_id`` / ``add_task_id``.
+    Catches regressions where someone adds a new ``project_name`` positional
+    but forgets ``add_project_name`` / ``add_task_id``.
     """
     import argparse as _ap
 
@@ -246,7 +246,7 @@ def test_every_project_id_and_task_id_has_completer(prog: str) -> None:
 
     missing: list[str] = []
     for action in _walk_actions(parser):
-        if action.dest in ("project_id", "task_id"):
+        if action.dest in ("project_name", "task_id"):
             if not hasattr(action, "completer") or action.completer is None:
                 missing.append(f"{action.dest} (option_strings={action.option_strings})")
 

--- a/tests/unit/cli/test_sickbay.py
+++ b/tests/unit/cli/test_sickbay.py
@@ -729,3 +729,89 @@ class TestCheckRecoveryAcknowledged:
             sev, label, detail = _check_recovery_acknowledged()
         assert sev == "warn"
         assert "boom" in detail
+
+
+class TestSickbayDispatch:
+    """``dispatch`` routes the sickbay command and resolves the task id."""
+
+    def test_ignores_foreign_command(self) -> None:
+        import argparse
+
+        from terok.cli.commands import sickbay as sb
+
+        assert sb.dispatch(argparse.Namespace(cmd="task")) is False
+
+    def test_resolves_task_and_invokes_check(self) -> None:
+        import argparse
+
+        from terok.cli.commands import sickbay as sb
+
+        args = argparse.Namespace(cmd="sickbay", project_name="alpha", task_id="1", fix=True)
+        with (
+            unittest.mock.patch.object(sb, "resolve_task_id", return_value="full-id") as resolve,
+            unittest.mock.patch.object(sb, "_cmd_sickbay") as run,
+        ):
+            assert sb.dispatch(args) is True
+        resolve.assert_called_once_with("alpha", "1")
+        run.assert_called_once_with(project_name="alpha", task_id="full-id", fix=True)
+
+
+class TestCheckUnfiredHooks:
+    """``_check_unfired_hooks`` walks projects and flags pending post_stop hooks."""
+
+    def test_skips_projects_without_post_stop_hook(self) -> None:
+        from types import SimpleNamespace
+
+        from terok.cli.commands import sickbay as sb
+
+        proj = SimpleNamespace(name="alpha", hook_post_stop=None)
+        with unittest.mock.patch.object(sb, "list_projects", return_value=[proj]):
+            assert sb._check_unfired_hooks(None, None, fix=False) == []
+
+    def test_collects_results_for_each_task(self, tmp_path: Path) -> None:
+        from types import SimpleNamespace
+
+        from terok.cli.commands import sickbay as sb
+
+        proj = SimpleNamespace(name="alpha", hook_post_stop="echo done")
+        meta_dir = tmp_path / "alpha"
+        meta_dir.mkdir()
+        with (
+            unittest.mock.patch.object(sb, "list_projects", return_value=[proj]),
+            unittest.mock.patch.object(sb, "tasks_meta_dir", return_value=meta_dir),
+            unittest.mock.patch.object(sb, "iter_task_ids", return_value=["t1"]),
+            unittest.mock.patch.object(sb, "_check_task_hook", return_value="RESULT") as check,
+        ):
+            results = sb._check_unfired_hooks(None, None, fix=True)
+        assert results == ["RESULT"]
+        check.assert_called_once_with("alpha", "t1", proj, fix=True)
+
+
+class TestStreamContainers:
+    """``_stream_containers`` runs the container doctor per task."""
+
+    def test_single_task_runs_doctor_once(self) -> None:
+        from terok.cli.commands import sickbay as sb
+
+        reporter = object()
+        with unittest.mock.patch.object(sb, "ContainerDoctor") as Doctor:
+            sb._stream_containers("alpha", "t1", fix=False, reporter=reporter)
+        Doctor.assert_called_once_with("alpha", "t1")
+        Doctor.return_value.run.assert_called_once()
+
+    def test_global_scope_iterates_all_tasks(self, tmp_path: Path) -> None:
+        from types import SimpleNamespace
+
+        from terok.cli.commands import sickbay as sb
+
+        proj = SimpleNamespace(name="alpha")
+        meta_dir = tmp_path / "alpha"
+        meta_dir.mkdir()
+        with (
+            unittest.mock.patch.object(sb, "list_projects", return_value=[proj]),
+            unittest.mock.patch.object(sb, "tasks_meta_dir", return_value=meta_dir),
+            unittest.mock.patch.object(sb, "iter_task_ids", return_value=["t1", "t2"]),
+            unittest.mock.patch.object(sb, "ContainerDoctor") as Doctor,
+        ):
+            sb._stream_containers(None, None, fix=False, reporter=object())
+        assert [c.args for c in Doctor.call_args_list] == [("alpha", "t1"), ("alpha", "t2")]

--- a/tests/unit/cli/test_sickbay.py
+++ b/tests/unit/cli/test_sickbay.py
@@ -46,7 +46,7 @@ class TestCheckSshSigner:
     @staticmethod
     def _mock_project(pid: str) -> unittest.mock.MagicMock:
         p = unittest.mock.MagicMock()
-        p.id = pid
+        p.name = pid
         return p
 
     def _patch_vault(self, assigned_scopes: list[str]):
@@ -567,7 +567,7 @@ class TestCheckShieldAnnotations:
         from terok.cli.commands.sickbay import _check_shield_annotations
 
         project = unittest.mock.MagicMock()
-        project.id = "p"
+        project.name = "p"
         with (
             unittest.mock.patch("terok.cli.commands.sickbay.load_project", return_value=project),
             unittest.mock.patch(
@@ -585,7 +585,7 @@ class TestCheckShieldAnnotations:
         meta_dir.mkdir()
         _write_meta(meta_dir, "g1abc", {"mode": "cli"})
         project = unittest.mock.MagicMock()
-        project.id = "proj"
+        project.name = "proj"
         with (
             unittest.mock.patch("terok.cli.commands.sickbay.list_projects", return_value=[project]),
             unittest.mock.patch("terok.cli.commands.sickbay.tasks_meta_dir", return_value=meta_dir),
@@ -607,7 +607,7 @@ class TestCheckShieldAnnotations:
         _write_meta(meta_dir, "g1abc", {"mode": "cli"})
         _write_meta(meta_dir, "g2xyz", {"mode": "cli"})
         project = unittest.mock.MagicMock()
-        project.id = "p"
+        project.name = "p"
         with (
             unittest.mock.patch("terok.cli.commands.sickbay.load_project", return_value=project),
             unittest.mock.patch("terok.cli.commands.sickbay.tasks_meta_dir", return_value=meta_dir),

--- a/tests/unit/lib/domain/test_acp_endpoints.py
+++ b/tests/unit/lib/domain/test_acp_endpoints.py
@@ -122,13 +122,13 @@ class TestACPEndpointDataclass:
     def test_construction_minimal(self, tmp_path: Path) -> None:
         """All fields are positional/keyword and survive equality."""
         ep1 = ACPEndpoint(
-            project_id="p",
+            project_name="p",
             task_id="t",
             socket_path=tmp_path / "x.sock",
             status=ACPEndpointStatus.READY,
         )
         ep2 = ACPEndpoint(
-            project_id="p",
+            project_name="p",
             task_id="t",
             socket_path=tmp_path / "x.sock",
             status=ACPEndpointStatus.READY,
@@ -139,7 +139,7 @@ class TestACPEndpointDataclass:
     def test_with_bound_agent(self, tmp_path: Path) -> None:
         """``bound_agent`` is set only when the daemon has bound a session."""
         ep = ACPEndpoint(
-            project_id="p",
+            project_name="p",
             task_id="t",
             socket_path=tmp_path / "x.sock",
             status=ACPEndpointStatus.ACTIVE,

--- a/tests/unit/lib/domain/test_domain_api.py
+++ b/tests/unit/lib/domain/test_domain_api.py
@@ -45,7 +45,8 @@ class TestListProjects:
         from terok.lib import api
         from terok.lib.domain.project import Project
 
-        a, b = MagicMock(id="a"), MagicMock(id="b")
+        a, b = MagicMock(), MagicMock()
+        a.name, b.name = "a", "b"
         with patch("terok.lib.domain.project._list_projects", return_value=[a, b]) as lister:
             result = api.list_projects()
         lister.assert_called_once()
@@ -66,7 +67,8 @@ class TestDeriveProject:
         from terok.lib import api
         from terok.lib.domain.project import Project
 
-        derived_cfg = MagicMock(id="derived")
+        derived_cfg = MagicMock()
+        derived_cfg.name = "derived"
         with (
             patch("terok.lib.domain.project._derive_project") as derive,
             patch("terok.lib.domain.project._share_ssh_key_assignments") as share,
@@ -112,11 +114,12 @@ class TestShareSshKeyAssignments:
         db.assign_ssh_key.assert_not_called()
 
 
-def _project_with_id(project_id: str, **extra: object) -> object:
-    """Build a minimal ``Project`` exposing just ``self._config.id`` (+overrides)."""
+def _project_with_id(project_name: str, **extra: object) -> object:
+    """Build a minimal ``Project`` exposing just ``self._config.name`` (+overrides)."""
     from terok.lib.domain.project import Project
 
-    config = MagicMock(id=project_id, **extra)
+    config = MagicMock(**extra)
+    config.name = project_name
     return Project(config)
 
 
@@ -216,7 +219,7 @@ class TestAuthenticate:
     """authenticate dispatches to the raw executor call with the right image+scope."""
 
     def test_project_scoped_uses_l2_image(self) -> None:
-        """``authenticate(provider, project_id)`` reuses the project's L2 image."""
+        """``authenticate(provider, project_name)`` reuses the project's L2 image."""
         from terok.lib import api
 
         # Shared-default project: scope-aware routing returns the same
@@ -239,11 +242,11 @@ class TestAuthenticate:
             patch("terok.lib.core.projects.load_project", return_value=fake_project),
             patch("terok.lib.domain.auth.Authenticator.run") as mock_auth,
         ):
-            api.authenticate("claude", project_id="p1")
+            api.authenticate("claude", project_name="p1")
 
         mock_l2.assert_called_once_with("p1")
         mock_auth.assert_called_once()
-        # Positional call arg 0 is the container-scope string: the project id.
+        # Positional call arg 0 is the container-scope string: the project name.
         assert mock_auth.call_args.args[0] == "p1"
         assert mock_auth.call_args.kwargs["image"] == "terok-p1:latest"
         assert mock_auth.call_args.kwargs["expose_token"] is False
@@ -274,7 +277,7 @@ class TestAuthenticate:
             patch("terok.lib.core.projects.load_project", return_value=fake_project),
             patch("terok.lib.domain.auth.Authenticator.run") as mock_auth,
         ):
-            api.authenticate("claude", project_id="p1")
+            api.authenticate("claude", project_name="p1")
 
         assert mock_auth.call_args.kwargs["mounts_dir"] == project_root / "mounts"
         assert mock_auth.call_args.kwargs["credential_set"] == "p1"
@@ -601,7 +604,8 @@ class TestProjectState:
     def test_delegates_with_loaded_config(self) -> None:
         from terok.lib.domain.project import Project
 
-        cfg = MagicMock(id="myproj")
+        cfg = MagicMock()
+        cfg.name = "myproj"
         with patch(
             "terok.lib.domain.project_state.get_project_state",
             return_value={"gate": True},
@@ -613,7 +617,8 @@ class TestProjectState:
     def test_threads_gate_commit_provider(self) -> None:
         from terok.lib.domain.project import Project
 
-        cfg = MagicMock(id="myproj")
+        cfg = MagicMock()
+        cfg.name = "myproj"
         provider = MagicMock()
         with patch(
             "terok.lib.domain.project_state.get_project_state",
@@ -626,10 +631,11 @@ class TestProjectState:
 class TestProjectStorageDetail:
     """Project.storage_detail() delegates to get_project_storage_detail."""
 
-    def test_delegates_with_project_id(self) -> None:
+    def test_delegates_with_project_name(self) -> None:
         from terok.lib.domain.project import Project
 
-        cfg = MagicMock(id="myproj")
+        cfg = MagicMock()
+        cfg.name = "myproj"
         sentinel = MagicMock()
         with patch(
             "terok.lib.domain.storage.get_project_storage_detail",
@@ -647,7 +653,8 @@ class TestTaskImageIsOld:
     def test_passes_through_helper_result(self, value: bool | None) -> None:
         from terok.lib.domain.task import Task
 
-        cfg = MagicMock(id="myproj")
+        cfg = MagicMock()
+        cfg.name = "myproj"
         meta = MagicMock()
         with patch(
             "terok.lib.domain.project_state.is_task_image_old",

--- a/tests/unit/lib/domain/test_project_aggregate.py
+++ b/tests/unit/lib/domain/test_project_aggregate.py
@@ -1,0 +1,164 @@
+# SPDX-FileCopyrightText: 2026 Jiri Vyskocil
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for the [`Project`][terok.lib.domain.project.Project] aggregate.
+
+Cover the identity semantics and the task-containment / infrastructure
+delegations.  Every delegation must thread the project *name* (the slug) into
+the orchestration layer — the invariant the project_id→project_name rename had
+to preserve.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest import mock
+
+import pytest
+
+from terok.lib.domain.project import Project
+
+_PROJ = "demoproj"
+
+
+def _project(**config_overrides: object) -> Project:
+    """Build a Project over a lightweight config stand-in."""
+    fields: dict[str, object] = {"name": _PROJ, "security_class": "online", "upstream_url": None}
+    fields.update(config_overrides)
+    return Project(SimpleNamespace(**fields))  # type: ignore[arg-type]
+
+
+class TestProjectIdentity:
+    """Identity delegates to the wrapped config; equality is name-based."""
+
+    def test_name_and_config_and_security_class(self) -> None:
+        p = _project()
+        assert p.name == _PROJ
+        assert p.security_class == "online"
+        assert p.config is p._config
+
+    def test_equality_and_hash_by_name(self) -> None:
+        assert _project() == _project()
+        assert _project() != _project(name="other")
+        assert _project() != object()
+        assert hash(_project()) == hash(_project())
+        assert {_project(), _project()} == {_project()}
+
+    def test_repr(self) -> None:
+        assert repr(_project()) == f"Project(name={_PROJ!r}, security='online')"
+
+
+class TestTaskContainment:
+    """create_task / get_task / list_tasks thread the project name."""
+
+    def test_create_task_delegates_and_wraps(self) -> None:
+        meta = SimpleNamespace(task_id="t1")
+        with (
+            mock.patch("terok.lib.domain.project.task_new", return_value="t1") as new,
+            mock.patch("terok.lib.domain.project.get_task_meta", return_value=meta) as get_meta,
+        ):
+            task = _project().create_task(name="fancy")
+        assert new.call_args == mock.call(_PROJ, name="fancy")
+        assert get_meta.call_args == mock.call(_PROJ, "t1")
+        assert task.id == "t1"
+
+    def test_get_task_delegates_and_wraps(self) -> None:
+        meta = SimpleNamespace(task_id="t9")
+        with mock.patch("terok.lib.domain.project.get_task_meta", return_value=meta) as get_meta:
+            task = _project().get_task("t9")
+        assert get_meta.call_args == mock.call(_PROJ, "t9")
+        assert task.id == "t9"
+
+    def test_list_tasks_hydrates_state_and_filters(self) -> None:
+        metas = [
+            SimpleNamespace(task_id="a", mode="cli", status="running", container_state=None),
+            SimpleNamespace(task_id="b", mode="run", status="stopped", container_state=None),
+        ]
+        with (
+            mock.patch("terok.lib.domain.project.get_tasks", return_value=metas) as get_tasks,
+            mock.patch(
+                "terok.lib.domain.project.get_all_task_states",
+                return_value={"a": "running", "b": "exited"},
+            ) as states,
+        ):
+            result = _project().list_tasks(mode="cli")
+        assert get_tasks.call_args == mock.call(_PROJ)
+        # State hydration runs over the already mode-filtered metas (cli-only).
+        assert states.call_args.args[0] == _PROJ
+        assert [m.task_id for m in states.call_args.args[1]] == ["a"]
+        # Only the cli-mode task survives the mode filter, and its live state was hydrated.
+        assert [t.id for t in result] == ["a"]
+        assert metas[0].container_state == "running"
+
+    def test_tasks_property_delegates_to_list_tasks(self) -> None:
+        with mock.patch.object(Project, "list_tasks", return_value=["sentinel"]) as lt:
+            assert _project().tasks == ["sentinel"]
+        lt.assert_called_once_with()
+
+
+# Each entry exercises a one-line delegation that must forward the project name.
+_NAME_DELEGATIONS = [
+    (lambda p: p.delete(), "terok.lib.domain.project.delete_project", mock.call(_PROJ)),
+    (
+        lambda p: p.generate_dockerfiles(),
+        "terok.lib.domain.project.generate_dockerfiles",
+        mock.call(_PROJ),
+    ),
+    (lambda p: p.list_presets(), "terok.lib.domain.project.list_presets", mock.call(_PROJ)),
+    (
+        lambda p: p.build_images(include_dev=True, refresh_agents=True, full=True),
+        "terok.lib.domain.project.build_images",
+        mock.call(_PROJ, include_dev=True, refresh_agents=True, full_rebuild=True),
+    ),
+    (
+        lambda p: p.storage_detail(),
+        "terok.lib.domain.storage.get_project_storage_detail",
+        mock.call(_PROJ),
+    ),
+    (
+        lambda p: p.followup_headless("t1", "go", follow=False),
+        "terok.lib.orchestration.task_runners.task_followup_headless",
+        mock.call(_PROJ, "t1", "go", follow=False),
+    ),
+]
+
+
+@pytest.mark.parametrize(("call", "symbol", "expected"), _NAME_DELEGATIONS)
+def test_name_delegations(call, symbol, expected) -> None:  # type: ignore[no-untyped-def]
+    """Infrastructure helpers forward the project name to the service layer."""
+    with mock.patch(symbol) as m:
+        call(_project())
+    assert m.call_args == expected
+
+
+class TestInfrastructureManagers:
+    """Lazy-initialized managers are built from the config and cached."""
+
+    def test_state_threads_name_and_config(self) -> None:
+        p = _project()
+        with mock.patch(
+            "terok.lib.domain.project_state.get_project_state", return_value={"ok": True}
+        ) as gs:
+            assert p.state() == {"ok": True}
+        assert gs.call_args == mock.call(_PROJ, gate_commit_provider=None, project=p._config)
+
+    def test_gate_is_lazy_and_cached(self) -> None:
+        p = _project()
+        with mock.patch("terok.lib.domain.project.make_git_gate", return_value="GATE") as factory:
+            assert p.gate == "GATE"
+            assert p.gate == "GATE"  # second access reuses the cache
+        factory.assert_called_once_with(p._config)
+
+    def test_ssh_is_lazy_and_cached(self) -> None:
+        p = _project()
+        with mock.patch("terok.lib.domain.project.make_ssh_manager", return_value="SSH") as factory:
+            assert p.ssh == "SSH"
+            assert p.ssh == "SSH"
+        factory.assert_called_once_with(p._config)
+
+    def test_agents_is_lazy_and_cached(self) -> None:
+        p = _project()
+        with mock.patch("terok.lib.domain.project.AgentManager", return_value="AGENTS") as factory:
+            assert p.agents == "AGENTS"
+            assert p.agents == "AGENTS"
+        factory.assert_called_once_with(p._config)

--- a/tests/unit/lib/domain/test_task_aggregate.py
+++ b/tests/unit/lib/domain/test_task_aggregate.py
@@ -1,0 +1,160 @@
+# SPDX-FileCopyrightText: 2026 Jiri Vyskocil
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for the [`Task`][terok.lib.domain.task.Task] aggregate.
+
+These verify the entity's identity semantics and that every lifecycle /
+observation method delegates to the orchestration layer threading the project
+*name* (the slug) and task id — the contract that the project_id→project_name
+rename had to preserve.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest import mock
+
+import pytest
+
+from terok.lib.domain.task import Task
+
+_PROJ = "demoproj"
+_TID = "swift-otter"
+
+
+def _task(*, mode: str | None = "cli", **meta_overrides: object) -> Task:
+    """Build a Task over lightweight config/meta stand-ins."""
+    config = SimpleNamespace(name=_PROJ)
+    meta_fields: dict[str, object] = {
+        "task_id": _TID,
+        "name": "my-task",
+        "mode": mode,
+        "status": "running",
+        "container_state": "running",
+    }
+    meta_fields.update(meta_overrides)
+    return Task(config, SimpleNamespace(**meta_fields))  # type: ignore[arg-type]
+
+
+class TestTaskIdentity:
+    """Identity properties read straight from the metadata / config."""
+
+    def test_identity_properties(self) -> None:
+        t = _task()
+        assert t.id == _TID
+        assert t.name == "my-task"
+        assert t.mode == "cli"
+        assert t.status == "running"
+        assert t.container_state == "running"
+        assert t.meta is t._meta
+
+    def test_equality_by_project_and_id(self) -> None:
+        assert _task() == _task()
+
+    def test_inequality_across_projects(self) -> None:
+        other = Task(SimpleNamespace(name="otherproj"), _task()._meta)  # type: ignore[arg-type]
+        assert _task() != other
+
+    def test_inequality_across_task_ids(self) -> None:
+        assert _task() != _task(task_id="different")
+
+    def test_hashes_by_project_and_id(self) -> None:
+        assert hash(_task()) == hash(_task())
+        assert {_task(), _task()} == {_task()}  # dedups in a set
+
+    def test_repr_carries_id_name_mode(self) -> None:
+        assert repr(_task()) == f"Task(id={_TID!r}, name='my-task', mode='cli')"
+
+
+# Each entry: (call, patched-symbol, expected positional/keyword call)
+_DELEGATIONS = [
+    (lambda t: t.run_cli(preset="p"), "task_run_cli", mock.call(_PROJ, _TID, preset="p")),
+    (lambda t: t.stop(timeout=5), "task_stop", mock.call(_PROJ, _TID, timeout=5)),
+    (lambda t: t.restart(), "task_restart", mock.call(_PROJ, _TID)),
+    (lambda t: t.delete(), "task_delete", mock.call(_PROJ, _TID)),
+    (lambda t: t.rename("fresh"), "task_rename", mock.call(_PROJ, _TID, "fresh")),
+    (
+        lambda t: t.followup("more", follow=False),
+        "task_followup_headless",
+        mock.call(_PROJ, _TID, "more", follow=False),
+    ),
+    (lambda t: t.login(), "task_login", mock.call(_PROJ, _TID)),
+]
+
+
+@pytest.mark.parametrize(("call", "symbol", "expected"), _DELEGATIONS)
+def test_lifecycle_delegations_thread_project_name(call, symbol, expected) -> None:  # type: ignore[no-untyped-def]
+    """Lifecycle methods forward (project_name, task_id, …) to the service layer."""
+    with mock.patch(f"terok.lib.domain.task.{symbol}") as m:
+        call(_task())
+    assert m.call_args == expected
+
+
+class TestTaskObservation:
+    """Read-side delegations and their return-value pass-through."""
+
+    def test_logs_forwards_identity_and_options(self) -> None:
+        with mock.patch("terok.lib.domain.task.task_logs") as m:
+            _task().logs()
+        args = m.call_args.args
+        assert args[:2] == (_PROJ, _TID)
+        from terok.lib.domain.task_logs import LogViewOptions
+
+        assert isinstance(args[2], LogViewOptions)
+
+    def test_get_login_command_passes_through(self) -> None:
+        with mock.patch(
+            "terok.lib.domain.task.get_login_command", return_value=["podman", "exec"]
+        ) as m:
+            assert _task().get_login_command() == ["podman", "exec"]
+        assert m.call_args == mock.call(_PROJ, _TID)
+
+    def test_get_workspace_diff_passes_through(self) -> None:
+        with mock.patch("terok.lib.domain.task.get_workspace_git_diff", return_value="diff") as m:
+            assert _task().get_workspace_diff(against="main") == "diff"
+        assert m.call_args == mock.call(_PROJ, _TID, against="main")
+
+    def test_wait_for_exit_builds_container_name(self) -> None:
+        with (
+            mock.patch("terok.lib.core.task_state.container_name", return_value="cname") as cn,
+            mock.patch(
+                "terok.lib.orchestration.tasks.wait_for_container_exit",
+                return_value=(0, None),
+            ) as wait,
+        ):
+            assert _task().wait_for_exit(timeout=10) == (0, None)
+        assert cn.call_args == mock.call(_PROJ, "cli", _TID)
+        assert wait.call_args == mock.call("cname", _PROJ, _TID, timeout=10)
+
+    def test_wait_for_exit_without_mode_raises(self) -> None:
+        with pytest.raises(RuntimeError, match="no mode"):
+            _task(mode=None).wait_for_exit()
+
+    def test_capture_logs_returns_none_without_mode(self) -> None:
+        assert _task(mode=None).capture_logs() is None
+
+    def test_capture_logs_delegates_with_config(self) -> None:
+        t = _task()
+        with mock.patch(
+            "terok.lib.orchestration.tasks.capture_task_logs", return_value="/log"
+        ) as m:
+            assert t.capture_logs() == "/log"
+        assert m.call_args == mock.call(t._config, _TID, "cli")
+
+    def test_image_is_old_delegates(self) -> None:
+        t = _task()
+        with mock.patch("terok.lib.domain.project_state.is_task_image_old", return_value=True) as m:
+            assert t.image_is_old() is True
+        assert m.call_args == mock.call(_PROJ, t._meta)
+
+    def test_show_status_delegates(self) -> None:
+        with mock.patch("terok.lib.orchestration.tasks.task_status") as m:
+            _task().show_status()
+        assert m.call_args == mock.call(_PROJ, _TID)
+
+    def test_doctor_constructs_with_identity(self) -> None:
+        with mock.patch("terok.lib.orchestration.container_doctor.ContainerDoctor") as Doctor:
+            Doctor.return_value.run.return_value = []
+            assert _task().doctor(fix=True) == []
+        assert Doctor.call_args == mock.call(_PROJ, _TID)
+        Doctor.return_value.run.assert_called_once()

--- a/tests/unit/lib/test_agent_config.py
+++ b/tests/unit/lib/test_agent_config.py
@@ -60,32 +60,34 @@ def make_layout(base: Path) -> AgentConfigLayout:
     )
 
 
-def write_test_project(layout: AgentConfigLayout, project_id: str, body: str | None = None) -> None:
+def write_test_project(
+    layout: AgentConfigLayout, project_name: str, body: str | None = None
+) -> None:
     """Write a test project config, defaulting to a minimal project definition."""
     write_project(
         layout.config_root / "projects",
-        project_id,
-        body or f"project:\n  id: {project_id}\n",
+        project_name,
+        body or f"project:\n  id: {project_name}\n",
     )
 
 
-def project_presets_dir(layout: AgentConfigLayout, project_id: str) -> Path:
+def project_presets_dir(layout: AgentConfigLayout, project_name: str) -> Path:
     """Return the per-project presets directory."""
-    presets_dir = layout.config_root / "projects" / project_id / "presets"
+    presets_dir = layout.config_root / "projects" / project_name / "presets"
     presets_dir.mkdir(parents=True, exist_ok=True)
     return presets_dir
 
 
 def write_project_preset(
     layout: AgentConfigLayout,
-    project_id: str,
+    project_name: str,
     name: str,
     content: str,
     *,
     suffix: str = ".yml",
 ) -> Path:
     """Create a project-scoped preset file."""
-    preset_path = project_presets_dir(layout, project_id) / f"{name}{suffix}"
+    preset_path = project_presets_dir(layout, project_name) / f"{name}{suffix}"
     preset_path.write_text(content, encoding="utf-8")
     return preset_path
 
@@ -130,7 +132,7 @@ def _patched_env(
 
 def resolve_test_agent_config(
     layout: AgentConfigLayout,
-    project_id: str,
+    project_name: str,
     *,
     global_config: Path | None = None,
     preset: str | None = None,
@@ -139,9 +141,9 @@ def resolve_test_agent_config(
     """Resolve agent config inside the isolated test environment."""
     with _patched_env(layout, global_config=global_config):
         with mock_git_config():
-            project = load_project(project_id)
+            project = load_project(project_name)
             return resolve_agent_config(
-                project_id,
+                project_name,
                 agent_config=project.agent_config,
                 project_root=project.root,
                 preset=preset,
@@ -151,19 +153,19 @@ def resolve_test_agent_config(
 
 def list_test_presets(
     layout: AgentConfigLayout,
-    project_id: str,
+    project_name: str,
     *,
     xdg_config_home: Path | None = None,
 ) -> list[object]:
     """List presets inside the isolated test environment."""
     with _patched_env(layout, xdg_config_home=xdg_config_home):
         with mock_git_config():
-            return list_presets(project_id)
+            return list_presets(project_name)
 
 
 def load_test_preset(
     layout: AgentConfigLayout,
-    project_id: str,
+    project_name: str,
     preset_name: str,
     *,
     xdg_config_home: Path | None = None,
@@ -171,19 +173,19 @@ def load_test_preset(
     """Load a preset inside the isolated test environment."""
     with _patched_env(layout, xdg_config_home=xdg_config_home):
         with mock_git_config():
-            return load_preset(project_id, preset_name)
+            return load_preset(project_name, preset_name)
 
 
-def load_test_project(layout: AgentConfigLayout, project_id: str) -> ProjectConfig:
+def load_test_project(layout: AgentConfigLayout, project_name: str) -> ProjectConfig:
     """Load a project inside the isolated test environment."""
     with _patched_env(layout):
         with mock_git_config():
-            return load_project(project_id)
+            return load_project(project_name)
 
 
 def build_test_agent_stack(
     layout: AgentConfigLayout,
-    project_id: str,
+    project_name: str,
     *,
     preset: str,
     xdg_config_home: Path | None = None,
@@ -191,9 +193,9 @@ def build_test_agent_stack(
     """Build an agent config stack inside the isolated test environment."""
     with _patched_env(layout, xdg_config_home=xdg_config_home):
         with mock_git_config():
-            project = load_project(project_id)
+            project = load_project(project_name)
             return build_agent_config_stack(
-                project_id,
+                project_name,
                 agent_config=project.agent_config,
                 project_root=project.root,
                 preset=preset,
@@ -571,21 +573,21 @@ class TestBundledPreset:
 
 
 class TestValidateProjectId:
-    """Tests for validate_project_id error messages."""
+    """Tests for validate_project_name error messages."""
 
     def test_error_message_mentions_first_char(self) -> None:
         """Error message describes the first-character requirement."""
-        from terok.lib.core.project_model import validate_project_id
+        from terok.lib.core.project_model import validate_project_name
 
         with pytest.raises(SystemExit) as ctx:
-            validate_project_id("-bad")
+            validate_project_name("-bad")
         msg = str(ctx.value)
         assert "must start with a lowercase letter or digit" in msg
 
     def test_uppercase_rejected(self) -> None:
-        """Uppercase letters in project ID are rejected."""
-        from terok.lib.core.project_model import validate_project_id
+        """Uppercase letters in project name are rejected."""
+        from terok.lib.core.project_model import validate_project_name
 
         with pytest.raises(SystemExit) as ctx:
-            validate_project_id("MyProject")
-        assert "Invalid project ID" in str(ctx.value)
+            validate_project_name("MyProject")
+        assert "Invalid project name" in str(ctx.value)

--- a/tests/unit/lib/test_container_exec.py
+++ b/tests/unit/lib/test_container_exec.py
@@ -17,9 +17,9 @@ def _mock_load_project():
     """Skip real project resolution — these tests care about exec dispatch only.
 
     ``container_git_diff`` resolves the per-project runtime via
-    ``load_project(project_id)`` so it can route through krun's
+    ``load_project(project_name)`` so it can route through krun's
     SSH-over-passt-TCP transport when needed.  Every test here passes
-    fake project IDs and patches ``resolve_runtime`` (via the autouse
+    fake project names and patches ``resolve_runtime`` (via the autouse
     ``mock_runtime``) to ignore the actual project, so we just need
     ``load_project`` not to raise on a non-existent ID.
     """

--- a/tests/unit/lib/test_container_lifecycle.py
+++ b/tests/unit/lib/test_container_lifecycle.py
@@ -28,33 +28,33 @@ from terok.lib.orchestration.tasks import (
 from tests.test_utils import mock_git_config, project_env
 
 
-def project_config(project_id: str, *, shutdown_timeout: int | None = None) -> str:
+def project_config(project_name: str, *, shutdown_timeout: int | None = None) -> str:
     """Build a minimal project config, optionally overriding shutdown timeout."""
-    lines = [f"project:\n  id: {project_id}"]
+    lines = [f"project:\n  id: {project_name}"]
     if shutdown_timeout is not None:
         lines.append(f"run:\n  shutdown_timeout: {shutdown_timeout}")
     return "\n".join(lines) + "\n"
 
 
-def task_meta_path(ctx: SimpleNamespace, project_id: str, task_id: str) -> Path:
+def task_meta_path(ctx: SimpleNamespace, project_name: str, task_id: str) -> Path:
     """Return the metadata path for *task_id* inside the temporary project env."""
-    return ctx.state_dir / "projects" / project_id / "tasks" / f"{task_id}_dossier.json"
+    return ctx.state_dir / "projects" / project_name / "tasks" / f"{task_id}_dossier.json"
 
 
 def update_task_meta(
-    ctx: SimpleNamespace, project_id: str, task_id: str, **changes: object
+    ctx: SimpleNamespace, project_name: str, task_id: str, **changes: object
 ) -> None:
     """Patch selected metadata keys for a generated task."""
-    dossier_handle = task_meta_path(ctx, project_id, task_id)
+    dossier_handle = task_meta_path(ctx, project_name, task_id)
     meta = read_task_meta(dossier_handle.parent, task_id) or {}
     meta.update(changes)
     write_task_meta(dossier_handle, meta)
 
 
-def create_task_with_mode(ctx: SimpleNamespace, project_id: str, *, mode: str = "cli") -> str:
+def create_task_with_mode(ctx: SimpleNamespace, project_name: str, *, mode: str = "cli") -> str:
     """Create a new task and persist the requested mode in its metadata."""
-    task_id = task_new(project_id)
-    update_task_meta(ctx, project_id, task_id, mode=mode)
+    task_id = task_new(project_name)
+    update_task_meta(ctx, project_name, task_id, mode=mode)
     return task_id
 
 
@@ -102,7 +102,7 @@ def test_container_state_handles_success_and_errors(
 
 
 @pytest.mark.parametrize(
-    ("project_id", "shutdown_timeout", "timeout_override", "expected_timeout"),
+    ("project_name", "shutdown_timeout", "timeout_override", "expected_timeout"),
     [
         pytest.param("proj_stop", None, None, 10, id="default-timeout"),
         pytest.param("proj_stop_cfg", 30, None, 30, id="config-timeout"),
@@ -110,17 +110,17 @@ def test_container_state_handles_success_and_errors(
     ],
 )
 def test_task_stop_uses_expected_timeout(
-    project_id: str,
+    project_name: str,
     shutdown_timeout: int | None,
     timeout_override: int | None,
     expected_timeout: int,
 ) -> None:
     """Stopping a task uses the default, configured, or explicit timeout."""
     with project_env(
-        project_config(project_id, shutdown_timeout=shutdown_timeout),
-        project_id=project_id,
+        project_config(project_name, shutdown_timeout=shutdown_timeout),
+        project_name=project_name,
     ) as ctx:
-        task_id = create_task_with_mode(ctx, project_id)
+        task_id = create_task_with_mode(ctx, project_name)
 
         container = _mock_container(state="running")
         runtime_mock = Mock(spec=PodmanRuntime)
@@ -131,30 +131,30 @@ def test_task_stop_uses_expected_timeout(
         ):
             capture_stdout(
                 task_stop,
-                project_id,
+                project_name,
                 task_id,
                 **({"timeout": timeout_override} if timeout_override is not None else {}),
             )
 
         # One call for state lookup, one call for stop
-        runtime_mock.container.assert_any_call(f"{project_id}-cli-{task_id}")
+        runtime_mock.container.assert_any_call(f"{project_name}-cli-{task_id}")
         container.stop.assert_called_once_with(timeout=expected_timeout)
 
 
 def test_task_stop_unknown_task_raises_system_exit() -> None:
     """Stopping a missing task raises a user-facing ``SystemExit``."""
-    project_id = "proj_stop_missing"
-    with project_env(project_config(project_id), project_id=project_id):
+    project_name = "proj_stop_missing"
+    with project_env(project_config(project_name), project_name=project_name):
         with mock_git_config(), pytest.raises(SystemExit, match="Unknown task"):
-            task_stop(project_id, "999")
+            task_stop(project_name, "999")
 
 
 def test_task_restart_starts_exited_container() -> None:
     """Restarting an exited task uses ``Container.start``."""
-    project_id = "proj_restart"
-    with project_env(project_config(project_id), project_id=project_id) as ctx:
-        task_id = create_task_with_mode(ctx, project_id)
-        container_name = f"{project_id}-cli-{task_id}"
+    project_name = "proj_restart"
+    with project_env(project_config(project_name), project_name=project_name) as ctx:
+        task_id = create_task_with_mode(ctx, project_name)
+        container_name = f"{project_name}-cli-{task_id}"
 
         # First state query → "exited"; subsequent queries (after start) → "running"
         container_states = iter(["exited", "running"])
@@ -180,7 +180,7 @@ def test_task_restart_starts_exited_container() -> None:
             mock_git_config(),
             patch("terok.lib.core.runtime.resolve_runtime", return_value=runtime_mock),
         ):
-            capture_stdout(task_restart, project_id, task_id)
+            capture_stdout(task_restart, project_name, task_id)
 
         runtime_mock.container.assert_any_call(container_name)
         assert container_name in cache, "runtime.container should have been queried for the task"
@@ -189,10 +189,10 @@ def test_task_restart_starts_exited_container() -> None:
 
 def test_task_restart_running_container_stops_then_starts() -> None:
     """Restarting a running task stops it first and then starts it again."""
-    project_id = "proj_restart_running"
-    with project_env(project_config(project_id), project_id=project_id) as ctx:
-        task_id = create_task_with_mode(ctx, project_id)
-        container_name = f"{project_id}-cli-{task_id}"
+    project_name = "proj_restart_running"
+    with project_env(project_config(project_name), project_name=project_name) as ctx:
+        task_id = create_task_with_mode(ctx, project_name)
+        container_name = f"{project_name}-cli-{task_id}"
 
         # Every state query returns "running"
         shared_container = _mock_container(state="running")
@@ -209,7 +209,7 @@ def test_task_restart_running_container_stops_then_starts() -> None:
             mock_git_config(),
             patch("terok.lib.core.runtime.resolve_runtime", return_value=runtime_mock),
         ):
-            output = capture_stdout(task_restart, project_id, task_id)
+            output = capture_stdout(task_restart, project_name, task_id)
 
         runtime_mock.container.assert_any_call(container_name)
         shared_container.stop.assert_called_once_with(timeout=10)
@@ -219,9 +219,9 @@ def test_task_restart_running_container_stops_then_starts() -> None:
 
 def test_task_status_reports_live_container_state() -> None:
     """Task status shows both live container state and derived effective status."""
-    project_id = "proj_status"
-    with project_env(project_config(project_id), project_id=project_id) as ctx:
-        task_id = create_task_with_mode(ctx, project_id)
+    project_name = "proj_status"
+    with project_env(project_config(project_name), project_name=project_name) as ctx:
+        task_id = create_task_with_mode(ctx, project_name)
 
         runtime_mock = Mock(spec=PodmanRuntime)
         runtime_mock.container.return_value = _mock_container(state="exited")
@@ -229,7 +229,7 @@ def test_task_status_reports_live_container_state() -> None:
             mock_git_config(),
             patch("terok.lib.core.runtime.resolve_runtime", return_value=runtime_mock),
         ):
-            output = capture_stdout(task_status, project_id, task_id)
+            output = capture_stdout(task_status, project_name, task_id)
 
     assert "exited" in output
     assert "stopped" in output
@@ -240,7 +240,7 @@ def test_get_task_container_state_returns_none_without_mode() -> None:
     assert get_task_container_state("proj", "1", None) is None
 
 
-def test_get_task_container_state_uses_project_id_and_mode() -> None:
+def test_get_task_container_state_uses_project_name_and_mode() -> None:
     """Task container lookup resolves the canonical container name.
 
     State queries are runtime-agnostic — ``podman inspect`` is the same
@@ -257,19 +257,19 @@ def test_get_task_container_state_uses_project_id_and_mode() -> None:
 
 def test_task_restart_no_mode_raises() -> None:
     """Restarting a task that never ran (no mode set) raises a user-facing SystemExit."""
-    project_id = "proj_restart_nomode"
-    with project_env(project_config(project_id), project_id=project_id):
+    project_name = "proj_restart_nomode"
+    with project_env(project_config(project_name), project_name=project_name):
         with mock_git_config():
-            task_id = task_new(project_id)  # fresh task — mode is None
+            task_id = task_new(project_name)  # fresh task — mode is None
             with pytest.raises(SystemExit, match="never been run"):
-                task_restart(project_id, task_id)
+                task_restart(project_name, task_id)
 
 
 def test_task_restart_missing_container_raises() -> None:
     """Restarting a task whose container is gone raises, pointing at ``task run``."""
-    project_id = "proj_restart_gone"
-    with project_env(project_config(project_id), project_id=project_id) as ctx:
-        task_id = create_task_with_mode(ctx, project_id)
+    project_name = "proj_restart_gone"
+    with project_env(project_config(project_name), project_name=project_name) as ctx:
+        task_id = create_task_with_mode(ctx, project_name)
 
         runtime_mock = Mock(spec=PodmanRuntime)
         runtime_mock.container.return_value = _mock_container(state=None)
@@ -278,14 +278,14 @@ def test_task_restart_missing_container_raises() -> None:
             patch("terok.lib.core.runtime.resolve_runtime", return_value=runtime_mock),
         ):
             with pytest.raises(SystemExit, match="no longer exists"):
-                task_restart(project_id, task_id)
+                task_restart(project_name, task_id)
 
 
 def test_task_restart_stop_failure_raises() -> None:
     """A RuntimeError from Container.stop surfaces as a user-facing SystemExit."""
-    project_id = "proj_restart_stopfail"
-    with project_env(project_config(project_id), project_id=project_id) as ctx:
-        task_id = create_task_with_mode(ctx, project_id)
+    project_name = "proj_restart_stopfail"
+    with project_env(project_config(project_name), project_name=project_name) as ctx:
+        task_id = create_task_with_mode(ctx, project_name)
 
         container = _mock_container(state="running")
         container.stop.side_effect = RuntimeError("container locked")
@@ -296,7 +296,7 @@ def test_task_restart_stop_failure_raises() -> None:
             patch("terok.lib.core.runtime.resolve_runtime", return_value=runtime_mock),
         ):
             with pytest.raises(SystemExit, match="Failed to stop container"):
-                task_restart(project_id, task_id)
+                task_restart(project_name, task_id)
 
 
 def test_task_restart_port_unavailable_aborts_before_stopping() -> None:
@@ -306,10 +306,10 @@ def test_task_restart_port_unavailable_aborts_before_stopping() -> None:
     safety property: a restart that would fail anyway must not first take
     down a working service.
     """
-    project_id = "proj_restart_port"
-    with project_env(project_config(project_id), project_id=project_id) as ctx:
-        task_id = create_task_with_mode(ctx, project_id, mode="toad")
-        update_task_meta(ctx, project_id, task_id, web_port=8080, web_token="tok")
+    project_name = "proj_restart_port"
+    with project_env(project_config(project_name), project_name=project_name) as ctx:
+        task_id = create_task_with_mode(ctx, project_name, mode="toad")
+        update_task_meta(ctx, project_name, task_id, web_port=8080, web_token="tok")
 
         container = _mock_container(state="running")
         runtime_mock = Mock(spec=PodmanRuntime)
@@ -324,18 +324,18 @@ def test_task_restart_port_unavailable_aborts_before_stopping() -> None:
             patch("terok.lib.orchestration.task_runners.restart.release_web_port") as release,
         ):
             with pytest.raises(SystemExit, match="no longer available"):
-                task_restart(project_id, task_id)
+                task_restart(project_name, task_id)
 
-        release.assert_called_once_with(project_id, task_id)
+        release.assert_called_once_with(project_name, task_id)
         container.stop.assert_not_called()
 
 
 def test_task_restart_toad_rehydrates_token_and_prints_url() -> None:
     """Restarting a running toad task rehydrates its token and prints the browser URL."""
-    project_id = "proj_restart_toad"
-    with project_env(project_config(project_id), project_id=project_id) as ctx:
-        task_id = create_task_with_mode(ctx, project_id, mode="toad")
-        update_task_meta(ctx, project_id, task_id, web_port=8080, web_token="sekret")
+    project_name = "proj_restart_toad"
+    with project_env(project_config(project_name), project_name=project_name) as ctx:
+        task_id = create_task_with_mode(ctx, project_name, mode="toad")
+        update_task_meta(ctx, project_name, task_id, web_port=8080, web_token="sekret")
 
         container = _mock_container(state="running")
         runtime_mock = Mock(spec=PodmanRuntime)
@@ -351,7 +351,7 @@ def test_task_restart_toad_rehydrates_token_and_prints_url() -> None:
                 "terok.lib.orchestration.task_runners.restart._rehydrate_toad_token"
             ) as rehydrate,
         ):
-            output = capture_stdout(task_restart, project_id, task_id)
+            output = capture_stdout(task_restart, project_name, task_id)
 
         rehydrate.assert_called_once()
         container.stop.assert_called_once()

--- a/tests/unit/lib/test_environment_gate_server.py
+++ b/tests/unit/lib/test_environment_gate_server.py
@@ -45,7 +45,7 @@ def gate_mounts(volumes: list) -> list:
 def resolve_security_env(
     yaml_text: str,
     *,
-    project_id: str,
+    project_name: str,
     with_gate: bool,
     token: str | None = None,
     use_socket: bool = False,
@@ -58,7 +58,7 @@ def resolve_security_env(
     """
     with (
         mock_git_config(),
-        project_env(yaml_text, project_id=project_id, with_gate=with_gate) as ctx,
+        project_env(yaml_text, project_name=project_name, with_gate=with_gate) as ctx,
         patch(
             "terok.lib.orchestration.environment.mint_gate_token",
             return_value=token or "tok" * 10 + "ab",
@@ -70,7 +70,7 @@ def resolve_security_env(
     ):
         from terok.lib.integrations.sandbox import SandboxConfig
 
-        project = load_project(project_id)
+        project = load_project(project_name)
         env, volumes = _security_mode_env_and_volumes(
             project, SandboxConfig(), use_socket=use_socket
         )
@@ -78,7 +78,7 @@ def resolve_security_env(
 
 
 @pytest.mark.parametrize(
-    ("yaml_text", "project_id", "token", "env_key"),
+    ("yaml_text", "project_name", "token", "env_key"),
     [
         pytest.param(_GATEKEEPING_YAML, "gk-proj", "deadbeef" * 4, "CODE_REPO", id="gatekeeping"),
         pytest.param(_ONLINE_YAML, "online-proj", "cafebabe" * 4, "CLONE_FROM", id="online"),
@@ -86,19 +86,19 @@ def resolve_security_env(
 )
 def test_gate_projects_use_http_urls_with_tokens(
     yaml_text: str,
-    project_id: str,
+    project_name: str,
     token: str,
     env_key: str,
 ) -> None:
     """Gate-backed project modes generate token-authenticated localhost HTTP URLs."""
     project, env, volumes = resolve_security_env(
         yaml_text,
-        project_id=project_id,
+        project_name=project_name,
         with_gate=True,
         token=token,
     )
 
-    assert env[env_key] == gate_repo_url(project_id, token)
+    assert env[env_key] == gate_repo_url(project_name, token)
     # The minted token is also surfaced for the supervisor to validate.
     assert env["TEROK_GATE_TOKEN"] == token
     # The gate runs in the per-container supervisor — no host bind-mount.
@@ -112,7 +112,7 @@ def test_gate_projects_use_http_urls_with_tokens(
 
 def test_gatekeeping_missing_gate_raises() -> None:
     """Gatekeeping mode requires a synced gate mirror before task startup."""
-    with mock_git_config(), project_env(_GATEKEEPING_YAML, project_id="gk-proj", with_gate=False):
+    with mock_git_config(), project_env(_GATEKEEPING_YAML, project_name="gk-proj", with_gate=False):
         project = load_project("gk-proj")
         with pytest.raises(SystemExit, match="gate-sync"):
             _security_mode_env_and_volumes(project, MagicMock())
@@ -122,7 +122,7 @@ def test_online_gate_uses_clone_from_and_gate_remote() -> None:
     """Online mode with a gate mirror uses CLONE_FROM + a named gate remote."""
     _project, env, volumes = resolve_security_env(
         _ONLINE_YAML,
-        project_id="online-proj",
+        project_name="online-proj",
         with_gate=True,
         token="cafebabe" * 4,
     )
@@ -141,7 +141,7 @@ def test_online_without_gate_has_no_clone_from() -> None:
     """Online mode without a gate mirror clones directly from upstream only."""
     _project, env, volumes = resolve_security_env(
         _ONLINE_YAML,
-        project_id="online-proj",
+        project_name="online-proj",
         with_gate=False,
     )
     assert "CLONE_FROM" not in env
@@ -155,7 +155,7 @@ def test_gatekeeping_does_not_set_gate_remote_url() -> None:
     """Gatekeeping mode keeps the gate as origin — no separate "gate" remote."""
     _project, env, _volumes = resolve_security_env(
         _GATEKEEPING_YAML,
-        project_id="gk-proj",
+        project_name="gk-proj",
         with_gate=True,
         token="deadbeef" * 4,
     )
@@ -175,7 +175,7 @@ def test_socket_mode_sets_gate_socket_env_without_mount() -> None:
 
     _project, env, volumes = resolve_security_env(
         _GATEKEEPING_YAML,
-        project_id="gk-proj",
+        project_name="gk-proj",
         with_gate=True,
         token="d" * 32,
         use_socket=True,
@@ -202,7 +202,7 @@ def test_project_mounts_dir_shared_returns_global() -> None:
     from terok.lib.core.config import sandbox_live_mounts_dir
     from terok.lib.orchestration.environment import project_mounts_dir
 
-    with mock_git_config(), project_env(_ONLINE_YAML, project_id="online-proj"):
+    with mock_git_config(), project_env(_ONLINE_YAML, project_name="online-proj"):
         project = load_project("online-proj")
         assert project_mounts_dir(project) == sandbox_live_mounts_dir()
 
@@ -212,7 +212,7 @@ def test_project_mounts_dir_project_returns_per_project_subtree() -> None:
     from terok.lib.orchestration.environment import project_mounts_dir
 
     yaml_text = _ONLINE_YAML + "credentials:\n  scope: project\n"
-    with mock_git_config(), project_env(yaml_text, project_id="online-proj"):
+    with mock_git_config(), project_env(yaml_text, project_name="online-proj"):
         project = load_project("online-proj")
         assert project_mounts_dir(project) == project.root / "mounts"
 
@@ -221,7 +221,7 @@ def test_check_project_credentials_present_shared_is_noop() -> None:
     """Shared-scope projects skip the check — host-wide bucket may be empty by design."""
     from terok.lib.orchestration.environment import _check_project_credentials_present
 
-    with mock_git_config(), project_env(_ONLINE_YAML, project_id="online-proj"):
+    with mock_git_config(), project_env(_ONLINE_YAML, project_name="online-proj"):
         project = load_project("online-proj")
         # Even with an empty vault, shared-scope projects must not raise —
         # the agent prompts for login on first turn (existing behaviour).
@@ -238,7 +238,7 @@ def test_check_project_credentials_present_empty_bucket_raises() -> None:
     from terok.lib.orchestration.environment import _check_project_credentials_present
 
     yaml_text = _ONLINE_YAML + "credentials:\n  scope: project\n"
-    with mock_git_config(), project_env(yaml_text, project_id="online-proj"):
+    with mock_git_config(), project_env(yaml_text, project_name="online-proj"):
         project = load_project("online-proj")
         with (
             patch("terok.lib.integrations.executor.list_authenticated_agents", return_value=[]),
@@ -252,7 +252,7 @@ def test_check_project_credentials_present_populated_bucket_passes() -> None:
     from terok.lib.orchestration.environment import _check_project_credentials_present
 
     yaml_text = _ONLINE_YAML + "credentials:\n  scope: project\n"
-    with mock_git_config(), project_env(yaml_text, project_id="online-proj"):
+    with mock_git_config(), project_env(yaml_text, project_name="online-proj"):
         project = load_project("online-proj")
         with patch(
             "terok.lib.integrations.executor.list_authenticated_agents",

--- a/tests/unit/lib/test_git_gate.py
+++ b/tests/unit/lib/test_git_gate.py
@@ -24,14 +24,14 @@ TEST_UPSTREAM_URL = "https://example.com/repo.git"
 
 
 def git_project_yaml(
-    project_id: str,
+    project_name: str,
     *,
     upstream_url: str | None = TEST_UPSTREAM_URL,
     default_branch: str | None = "main",
     gate_path: Path | None = None,
 ) -> str:
     """Build a project config for git-gate-related tests."""
-    lines = [f"project:\n  id: {project_id}\n"]
+    lines = [f"project:\n  id: {project_name}\n"]
     if upstream_url is not None or default_branch is not None:
         lines.append("git:\n")
         if upstream_url is not None:
@@ -51,7 +51,7 @@ def git_result(*, returncode: int = 0, stdout: str = "", stderr: str = "") -> Ma
 
 def configure_shared_gate(
     ctx,
-    project_id: str,
+    project_name: str,
     upstream_url: str,
     gate_name: str,
 ) -> Path:
@@ -60,9 +60,9 @@ def configure_shared_gate(
     shared_gate.mkdir(parents=True, exist_ok=True)
     write_project(
         ctx.config_root,
-        project_id,
+        project_name,
         git_project_yaml(
-            project_id, upstream_url=upstream_url, default_branch=None, gate_path=shared_gate
+            project_name, upstream_url=upstream_url, default_branch=None, gate_path=shared_gate
         ),
     )
     return shared_gate
@@ -72,27 +72,27 @@ def test_sync_project_gate_ssh_requires_config() -> None:
     """SSH upstreams require a vault key or explicit personal-SSH opt-in before syncing."""
     from terok_sandbox.gate.mirror import GateAuthNotConfigured
 
-    project_id = "proj6"
+    project_name = "proj6"
     with (
         project_env(
             git_project_yaml(
-                project_id, upstream_url="git@github.com:org/repo.git", default_branch=None
+                project_name, upstream_url="git@github.com:org/repo.git", default_branch=None
             ),
-            project_id=project_id,
+            project_name=project_name,
             with_config_file=True,
         ),
         pytest.raises(GateAuthNotConfigured),
     ):
-        make_git_gate(load_project(project_id)).sync()
+        make_git_gate(load_project(project_name)).sync()
 
 
 def test_sync_project_gate_https_clone() -> None:
     """Initial gate sync performs a mirror clone with git env overrides."""
-    project_id = "proj7"
+    project_name = "proj7"
     with project_env(
-        git_project_yaml(project_id, default_branch=None), project_id=project_id
+        git_project_yaml(project_name, default_branch=None), project_name=project_name
     ) as ctx:
-        gate_dir = ctx.base / "sandbox-state" / "gate" / f"{project_id}.git"
+        gate_dir = ctx.base / "sandbox-state" / "gate" / f"{project_name}.git"
 
         def run_side_effect(cmd: list[str], **kwargs: object) -> MagicMock:
             if cmd[:3] == ["git", "clone", "--mirror"]:
@@ -105,7 +105,7 @@ def test_sync_project_gate_https_clone() -> None:
         with patch(
             "terok_sandbox.gate.mirror.subprocess.run", side_effect=run_side_effect
         ) as run_mock:
-            result = make_git_gate(load_project(project_id)).sync()
+            result = make_git_gate(load_project(project_name)).sync()
 
     assert result == {
         "path": str(gate_dir),
@@ -143,13 +143,13 @@ def test_sync_project_gate_https_clone() -> None:
 )
 def test_last_commit(with_gate: bool, run_result: MagicMock | None, expected: dict | None) -> None:
     """Last-commit lookup returns commit metadata when the gate exists."""
-    project_id = "proj-last-commit"
+    project_name = "proj-last-commit"
     with project_env(
-        git_project_yaml(project_id, default_branch=None),
-        project_id=project_id,
+        git_project_yaml(project_name, default_branch=None),
+        project_name=project_name,
         with_gate=with_gate,
     ):
-        gate = make_git_gate(load_project(project_id))
+        gate = make_git_gate(load_project(project_name))
         if run_result is None:
             assert gate.last_commit() is None
         else:
@@ -158,7 +158,7 @@ def test_last_commit(with_gate: bool, run_result: MagicMock | None, expected: di
 
 
 @pytest.mark.parametrize(
-    ("project_id", "yaml_text", "branch", "run_behavior", "expected"),
+    ("project_name", "yaml_text", "branch", "run_behavior", "expected"),
     [
         pytest.param(
             "proj-upstream-ok",
@@ -223,15 +223,15 @@ def test_last_commit(with_gate: bool, run_result: MagicMock | None, expected: di
     ],
 )
 def test_get_upstream_head(
-    project_id: str,
+    project_name: str,
     yaml_text: str,
     branch: str | None,
     run_behavior: dict[str, object] | None,
     expected: dict | None,
 ) -> None:
     """Upstream HEAD lookup handles success, missing config, and network failures."""
-    with project_env(yaml_text, project_id=project_id):
-        project = load_project(project_id)
+    with project_env(yaml_text, project_name=project_name):
+        project = load_project(project_name)
         if project.upstream_url is None or run_behavior is None:
             assert expected is None
         else:
@@ -263,9 +263,11 @@ def test_get_gate_branch_head(
     expected: str | None,
 ) -> None:
     """Gate branch HEAD lookup returns the branch commit or ``None``."""
-    project_id = "proj-gate-head"
-    with project_env(git_project_yaml(project_id), project_id=project_id, with_gate=with_gate):
-        project = load_project(project_id)
+    project_name = "proj-gate-head"
+    with project_env(
+        git_project_yaml(project_name), project_name=project_name, with_gate=with_gate
+    ):
+        project = load_project(project_name)
         effective_branch = branch or project.default_branch
         if run_result is None:
             assert _get_gate_branch_head(project.gate_path, effective_branch, {}) is None
@@ -380,7 +382,7 @@ def test_compare_gate_vs_upstream(
     expected: dict[str, object],
 ) -> None:
     """Gate staleness comparison reports sync, stale, and error states."""
-    project_id = "proj-compare"
+    project_name = "proj-compare"
 
     def _range_side_effect(_gate_dir, from_ref, to_ref, _env):
         """Return behind or ahead count depending on ref order."""
@@ -391,7 +393,9 @@ def test_compare_gate_vs_upstream(
                 return count_ahead
         return None
 
-    with project_env(git_project_yaml(project_id), project_id=project_id, with_gate=with_gate):
+    with project_env(
+        git_project_yaml(project_name), project_name=project_name, with_gate=with_gate
+    ):
         with (
             patch("terok_sandbox.gate.mirror._get_gate_branch_head", return_value=gate_head),
             patch("terok_sandbox.gate.mirror._get_upstream_head", return_value=upstream_info),
@@ -400,7 +404,7 @@ def test_compare_gate_vs_upstream(
                 side_effect=_range_side_effect,
             ),
         ):
-            result = make_git_gate(load_project(project_id)).compare_vs_upstream()
+            result = make_git_gate(load_project(project_name)).compare_vs_upstream()
 
     assert result.branch == "main"
     for key, value in expected.items():
@@ -458,9 +462,11 @@ def test_sync_branches(
     expected: dict[str, object],
 ) -> None:
     """Branch sync reports success, initialization problems, and fetch failures."""
-    project_id = "proj-sync-branches"
-    with project_env(git_project_yaml(project_id), project_id=project_id, with_gate=with_gate):
-        gate = make_git_gate(load_project(project_id))
+    project_name = "proj-sync-branches"
+    with project_env(
+        git_project_yaml(project_name), project_name=project_name, with_gate=with_gate
+    ):
+        gate = make_git_gate(load_project(project_name))
         if run_behavior is None:
             assert gate.sync_branches(branches) == expected
         else:
@@ -476,7 +482,7 @@ def test_sync_branches_rejects_mismatched_upstream() -> None:
             upstream_url="https://github.com/org/existing-repo.git",
             default_branch=None,
         ),
-        project_id="existing-proj",
+        project_name="existing-proj",
     ) as ctx:
         shared_gate = configure_shared_gate(
             ctx, "existing-proj", "https://github.com/org/existing-repo.git", "sync-conflict.git"
@@ -502,7 +508,7 @@ def test_find_projects_sharing_gate() -> None:
         git_project_yaml(
             "proj-a", upstream_url="https://github.com/org/repo.git", default_branch=None
         ),
-        project_id="proj-a",
+        project_name="proj-a",
     ) as ctx:
         shared_gate = configure_shared_gate(
             ctx, "proj-a", "https://github.com/org/repo.git", "shared.git"
@@ -529,7 +535,7 @@ def test_validate_gate_upstream_match_same_url() -> None:
         git_project_yaml(
             "proj-same-a", upstream_url="https://github.com/org/repo.git", default_branch=None
         ),
-        project_id="proj-same-a",
+        project_name="proj-same-a",
     ) as ctx:
         shared_gate = configure_shared_gate(
             ctx, "proj-same-a", "https://github.com/org/repo.git", "shared.git"
@@ -555,7 +561,7 @@ def test_validate_gate_upstream_match_different_url_fails() -> None:
         git_project_yaml(
             "proj-conflict-a", upstream_url="https://github.com/org/repo-A.git", default_branch=None
         ),
-        project_id="proj-conflict-a",
+        project_name="proj-conflict-a",
     ) as ctx:
         shared_gate = configure_shared_gate(
             ctx, "proj-conflict-a", "https://github.com/org/repo-A.git", "conflict.git"
@@ -590,7 +596,7 @@ def test_sync_project_gate_rejects_mismatched_upstream() -> None:
             upstream_url="https://github.com/org/existing-repo.git",
             default_branch=None,
         ),
-        project_id="existing-proj",
+        project_name="existing-proj",
     ) as ctx:
         shared_gate = configure_shared_gate(
             ctx, "existing-proj", "https://github.com/org/existing-repo.git", "init-conflict.git"

--- a/tests/unit/lib/test_hooks.py
+++ b/tests/unit/lib/test_hooks.py
@@ -22,7 +22,7 @@ class TestBuildHookEnv:
         """Verify core environment variables are set."""
         env = _build_hook_env("proj", "1", "toad", "proj-toad-1", "post_ready")
         assert env["TEROK_HOOK"] == "post_ready"
-        assert env["TEROK_PROJECT_ID"] == "proj"
+        assert env["TEROK_PROJECT_NAME"] == "proj"
         assert env["TEROK_TASK_ID"] == "1"
         assert env["TEROK_TASK_MODE"] == "toad"
         assert env["TEROK_CONTAINER_NAME"] == "proj-toad-1"
@@ -155,7 +155,7 @@ class TestRunHook:
         run_hook(
             "post_start",
             None,
-            project_id="p",
+            project_name="p",
             task_id="1",
             mode="cli",
             cname="c",
@@ -166,7 +166,7 @@ class TestRunHook:
         run_hook(
             "post_start",
             "",
-            project_id="p",
+            project_name="p",
             task_id="1",
             mode="cli",
             cname="c",
@@ -178,7 +178,7 @@ class TestRunHook:
             run_hook(
                 "post_start",
                 "echo hello",
-                project_id="proj",
+                project_name="proj",
                 task_id="1",
                 mode="cli",
                 cname="proj-cli-1",
@@ -189,7 +189,7 @@ class TestRunHook:
             assert args[0][0] == ["sh", "-c", "echo hello"]
             env = args[1]["env"]
             assert env["TEROK_HOOK"] == "post_start"
-            assert env["TEROK_PROJECT_ID"] == "proj"
+            assert env["TEROK_PROJECT_NAME"] == "proj"
 
     def test_post_stop_has_timeout(self) -> None:
         """Verify post_stop hooks have a 30s timeout."""
@@ -197,7 +197,7 @@ class TestRunHook:
             run_hook(
                 "post_stop",
                 "cleanup.sh",
-                project_id="p",
+                project_name="p",
                 task_id="1",
                 mode="cli",
                 cname="c",
@@ -210,7 +210,7 @@ class TestRunHook:
             run_hook(
                 "pre_start",
                 "setup.sh",
-                project_id="p",
+                project_name="p",
                 task_id="1",
                 mode="cli",
                 cname="c",
@@ -223,7 +223,7 @@ class TestRunHook:
             run_hook(
                 "post_start",
                 "setup.sh",
-                project_id="p",
+                project_name="p",
                 task_id="1",
                 mode="cli",
                 cname="c",
@@ -236,7 +236,7 @@ class TestRunHook:
             run_hook(
                 "post_ready",
                 "fwd.sh",
-                project_id="p",
+                project_name="p",
                 task_id="1",
                 mode="toad",
                 cname="c",
@@ -254,7 +254,7 @@ class TestRunHook:
             run_hook(
                 "post_start",
                 "fail.sh",
-                project_id="p",
+                project_name="p",
                 task_id="1",
                 mode="cli",
                 cname="c",
@@ -269,7 +269,7 @@ class TestRunHook:
             run_hook(
                 "post_stop",
                 "slow.sh",
-                project_id="p",
+                project_name="p",
                 task_id="1",
                 mode="cli",
                 cname="c",
@@ -288,7 +288,7 @@ class TestRunHook:
             run_hook(
                 "post_start",
                 "echo hi",
-                project_id="p",
+                project_name="p",
                 task_id="1",
                 mode="cli",
                 cname="c",
@@ -309,7 +309,7 @@ class TestRunHook:
         run_hook(
             "post_ready",
             None,
-            project_id="p",
+            project_name="p",
             task_id="1",
             mode="cli",
             cname="c",

--- a/tests/unit/lib/test_image.py
+++ b/tests/unit/lib/test_image.py
@@ -18,7 +18,7 @@ DEFAULT_BRANCH = "main"
 
 
 @contextmanager
-def image_project(project_id: str, *, security_class: str = "online") -> Iterator[object]:
+def image_project(project_name: str, *, security_class: str = "online") -> Iterator[object]:
     """Create a minimal project config suitable for Dockerfile generation tests.
 
     Pins ``image.base_image`` to ubuntu:24.04 so generated Dockerfiles
@@ -28,7 +28,7 @@ def image_project(project_id: str, *, security_class: str = "online") -> Iterato
     every time the upstream default moves (e.g. ubuntu→fedora).
     """
     lines = [
-        f"project:\n  id: {project_id}\n",
+        f"project:\n  id: {project_name}\n",
         f"  security_class: {security_class}\n",
         "git:\n",
     ]
@@ -36,7 +36,7 @@ def image_project(project_id: str, *, security_class: str = "online") -> Iterato
     lines.append(f"  default_branch: {DEFAULT_BRANCH}\n")
     lines.append("image:\n  base_image: ubuntu:24.04\n")
     yaml = "".join(lines)
-    with project_env(yaml, project_id=project_id) as env:
+    with project_env(yaml, project_name=project_name) as env:
         yield env
 
 
@@ -48,7 +48,7 @@ def _mock_base_images(base_image: str = "ubuntu:24.04") -> ImageSet:
 
 
 def build_commands(
-    project_id: str,
+    project_name: str,
     *,
     image_exists: bool = True,
     image_exists_side_effect: Callable[[str], bool] | None = None,
@@ -80,16 +80,16 @@ def build_commands(
         image_exists_patch,
         mock_git_config(),
     ):
-        build_images(project_id, **build_kwargs)
+        build_images(project_name, **build_kwargs)
     return commands
 
 
 def test_generate_dockerfiles_outputs_expected_files_and_content() -> None:
     """Dockerfile generation writes all expected layers and helper scripts."""
-    project_id = "proj4"
-    with image_project(project_id):
-        generate_dockerfiles(project_id)
-        out_dir = build_dir() / project_id
+    project_name = "proj4"
+    with image_project(project_name):
+        generate_dockerfiles(project_name)
+        out_dir = build_dir() / project_name
 
         assert all(
             (out_dir / name).is_file()
@@ -134,7 +134,7 @@ def test_l2_includes_user_snippet_inline() -> None:
         "git:\n  upstream_url: https://example.com/repo.git\n"
         "image:\n  user_snippet_inline: RUN apt-get install -y fortran-compiler\n"
     )
-    with project_env(yaml, project_id="proj_snippet"):
+    with project_env(yaml, project_name="proj_snippet"):
         generate_dockerfiles("proj_snippet")
         content = (build_dir() / "proj_snippet" / "L2.Dockerfile").read_text(encoding="utf-8")
         assert "RUN apt-get install -y fortran-compiler" in content
@@ -155,7 +155,7 @@ def test_l2_includes_user_snippet_from_file() -> None:
             "git:\n  upstream_url: https://example.com/repo.git\n"
             f"image:\n  user_snippet_file: {snippet_path}\n"
         )
-        with project_env(yaml, project_id="proj_snippet_file"):
+        with project_env(yaml, project_name="proj_snippet_file"):
             generate_dockerfiles("proj_snippet_file")
             content = (build_dir() / "proj_snippet_file" / "L2.Dockerfile").read_text(
                 encoding="utf-8"
@@ -181,7 +181,7 @@ def test_l2_combines_snippet_file_and_inline() -> None:
             f"image:\n  user_snippet_file: {snippet_path}\n"
             "  user_snippet_inline: RUN apt-get install -y fortran-compiler\n"
         )
-        with project_env(yaml, project_id="proj_both_snippets"):
+        with project_env(yaml, project_name="proj_both_snippets"):
             generate_dockerfiles("proj_both_snippets")
             content = (build_dir() / "proj_both_snippets" / "L2.Dockerfile").read_text(
                 encoding="utf-8"
@@ -203,7 +203,7 @@ def test_l2_missing_snippet_file_exits() -> None:
         "git:\n  upstream_url: https://example.com/repo.git\n"
         "image:\n  user_snippet_file: /nonexistent/snippet.dockerfile\n"
     )
-    with project_env(yaml, project_id="proj_bad_snippet"):
+    with project_env(yaml, project_name="proj_bad_snippet"):
         with pytest.raises(SystemExit, match="not found"):
             generate_dockerfiles("proj_bad_snippet")
 
@@ -361,14 +361,14 @@ class TestPerLayerHashes:
 
 @contextmanager
 def image_project_with(
-    project_id: str,
+    project_name: str,
     *,
     base_image: str = "ubuntu:24.04",
     family: str | None = None,
 ) -> Iterator[object]:
     """Variant of `image_project` that sets ``image.base_image`` (and ``image.family``)."""
     lines = [
-        f"project:\n  id: {project_id}\n",
+        f"project:\n  id: {project_name}\n",
         "git:\n",
         f"  upstream_url: {UPSTREAM_URL}\n",
         f"  default_branch: {DEFAULT_BRANCH}\n",
@@ -377,7 +377,7 @@ def image_project_with(
     ]
     if family is not None:
         lines.append(f"  family: {family}\n")
-    with project_env("".join(lines), project_id=project_id) as env:
+    with project_env("".join(lines), project_name=project_name) as env:
         yield env
 
 

--- a/tests/unit/lib/test_image_cleanup.py
+++ b/tests/unit/lib/test_image_cleanup.py
@@ -79,7 +79,7 @@ class TestListImages:
     """Tests for ``list_images()``."""
 
     @pytest.mark.parametrize(
-        ("images_spec", "project_id", "expected_names"),
+        ("images_spec", "project_name", "expected_names"),
         [
             (
                 [
@@ -112,18 +112,18 @@ class TestListImages:
         self,
         mock_runtime: unittest.mock.Mock,
         images_spec: list[tuple[str, str, str]],
-        project_id: str | None,
+        project_name: str | None,
         expected_names: set[str],
     ) -> None:
         """Runtime enumeration is filtered to terok images (optionally by project)."""
         mock_runtime.images.return_value = [
             _mock_image(ref=ref, repository=repo, tag=tag) for ref, repo, tag in images_spec
         ]
-        images = list_images(project_id)
+        images = list_images(project_name)
         assert {image.full_name for image in images} == expected_names
 
     @pytest.mark.parametrize(
-        ("project_id", "expected_names"),
+        ("project_name", "expected_names"),
         [
             (
                 None,
@@ -143,7 +143,7 @@ class TestListImages:
     def test_list_images_handles_localhost_prefix(
         self,
         mock_runtime: unittest.mock.Mock,
-        project_id: str | None,
+        project_name: str | None,
         expected_names: set[str],
     ) -> None:
         """Podman's ``localhost/`` prefix on the repo must not hide terok images."""
@@ -152,7 +152,7 @@ class TestListImages:
             _mock_image(ref="sha256:aa", repository="localhost/proj-a", tag="l2-cli"),
             _mock_image(ref="sha256:bb", repository="localhost/proj-b", tag="l2-cli"),
         ]
-        images = list_images(project_id)
+        images = list_images(project_name)
         assert {image.full_name for image in images} == expected_names
 
     # removed — mock_runtime fixture handles it
@@ -210,7 +210,7 @@ class TestFindOrphanedImages:
     @unittest.mock.patch("terok.lib.domain.image_cleanup._is_terok_built_image")
     @unittest.mock.patch("terok.lib.domain.image_cleanup._find_dangling_terok_images")
     @unittest.mock.patch("terok.lib.domain.image_cleanup.list_images")
-    @unittest.mock.patch("terok.lib.domain.image_cleanup._known_project_ids")
+    @unittest.mock.patch("terok.lib.domain.image_cleanup._known_project_names")
     def test_find_orphaned_images(
         self,
         mock_known: unittest.mock.Mock,
@@ -238,8 +238,8 @@ class TestFindOrphanedImages:
         "terok.lib.domain.image_cleanup._find_dangling_terok_images", return_value=[]
     )
     @unittest.mock.patch("terok.lib.domain.image_cleanup.list_images")
-    @unittest.mock.patch("terok.lib.domain.image_cleanup._known_project_ids")
-    def test_localhost_prefixed_image_matches_bare_project_id(
+    @unittest.mock.patch("terok.lib.domain.image_cleanup._known_project_names")
+    def test_localhost_prefixed_image_matches_bare_project_name(
         self,
         mock_known: unittest.mock.Mock,
         mock_list: unittest.mock.Mock,

--- a/tests/unit/lib/test_krun_runtime_wiring.py
+++ b/tests/unit/lib/test_krun_runtime_wiring.py
@@ -26,7 +26,7 @@ def _krun_project(**overrides):  # type: ignore[no-untyped-def]
     from terok.lib.core.project_model import ProjectConfig
 
     defaults: dict[str, object] = {
-        "id": "p",
+        "name": "p",
         "security_class": "online",
         "upstream_url": None,
         "default_branch": None,
@@ -45,7 +45,7 @@ def _project(**overrides):  # type: ignore[no-untyped-def]
     from terok.lib.core.project_model import ProjectConfig
 
     defaults: dict[str, object] = {
-        "id": "demoproj",
+        "name": "demoproj",
         "security_class": "online",
         "upstream_url": None,
         "default_branch": None,

--- a/tests/unit/lib/test_login.py
+++ b/tests/unit/lib/test_login.py
@@ -21,14 +21,14 @@ from terok.lib.orchestration.tasks import (
 from tests.test_utils import mock_git_config, project_env
 
 
-def project_yaml(project_id: str, extra: str = "") -> str:
+def project_yaml(project_name: str, extra: str = "") -> str:
     """Build a minimal project config for login tests."""
-    return f"project:\n  id: {project_id}\n{extra}"
+    return f"project:\n  id: {project_name}\n{extra}"
 
 
 def setup_task_with_mode(
     ctx: types.SimpleNamespace,
-    project_id: str,
+    project_name: str,
     *,
     mode: str | None = None,
 ) -> str:
@@ -36,9 +36,9 @@ def setup_task_with_mode(
 
     Returns the task ID.
     """
-    task_id = task_new(project_id)
+    task_id = task_new(project_name)
     if mode:
-        meta_dir = ctx.state_dir / "projects" / project_id / "tasks"
+        meta_dir = ctx.state_dir / "projects" / project_name / "tasks"
         meta = read_task_meta(meta_dir, task_id) or {}
         meta["mode"] = mode
         write_task_meta(dossier_path(meta_dir, task_id), meta)
@@ -64,7 +64,7 @@ class TestLogin:
     """Tests for task_login, get_login_command, and validation."""
 
     @pytest.mark.parametrize(
-        ("project_id", "mode", "container_state", "error_text"),
+        ("project_name", "mode", "container_state", "error_text"),
         [
             ("proj_login_unknown", None, None, "Unknown task"),
             ("proj_login_nomode", None, None, "never been run"),
@@ -75,27 +75,29 @@ class TestLogin:
     )
     def test_task_login_errors(
         self,
-        project_id: str,
+        project_name: str,
         mode: str | None,
         container_state: str | None,
         error_text: str,
         mock_runtime,
     ) -> None:
         mock_runtime.container.return_value.state = container_state
-        with project_env(project_yaml(project_id), project_id=project_id) as ctx:
+        with project_env(project_yaml(project_name), project_name=project_name) as ctx:
             task_id = "k3v8h"  # nonexistent by default
-            if project_id != "proj_login_unknown":
-                task_id = setup_task_with_mode(ctx, project_id, mode=mode)
+            if project_name != "proj_login_unknown":
+                task_id = setup_task_with_mode(ctx, project_name, mode=mode)
             with pytest.raises(SystemExit) as exc_ctx:
-                task_login(project_id, "k3v8h" if project_id == "proj_login_unknown" else task_id)
+                task_login(
+                    project_name, "k3v8h" if project_name == "proj_login_unknown" else task_id
+                )
             assert error_text in str(exc_ctx.value)
 
     def test_task_login_success(self, mock_runtime) -> None:
         """task_login calls os.execvp with the correct podman+tmux command."""
-        project_id = "proj-cli"
-        with project_env(project_yaml(project_id), project_id=project_id) as ctx:
-            task_id = setup_task_with_mode(ctx, project_id, mode="cli")
-            expected_container = f"{project_id}-cli-{task_id}"
+        project_name = "proj-cli"
+        with project_env(project_yaml(project_name), project_name=project_name) as ctx:
+            task_id = setup_task_with_mode(ctx, project_name, mode="cli")
+            expected_container = f"{project_name}-cli-{task_id}"
             mock_runtime.container.return_value.state = "running"
             mock_runtime.container.return_value.login_command.return_value = _login_command(
                 expected_container
@@ -103,7 +105,7 @@ class TestLogin:
             with unittest.mock.patch(
                 "terok.lib.orchestration.tasks.lifecycle.os.execvp"
             ) as mock_exec:
-                task_login(project_id, task_id)
+                task_login(project_name, task_id)
         mock_exec.assert_called_once_with("podman", _login_command(expected_container))
 
     @pytest.mark.parametrize(
@@ -116,31 +118,31 @@ class TestLogin:
         mode: str,
         mock_runtime,
     ) -> None:
-        project_id = "proj_logincmd" if mode == "cli" else "proj_loginweb"
-        with project_env(project_yaml(project_id), project_id=project_id) as ctx:
-            task_id = setup_task_with_mode(ctx, project_id, mode=mode)
-            expected_container = f"{project_id}-{mode}-{task_id}"
+        project_name = "proj_logincmd" if mode == "cli" else "proj_loginweb"
+        with project_env(project_yaml(project_name), project_name=project_name) as ctx:
+            task_id = setup_task_with_mode(ctx, project_name, mode=mode)
+            expected_container = f"{project_name}-{mode}-{task_id}"
             mock_runtime.container.return_value.state = "running"
             mock_runtime.container.return_value.login_command.return_value = _login_command(
                 expected_container
             )
-            command = get_login_command(project_id, task_id)
+            command = get_login_command(project_name, task_id)
         assert command[3] == expected_container
         assert command[-5:] == ["tmux", "new-session", "-A", "-s", "main"]
 
     def test_login_no_longer_injects_agent_config(self, mock_runtime) -> None:
         """get_login_command does NOT inject agent config (handled via mount)."""
-        project_id = "proj_login_cfg"
-        yaml_text = f"project:\n  id: {project_id}\nagent:\n  model: sonnet\n"
-        with project_env(yaml_text, project_id=project_id) as ctx:
-            task_id = setup_task_with_mode(ctx, project_id, mode="cli")
-            expected_container = f"{project_id}-cli-{task_id}"
+        project_name = "proj_login_cfg"
+        yaml_text = f"project:\n  id: {project_name}\nagent:\n  model: sonnet\n"
+        with project_env(yaml_text, project_name=project_name) as ctx:
+            task_id = setup_task_with_mode(ctx, project_name, mode="cli")
+            expected_container = f"{project_name}-cli-{task_id}"
             mock_runtime.container.return_value.state = "running"
             mock_runtime.container.return_value.login_command.return_value = _login_command(
                 expected_container
             )
             with mock_git_config():
-                command = get_login_command(project_id, task_id)
+                command = get_login_command(project_name, task_id)
 
         assert command[3] == expected_container
         assert "tmux" in command

--- a/tests/unit/lib/test_panic.py
+++ b/tests/unit/lib/test_panic.py
@@ -26,10 +26,10 @@ _LOCK = "terok.lib.domain.panic._write_panic_lock"
 _STOP = "terok.lib.domain.panic._stop_containers"
 
 
-def _target(project_id="proj1", task_id="1", mode="cli"):
+def _target(project_name="proj1", task_id="1", mode="cli"):
     """Build a target tuple for testing."""
-    cname = f"{project_id}-{mode}-{task_id}"
-    return (project_id, task_id, mode, cname, FAKE_PROJECT_TASKS_ROOT / task_id)
+    cname = f"{project_name}-{mode}-{task_id}"
+    return (project_name, task_id, mode, cname, FAKE_PROJECT_TASKS_ROOT / task_id)
 
 
 def _task_meta(task_id, mode="cli"):
@@ -47,7 +47,8 @@ class TestDiscovery:
     @patch("terok.lib.domain.panic.get_all_task_states")
     def test_finds_running_skips_exited(self, mock_states, mock_tasks, mock_projects):
         """Only running/paused containers are discovered."""
-        cfg = MagicMock(id="proj1", tasks_root=FAKE_PROJECT_TASKS_ROOT)
+        cfg = MagicMock(tasks_root=FAKE_PROJECT_TASKS_ROOT)
+        cfg.name = "proj1"
         mock_projects.return_value = [cfg]
         mock_tasks.return_value = [_task_meta("1"), _task_meta("2", "web"), _task_meta("3", None)]
         mock_states.return_value = {"1": "running", "2": "exited", "3": None}
@@ -62,7 +63,9 @@ class TestDiscovery:
     @patch("terok.lib.domain.panic.get_tasks")
     def test_skips_broken_projects(self, mock_tasks, mock_projects):
         """Projects where get_tasks raises are skipped."""
-        mock_projects.return_value = [MagicMock(id="broken")]
+        broken = MagicMock()
+        broken.name = "broken"
+        mock_projects.return_value = [broken]
         mock_tasks.side_effect = Exception("boom")
 
         from terok.lib.domain.panic import _discover_targets
@@ -73,7 +76,9 @@ class TestDiscovery:
     @patch("terok.lib.domain.panic.get_tasks")
     def test_skips_projects_with_no_tasks(self, mock_tasks, mock_projects):
         """Projects with empty task list are skipped."""
-        mock_projects.return_value = [MagicMock(id="empty")]
+        empty = MagicMock()
+        empty.name = "empty"
+        mock_projects.return_value = [empty]
         mock_tasks.return_value = []
 
         from terok.lib.domain.panic import _discover_targets
@@ -85,7 +90,8 @@ class TestDiscovery:
     @patch("terok.lib.domain.panic.get_all_task_states")
     def test_includes_paused_containers(self, mock_states, mock_tasks, mock_projects):
         """Paused containers are also discovered."""
-        cfg = MagicMock(id="proj1", tasks_root=FAKE_PROJECT_TASKS_ROOT)
+        cfg = MagicMock(tasks_root=FAKE_PROJECT_TASKS_ROOT)
+        cfg.name = "proj1"
         mock_projects.return_value = [cfg]
         mock_tasks.return_value = [_task_meta("1")]
         mock_states.return_value = {"1": "paused"}
@@ -99,7 +105,8 @@ class TestDiscovery:
     @patch("terok.lib.domain.panic.get_all_task_states")
     def test_skips_broken_task_states(self, mock_states, mock_tasks, mock_projects):
         """Projects where get_all_task_states raises are skipped."""
-        cfg = MagicMock(id="proj1", tasks_root=FAKE_PROJECT_TASKS_ROOT)
+        cfg = MagicMock(tasks_root=FAKE_PROJECT_TASKS_ROOT)
+        cfg.name = "proj1"
         mock_projects.return_value = [cfg]
         mock_tasks.return_value = [_task_meta("1")]
         mock_states.side_effect = Exception("state lookup failed")

--- a/tests/unit/lib/test_project_archive.py
+++ b/tests/unit/lib/test_project_archive.py
@@ -29,9 +29,9 @@ from terok.lib.util.fs import (
 from tests.test_utils import project_env
 
 
-def project_yaml(project_id: str) -> str:
+def project_yaml(project_name: str) -> str:
     """Build a minimal project config for archive tests."""
-    return f"project:\n  id: {project_id}\ngit:\n  upstream_url: https://example.com/repo.git\n"
+    return f"project:\n  id: {project_name}\ngit:\n  upstream_url: https://example.com/repo.git\n"
 
 
 def archive_member_names(path: str) -> list[str]:
@@ -40,16 +40,16 @@ def archive_member_names(path: str) -> list[str]:
         return tar.getnames()
 
 
-def create_task_state(project_id: str) -> None:
+def create_task_state(project_name: str) -> None:
     """Create a sample task metadata file for an archived project."""
-    meta_dir = core_state_dir() / "projects" / project_id / "tasks"
+    meta_dir = core_state_dir() / "projects" / project_name / "tasks"
     meta_dir.mkdir(parents=True, exist_ok=True)
     (meta_dir / "1.yml").write_text("task_id: '1'\nname: test\n")
 
 
-def create_build_dir(project_id: str) -> None:
+def create_build_dir(project_name: str) -> None:
     """Create a sample build artifact for an archived project."""
-    staging = build_dir() / project_id
+    staging = build_dir() / project_name
     staging.mkdir(parents=True, exist_ok=True)
     (staging / "L2.Dockerfile").write_text("FROM scratch")
 
@@ -140,7 +140,7 @@ class TestArchiveProject:
     """Tests for _archive_project()."""
 
     @pytest.mark.parametrize(
-        ("project_id", "setup", "expected_fragment"),
+        ("project_name", "setup", "expected_fragment"),
         [
             ("arch-cfg", lambda _pid: None, "config/"),
             ("arch-state", create_task_state, "state/"),
@@ -150,24 +150,24 @@ class TestArchiveProject:
     )
     def test_archive_includes_expected_sections(
         self,
-        project_id: str,
+        project_name: str,
         setup: Callable[[str], None],
         expected_fragment: str,
     ) -> None:
-        with project_env(project_yaml(project_id), project_id=project_id):
-            setup(project_id)
-            archive_path = _archive_project(project_id)
+        with project_env(project_yaml(project_name), project_name=project_name):
+            setup(project_name)
+            archive_path = _archive_project(project_name)
             assert archive_path is not None
             assert any(expected_fragment in name for name in archive_member_names(archive_path))
 
     def test_missing_dirs_graceful(self) -> None:
-        with project_env(project_yaml("arch-min"), project_id="arch-min"):
+        with project_env(project_yaml("arch-min"), project_name="arch-min"):
             archive_path = _archive_project("arch-min")
             assert archive_path is not None
             assert Path(archive_path).is_file()
 
     def test_archive_stored_in_archive_dir(self) -> None:
-        with project_env(project_yaml("arch-loc"), project_id="arch-loc"):
+        with project_env(project_yaml("arch-loc"), project_name="arch-loc"):
             archive_path = _archive_project("arch-loc")
             assert archive_path is not None
             assert Path(archive_path).parent == archive_dir()
@@ -175,7 +175,7 @@ class TestArchiveProject:
     def test_archive_bundles_task_archives_and_cleans_up(self) -> None:
         """Project archive includes task archives and removes the subtree."""
         pid = "arch-tasks"
-        with project_env(project_yaml(pid), project_id=pid):
+        with project_env(project_yaml(pid), project_name=pid):
             # Populate task archive entries
             task_archive_root = archive_dir() / pid / "tasks"
             task_archive_root.mkdir(parents=True, exist_ok=True)
@@ -195,7 +195,7 @@ class TestDeleteProjectArchive:
     """Tests for delete_project() archive integration."""
 
     def test_delete_creates_archive_before_deleting(self) -> None:
-        with project_env(project_yaml("del-arch"), project_id="del-arch"):
+        with project_env(project_yaml("del-arch"), project_name="del-arch"):
             create_task_state("del-arch")
             create_build_dir("del-arch")
             result = delete_project("del-arch")
@@ -208,14 +208,14 @@ class TestDeleteProjectArchive:
             assert "build/L2.Dockerfile" in members
 
     def test_archive_survives_deletion(self) -> None:
-        with project_env(project_yaml("del-surv"), project_id="del-surv"):
+        with project_env(project_yaml("del-surv"), project_name="del-surv"):
             project = load_project("del-surv")
             result = delete_project("del-surv")
             assert not project.root.is_dir()
             assert Path(result["archive"]).is_file()
 
     def test_archive_contains_project_config(self) -> None:
-        with project_env(project_yaml("del-cont"), project_id="del-cont"):
+        with project_env(project_yaml("del-cont"), project_name="del-cont"):
             result = delete_project("del-cont")
             assert any(
                 name.startswith("config/") for name in archive_member_names(result["archive"])

--- a/tests/unit/lib/test_project_delete.py
+++ b/tests/unit/lib/test_project_delete.py
@@ -20,53 +20,53 @@ from tests.test_utils import project_env, write_project
 EnvSetup = Callable[[SimpleNamespace, str], Path]
 
 
-def project_yaml(project_id: str, *, upstream_url: str = "https://example.com/repo.git") -> str:
+def project_yaml(project_name: str, *, upstream_url: str = "https://example.com/repo.git") -> str:
     """Build a minimal project config for deletion tests."""
-    return f"project:\n  id: {project_id}\ngit:\n  upstream_url: {upstream_url}\n"
+    return f"project:\n  id: {project_name}\ngit:\n  upstream_url: {upstream_url}\n"
 
 
-def project_root(_env: SimpleNamespace, project_id: str) -> Path:
+def project_root(_env: SimpleNamespace, project_name: str) -> Path:
     """Return the config-root directory for a loaded project."""
-    return load_project(project_id).root
+    return load_project(project_name).root
 
 
-def build_dir(_env: SimpleNamespace, project_id: str) -> Path:
+def build_dir(_env: SimpleNamespace, project_name: str) -> Path:
     """Create and return the project's build dir."""
-    target = cfg_build_dir() / project_id
+    target = cfg_build_dir() / project_name
     target.mkdir(parents=True, exist_ok=True)
     (target / "L2.Dockerfile").write_text("FROM scratch", encoding="utf-8")
     return target
 
 
-def task_state_dir(_env: SimpleNamespace, project_id: str) -> Path:
+def task_state_dir(_env: SimpleNamespace, project_name: str) -> Path:
     """Create and return the project's state metadata dir."""
-    target = cfg_state_dir() / "projects" / project_id
+    target = cfg_state_dir() / "projects" / project_name
     tasks_dir = target / "tasks"
     tasks_dir.mkdir(parents=True, exist_ok=True)
     (tasks_dir / "1.yml").write_text("task_id: '1'\n", encoding="utf-8")
     return target
 
 
-def gate_dir(env: SimpleNamespace, _project_id: str) -> Path:
+def gate_dir(env: SimpleNamespace, _project_name: str) -> Path:
     """Return the gate mirror directory from ``project_env``."""
     assert env.gate_dir is not None
     return env.gate_dir
 
 
-def task_archive_subdir(_env: SimpleNamespace, project_id: str) -> Path:
+def task_archive_subdir(_env: SimpleNamespace, project_name: str) -> Path:
     """Create and return the project's task archive dir (under namespace archive)."""
     from terok.lib.core.config import archive_dir as cfg_archive_dir
 
-    target = cfg_archive_dir() / project_id / "tasks"
+    target = cfg_archive_dir() / project_name / "tasks"
     target.mkdir(parents=True, exist_ok=True)
     entry = target / "20260101T000000Z_1_old-task"
     entry.mkdir()
     (entry / "task.yml").write_text("task_id: '1'\n", encoding="utf-8")
-    return target.parent  # archive/<project_id>/ — should be removed
+    return target.parent  # archive/<project_name>/ — should be removed
 
 
 @pytest.mark.parametrize(
-    ("project_id", "env_kwargs", "setup_target"),
+    ("project_name", "env_kwargs", "setup_target"),
     [
         ("del-proj", {"with_config_file": True}, project_root),
         ("del-build", {"with_config_file": True}, build_dir),
@@ -77,14 +77,14 @@ def task_archive_subdir(_env: SimpleNamespace, project_id: str) -> Path:
     ids=["config-dir", "build-dir", "task-metadata-dir", "gate-dir", "task-archive-dir"],
 )
 def test_delete_project_removes_managed_directories(
-    project_id: str,
+    project_name: str,
     env_kwargs: dict[str, bool],
     setup_target: EnvSetup,
 ) -> None:
-    with project_env(project_yaml(project_id), project_id=project_id, **env_kwargs) as env:
-        target = setup_target(env, project_id)
+    with project_env(project_yaml(project_name), project_name=project_name, **env_kwargs) as env:
+        target = setup_target(env, project_name)
         assert target.is_dir()
-        delete_project(project_id)
+        delete_project(project_name)
         assert not target.exists()
 
 
@@ -104,11 +104,11 @@ def test_delete_project_skips_shared_gate(monkeypatch: pytest.MonkeyPatch, tmp_p
         encoding="utf-8",
     )
 
-    for project_id, upstream in (("proj-a", "a"), ("proj-b", "b")):
+    for project_name, upstream in (("proj-a", "a"), ("proj-b", "b")):
         write_project(
             projects_root,
-            project_id,
-            project_yaml(project_id, upstream_url=f"https://example.com/{upstream}.git")
+            project_name,
+            project_yaml(project_name, upstream_url=f"https://example.com/{upstream}.git")
             + f"gate:\n  path: {gate_path}\n",
         )
 
@@ -124,14 +124,14 @@ def test_delete_project_skips_shared_gate(monkeypatch: pytest.MonkeyPatch, tmp_p
 
 
 def test_delete_project_returns_deleted_paths() -> None:
-    project_id = "del-ret"
-    with project_env(project_yaml(project_id), project_id=project_id):
-        result = delete_project(project_id)
+    project_name = "del-ret"
+    with project_env(project_yaml(project_name), project_name=project_name):
+        result = delete_project(project_name)
         assert isinstance(result["deleted"], list)
         assert isinstance(result["skipped"], list)
         assert result["archive"] is not None
         assert Path(result["archive"]).is_file()
-        assert any(project_id in path for path in result["deleted"])
+        assert any(project_name in path for path in result["deleted"])
 
 
 def test_delete_project_uses_task_task_id_not_id(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -145,7 +145,7 @@ def test_delete_project_uses_task_task_id_not_id(monkeypatch: pytest.MonkeyPatch
     """
     from terok.lib.orchestration.tasks import TaskMeta
 
-    project_id = "del-task-ids"
+    project_name = "del-task-ids"
     fake_tasks = [
         TaskMeta(task_id="42", mode="cli", workspace="", web_port=None, name="t42"),
         TaskMeta(task_id="7", mode="cli", workspace="", web_port=None, name="t7"),
@@ -155,12 +155,12 @@ def test_delete_project_uses_task_task_id_not_id(monkeypatch: pytest.MonkeyPatch
     def fake_task_delete(pid: str, tid: str) -> None:
         seen.append((pid, tid))
 
-    with project_env(project_yaml(project_id), project_id=project_id):
+    with project_env(project_yaml(project_name), project_name=project_name):
         monkeypatch.setattr("terok.lib.domain.project.get_tasks", lambda _pid: fake_tasks)
         monkeypatch.setattr("terok.lib.domain.project.task_delete", fake_task_delete)
-        delete_project(project_id)
+        delete_project(project_name)
 
-    assert seen == [(project_id, "42"), (project_id, "7")]
+    assert seen == [(project_name, "42"), (project_name, "7")]
 
 
 # ---------- _is_under_terok_root safety guard ----------

--- a/tests/unit/lib/test_projects.py
+++ b/tests/unit/lib/test_projects.py
@@ -19,6 +19,7 @@ from terok.lib.core.projects import (
     discover_projects,
     list_projects,
     load_project,
+    normalize_project_name,
     set_project_image_agents,
 )
 from terok.lib.domain.project_state import get_project_state
@@ -262,6 +263,110 @@ class TestProject:
             project = load_project("hostless")
         assert project.gate_enabled is False
         assert project.upstream_url == "git@github.com:user/repo.git"
+
+    def test_load_project_rejects_new_name_mismatching_directory(self) -> None:
+        """``project.name`` and the project directory must be the same identity."""
+        yaml = "project:\n  name: other\n"
+        with project_env(yaml, project_name="actual"):
+            with pytest.raises(SystemExit) as exc_info:
+                load_project("actual")
+        message = str(exc_info.value)
+        assert "Project name mismatch" in message
+        assert "directory name: 'actual'" in message
+        assert "project.yml name: 'other'" in message
+        assert "terok project normalize-name actual" in message
+
+    def test_load_project_rejects_legacy_id_mismatching_directory(self) -> None:
+        """Legacy ``project.id`` is normalised first, then compared to the directory."""
+        yaml = "project:\n  id: old-slug\n  name: Pretty Project\n"
+        with project_env(yaml, project_name="actual"):
+            with pytest.raises(SystemExit) as exc_info:
+                load_project("actual")
+        message = str(exc_info.value)
+        assert "Project name mismatch" in message
+        assert "project.yml name: 'old-slug'" in message
+
+    def test_discover_projects_surfaces_name_mismatch_as_broken(self) -> None:
+        """Mismatch errors flow through discovery so the TUI can render the broken row."""
+        with tempfile.TemporaryDirectory() as td:
+            base = Path(td)
+            config_base = base / "config"
+            projects_root = config_base / "projects"
+            write_project(projects_root, "actual", "project:\n  name: other\n")
+            with unittest.mock.patch.dict(
+                os.environ,
+                {"TEROK_CONFIG_DIR": str(config_base), "XDG_CONFIG_HOME": str(base / "empty")},
+            ):
+                valid, broken = discover_projects()
+
+        assert valid == []
+        assert [bp.name for bp in broken] == ["actual"]
+        assert "normalize-name actual" in broken[0].error
+
+    def test_normalize_project_name_rewrites_mismatching_new_name(self) -> None:
+        """Quick fix makes the config identity match the directory name."""
+        yaml = "project:\n  name: other\n  description: Kept\n"
+        with project_env(yaml, project_name="actual") as ctx:
+            path = normalize_project_name("actual")
+            assert path == ctx.config_root / "actual" / "project.yml"
+            project = load_project("actual")
+            content = path.read_text(encoding="utf-8")
+
+        assert project.name == "actual"
+        assert project.description == "Kept"
+        assert "name: actual" in content
+        assert "description: Kept" in content
+        assert "id:" not in content
+
+    def test_normalize_project_name_preserves_legacy_display_name(self) -> None:
+        """Legacy ``id`` + display ``name`` becomes new ``name`` + ``description``."""
+        yaml = "project:\n  id: old-slug\n  name: Pretty Project\n"
+        with project_env(yaml, project_name="actual") as ctx:
+            path = normalize_project_name("actual")
+            project = load_project("actual")
+            content = path.read_text(encoding="utf-8")
+
+        assert path == ctx.config_root / "actual" / "project.yml"
+        assert project.name == "actual"
+        assert project.description == "Pretty Project"
+        assert "name: actual" in content
+        assert "description: Pretty Project" in content
+        assert "id:" not in content
+
+    def test_normalize_project_name_preserves_no_id_display_name(self) -> None:
+        """Old display-only ``name`` without ``id`` is retained as description."""
+        yaml = "project:\n  name: Pretty Project\n"
+        with project_env(yaml, project_name="actual"):
+            path = normalize_project_name("actual")
+            project = load_project("actual")
+            content = path.read_text(encoding="utf-8")
+
+        assert project.name == "actual"
+        assert project.description == "Pretty Project"
+        assert "name: actual" in content
+        assert "description: Pretty Project" in content
+
+    def test_derive_project_preserves_legacy_display_name_as_description(self) -> None:
+        """Deriving a legacy config does not discard the old display label."""
+        source = (
+            "project:\n"
+            "  id: source\n"
+            "  name: Pretty Source\n"
+            "git:\n"
+            "  upstream_url: https://example.com/repo.git\n"
+        )
+        with project_env(source, project_name="source") as ctx:
+            derived_root = derive_project("source", "derived")
+            content = (derived_root / "project.yml").read_text(encoding="utf-8")
+            derived = load_project("derived")
+
+        assert derived_root.name == "derived"
+        assert derived_root != ctx.config_root / "derived"  # derive writes to the user project root
+        assert derived.name == "derived"
+        assert derived.description == "Pretty Source"
+        assert "name: derived" in content
+        assert "description: Pretty Source" in content
+        assert "id:" not in content
 
     def test_discover_projects_splits_valid_and_broken(
         self, capsys: pytest.CaptureFixture[str]

--- a/tests/unit/lib/test_projects.py
+++ b/tests/unit/lib/test_projects.py
@@ -25,7 +25,7 @@ from tests.test_utils import project_env, write_project
 
 
 def project_yaml(
-    project_id: str,
+    project_name: str,
     *,
     security_class: str | None = None,
     authorship: str | None = None,
@@ -36,7 +36,7 @@ def project_yaml(
     credentials_scope: str | None = None,
 ) -> str:
     """Build project YAML for tests with optional sections."""
-    lines = ["project:", f"  id: {project_id}"]
+    lines = ["project:", f"  id: {project_name}"]
     if security_class is not None:
         lines.append(f"  security_class: {security_class}")
     lines += ["git:", "  upstream_url: https://example.com/repo.git"]
@@ -62,20 +62,20 @@ class TestProject:
     """Tests for project loading/listing."""
 
     def test_load_project_gatekeeping_defaults(self) -> None:
-        project_id = "proj1"
+        project_name = "proj1"
         with project_env(
-            project_yaml(project_id, security_class="gatekeeping"),
-            project_id=project_id,
+            project_yaml(project_name, security_class="gatekeeping"),
+            project_name=project_name,
         ):
-            project = load_project(project_id)
-            assert project.id == project_id
+            project = load_project(project_name)
+            assert project.name == project_name
             assert project.security_class == "gatekeeping"
-            assert project.tasks_root == (sandbox_live_dir() / "tasks" / project_id).resolve()
+            assert project.tasks_root == (sandbox_live_dir() / "tasks" / project_name).resolve()
             assert (
                 project.gate_path
-                == (make_sandbox_config().gate_base_path / f"{project_id}.git").resolve()
+                == (make_sandbox_config().gate_base_path / f"{project_name}.git").resolve()
             )
-            assert project.staging_root == (build_dir() / project_id).resolve()
+            assert project.staging_root == (build_dir() / project_name).resolve()
             assert project.git_authorship == "agent-human"
             # Default credentials.scope: shared bucket, no per-project carve-out.
             assert project.credentials_scope == "shared"
@@ -83,18 +83,18 @@ class TestProject:
 
     def test_load_project_with_per_project_credentials(self) -> None:
         """``credentials.scope: project`` flips credential_set + project_mounts_dir."""
-        project_id = "proj-creds"
+        project_name = "proj-creds"
         with project_env(
-            project_yaml(project_id, credentials_scope="project"),
-            project_id=project_id,
+            project_yaml(project_name, credentials_scope="project"),
+            project_name=project_name,
         ):
-            project = load_project(project_id)
+            project = load_project(project_name)
             assert project.credentials_scope == "project"
-            assert project.credential_set == project_id
+            assert project.credential_set == project_name
             assert project.project_mounts_dir == project.root / "mounts"
 
     @pytest.mark.parametrize(
-        ("project_id", "yaml_text", "config_text", "expected"),
+        ("project_name", "yaml_text", "config_text", "expected"),
         [
             (
                 "proj-authorship",
@@ -113,23 +113,23 @@ class TestProject:
     )
     def test_git_authorship_resolution(
         self,
-        project_id: str,
+        project_name: str,
         yaml_text: str,
         config_text: str | None,
         expected: str,
     ) -> None:
-        with project_env(yaml_text, project_id=project_id) as ctx:
+        with project_env(yaml_text, project_name=project_name) as ctx:
             if config_text is None:
-                project = load_project(project_id)
+                project = load_project(project_name)
             else:
                 config_file = ctx.base / "config.yml"
                 config_file.write_text(config_text, encoding="utf-8")
                 with unittest.mock.patch.dict(os.environ, {"TEROK_CONFIG_FILE": str(config_file)}):
-                    project = load_project(project_id)
+                    project = load_project(project_name)
         assert project.git_authorship == expected
 
     @pytest.mark.parametrize(
-        ("project_id", "yaml_text", "config_text", "expected"),
+        ("project_name", "yaml_text", "config_text", "expected"),
         [
             pytest.param(
                 "ssh-default", project_yaml("ssh-default"), None, False, id="default-false"
@@ -159,7 +159,7 @@ class TestProject:
     )
     def test_ssh_use_personal_resolution(
         self,
-        project_id: str,
+        project_name: str,
         yaml_text: str,
         config_text: str | None,
         expected: bool,
@@ -175,20 +175,20 @@ class TestProject:
         global-tier reader (``gate_use_personal_ssh_default``); terok
         composes the project layer via ``_build_project_config``.
         """
-        with project_env(yaml_text, project_id=project_id) as ctx:
+        with project_env(yaml_text, project_name=project_name) as ctx:
             if config_text is None:
-                project = load_project(project_id)
+                project = load_project(project_name)
             else:
                 config_file = ctx.base / "config.yml"
                 config_file.write_text(config_text, encoding="utf-8")
                 with unittest.mock.patch.dict(os.environ, {"TEROK_CONFIG_FILE": str(config_file)}):
-                    project = load_project(project_id)
+                    project = load_project(project_name)
         assert project.ssh_use_personal is expected
 
     def test_load_project_invalid_git_authorship_raises(self) -> None:
         with project_env(
             project_yaml("proj-bad-authorship", authorship="mystery-mode"),
-            project_id="proj-bad-authorship",
+            project_name="proj-bad-authorship",
         ):
             with pytest.raises(SystemExit, match="git.authorship"):
                 load_project("proj-bad-authorship")
@@ -234,14 +234,14 @@ class TestProject:
             "gate:\n"
             "  enabled: false\n"
         )
-        with project_env(yaml, project_id="bad"):
+        with project_env(yaml, project_name="bad"):
             with pytest.raises(SystemExit, match="gatekeeping"):
                 load_project("bad")
 
     def test_gate_enabled_defaults_true(self) -> None:
         """Projects without an explicit gate section keep the old default (enabled)."""
         yaml = "project:\n  id: p\ngit:\n  upstream_url: https://example.com/r.git\n"
-        with project_env(yaml, project_id="p"):
+        with project_env(yaml, project_name="p"):
             project = load_project("p")
         assert project.gate_enabled is True
 
@@ -256,7 +256,7 @@ class TestProject:
             "gate:\n"
             "  enabled: false\n"
         )
-        with project_env(yaml, project_id="hostless"):
+        with project_env(yaml, project_name="hostless"):
             project = load_project("hostless")
         assert project.gate_enabled is False
         assert project.upstream_url == "git@github.com:user/repo.git"
@@ -281,8 +281,8 @@ class TestProject:
             ):
                 valid, broken = discover_projects()
 
-        assert [p.id for p in valid] == ["good"]
-        assert [bp.id for bp in broken] == ["bad"]
+        assert [p.name for p in valid] == ["good"]
+        assert [bp.name for bp in broken] == ["bad"]
         bp = broken[0]
         assert isinstance(bp, BrokenProject)
         assert bp.config_path == (projects_root / "bad" / "project.yml")
@@ -317,8 +317,8 @@ class TestProject:
             ):
                 valid, broken = discover_projects()
 
-        assert [p.id for p in valid] == []
-        assert [bp.id for bp in broken] == ["default"]
+        assert [p.name for p in valid] == []
+        assert [bp.name for bp in broken] == ["default"]
         assert "reserved" in broken[0].error
 
     def test_list_projects_skips_malformed_yaml(self) -> None:
@@ -338,7 +338,7 @@ class TestProject:
             ):
                 projects = list_projects()
         assert len(projects) == 1
-        assert projects[0].id == "good"
+        assert projects[0].name == "good"
 
     def test_list_projects_sanitizes_control_chars_in_stderr(
         self, capsys: pytest.CaptureFixture[str]
@@ -369,7 +369,7 @@ class TestProject:
             ):
                 result = list_projects()
         # Skip-and-continue: 'evil' is dropped, 'good' survives.
-        ids = {p.id for p in result}
+        ids = {p.name for p in result}
         assert ids == {"good"}
         err = capsys.readouterr().err
         assert "warning: skipping broken project 'evil'" in err
@@ -378,7 +378,7 @@ class TestProject:
 
     def test_load_project_malformed_yaml(self) -> None:
         malformed = "project:\n  id: bad-yaml\n  foo: [invalid yaml\n"
-        with project_env(malformed, project_id="bad-yaml"):
+        with project_env(malformed, project_name="bad-yaml"):
             with pytest.raises(SystemExit, match="Failed to read"):
                 load_project("bad-yaml")
 
@@ -401,7 +401,7 @@ class TestProject:
         def _raise_index_error(text: str) -> object:
             raise IndexError("string index out of range")
 
-        with project_env(project_yaml("weird"), project_id="weird"):
+        with project_env(project_yaml("weird"), project_name="weird"):
             with unittest.mock.patch.object(
                 projects_mod, "_yaml_load", side_effect=_raise_index_error
             ):
@@ -416,7 +416,7 @@ class TestProject:
         assert isinstance(exc_info.value.__cause__, IndexError)
 
     @pytest.mark.parametrize(
-        ("project_id", "yaml_text", "expected"),
+        ("project_name", "yaml_text", "expected"),
         [
             ("proj-shield-default", project_yaml("proj-shield-default"), True),
             (
@@ -434,16 +434,16 @@ class TestProject:
     )
     def test_shield_drop_on_task_run(
         self,
-        project_id: str,
+        project_name: str,
         yaml_text: str,
         expected: bool,
     ) -> None:
         """Project-level drop_on_task_run overrides global default."""
-        with project_env(yaml_text, project_id=project_id):
-            assert load_project(project_id).shield_drop_on_task_run is expected
+        with project_env(yaml_text, project_name=project_name):
+            assert load_project(project_name).shield_drop_on_task_run is expected
 
     @pytest.mark.parametrize(
-        ("project_id", "yaml_text", "expected"),
+        ("project_name", "yaml_text", "expected"),
         [
             ("proj-restart-default", project_yaml("proj-restart-default"), "retain"),
             (
@@ -456,18 +456,18 @@ class TestProject:
     )
     def test_shield_on_task_restart(
         self,
-        project_id: str,
+        project_name: str,
         yaml_text: str,
         expected: str,
     ) -> None:
         """Project-level on_task_restart overrides global default."""
-        with project_env(yaml_text, project_id=project_id):
-            assert load_project(project_id).shield_on_task_restart == expected
+        with project_env(yaml_text, project_name=project_name):
+            assert load_project(project_name).shield_on_task_restart == expected
 
     def test_shared_dir_true_resolves_to_tasks_root(self) -> None:
         """``shared_dir: true`` resolves to tasks_root/_shared."""
         yaml_text = project_yaml("proj-shared") + "shared_dir: true\n"
-        with project_env(yaml_text, project_id="proj-shared"):
+        with project_env(yaml_text, project_name="proj-shared"):
             project = load_project("proj-shared")
         assert project.shared_dir is not None
         assert project.shared_dir.name == "_shared"
@@ -476,20 +476,20 @@ class TestProject:
     def test_shared_dir_path_resolves_absolute(self) -> None:
         """``shared_dir: /path`` resolves to an absolute Path."""
         yaml_text = project_yaml("proj-shared-path") + "shared_dir: /tmp/terok-testing/custom\n"
-        with project_env(yaml_text, project_id="proj-shared-path"):
+        with project_env(yaml_text, project_name="proj-shared-path"):
             project = load_project("proj-shared-path")
         assert project.shared_dir == Path("/tmp/terok-testing/custom")
 
     def test_shared_dir_relative_path_rejected(self) -> None:
         """Relative path in shared_dir raises SystemExit."""
         yaml_text = project_yaml("proj-shared-rel") + "shared_dir: relative/path\n"
-        with project_env(yaml_text, project_id="proj-shared-rel"):
+        with project_env(yaml_text, project_name="proj-shared-rel"):
             with pytest.raises(SystemExit, match="absolute path"):
                 load_project("proj-shared-rel")
 
     def test_shared_dir_omitted_is_none(self) -> None:
         """Omitting ``shared_dir`` leaves it None (disabled)."""
-        with project_env(project_yaml("proj-no-shared"), project_id="proj-no-shared"):
+        with project_env(project_yaml("proj-no-shared"), project_name="proj-no-shared"):
             project = load_project("proj-no-shared")
         assert project.shared_dir is None
 
@@ -497,26 +497,26 @@ class TestProject:
         """``run.timezone`` in project.yml surfaces on ``ProjectConfig.timezone``."""
         with project_env(
             project_yaml("proj-tz", timezone="Europe/Prague"),
-            project_id="proj-tz",
+            project_name="proj-tz",
         ):
             assert load_project("proj-tz").timezone == "Europe/Prague"
 
     def test_timezone_omitted_is_none(self) -> None:
         """Without ``run.timezone`` the field is ``None`` — terok-executor will follow the host."""
-        with project_env(project_yaml("proj-no-tz"), project_id="proj-no-tz"):
+        with project_env(project_yaml("proj-no-tz"), project_name="proj-no-tz"):
             assert load_project("proj-no-tz").timezone is None
 
     def test_get_project_state(self, mock_runtime) -> None:
-        project_id = "proj3"
+        project_name = "proj3"
         with project_env(
-            project_yaml(project_id), project_id=project_id, with_config_file=True
+            project_yaml(project_name), project_name=project_name, with_config_file=True
         ) as env:
-            stage_dir = build_dir() / project_id
+            stage_dir = build_dir() / project_name
             stage_dir.mkdir(parents=True, exist_ok=True)
             for name in ("L0.Dockerfile", "L1.cli.Dockerfile", "L1.ui.Dockerfile", "L2.Dockerfile"):
                 (stage_dir / name).write_text("", encoding="utf-8")
 
-            gate_dir = make_sandbox_config().gate_base_path / f"{project_id}.git"
+            gate_dir = make_sandbox_config().gate_base_path / f"{project_name}.git"
             gate_dir.mkdir(parents=True, exist_ok=True)
 
             mock_runtime.image.return_value.exists.return_value = True
@@ -530,7 +530,7 @@ class TestProject:
                     return_value=True,
                 ),
             ):
-                state = get_project_state(project_id, gate_commit_provider=lambda _pid: None)
+                state = get_project_state(project_name, gate_commit_provider=lambda _pid: None)
             _ = env  # silence unused; tmp-env drives config resolution
 
         assert state == {
@@ -586,54 +586,54 @@ class TestSetProjectImageAgents:
 
     def test_writes_into_existing_image_section(self) -> None:
         """Updating ``image.agents`` keeps unrelated keys in the same section."""
-        project_id = "proj-set-agents"
+        project_name = "proj-set-agents"
         yaml_text = (
             "project:\n"
-            f"  id: {project_id}\n"
+            f"  id: {project_name}\n"
             "git:\n"
             "  upstream_url: https://example.com/repo.git\n"
             "image:\n"
             "  base_image: ubuntu:24.04\n"
             "  agents: claude\n"
         )
-        with project_env(yaml_text, project_id=project_id) as env:
-            written = set_project_image_agents(project_id, "all,-vibe")
+        with project_env(yaml_text, project_name=project_name) as env:
+            written = set_project_image_agents(project_name, "all,-vibe")
             content = written.read_text(encoding="utf-8")
             assert "agents: all,-vibe" in content
             assert "base_image: ubuntu:24.04" in content
             # Sanity-check the path landed where the loader expects it.
-            assert written == env.config_root / project_id / "project.yml"
+            assert written == env.config_root / project_name / "project.yml"
 
     def test_creates_image_section_when_missing(self) -> None:
         """A project.yml without ``image:`` gets the section minted on write."""
-        project_id = "proj-no-image"
+        project_name = "proj-no-image"
         yaml_text = (
-            f"project:\n  id: {project_id}\ngit:\n  upstream_url: https://example.com/repo.git\n"
+            f"project:\n  id: {project_name}\ngit:\n  upstream_url: https://example.com/repo.git\n"
         )
-        with project_env(yaml_text, project_id=project_id):
-            written = set_project_image_agents(project_id, "claude")
+        with project_env(yaml_text, project_name=project_name):
+            written = set_project_image_agents(project_name, "claude")
             content = written.read_text(encoding="utf-8")
             assert "image:" in content
             assert "agents: claude" in content
 
     def test_preserves_comments_on_write(self) -> None:
         """ruamel round-trip keeps inline comments around the edited section."""
-        project_id = "proj-comments"
+        project_name = "proj-comments"
         yaml_text = (
-            f"project:\n  id: {project_id}\n"
+            f"project:\n  id: {project_name}\n"
             "git:\n  upstream_url: https://example.com/repo.git\n"
             "image:\n"
             "  # base image pin\n"
             "  base_image: ubuntu:24.04\n"
             "  agents: claude\n"
         )
-        with project_env(yaml_text, project_id=project_id):
-            written = set_project_image_agents(project_id, "vibe")
+        with project_env(yaml_text, project_name=project_name):
+            written = set_project_image_agents(project_name, "vibe")
             content = written.read_text(encoding="utf-8")
             assert "# base image pin" in content
             assert "agents: vibe" in content
 
     def test_missing_project_raises(self) -> None:
-        """An unknown project ID raises ``SystemExit`` with a not-found message."""
+        """An unknown project name raises ``SystemExit`` with a not-found message."""
         with pytest.raises(SystemExit, match="not found"):
             set_project_image_agents("nonexistent-project", "all")

--- a/tests/unit/lib/test_projects.py
+++ b/tests/unit/lib/test_projects.py
@@ -20,6 +20,7 @@ from terok.lib.core.projects import (
     list_projects,
     load_project,
     normalize_project_name,
+    require_project_exists,
     set_project_image_agents,
 )
 from terok.lib.domain.project_state import get_project_state
@@ -346,6 +347,38 @@ class TestProject:
         assert "name: actual" in content
         assert "description: Pretty Project" in content
 
+    def test_normalize_project_name_replaces_invalid_project_section(self) -> None:
+        """The quick fix repairs an invalid ``project:`` scalar section."""
+        yaml = "project: Pretty Project\n"
+        with project_env(yaml, project_name="actual"):
+            path = normalize_project_name("actual")
+            project = load_project("actual")
+            raw = yaml_load(path.read_text(encoding="utf-8"))
+
+        assert project.name == "actual"
+        assert raw["project"]["name"] == "actual"
+
+    def test_normalize_project_name_rejects_malformed_yaml(self) -> None:
+        """Malformed ``project.yml`` still reports an explicit read/parse failure."""
+        with project_env(project_yaml("actual"), project_name="actual") as ctx:
+            path = ctx.config_root / "actual" / "project.yml"
+            path.write_text("project:\n  name: [unterminated\n", encoding="utf-8")
+            with pytest.raises(SystemExit, match="Failed to read"):
+                normalize_project_name("actual")
+
+    def test_normalize_project_name_rejects_non_mapping_yaml(self) -> None:
+        """The quick fix requires the top-level YAML document to be a mapping."""
+        with project_env(project_yaml("actual"), project_name="actual") as ctx:
+            path = ctx.config_root / "actual" / "project.yml"
+            path.write_text("- not-a-mapping\n", encoding="utf-8")
+            with pytest.raises(SystemExit, match="expected a mapping"):
+                normalize_project_name("actual")
+
+    def test_require_project_exists_accepts_existing_project(self) -> None:
+        """The stat-only project existence guard accepts a known project."""
+        with project_env(project_yaml("actual"), project_name="actual"):
+            require_project_exists("actual")
+
     def test_derive_project_preserves_legacy_display_name_as_description(self) -> None:
         """Deriving a legacy config does not discard the old display label."""
         source = (
@@ -367,6 +400,15 @@ class TestProject:
         assert "name: derived" in content
         assert "description: Pretty Source" in content
         assert "id:" not in content
+
+    def test_derive_project_rejects_target_path_escape(self) -> None:
+        """The derive target stays under the user projects directory."""
+        with project_env(project_yaml("source"), project_name="source"):
+            with (
+                unittest.mock.patch("terok.lib.core.projects.validate_project_name"),
+                pytest.raises(SystemExit, match="path escapes projects directory"),
+            ):
+                derive_project("source", "../escape")
 
     def test_discover_projects_splits_valid_and_broken(
         self, capsys: pytest.CaptureFixture[str]

--- a/tests/unit/lib/test_projects.py
+++ b/tests/unit/lib/test_projects.py
@@ -15,12 +15,14 @@ import pytest
 from terok.lib.core.config import build_dir, make_sandbox_config, sandbox_live_dir
 from terok.lib.core.projects import (
     BrokenProject,
+    derive_project,
     discover_projects,
     list_projects,
     load_project,
     set_project_image_agents,
 )
 from terok.lib.domain.project_state import get_project_state
+from terok.lib.util.yaml import load as yaml_load
 from tests.test_utils import project_env, write_project
 
 
@@ -637,3 +639,50 @@ class TestSetProjectImageAgents:
         """An unknown project name raises ``SystemExit`` with a not-found message."""
         with pytest.raises(SystemExit, match="not found"):
             set_project_image_agents("nonexistent-project", "all")
+
+
+class TestDeriveProject:
+    """``derive_project`` clones a project's config onto a fresh slug."""
+
+    def test_renames_slug_drops_legacy_id_and_clears_agent(self) -> None:
+        """Derive writes ``name``, drops a legacy ``id`` key, and clears ``agent``."""
+        source = (
+            "project:\n"
+            "  id: src\n"  # legacy slug key — must be read, then dropped on write
+            "  description: My source project\n"
+            "  security_class: online\n"
+            "git:\n  upstream_url: https://example.com/repo.git\n"
+            "agent:\n  provider: codex\n"
+        )
+        with project_env(source, project_name="src"):
+            target = derive_project("src", "derived")
+            out = yaml_load((target / "project.yml").read_text(encoding="utf-8"))
+            assert out["project"]["name"] == "derived"
+            assert "id" not in out["project"]  # stale slug can't shadow name on reload
+            assert out["project"]["description"] == "My source project"
+            assert "agent" not in out  # agent section cleared
+            assert out["gate"]["path"]  # gate pinned to the shared source mirror
+            # The derived project re-loads cleanly under its new name.
+            assert load_project("derived").name == "derived"
+
+    def test_copies_instructions_md_when_present(self) -> None:
+        """A source ``instructions.md`` is carried into the derived project."""
+        source = (
+            "project:\n  name: src\n  security_class: online\n"
+            "git:\n  upstream_url: https://example.com/repo.git\n"
+        )
+        with project_env(source, project_name="src") as env:
+            (env.config_root / "src" / "instructions.md").write_text("house rules\n")
+            target = derive_project("src", "derived")
+            assert (target / "instructions.md").read_text() == "house rules\n"
+
+    def test_rejects_existing_target(self) -> None:
+        """Deriving onto an existing project name aborts rather than overwriting."""
+        source = (
+            "project:\n  name: src\n  security_class: online\n"
+            "git:\n  upstream_url: https://example.com/repo.git\n"
+        )
+        with project_env(source, project_name="src"):
+            derive_project("src", "derived")
+            with pytest.raises(SystemExit, match="already exists"):
+                derive_project("src", "derived")

--- a/tests/unit/lib/test_ssh.py
+++ b/tests/unit/lib/test_ssh.py
@@ -15,12 +15,12 @@ def _patch_vault_db(db):
     return patch_vault_db(db, module="project")
 
 
-def _make_project(project_id: str) -> object:
-    """Build a minimal ``Project`` whose only requirement is ``self._config.id``."""
+def _make_project(project_name: str) -> object:
+    """Build a minimal ``Project`` whose only requirement is ``self._config.name``."""
     from terok.lib.domain.project import Project
 
     config = MagicMock()
-    config.id = project_id
+    config.name = project_name
     return Project(config)
 
 

--- a/tests/unit/lib/test_staleness_detection.py
+++ b/tests/unit/lib/test_staleness_detection.py
@@ -26,7 +26,8 @@ class TestDetectStaleLayers:
         """All layers current → empty stale list."""
         from terok.lib.domain.project_state import _detect_stale_layers
 
-        project = Mock(id="p1", base_image="ubuntu:24.04")
+        project = Mock(base_image="ubuntu:24.04")
+        project.name = "p1"
         rendered = {
             "L0.Dockerfile": "FROM ubuntu:24.04",
             "L1.cli.Dockerfile": "FROM l0",
@@ -48,7 +49,8 @@ class TestDetectStaleLayers:
         """L1 hash mismatch → ["l1"] returned."""
         from terok.lib.domain.project_state import _detect_stale_layers
 
-        project = Mock(id="p1", base_image="ubuntu:24.04")
+        project = Mock(base_image="ubuntu:24.04")
+        project.name = "p1"
         rendered = {
             "L0.Dockerfile": "FROM ubuntu:24.04",
             "L1.cli.Dockerfile": "FROM l0 CHANGED",
@@ -74,7 +76,8 @@ class TestDetectStaleLayers:
         """No manifest → all layers stale."""
         from terok.lib.domain.project_state import _detect_stale_layers
 
-        project = Mock(id="p1", base_image="ubuntu:24.04")
+        project = Mock(base_image="ubuntu:24.04")
+        project.name = "p1"
         rendered = {"L0.Dockerfile": "x", "L1.cli.Dockerfile": "y", "L2.Dockerfile": "z"}
 
         with (
@@ -92,14 +95,16 @@ class TestDetectStaleLayers:
         """None rendered dict → all layers stale."""
         from terok.lib.domain.project_state import _detect_stale_layers
 
-        project = Mock(id="p1", base_image="ubuntu:24.04")
+        project = Mock(base_image="ubuntu:24.04")
+        project.name = "p1"
         assert _detect_stale_layers(project, None) == ["l0", "l1", "l2"]
 
     def test_multiple_stale_layers(self) -> None:
         """L0 + L2 stale, L1 current → ["l0", "l2"]."""
         from terok.lib.domain.project_state import _detect_stale_layers
 
-        project = Mock(id="p1", base_image="ubuntu:24.04")
+        project = Mock(base_image="ubuntu:24.04")
+        project.name = "p1"
         rendered = {"L0.Dockerfile": "x", "L1.cli.Dockerfile": "y", "L2.Dockerfile": "z"}
 
         with (
@@ -124,7 +129,8 @@ class TestDetectStaleLayers:
         """Manifest with non-dict layer entry → that layer is stale."""
         from terok.lib.domain.project_state import _detect_stale_layers
 
-        project = Mock(id="p1", base_image="ubuntu:24.04")
+        project = Mock(base_image="ubuntu:24.04")
+        project.name = "p1"
         rendered = {"L0.Dockerfile": "x", "L1.cli.Dockerfile": "y", "L2.Dockerfile": "z"}
 
         # l1 entry is a string instead of a dict
@@ -148,7 +154,8 @@ class TestDetectStaleLayers:
         """Manifest missing a layer key entirely → that layer is stale."""
         from terok.lib.domain.project_state import _detect_stale_layers
 
-        project = Mock(id="p1", base_image="ubuntu:24.04")
+        project = Mock(base_image="ubuntu:24.04")
+        project.name = "p1"
         rendered = {"L0.Dockerfile": "x", "L1.cli.Dockerfile": "y", "L2.Dockerfile": "z"}
 
         manifest = self._make_manifest("h0", "h1", "h2")
@@ -170,7 +177,8 @@ class TestDetectStaleLayers:
         """ImportError during hash computation → all layers stale."""
         from terok.lib.domain.project_state import _detect_stale_layers
 
-        project = Mock(id="p1", base_image="ubuntu:24.04")
+        project = Mock(base_image="ubuntu:24.04")
+        project.name = "p1"
         rendered = {"L0.Dockerfile": "x", "L1.cli.Dockerfile": "y", "L2.Dockerfile": "z"}
 
         with patch(
@@ -247,7 +255,7 @@ class TestIsTaskImageOld:
         assert is_task_image_old("proj1", task) is None
 
     def test_returns_none_for_none_project(self) -> None:
-        """None project_id → None."""
+        """None project_name → None."""
         from terok.lib.domain.project_state import is_task_image_old
 
         task = Mock(mode="cli", task_id="42")

--- a/tests/unit/lib/test_storage.py
+++ b/tests/unit/lib/test_storage.py
@@ -14,7 +14,7 @@ from unittest.mock import patch
 
 from terok.lib.domain.image_cleanup import ImageInfo
 from terok.lib.domain.storage import (
-    ORPHAN_PROJECT_ID,
+    ORPHAN_PROJECT_NAME,
     ProjectSummary,
     StorageOverview,
     _is_global_image,
@@ -157,7 +157,7 @@ class TestGetStorageOverview:
         assert len(overview.global_images) == 1
         assert overview.global_images[0].repository == "terok-l0"
         assert len(overview.projects) == 1
-        assert overview.projects[0].project_id == "myproject"
+        assert overview.projects[0].project_name == "myproject"
 
     @patch("terok.lib.domain.storage.SharedMountStorageInfo.measure_all", return_value=[])
     @patch("terok.lib.domain.storage.TaskStorageInfo.measure_all", return_value=[])
@@ -176,14 +176,14 @@ class TestGetStorageOverview:
     def test_localhost_prefix_attributes_to_project(
         self, _mounts, mock_images, mock_projects, _tasks, _shared
     ):
-        """L2 images with podman's ``localhost/`` prefix roll up to the bare project id."""
+        """L2 images with podman's ``localhost/`` prefix roll up to the bare project name."""
         mock_images.return_value = [
             ImageInfo("localhost/myproject", "l2-cli", "id", "3GB", "1d ago"),
         ]
         mock_projects.return_value = [_fake_project("myproject")]
         overview = get_storage_overview()
         assert len(overview.projects) == 1
-        assert overview.projects[0].project_id == "myproject"
+        assert overview.projects[0].project_name == "myproject"
         assert overview.projects[0].image_bytes == 3_000_000_000
 
     @patch("terok.lib.domain.storage.SharedMountStorageInfo.measure_all", return_value=[])
@@ -201,9 +201,9 @@ class TestGetStorageOverview:
         ]
         mock_projects.return_value = [_fake_project("myproject")]
         overview = get_storage_overview()
-        project_ids = [p.project_id for p in overview.projects]
-        assert ORPHAN_PROJECT_ID in project_ids
-        orphan = next(p for p in overview.projects if p.project_id == ORPHAN_PROJECT_ID)
+        project_names = [p.project_name for p in overview.projects]
+        assert ORPHAN_PROJECT_NAME in project_names
+        orphan = next(p for p in overview.projects if p.project_name == ORPHAN_PROJECT_NAME)
         assert orphan.image_bytes == 2_000_000_000
         assert orphan.task_count == 0
         # Orphan bytes contribute to the grand total.
@@ -223,7 +223,7 @@ class TestGetStorageOverview:
         ]
         mock_projects.return_value = [_fake_project("myproject")]
         overview = get_storage_overview()
-        assert all(p.project_id != ORPHAN_PROJECT_ID for p in overview.projects)
+        assert all(p.project_name != ORPHAN_PROJECT_NAME for p in overview.projects)
 
 
 # ---------------------------------------------------------------------------
@@ -241,7 +241,7 @@ class TestGetProjectStorageDetail:
         mock_runtime.container_rw_sizes.return_value = {"abc": 1024}
         mock_load.return_value = _fake_project("myproject")
         detail = get_project_storage_detail("myproject")
-        assert detail.project_id == "myproject"
+        assert detail.project_name == "myproject"
         assert detail.overlays == {"abc": 1024}
 
 
@@ -255,6 +255,6 @@ def _fake_project(pid: str):
     from unittest.mock import MagicMock
 
     p = MagicMock()
-    p.id = pid
+    p.name = pid
     p.tasks_root = MOCK_BASE / "tasks" / pid
     return p

--- a/tests/unit/lib/test_task_ids.py
+++ b/tests/unit/lib/test_task_ids.py
@@ -110,10 +110,10 @@ class TestNormalizeTaskIdInput:
 class TestResolveTaskId:
     """Tests for CLI prefix-matching task ID resolution."""
 
-    def _write_meta(self, project_id: str, task_id: str) -> None:
+    def _write_meta(self, project_name: str, task_id: str) -> None:
         """Write a minimal task metadata file."""
         meta = {"task_id": task_id, "name": "test-task", "mode": None, "workspace": "/tmp/ws"}
-        write_task_meta(dossier_path(tasks_meta_dir(project_id), task_id), meta)
+        write_task_meta(dossier_path(tasks_meta_dir(project_name), task_id), meta)
 
     def test_exact_match(self) -> None:
         """Full task ID should resolve immediately."""

--- a/tests/unit/lib/test_task_names.py
+++ b/tests/unit/lib/test_task_names.py
@@ -32,26 +32,26 @@ from tests.test_utils import project_env
 SLUG_PATTERN = r"^[a-z]+-[a-z0-9]+$"
 
 
-def project_yaml(project_id: str, *, name_categories: list[str] | None = None) -> str:
+def project_yaml(project_name: str, *, name_categories: list[str] | None = None) -> str:
     """Build a minimal project config with optional task name categories."""
-    yaml_text = f"project:\n  id: {project_id}\n"
+    yaml_text = f"project:\n  id: {project_name}\n"
     if name_categories:
         yaml_text += "tasks:\n  name_categories:\n"
         yaml_text += "".join(f"    - {category}\n" for category in name_categories)
     return yaml_text
 
 
-def task_meta_name(ctx, project_id: str, task_id: str) -> str:
+def task_meta_name(ctx, project_name: str, task_id: str) -> str:
     """Return the persisted task name from task metadata."""
-    meta_path = ctx.state_dir / "projects" / project_id / "tasks" / f"{task_id}_dossier.json"
+    meta_path = ctx.state_dir / "projects" / project_name / "tasks" / f"{task_id}_dossier.json"
     return json.loads(meta_path.read_text() or "{}")["name"]
 
 
-def create_task_and_get_name(project_id: str, *, explicit_name: str | None = None) -> str:
+def create_task_and_get_name(project_name: str, *, explicit_name: str | None = None) -> str:
     """Create one task in a temporary project env and return its resulting task name."""
-    with project_env(project_yaml(project_id), project_id=project_id):
-        task_new(project_id, name=explicit_name)
-        tasks = get_tasks(project_id)
+    with project_env(project_yaml(project_name), project_name=project_name):
+        task_new(project_name, name=explicit_name)
+        tasks = get_tasks(project_name)
         assert len(tasks) == 1
         return tasks[0].name
 
@@ -111,20 +111,20 @@ def test_generate_task_name_outputs_non_empty_slug() -> None:
 
 
 @pytest.mark.parametrize(
-    ("project_id", "explicit_name", "expected", "pattern"),
+    ("project_name", "explicit_name", "expected", "pattern"),
     [
         pytest.param("proj_name1", "Fix Auth Bug", "fix-auth-bug", None, id="explicit-sanitized"),
         pytest.param("proj_name2", None, None, SLUG_PATTERN, id="generated-default"),
     ],
 )
 def test_task_new_assigns_expected_name(
-    project_id: str,
+    project_name: str,
     explicit_name: str | None,
     expected: str | None,
     pattern: str | None,
 ) -> None:
     """New tasks use either the explicit sanitized name or an auto-generated slug."""
-    name = create_task_and_get_name(project_id, explicit_name=explicit_name)
+    name = create_task_and_get_name(project_name, explicit_name=explicit_name)
     if expected is not None:
         assert name == expected
     else:
@@ -134,21 +134,21 @@ def test_task_new_assigns_expected_name(
 @pytest.mark.parametrize("bad_name", ["@#$", "-my-task"], ids=["invalid", "leading-hyphen"])
 def test_task_new_rejects_invalid_names(bad_name: str) -> None:
     """Invalid task names fail before writing task metadata."""
-    project_id = "proj_name_invalid"
-    with project_env(project_yaml(project_id), project_id=project_id) as ctx:
+    project_name = "proj_name_invalid"
+    with project_env(project_yaml(project_name), project_name=project_name) as ctx:
         with pytest.raises(SystemExit):
-            task_new(project_id, name=bad_name)
-        tasks_dir = ctx.state_dir / "projects" / project_id / "tasks"
+            task_new(project_name, name=bad_name)
+        tasks_dir = ctx.state_dir / "projects" / project_name / "tasks"
         assert not tasks_dir.exists() or not list(iter_task_ids(tasks_dir))
 
 
 def test_task_new_prints_name() -> None:
     """Task creation output includes the resolved task name."""
-    project_id = "proj_name3"
-    with project_env(project_yaml(project_id), project_id=project_id):
+    project_name = "proj_name3"
+    with project_env(project_yaml(project_name), project_name=project_name):
         output = StringIO()
         with redirect_stdout(output):
-            task_new(project_id, name="my-task")
+            task_new(project_name, name="my-task")
     assert "my-task" in output.getvalue()
 
 
@@ -168,33 +168,33 @@ def test_task_rename_updates_or_rejects(
     raises: bool,
 ) -> None:
     """Task renaming persists the sanitized value or rejects invalid names."""
-    project_id = "proj_rename"
-    with project_env(project_yaml(project_id), project_id=project_id) as ctx:
-        task_id = task_new(project_id, name=initial_name)
+    project_name = "proj_rename"
+    with project_env(project_yaml(project_name), project_name=project_name) as ctx:
+        task_id = task_new(project_name, name=initial_name)
         if raises:
             with pytest.raises(SystemExit):
-                task_rename(project_id, task_id, new_name)
+                task_rename(project_name, task_id, new_name)
         else:
-            task_rename(project_id, task_id, new_name)
-            assert task_meta_name(ctx, project_id, task_id) == expected
+            task_rename(project_name, task_id, new_name)
+            assert task_meta_name(ctx, project_name, task_id) == expected
 
 
 def test_task_rename_unknown_task_raises() -> None:
     """Renaming an unknown task raises ``SystemExit``."""
-    project_id = "proj_rename_unknown"
-    with project_env(project_yaml(project_id), project_id=project_id):
+    project_name = "proj_rename_unknown"
+    with project_env(project_yaml(project_name), project_name=project_name):
         with pytest.raises(SystemExit):
-            task_rename(project_id, "999", "new-name")
+            task_rename(project_name, "999", "new-name")
 
 
 def test_get_tasks_loads_name() -> None:
     """Task loading populates ``TaskMeta.name`` from YAML."""
-    project_id = "proj_load_name"
-    assert create_task_and_get_name(project_id, explicit_name="test-task") == "test-task"
+    project_name = "proj_load_name"
+    assert create_task_and_get_name(project_name, explicit_name="test-task") == "test-task"
 
 
 def test_default_categories_for_project_are_valid_and_deterministic() -> None:
-    """Hash-based default categories are valid and stable per project ID."""
+    """Hash-based default categories are valid and stable per project name."""
     import namer
 
     categories = _default_categories_for_project("stable-proj")
@@ -220,39 +220,42 @@ def test_resolve_name_categories(
     expected: list[str] | None,
 ) -> None:
     """Project config wins, then global config, then the deterministic hash fallback."""
-    project_id = "proj_categories"
+    project_name = "proj_categories"
     with (
         project_env(
-            project_yaml(project_id, name_categories=project_categories), project_id=project_id
+            project_yaml(project_name, name_categories=project_categories),
+            project_name=project_name,
         ),
         patch("terok.lib.core.config.get_task_name_categories", return_value=global_categories),
     ):
-        categories = _resolve_name_categories(project_id)
+        categories = _resolve_name_categories(project_name)
 
-    assert categories == (expected or _default_categories_for_project(project_id))
+    assert categories == (expected or _default_categories_for_project(project_name))
 
 
-@pytest.mark.parametrize("project_id", [None, "proj_gen_cat"], ids=["no-project", "project-aware"])
-def test_generate_task_name_with_optional_project_id(project_id: str | None) -> None:
+@pytest.mark.parametrize(
+    "project_name", [None, "proj_gen_cat"], ids=["no-project", "project-aware"]
+)
+def test_generate_task_name_with_optional_project_name(project_name: str | None) -> None:
     """Task-name generation works with and without project-aware category resolution."""
-    if project_id is None:
+    if project_name is None:
         name = generate_task_name()
     else:
         with project_env(
-            project_yaml(project_id, name_categories=["animals"]), project_id=project_id
+            project_yaml(project_name, name_categories=["animals"]), project_name=project_name
         ):
-            name = generate_task_name(project_id)
+            name = generate_task_name(project_name)
 
     assert isinstance(name, str)
     assert re.search(SLUG_PATTERN, name)
 
 
 def test_task_new_uses_project_categories() -> None:
-    """Task creation passes the project ID through for category resolution."""
-    project_id = "proj_new_cat"
-    with project_env(project_yaml(project_id), project_id=project_id):
-        task_new(project_id)
-        tasks = get_tasks(project_id)
+    """Task creation passes the project name through for category resolution."""
+    project_name = "proj_new_cat"
+    with project_env(project_yaml(project_name), project_name=project_name):
+        task_new(project_name)
+        tasks = get_tasks(project_name)
 
     assert len(tasks) == 1
     assert tasks[0].name is not None

--- a/tests/unit/lib/test_task_runner_internals.py
+++ b/tests/unit/lib/test_task_runner_internals.py
@@ -526,7 +526,7 @@ class TestRunContainer:
         from terok.lib.core.project_model import ProjectConfig
 
         p = MagicMock(spec=ProjectConfig)
-        p.id = "p1"
+        p.name = "p1"
         p.gpu_enabled = False
         p.root = MOCK_TASK_DIR
         p.isolation = "shared"
@@ -1071,7 +1071,7 @@ class TestLaunchPreparedIdentity:
     """``_run_container`` threads project/task identity into the sidecar.
 
     The supervisor reads the sidecar JSON at OCI prestart hook time, so
-    every ``podman run`` issued by terok must carry ``project_id`` /
+    every ``podman run`` issued by terok must carry ``project_name`` /
     ``task_id`` / ``dossier_path`` for the supervisor to scope its
     state correctly.
     """
@@ -1080,7 +1080,7 @@ class TestLaunchPreparedIdentity:
         from terok.lib.core.project_model import ProjectConfig
 
         p = MagicMock(spec=ProjectConfig)
-        p.id = "proj-id-x"
+        p.name = "proj-id-x"
         p.gpu_enabled = False
         p.root = MOCK_TASK_DIR
         p.isolation = "shared"
@@ -1092,7 +1092,7 @@ class TestLaunchPreparedIdentity:
         return p
 
     def test_identity_kwargs_passed_through(self) -> None:
-        """``launch_prepared`` receives ``project_id``, ``task_id``, ``dossier_path``."""
+        """``launch_prepared`` receives ``project_name``, ``task_id``, ``dossier_path``."""
         from terok.lib.orchestration.tasks import dossier_path, tasks_meta_dir
 
         project = self._make_project()
@@ -1114,7 +1114,9 @@ class TestLaunchPreparedIdentity:
             )
 
         kwargs = sandbox_factory.return_value.launch_prepared.call_args.kwargs
-        assert kwargs["project_id"] == "proj-id-x"
+        assert (
+            kwargs["project_id"] == "proj-id-x"
+        )  # executor API kwarg name (value is the project name)
         assert kwargs["task_id"] == "task-id-y"
         expected_dossier = dossier_path(tasks_meta_dir("proj-id-x"), "task-id-y")
         assert kwargs["dossier_path"] == expected_dossier

--- a/tests/unit/lib/test_tasks.py
+++ b/tests/unit/lib/test_tasks.py
@@ -69,7 +69,7 @@ def _set_state_sequence(mock_runtime, states: list[str | None]):
     )
 
 
-def _gate_repo_fragment(project_id: str, *, port: int = GATE_PORT) -> str:
+def _gate_repo_fragment(project_name: str, *, port: int = GATE_PORT) -> str:
     """Return the gate URL fragment embedded in task env vars.
 
     Intentionally mode-agnostic: socket transport builds URLs with
@@ -77,7 +77,7 @@ def _gate_repo_fragment(project_id: str, *, port: int = GATE_PORT) -> str:
     with ``host.containers.internal:<port>``.  We only assert on the
     repo path so these tests pass regardless of ``services.mode``.
     """
-    return f":{port}/{project_id}.git"
+    return f":{port}/{project_name}.git"
 
 
 class TestTask:
@@ -108,14 +108,14 @@ class TestTask:
         run_mock.assert_called()
 
     def test_task_new_and_delete(self) -> None:
-        project_id = "proj8"
+        project_name = "proj8"
         with project_env(
-            f"project:\n  id: {project_id}\n",
-            project_id=project_id,
+            f"project:\n  id: {project_name}\n",
+            project_name=project_name,
         ) as ctx:
-            returned_id = task_new(project_id)
+            returned_id = task_new(project_name)
             assert_task_id(returned_id)
-            meta_dir = ctx.state_dir / "projects" / project_id / "tasks"
+            meta_dir = ctx.state_dir / "projects" / project_name / "tasks"
             meta_path = meta_dir / f"{returned_id}_dossier.json"
             assert meta_path.is_file()
 
@@ -127,7 +127,7 @@ class TestTask:
             assert workspace.is_dir()
 
             # Verify second task returns a different hex ID
-            second_id = task_new(project_id)
+            second_id = task_new(project_name)
             assert_task_id(second_id)
             assert second_id != returned_id
 
@@ -135,7 +135,7 @@ class TestTask:
                 unittest.mock.patch("terok_executor.AgentRunner.capture_logs", return_value=False),
                 mock_git_config(),
             ):
-                result = task_delete(project_id, returned_id)
+                result = task_delete(project_name, returned_id)
 
             assert isinstance(result, TaskDeleteResult)
             assert not meta_path.exists()
@@ -147,13 +147,13 @@ class TestTask:
         The TUI uses this field to sort tasks newest-first; task_id is random hex
         and carries no temporal information.
         """
-        project_id = "proj_created_at"
+        project_name = "proj_created_at"
         with project_env(
-            f"project:\n  id: {project_id}\n",
-            project_id=project_id,
+            f"project:\n  id: {project_name}\n",
+            project_name=project_name,
         ) as ctx:
-            tid = task_new(project_id)
-            meta_dir = ctx.state_dir / "projects" / project_id / "tasks"
+            tid = task_new(project_name)
+            meta_dir = ctx.state_dir / "projects" / project_name / "tasks"
             meta = read_task_meta(meta_dir, tid) or {}
 
             assert "created_at" in meta
@@ -161,7 +161,7 @@ class TestTask:
             assert parsed.tzinfo is not None, "created_at must be timezone-aware"
             assert parsed.utcoffset() == timedelta(0), "created_at must be UTC"
 
-            [task] = [t for t in get_tasks(project_id) if t.task_id == tid]
+            [task] = [t for t in get_tasks(project_name) if t.task_id == tid]
             assert task.created_at == meta["created_at"]
 
     def test_task_new_creates_marker_file(self) -> None:
@@ -171,16 +171,16 @@ class TestTask:
         task and the workspace should be reset to the latest remote HEAD.
         See the docstring in task_new() for the full protocol description.
         """
-        project_id = "proj_marker"
+        project_name = "proj_marker"
         with project_env(
-            f"project:\n  id: {project_id}\n",
-            project_id=project_id,
+            f"project:\n  id: {project_name}\n",
+            project_name=project_name,
         ) as ctx:
-            task_id = task_new(project_id)
+            task_id = task_new(project_name)
 
             # Verify marker file exists in the workspace subdirectory
             sandbox_live = ctx.base / "sandbox-live"
-            workspace_dir = sandbox_live / "tasks" / project_id / task_id / "workspace-dangerous"
+            workspace_dir = sandbox_live / "tasks" / project_name / task_id / "workspace-dangerous"
             marker_path = workspace_dir / ".new-task-marker"
             assert marker_path.is_file()
 
@@ -189,9 +189,9 @@ class TestTask:
             assert "reset to the latest remote HEAD" in marker_content
 
     @staticmethod
-    def _patch_task_meta(ctx, project_id: str, tid: str, **updates) -> None:
+    def _patch_task_meta(ctx, project_name: str, tid: str, **updates) -> None:
         """Load a task's metadata, apply updates, and write it back."""
-        meta_dir = ctx.state_dir / "projects" / project_id / "tasks"
+        meta_dir = ctx.state_dir / "projects" / project_name / "tasks"
         meta = read_task_meta(meta_dir, tid) or {}
         meta.update(updates)
         # Setting mode implies the task reached readiness (ready_at marker).
@@ -200,7 +200,7 @@ class TestTask:
         write_task_meta(dossier_path(meta_dir, tid), meta)
 
     @staticmethod
-    def _task_list_output(project_id: str, states: dict[str, str | None], **filters: str) -> str:
+    def _task_list_output(project_name: str, states: dict[str, str | None], **filters: str) -> str:
         """Run ``task_list`` with mocked container states and capture stdout."""
         with unittest.mock.patch(
             "terok.lib.orchestration.tasks.query.get_all_task_states",
@@ -208,7 +208,7 @@ class TestTask:
         ):
             buf = StringIO()
             with redirect_stdout(buf):
-                task_list(project_id, **filters)
+                task_list(project_name, **filters)
         return buf.getvalue()
 
     @staticmethod
@@ -218,18 +218,18 @@ class TestTask:
 
     def test_task_list_no_filters(self) -> None:
         """task_list with no filters prints all tasks."""
-        project_id = "proj_list"
+        project_name = "proj_list"
         with project_env(
-            f"project:\n  id: {project_id}\n",
-            project_id=project_id,
+            f"project:\n  id: {project_name}\n",
+            project_name=project_name,
         ) as ctx:
-            tid1 = task_new(project_id)
-            tid2 = task_new(project_id)
+            tid1 = task_new(project_name)
+            tid2 = task_new(project_name)
 
-            self._patch_task_meta(ctx, project_id, tid1, mode="cli")
-            self._patch_task_meta(ctx, project_id, tid2, mode="web")
+            self._patch_task_meta(ctx, project_name, tid1, mode="cli")
+            self._patch_task_meta(ctx, project_name, tid2, mode="web")
 
-            output = self._task_list_output(project_id, {tid1: "running", tid2: "exited"})
+            output = self._task_list_output(project_name, {tid1: "running", tid2: "exited"})
             assert self._task_row_pattern(tid1).search(output)
             assert "running" in output
             assert self._task_row_pattern(tid2).search(output)
@@ -237,19 +237,19 @@ class TestTask:
 
     def test_task_list_filter_by_status(self) -> None:
         """task_list --status filters tasks by effective status."""
-        project_id = "proj_filt_status"
+        project_name = "proj_filt_status"
         with project_env(
-            f"project:\n  id: {project_id}\n",
-            project_id=project_id,
+            f"project:\n  id: {project_name}\n",
+            project_name=project_name,
         ) as ctx:
-            tid1 = task_new(project_id)
-            tid2 = task_new(project_id)
+            tid1 = task_new(project_name)
+            tid2 = task_new(project_name)
 
-            self._patch_task_meta(ctx, project_id, tid1, mode="cli")
-            self._patch_task_meta(ctx, project_id, tid2, mode="cli")
+            self._patch_task_meta(ctx, project_name, tid1, mode="cli")
+            self._patch_task_meta(ctx, project_name, tid2, mode="cli")
 
             output = self._task_list_output(
-                project_id, {tid1: "running", tid2: "exited"}, status="running"
+                project_name, {tid1: "running", tid2: "exited"}, status="running"
             )
             assert self._task_row_pattern(tid1).search(output)
             assert "running" in output
@@ -257,18 +257,18 @@ class TestTask:
 
     def test_task_list_id_format(self) -> None:
         """task_list prints hex task IDs with no alignment padding."""
-        project_id = "proj_align"
+        project_name = "proj_align"
         with project_env(
-            f"project:\n  id: {project_id}\n",
-            project_id=project_id,
+            f"project:\n  id: {project_name}\n",
+            project_name=project_name,
         ) as ctx:
-            tid1 = task_new(project_id)
-            tid2 = task_new(project_id)
-            self._patch_task_meta(ctx, project_id, tid1, mode="cli")
-            self._patch_task_meta(ctx, project_id, tid2, mode="cli")
+            tid1 = task_new(project_name)
+            tid2 = task_new(project_name)
+            self._patch_task_meta(ctx, project_name, tid1, mode="cli")
+            self._patch_task_meta(ctx, project_name, tid2, mode="cli")
 
             output = self._task_list_output(
-                project_id,
+                project_name,
                 {
                     tid1: "running",
                     tid2: "exited",
@@ -280,59 +280,59 @@ class TestTask:
 
     def test_task_list_filter_by_mode(self) -> None:
         """task_list --mode filters tasks by their mode field."""
-        project_id = "proj_filt_mode"
+        project_name = "proj_filt_mode"
         with project_env(
-            f"project:\n  id: {project_id}\n",
-            project_id=project_id,
+            f"project:\n  id: {project_name}\n",
+            project_name=project_name,
         ) as ctx:
-            tid1 = task_new(project_id)
-            tid2 = task_new(project_id)
+            tid1 = task_new(project_name)
+            tid2 = task_new(project_name)
 
-            self._patch_task_meta(ctx, project_id, tid1, mode="cli")
-            self._patch_task_meta(ctx, project_id, tid2, mode="web")
+            self._patch_task_meta(ctx, project_name, tid1, mode="cli")
+            self._patch_task_meta(ctx, project_name, tid2, mode="web")
 
-            output = self._task_list_output(project_id, {tid2: None}, mode="web")
+            output = self._task_list_output(project_name, {tid2: None}, mode="web")
             assert not self._task_row_pattern(tid1).search(output)
             assert self._task_row_pattern(tid2).search(output)
 
     def test_task_list_filter_by_agent(self) -> None:
         """task_list --agent filters tasks by their preset field."""
-        project_id = "proj_filt_agent"
+        project_name = "proj_filt_agent"
         with project_env(
-            f"project:\n  id: {project_id}\n",
-            project_id=project_id,
+            f"project:\n  id: {project_name}\n",
+            project_name=project_name,
         ) as ctx:
-            tid1 = task_new(project_id)
-            tid2 = task_new(project_id)
+            tid1 = task_new(project_name)
+            tid2 = task_new(project_name)
 
-            self._patch_task_meta(ctx, project_id, tid1, preset="claude")
-            self._patch_task_meta(ctx, project_id, tid2, preset="codex")
+            self._patch_task_meta(ctx, project_name, tid1, preset="claude")
+            self._patch_task_meta(ctx, project_name, tid2, preset="codex")
 
-            output = self._task_list_output(project_id, {tid1: None, tid2: None}, agent="claude")
+            output = self._task_list_output(project_name, {tid1: None, tid2: None}, agent="claude")
             assert self._task_row_pattern(tid1).search(output)
             assert not self._task_row_pattern(tid2).search(output)
 
     def test_task_list_combined_filters(self) -> None:
         """task_list with multiple filters applies all of them (AND logic)."""
-        project_id = "proj_filt_combo"
+        project_name = "proj_filt_combo"
         with project_env(
-            f"project:\n  id: {project_id}\n",
-            project_id=project_id,
+            f"project:\n  id: {project_name}\n",
+            project_name=project_name,
         ) as ctx:
-            tid1 = task_new(project_id)
-            tid2 = task_new(project_id)
-            tid3 = task_new(project_id)
+            tid1 = task_new(project_name)
+            tid2 = task_new(project_name)
+            tid3 = task_new(project_name)
 
             for tid, mode in [
                 (tid1, "cli"),
                 (tid2, "web"),
                 (tid3, "cli"),
             ]:
-                self._patch_task_meta(ctx, project_id, tid, mode=mode)
+                self._patch_task_meta(ctx, project_name, tid, mode=mode)
 
             # mode filter narrows to cli first, then status=running keeps only task 1
             output = self._task_list_output(
-                project_id, {tid1: "running", tid3: "exited"}, status="running", mode="cli"
+                project_name, {tid1: "running", tid3: "exited"}, status="running", mode="cli"
             )
             assert self._task_row_pattern(tid1).search(output)
             assert not self._task_row_pattern(tid2).search(output)
@@ -340,35 +340,35 @@ class TestTask:
 
     def test_task_list_no_match(self) -> None:
         """task_list prints 'No tasks found' when filters match nothing."""
-        project_id = "proj_filt_none"
+        project_name = "proj_filt_none"
         with project_env(
-            f"project:\n  id: {project_id}\n",
-            project_id=project_id,
+            f"project:\n  id: {project_name}\n",
+            project_name=project_name,
         ):
-            tid = task_new(project_id)
+            tid = task_new(project_name)
 
             # New task has no mode → effective status is "created", not "running"
-            output = self._task_list_output(project_id, {tid: None}, status="running")
+            output = self._task_list_output(project_name, {tid: None}, status="running")
             assert "No tasks found" in output
 
     @unittest.mock.patch(
         "terok.lib.orchestration.environment.mint_gate_token", return_value="tok" * 10 + "ab"
     )
     def test_build_task_env_gatekeeping(self, *_mocks) -> None:
-        project_id = "proj9"
+        project_name = "proj9"
         with project_env(
-            f"project:\n  id: {project_id}\n  security_class: gatekeeping\ngit:\n  default_branch: main\n",
-            project_id=project_id,
+            f"project:\n  id: {project_name}\n  security_class: gatekeeping\ngit:\n  default_branch: main\n",
+            project_name=project_name,
             with_config_file=True,
             with_gate=True,
         ):
             env, volumes = build_task_env_and_volumes(
-                project=load_project(project_id),
+                project=load_project(project_name),
                 task_id="7",
             )
 
             assert "http://" in env["CODE_REPO"]
-            assert _gate_repo_fragment(project_id) in env["CODE_REPO"]
+            assert _gate_repo_fragment(project_name) in env["CODE_REPO"]
             # The minted gate token is surfaced for the per-container
             # supervisor to validate.  The gate runs inside the supervisor
             # now — no host gate-socket bind-mount is emitted.
@@ -384,27 +384,27 @@ class TestTask:
     )
     def test_build_task_env_gatekeeping_with_ssh(self, *_mocks) -> None:
         """Gatekeeping mode does not bind-mount SSH (keys go via SSH agent proxy)."""
-        project_id = "proj_gatekeeping_ssh"
+        project_name = "proj_gatekeeping_ssh"
         with project_env(
             "placeholder",
-            project_id=project_id,
+            project_name=project_name,
             with_config_file=True,
             with_gate=True,
         ) as ctx:
             write_project(
                 ctx.config_root,
-                project_id,
-                f"project:\n  id: {project_id}\n  security_class: gatekeeping\ngit:\n  default_branch: main\n",
+                project_name,
+                f"project:\n  id: {project_name}\n  security_class: gatekeeping\ngit:\n  default_branch: main\n",
             )
 
             env, volumes = build_task_env_and_volumes(
-                project=load_project(project_id),
+                project=load_project(project_name),
                 task_id="9",
             )
 
             # Verify gatekeeping behavior: CODE_REPO is http:// URL with token
             assert "http://" in env["CODE_REPO"]
-            assert _gate_repo_fragment(project_id) in env["CODE_REPO"]
+            assert _gate_repo_fragment(project_name) in env["CODE_REPO"]
             # Verify SSH is NOT mounted (keys are served via SSH agent proxy)
             ssh_mounts = [v for v in volumes if str(CONTAINER_SSH_DIR) in v.container_path]
             assert ssh_mounts == []
@@ -413,49 +413,49 @@ class TestTask:
         "terok.lib.orchestration.environment.mint_gate_token", return_value="tok" * 10 + "ab"
     )
     def test_build_task_env_online(self, *_mocks) -> None:
-        project_id = "proj10"
+        project_name = "proj10"
         with project_env(
             "placeholder",
-            project_id=project_id,
+            project_name=project_name,
             with_config_file=True,
             with_gate=True,
         ) as ctx:
             write_project(
                 ctx.config_root,
-                project_id,
-                f"project:\n  id: {project_id}\n  security_class: online\ngit:\n  upstream_url: https://example.com/repo.git\n  default_branch: main\n",
+                project_name,
+                f"project:\n  id: {project_name}\n  security_class: online\ngit:\n  upstream_url: https://example.com/repo.git\n  default_branch: main\n",
             )
 
-            env, volumes = build_task_env_and_volumes(load_project(project_id), task_id="8")
+            env, volumes = build_task_env_and_volumes(load_project(project_name), task_id="8")
             assert env["CODE_REPO"] == "https://example.com/repo.git"
             assert env["GIT_BRANCH"] == "main"
             assert env["TEROK_GIT_AUTHORSHIP"] == "agent-human"
             assert "http://" in env["CLONE_FROM"]
-            assert _gate_repo_fragment(project_id) in env["CLONE_FROM"]
+            assert _gate_repo_fragment(project_name) in env["CLONE_FROM"]
             # SSH is NOT bind-mounted (keys are served via SSH agent proxy)
             ssh_mounts = [v for v in volumes if str(CONTAINER_SSH_DIR) in v.container_path]
             assert ssh_mounts == []
 
     def test_build_task_env_uses_configured_git_authorship(self) -> None:
         """Task containers receive the resolved Git authorship mode."""
-        project_id = "proj_authorship_env"
+        project_name = "proj_authorship_env"
         with project_env(
-            f"project:\n  id: {project_id}\n  security_class: online\ngit:\n  upstream_url: https://example.com/repo.git\n  authorship: human-agent\n",
-            project_id=project_id,
+            f"project:\n  id: {project_name}\n  security_class: online\ngit:\n  upstream_url: https://example.com/repo.git\n  authorship: human-agent\n",
+            project_name=project_name,
         ):
-            env, _volumes = build_task_env_and_volumes(load_project(project_id), task_id="1")
+            env, _volumes = build_task_env_and_volumes(load_project(project_name), task_id="1")
             assert env["TEROK_GIT_AUTHORSHIP"] == "human-agent"
 
     def test_task_run_cli_colors_login_lines_when_tty(self, mock_runtime) -> None:
-        project_id = "proj_cli_color"
+        project_name = "proj_cli_color"
         with project_env(
-            f"project:\n  id: {project_id}\n  security_class: online\n",
-            project_id=project_id,
+            f"project:\n  id: {project_name}\n  security_class: online\n",
+            project_name=project_name,
             with_config_file=True,
             clear_env=True,
         ):
-            tid = task_new(project_id)
-            cname = f"{project_id}-cli-{tid}"
+            tid = task_new(project_name)
+            cname = f"{project_name}-cli-{tid}"
             mock_runtime.container.return_value.login_command.return_value = [
                 "podman",
                 "exec",
@@ -473,10 +473,10 @@ class TestTask:
             ):
                 buffer = StringIO()
                 with redirect_stdout(buffer):
-                    task_run_cli(project_id, tid)
+                    task_run_cli(project_name, tid)
 
             output = buffer.getvalue()
-            cname = f"{project_id}-cli-{tid}"
+            cname = f"{project_name}-cli-{tid}"
             expected_name = f"\x1b[32m{cname}\x1b[0m"
             expected_enter = f"\x1b[34mpodman exec -it {cname} bash\x1b[0m"
             expected_stop = f"\x1b[31mpodman stop {cname}\x1b[0m"
@@ -486,22 +486,22 @@ class TestTask:
 
     def test_task_run_cli_does_not_add_files_before_clone(self, mock_runtime) -> None:
         """Interactive CLI startup must not add files to workspace before init clone."""
-        project_id = "proj_cli_clean_workspace"
+        project_name = "proj_cli_clean_workspace"
         with project_env(
-            f"project:\n  id: {project_id}\n  security_class: online\n",
-            project_id=project_id,
+            f"project:\n  id: {project_name}\n  security_class: online\n",
+            project_name=project_name,
             with_config_file=True,
             clear_env=True,
         ) as ctx:
-            tid = task_new(project_id)
+            tid = task_new(project_name)
             sandbox_live = ctx.base / "sandbox-live"
-            workspace_dir = sandbox_live / "tasks" / project_id / tid / "workspace-dangerous"
+            workspace_dir = sandbox_live / "tasks" / project_name / tid / "workspace-dangerous"
             assert sorted(p.name for p in workspace_dir.iterdir()) == [".new-task-marker"]
             with (
                 _set_state_sequence(mock_runtime, [None, "running"]),
                 mock_git_config(),
             ):
-                task_run_cli(project_id, tid)
+                task_run_cli(project_name, tid)
 
             assert sorted(p.name for p in workspace_dir.iterdir()) == [".new-task-marker"]
             agent_mounts = ctx.base / "sandbox-live" / "mounts"
@@ -509,14 +509,14 @@ class TestTask:
 
     def test_task_run_toad_passes_public_url(self, mock_runtime) -> None:
         """task_run_toad must pass --public-url with the host port to toad serve."""
-        project_id = "proj_toad_url"
+        project_name = "proj_toad_url"
         with project_env(
-            f"project:\n  id: {project_id}\n  security_class: online\n",
-            project_id=project_id,
+            f"project:\n  id: {project_name}\n  security_class: online\n",
+            project_name=project_name,
             with_config_file=True,
             clear_env=True,
         ):
-            tid = task_new(project_id)
+            tid = task_new(project_name)
             mock_runtime.container.return_value.state = None
             mock_runtime.container.return_value.running = True
             with (
@@ -529,7 +529,7 @@ class TestTask:
                     "terok.lib.orchestration.task_runners.container._agent_runner"
                 ) as sandbox_factory,
             ):
-                task_run_toad(project_id, tid)
+                task_run_toad(project_name, tid)
 
             spec = captured_runspec(sandbox_factory)
             bash_cmd = spec.command[-1]
@@ -548,17 +548,17 @@ class TestTask:
         self, monkeypatch: pytest.MonkeyPatch, mock_runtime
     ) -> None:
         """task_run_toad must use TEROK_PUBLIC_HOST for URLs and bind to 0.0.0.0."""
-        project_id = "proj_toad_pub"
+        project_name = "proj_toad_pub"
         monkeypatch.setenv("TEROK_PUBLIC_HOST", "myserver")
         with project_env(
-            f"project:\n  id: {project_id}\n  security_class: online\n",
-            project_id=project_id,
+            f"project:\n  id: {project_name}\n  security_class: online\n",
+            project_name=project_name,
             with_config_file=True,
             clear_env=True,
         ):
             # Re-apply after clear_env
             monkeypatch.setenv("TEROK_PUBLIC_HOST", "myserver")
-            tid = task_new(project_id)
+            tid = task_new(project_name)
             mock_runtime.container.return_value.state = None
             mock_runtime.container.return_value.running = True
             with (
@@ -571,7 +571,7 @@ class TestTask:
                     "terok.lib.orchestration.task_runners.container._agent_runner"
                 ) as sandbox_factory,
             ):
-                task_run_toad(project_id, tid)
+                task_run_toad(project_name, tid)
 
             spec = captured_runspec(sandbox_factory)
             bash_cmd = spec.command[-1]
@@ -584,17 +584,17 @@ class TestTask:
 
     def test_task_run_cli_already_running(self, mock_runtime) -> None:
         """task_run_cli prints message and exits when container is already running."""
-        project_id = "proj_cli_running"
+        project_name = "proj_cli_running"
         with project_env(
-            f"project:\n  id: {project_id}\n",
-            project_id=project_id,
+            f"project:\n  id: {project_name}\n",
+            project_name=project_name,
         ):
-            tid = task_new(project_id)
+            tid = task_new(project_name)
             mock_runtime.container.return_value.state = "running"
             with mock_git_config():
                 buffer = StringIO()
                 with redirect_stdout(buffer):
-                    task_run_cli(project_id, tid)
+                    task_run_cli(project_name, tid)
 
                 # Verify message indicates already running
                 output = buffer.getvalue()
@@ -602,27 +602,27 @@ class TestTask:
 
     def test_task_run_cli_starts_stopped_container(self, mock_runtime) -> None:
         """task_run_cli uses 'podman start' for stopped container."""
-        project_id = "proj_cli_stopped"
+        project_name = "proj_cli_stopped"
         with project_env(
-            f"project:\n  id: {project_id}\n",
-            project_id=project_id,
+            f"project:\n  id: {project_name}\n",
+            project_name=project_name,
         ) as ctx:
-            tid = task_new(project_id)
-            meta_dir = ctx.state_dir / "projects" / project_id / "tasks"
+            tid = task_new(project_name)
+            meta_dir = ctx.state_dir / "projects" / project_name / "tasks"
 
             # Simulate task was previously run
             meta = read_task_meta(meta_dir, tid) or {}
             meta["mode"] = "cli"
             write_task_meta(dossier_path(meta_dir, tid), meta)
 
-            cname = f"{project_id}-cli-{tid}"
+            cname = f"{project_name}-cli-{tid}"
             with (
                 _set_state_sequence(mock_runtime, ["exited", "running"]),
                 mock_git_config(),
             ):
                 buffer = StringIO()
                 with redirect_stdout(buffer):
-                    task_run_cli(project_id, tid)
+                    task_run_cli(project_name, tid)
 
                 # Verify container(cname).start() was called
                 mock_runtime.container.assert_any_call(cname)
@@ -634,35 +634,35 @@ class TestTask:
 
     def test_get_workspace_git_diff_no_task(self) -> None:
         """Test get_workspace_git_diff returns None when task doesn't exist."""
-        project_id = "proj_diff_1"
+        project_name = "proj_diff_1"
         with project_env(
-            f"project:\n  id: {project_id}\n",
-            project_id=project_id,
+            f"project:\n  id: {project_name}\n",
+            project_name=project_name,
         ):
-            result = get_workspace_git_diff(project_id, "999")
+            result = get_workspace_git_diff(project_name, "999")
             assert result is None
 
     def test_get_workspace_git_diff_no_mode(self) -> None:
         """Test get_workspace_git_diff returns None when task has no mode set."""
-        project_id = "proj_diff_2"
+        project_name = "proj_diff_2"
         with project_env(
-            f"project:\n  id: {project_id}\n",
-            project_id=project_id,
+            f"project:\n  id: {project_name}\n",
+            project_name=project_name,
         ):
-            tid = task_new(project_id)
+            tid = task_new(project_name)
             # Task exists but has never been run (mode=None)
-            result = get_workspace_git_diff(project_id, tid)
+            result = get_workspace_git_diff(project_name, tid)
             assert result is None
 
     def test_get_workspace_git_diff_delegates_to_container(self) -> None:
         """Test get_workspace_git_diff delegates to container_git_diff."""
-        project_id = "proj_diff_3"
+        project_name = "proj_diff_3"
         with project_env(
-            f"project:\n  id: {project_id}\n",
-            project_id=project_id,
+            f"project:\n  id: {project_name}\n",
+            project_name=project_name,
         ):
-            tid = task_new(project_id)
-            meta_dir = tasks_meta_dir(project_id)
+            tid = task_new(project_name)
+            meta_dir = tasks_meta_dir(project_name)
             meta = read_task_meta(meta_dir, tid) or {}
             meta["mode"] = "cli"
             write_task_meta(dossier_path(meta_dir, tid), meta)
@@ -672,19 +672,19 @@ class TestTask:
                 "terok.lib.orchestration.tasks.query.container_git_diff",
                 return_value=expected,
             ) as mock_diff:
-                result = get_workspace_git_diff(project_id, tid, "HEAD")
+                result = get_workspace_git_diff(project_name, tid, "HEAD")
                 assert result == expected
-                mock_diff.assert_called_once_with(project_id, tid, "cli", "HEAD")
+                mock_diff.assert_called_once_with(project_name, tid, "cli", "HEAD")
 
     def test_get_workspace_git_diff_prev_commit(self) -> None:
         """Test get_workspace_git_diff with PREV option passes HEAD~1..HEAD."""
-        project_id = "proj_diff_5"
+        project_name = "proj_diff_5"
         with project_env(
-            f"project:\n  id: {project_id}\n",
-            project_id=project_id,
+            f"project:\n  id: {project_name}\n",
+            project_name=project_name,
         ):
-            tid = task_new(project_id)
-            meta_dir = tasks_meta_dir(project_id)
+            tid = task_new(project_name)
+            meta_dir = tasks_meta_dir(project_name)
             meta = read_task_meta(meta_dir, tid) or {}
             meta["mode"] = "run"
             write_task_meta(dossier_path(meta_dir, tid), meta)
@@ -694,19 +694,19 @@ class TestTask:
                 "terok.lib.orchestration.tasks.query.container_git_diff",
                 return_value=expected,
             ) as mock_diff:
-                result = get_workspace_git_diff(project_id, tid, "PREV")
+                result = get_workspace_git_diff(project_name, tid, "PREV")
                 assert result == expected
-                mock_diff.assert_called_once_with(project_id, tid, "run", "HEAD~1", "HEAD")
+                mock_diff.assert_called_once_with(project_name, tid, "run", "HEAD~1", "HEAD")
 
     def test_get_workspace_git_diff_container_failure(self) -> None:
         """Test get_workspace_git_diff returns None when container exec fails."""
-        project_id = "proj_diff_6"
+        project_name = "proj_diff_6"
         with project_env(
-            f"project:\n  id: {project_id}\n",
-            project_id=project_id,
+            f"project:\n  id: {project_name}\n",
+            project_name=project_name,
         ):
-            tid = task_new(project_id)
-            meta_dir = tasks_meta_dir(project_id)
+            tid = task_new(project_name)
+            meta_dir = tasks_meta_dir(project_name)
             meta = read_task_meta(meta_dir, tid) or {}
             meta["mode"] = "cli"
             write_task_meta(dossier_path(meta_dir, tid), meta)
@@ -715,7 +715,7 @@ class TestTask:
                 "terok.lib.orchestration.tasks.query.container_git_diff",
                 return_value=None,
             ):
-                result = get_workspace_git_diff(project_id, tid)
+                result = get_workspace_git_diff(project_name, tid)
                 assert result is None
 
     def test_copy_to_clipboard_empty_text(self) -> None:
@@ -876,16 +876,16 @@ class TestTask:
     )
     def test_build_task_env_gatekeeping_expose_external_remote_enabled(self, *_mocks) -> None:
         """Test expose_external_remote=true with upstream_url sets EXTERNAL_REMOTE_URL."""
-        project_id = "proj_external_remote_enabled"
+        project_name = "proj_external_remote_enabled"
         upstream_url = "https://github.com/example/repo.git"
         with project_env(
-            f"project:\n  id: {project_id}\n  security_class: gatekeeping\ngit:\n  upstream_url: {upstream_url}\n  default_branch: main\ngatekeeping:\n  expose_external_remote: true\n",
-            project_id=project_id,
+            f"project:\n  id: {project_name}\n  security_class: gatekeeping\ngit:\n  upstream_url: {upstream_url}\n  default_branch: main\ngatekeeping:\n  expose_external_remote: true\n",
+            project_name=project_name,
             with_config_file=True,
             with_gate=True,
         ):
             env, _ = build_task_env_and_volumes(
-                project=load_project(project_id),
+                project=load_project(project_name),
                 task_id="10",
             )
 
@@ -893,23 +893,23 @@ class TestTask:
             assert env["EXTERNAL_REMOTE_URL"] == upstream_url
             # Verify gatekeeping mode settings are still correct
             assert "http://" in env["CODE_REPO"]
-            assert _gate_repo_fragment(project_id) in env["CODE_REPO"]
+            assert _gate_repo_fragment(project_name) in env["CODE_REPO"]
 
     @unittest.mock.patch(
         "terok.lib.orchestration.environment.mint_gate_token", return_value="tok" * 10 + "ab"
     )
     def test_build_task_env_gatekeeping_expose_external_remote_disabled(self, *_mocks) -> None:
         """Test expose_external_remote=false does not set EXTERNAL_REMOTE_URL."""
-        project_id = "proj_external_remote_disabled"
+        project_name = "proj_external_remote_disabled"
         upstream_url = "https://github.com/example/repo.git"
         with project_env(
-            f"project:\n  id: {project_id}\n  security_class: gatekeeping\ngit:\n  upstream_url: {upstream_url}\n  default_branch: main\ngatekeeping:\n  expose_external_remote: false\n",
-            project_id=project_id,
+            f"project:\n  id: {project_name}\n  security_class: gatekeeping\ngit:\n  upstream_url: {upstream_url}\n  default_branch: main\ngatekeeping:\n  expose_external_remote: false\n",
+            project_name=project_name,
             with_config_file=True,
             with_gate=True,
         ):
             env, _ = build_task_env_and_volumes(
-                project=load_project(project_id),
+                project=load_project(project_name),
                 task_id="11",
             )
 
@@ -917,22 +917,22 @@ class TestTask:
             assert "EXTERNAL_REMOTE_URL" not in env
             # Verify gatekeeping mode settings are still correct
             assert "http://" in env["CODE_REPO"]
-            assert _gate_repo_fragment(project_id) in env["CODE_REPO"]
+            assert _gate_repo_fragment(project_name) in env["CODE_REPO"]
 
     @unittest.mock.patch(
         "terok.lib.orchestration.environment.mint_gate_token", return_value="tok" * 10 + "ab"
     )
     def test_build_task_env_gatekeeping_expose_external_remote_no_upstream(self, *_mocks) -> None:
         """Test expose_external_remote=true without upstream_url does not set EXTERNAL_REMOTE_URL."""
-        project_id = "proj_external_remote_no_upstream"
+        project_name = "proj_external_remote_no_upstream"
         with project_env(
-            f"project:\n  id: {project_id}\n  security_class: gatekeeping\ngit:\n  default_branch: main\ngatekeeping:\n  expose_external_remote: true\n",
-            project_id=project_id,
+            f"project:\n  id: {project_name}\n  security_class: gatekeeping\ngit:\n  default_branch: main\ngatekeeping:\n  expose_external_remote: true\n",
+            project_name=project_name,
             with_config_file=True,
             with_gate=True,
         ):
             env, _ = build_task_env_and_volumes(
-                project=load_project(project_id),
+                project=load_project(project_name),
                 task_id="12",
             )
 
@@ -940,7 +940,7 @@ class TestTask:
             assert "EXTERNAL_REMOTE_URL" not in env
             # Verify gatekeeping mode settings are still correct
             assert "http://" in env["CODE_REPO"]
-            assert _gate_repo_fragment(project_id) in env["CODE_REPO"]
+            assert _gate_repo_fragment(project_name) in env["CODE_REPO"]
 
     @unittest.mock.patch(
         "terok.lib.orchestration.environment.mint_gate_token", return_value="tok" * 10 + "ab"
@@ -953,21 +953,21 @@ class TestTask:
         allowlist of keys from ``sec_env``.  Missing the var here means
         the init script never adds the ``gate`` remote.
         """
-        project_id = "proj_gate_remote_online"
+        project_name = "proj_gate_remote_online"
         upstream_url = "https://github.com/example/repo.git"
         with project_env(
-            f"project:\n  id: {project_id}\n  security_class: online\ngit:\n  upstream_url: {upstream_url}\n  default_branch: main\n",
-            project_id=project_id,
+            f"project:\n  id: {project_name}\n  security_class: online\ngit:\n  upstream_url: {upstream_url}\n  default_branch: main\n",
+            project_name=project_name,
             with_config_file=True,
             with_gate=True,
         ):
             env, _ = build_task_env_and_volumes(
-                project=load_project(project_id),
+                project=load_project(project_name),
                 task_id="13",
             )
 
             assert "http://" in env["GATE_REMOTE_URL"]
-            assert _gate_repo_fragment(project_id) in env["GATE_REMOTE_URL"]
+            assert _gate_repo_fragment(project_name) in env["GATE_REMOTE_URL"]
             # Origin still points at upstream — gate is the secondary remote.
             assert env["CODE_REPO"] == upstream_url
 
@@ -1044,15 +1044,15 @@ class TestToadHelpers:
 
     def test_rehydrate_toad_token_writes_file_from_metadata(self, tmp_path: Path) -> None:
         """Saved token in ``meta`` is returned and rewritten to disk."""
-        project_id = "proj_rehydrate"
+        project_name = "proj_rehydrate"
         with project_env(
-            f"project:\n  id: {project_id}\n",
-            project_id=project_id,
+            f"project:\n  id: {project_name}\n",
+            project_name=project_name,
             with_config_file=True,
             clear_env=True,
         ):
-            task_id = task_new(project_id)
-            project = load_project(project_id)
+            task_id = task_new(project_name)
+            project = load_project(project_name)
             agent_cfg = project.tasks_root / str(task_id) / "agent-config"
             agent_cfg.mkdir(parents=True, exist_ok=True)
 
@@ -1064,15 +1064,15 @@ class TestToadHelpers:
 
     def test_rehydrate_toad_token_requires_metadata(self) -> None:
         """Missing ``web_token`` raises a clear SystemExit — tells the user to re-create."""
-        project_id = "proj_no_token"
+        project_name = "proj_no_token"
         with project_env(
-            f"project:\n  id: {project_id}\n",
-            project_id=project_id,
+            f"project:\n  id: {project_name}\n",
+            project_name=project_name,
             with_config_file=True,
             clear_env=True,
         ):
-            task_id = task_new(project_id)
-            project = load_project(project_id)
+            task_id = task_new(project_name)
+            project = load_project(project_name)
             with pytest.raises(SystemExit, match="no saved web_token"):
                 _rehydrate_toad_token(project, task_id, {}, cname="c1")
 
@@ -1081,25 +1081,25 @@ class TestResumeToadContainer:
     """End-to-end tests for the existing-container resume branch of ``task_run_toad``."""
 
     @staticmethod
-    def _seed_toad_meta(project_id: str, task_id: str, *, port: int, token: str) -> None:
+    def _seed_toad_meta(project_name: str, task_id: str, *, port: int, token: str) -> None:
         """Preload task metadata as if a toad launch had already succeeded."""
-        project = load_project(project_id)
-        meta, dossier_handle = load_task_meta(project.id, task_id, "toad")
+        project = load_project(project_name)
+        meta, dossier_handle = load_task_meta(project.name, task_id, "toad")
         meta.update({"mode": "toad", "web_port": port, "web_token": token})
         write_task_meta(dossier_handle, meta)
         (project.tasks_root / str(task_id) / "agent-config").mkdir(parents=True, exist_ok=True)
 
     def test_resume_running_container_prints_tokenized_url(self, mock_runtime) -> None:
         """A running container short-circuits with the printed ``?token=…`` URL."""
-        project_id = "proj_resume_running"
+        project_name = "proj_resume_running"
         with project_env(
-            f"project:\n  id: {project_id}\n",
-            project_id=project_id,
+            f"project:\n  id: {project_name}\n",
+            project_name=project_name,
             with_config_file=True,
             clear_env=True,
         ):
-            tid = task_new(project_id)
-            self._seed_toad_meta(project_id, tid, port=7862, token="tok-running")
+            tid = task_new(project_name)
+            self._seed_toad_meta(project_name, tid, port=7862, token="tok-running")
             mock_runtime.container.return_value.state = "running"
             buf = StringIO()
             with (
@@ -1110,27 +1110,27 @@ class TestResumeToadContainer:
                 ),
                 redirect_stdout(buf),
             ):
-                task_run_toad(project_id, tid)
+                task_run_toad(project_name, tid)
             out = buf.getvalue()
             assert "is already running" in out
             assert "?token=tok-running" in out
             # Token file rehydrated even though the container was already up.
-            project = load_project(project_id)
+            project = load_project(project_name)
             assert (
                 project.tasks_root / str(tid) / "agent-config" / "toad.token"
             ).read_text() == "tok-running"
 
     def test_resume_stopped_container_restarts_and_prints_url(self, mock_runtime) -> None:
         """An existing-but-stopped container is started again with the same token."""
-        project_id = "proj_resume_stopped"
+        project_name = "proj_resume_stopped"
         with project_env(
-            f"project:\n  id: {project_id}\n",
-            project_id=project_id,
+            f"project:\n  id: {project_name}\n",
+            project_name=project_name,
             with_config_file=True,
             clear_env=True,
         ):
-            tid = task_new(project_id)
-            self._seed_toad_meta(project_id, tid, port=7863, token="tok-stopped")
+            tid = task_new(project_name)
+            self._seed_toad_meta(project_name, tid, port=7863, token="tok-stopped")
             mock_runtime.container.return_value.state = "exited"
             buf = StringIO()
             with (
@@ -1150,7 +1150,7 @@ class TestResumeToadContainer:
                 ),
                 redirect_stdout(buf),
             ):
-                task_run_toad(project_id, tid)
+                task_run_toad(project_name, tid)
             out = buf.getvalue()
             assert "Starting existing container" in out
             assert "Container started" in out
@@ -1158,15 +1158,15 @@ class TestResumeToadContainer:
 
     def test_resume_rejects_changed_port(self, mock_runtime) -> None:
         """If the saved port is taken by another user, fail fast."""
-        project_id = "proj_resume_taken"
+        project_name = "proj_resume_taken"
         with project_env(
-            f"project:\n  id: {project_id}\n",
-            project_id=project_id,
+            f"project:\n  id: {project_name}\n",
+            project_name=project_name,
             with_config_file=True,
             clear_env=True,
         ):
-            tid = task_new(project_id)
-            self._seed_toad_meta(project_id, tid, port=7864, token="tok")
+            tid = task_new(project_name)
+            self._seed_toad_meta(project_name, tid, port=7864, token="tok")
             mock_runtime.container.return_value.state = "running"
             with (
                 unittest.mock.patch(
@@ -1175,17 +1175,17 @@ class TestResumeToadContainer:
                 ),
                 pytest.raises(SystemExit, match="no longer available"),
             ):
-                task_run_toad(project_id, tid)
+                task_run_toad(project_name, tid)
 
 
 class TestTaskLogs:
     """Tests for task_logs() function."""
 
-    def _setup_task_with_mode(self, project_id, mode="run"):
+    def _setup_task_with_mode(self, project_name, mode="run"):
         """Create a task and set its mode in metadata."""
-        task_id = task_new(project_id)
+        task_id = task_new(project_name)
         # Manually update metadata to set mode (normally done by task runners)
-        meta_dir = tasks_meta_dir(project_id)
+        meta_dir = tasks_meta_dir(project_name)
         meta = read_task_meta(meta_dir, task_id) or {}
         meta["mode"] = mode
         write_task_meta(dossier_path(meta_dir, task_id), meta)
@@ -1195,7 +1195,7 @@ class TestTaskLogs:
         """task_logs raises SystemExit for non-existent task."""
         with project_env(
             "project:\n  id: proj_logs1\n",
-            project_id="proj_logs1",
+            project_name="proj_logs1",
         ):
             with mock_git_config():
                 with pytest.raises(SystemExit) as cm:
@@ -1206,7 +1206,7 @@ class TestTaskLogs:
         """task_logs raises SystemExit when task has no mode set."""
         with project_env(
             "project:\n  id: proj_logs2\n",
-            project_id="proj_logs2",
+            project_name="proj_logs2",
         ):
             with mock_git_config():
                 task_id = task_new("proj_logs2")
@@ -1219,7 +1219,7 @@ class TestTaskLogs:
         mock_runtime.container.return_value.state = None
         with project_env(
             "project:\n  id: proj_logs3\n",
-            project_id="proj_logs3",
+            project_name="proj_logs3",
         ):
             with mock_git_config():
                 task_id = self._setup_task_with_mode("proj_logs3", "run")
@@ -1232,7 +1232,7 @@ class TestTaskLogs:
         mock_runtime.container.return_value.state = "running"
         with project_env(
             "project:\n  id: proj_logs4\n",
-            project_id="proj_logs4",
+            project_name="proj_logs4",
         ):
             with mock_git_config():
                 task_id = self._setup_task_with_mode("proj_logs4", "run")
@@ -1245,7 +1245,7 @@ class TestTaskLogs:
         mock_runtime.container.return_value.state = "exited"
         with project_env(
             "project:\n  id: proj_logs5\n",
-            project_id="proj_logs5",
+            project_name="proj_logs5",
         ):
             with mock_git_config():
                 task_id = self._setup_task_with_mode("proj_logs5", "cli")
@@ -1271,7 +1271,7 @@ class TestTaskLogs:
         mock_runtime.container.return_value.state = "exited"
         with project_env(
             "project:\n  id: proj_logs6\n",
-            project_id="proj_logs6",
+            project_name="proj_logs6",
         ):
             with mock_git_config():
                 task_id = self._setup_task_with_mode("proj_logs6", "cli")
@@ -1288,7 +1288,7 @@ class TestTaskLogs:
         mock_runtime.container.return_value.state = "exited"
         with project_env(
             "project:\n  id: proj_logs7\n",
-            project_id="proj_logs7",
+            project_name="proj_logs7",
         ):
             with mock_git_config():
                 task_id = self._setup_task_with_mode("proj_logs7", "run")
@@ -1335,7 +1335,7 @@ class TestTaskLogs:
         mock_runtime.container.return_value.state = "running"
         with project_env(
             "project:\n  id: proj_logs8\n",
-            project_id="proj_logs8",
+            project_name="proj_logs8",
         ):
             with mock_git_config():
                 task_id = self._setup_task_with_mode("proj_logs8", "run")
@@ -1354,7 +1354,7 @@ class TestTaskLogs:
         mock_runtime.container.return_value.state = None
         with project_env(
             "project:\n  id: proj_logs_persist\n",
-            project_id="proj_logs_persist",
+            project_name="proj_logs_persist",
         ):
             with mock_git_config():
                 task_id = self._setup_task_with_mode("proj_logs_persist", "run")
@@ -1387,7 +1387,7 @@ class TestTaskLogs:
         mock_runtime.container.return_value.state = None
         with project_env(
             "project:\n  id: proj_logs_tail\n",
-            project_id="proj_logs_tail",
+            project_name="proj_logs_tail",
         ):
             with mock_git_config():
                 task_id = self._setup_task_with_mode("proj_logs_tail", "run")
@@ -1414,7 +1414,7 @@ class TestTaskLogs:
         mock_runtime.container.return_value.state = None
         with project_env(
             "project:\n  id: proj_logs_nolog\n",
-            project_id="proj_logs_nolog",
+            project_name="proj_logs_nolog",
         ):
             with mock_git_config():
                 task_id = self._setup_task_with_mode("proj_logs_nolog", "run")
@@ -1427,7 +1427,7 @@ class TestTaskLogs:
         mock_runtime.container.return_value.state = None
         with project_env(
             "project:\n  id: proj_logs_negtail\n",
-            project_id="proj_logs_negtail",
+            project_name="proj_logs_negtail",
         ):
             with mock_git_config():
                 task_id = self._setup_task_with_mode("proj_logs_negtail", "run")
@@ -1449,14 +1449,14 @@ class TestTaskArchive:
 
     def test_task_delete_creates_archive(self) -> None:
         """task_delete archives metadata and logs before cleanup."""
-        project_id = "proj_archive1"
+        project_name = "proj_archive1"
         with project_env(
-            f"project:\n  id: {project_id}\n",
-            project_id=project_id,
+            f"project:\n  id: {project_name}\n",
+            project_name=project_name,
         ) as ctx:
             with mock_git_config():
-                task_id = task_new(project_id)
-                meta_dir = ctx.state_dir / "projects" / project_id / "tasks"
+                task_id = task_new(project_name)
+                meta_dir = ctx.state_dir / "projects" / project_name / "tasks"
 
                 # Set mode in metadata (simulating a task that ran)
                 meta = read_task_meta(meta_dir, task_id) or {}
@@ -1466,7 +1466,7 @@ class TestTaskArchive:
                 write_task_meta(dossier_path(meta_dir, task_id), meta)
 
                 # Create logs dir to simulate persisted logs
-                task_dir = ctx.state_dir / "tasks" / project_id / task_id
+                task_dir = ctx.state_dir / "tasks" / project_name / task_id
                 logs_dir = task_dir / "logs"
                 logs_dir.mkdir(parents=True, exist_ok=True)
                 (logs_dir / "container.log").write_text("log content\n")
@@ -1481,7 +1481,7 @@ class TestTaskArchive:
                     "terok_executor.AgentRunner.capture_logs",
                     new=_fake_capture,
                 ):
-                    task_delete(project_id, task_id)
+                    task_delete(project_name, task_id)
 
                 # Task should be deleted
                 assert not dossier_path(meta_dir, task_id).exists()
@@ -1489,7 +1489,7 @@ class TestTaskArchive:
                 # Archive should exist under namespace archive tree
                 from terok.lib.orchestration.tasks import tasks_archive_dir
 
-                archive_root = tasks_archive_dir(project_id)
+                archive_root = tasks_archive_dir(project_name)
                 assert archive_root.is_dir()
                 archives = list(archive_root.iterdir())
                 assert len(archives) == 1
@@ -1513,13 +1513,13 @@ class TestTaskArchive:
 
     def test_task_delete_archives_without_logs(self) -> None:
         """task_delete still archives metadata even when no logs exist."""
-        project_id = "proj_archive2"
+        project_name = "proj_archive2"
         with project_env(
-            f"project:\n  id: {project_id}\n",
-            project_id=project_id,
+            f"project:\n  id: {project_name}\n",
+            project_name=project_name,
         ):
             with mock_git_config():
-                task_id = task_new(project_id)
+                task_id = task_new(project_name)
 
                 def fake_run(cmd, *, stdout=None, stderr=None, timeout=None, **kw):
                     """No-op mock for subprocess.run."""
@@ -1531,11 +1531,11 @@ class TestTaskArchive:
                     "terok_executor.AgentRunner.capture_logs",
                     return_value=True,
                 ):
-                    task_delete(project_id, task_id)
+                    task_delete(project_name, task_id)
 
                 from terok.lib.orchestration.tasks import tasks_archive_dir
 
-                archive_root = tasks_archive_dir(project_id)
+                archive_root = tasks_archive_dir(project_name)
                 assert archive_root.is_dir()
                 archives = list(archive_root.iterdir())
                 assert len(archives) == 1
@@ -1549,13 +1549,13 @@ class TestTaskArchive:
         """list_archived_tasks returns archived tasks sorted newest-first."""
         from terok.lib.orchestration.tasks import list_archived_tasks, tasks_archive_dir
 
-        project_id = "proj_archive3"
+        project_name = "proj_archive3"
         with project_env(
-            f"project:\n  id: {project_id}\n",
-            project_id=project_id,
+            f"project:\n  id: {project_name}\n",
+            project_name=project_name,
         ):
             # Create archive entries manually
-            archive_root = tasks_archive_dir(project_id)
+            archive_root = tasks_archive_dir(project_name)
             archive_root.mkdir(parents=True, exist_ok=True)
 
             for i, ts in enumerate(["20260301T100000Z", "20260302T100000Z", "20260303T100000Z"]):
@@ -1573,7 +1573,7 @@ class TestTaskArchive:
                     )
                 )
 
-            archived = list_archived_tasks(project_id)
+            archived = list_archived_tasks(project_name)
             assert len(archived) == 3
             # Newest first
             assert archived[0].task_id == "3"
@@ -1585,42 +1585,42 @@ class TestTaskArchive:
         """task_archive_logs returns log file path for matching archive."""
         from terok.lib.orchestration.tasks import task_archive_logs, tasks_archive_dir
 
-        project_id = "proj_archive4"
+        project_name = "proj_archive4"
         with project_env(
-            f"project:\n  id: {project_id}\n",
-            project_id=project_id,
+            f"project:\n  id: {project_name}\n",
+            project_name=project_name,
         ):
-            archive_root = tasks_archive_dir(project_id)
+            archive_root = tasks_archive_dir(project_name)
             entry_dir = archive_root / "20260305T120000Z_1_my-task"
             logs_dir = entry_dir / "logs"
             logs_dir.mkdir(parents=True, exist_ok=True)
             (logs_dir / "container.log").write_text("archived log\n")
 
             # Full match
-            result = task_archive_logs(project_id, "20260305T120000Z_1_my-task")
+            result = task_archive_logs(project_name, "20260305T120000Z_1_my-task")
             assert result is not None
             assert result.read_text() == "archived log\n"
 
             # Prefix match
-            result = task_archive_logs(project_id, "20260305T120000Z")
+            result = task_archive_logs(project_name, "20260305T120000Z")
             assert result is not None
 
             # No match
-            result = task_archive_logs(project_id, "20990101")
+            result = task_archive_logs(project_name, "20990101")
             assert result is None
 
     def test_task_archive_list_empty(self) -> None:
         """task_archive_list prints message when no archives exist."""
         from terok.lib.orchestration.tasks import task_archive_list
 
-        project_id = "proj_archive5"
+        project_name = "proj_archive5"
         with project_env(
-            f"project:\n  id: {project_id}\n",
-            project_id=project_id,
+            f"project:\n  id: {project_name}\n",
+            project_name=project_name,
         ):
             buf = StringIO()
             with redirect_stdout(buf):
-                task_archive_list(project_id)
+                task_archive_list(project_name)
             assert "No archived tasks found" in buf.getvalue()
 
     def test_capture_task_logs(self) -> None:
@@ -1628,13 +1628,13 @@ class TestTaskArchive:
         returns the log file path when the executor reports success."""
         from terok.lib.orchestration.tasks import capture_task_logs
 
-        project_id = "proj_capture1"
+        project_name = "proj_capture1"
         with project_env(
-            f"project:\n  id: {project_id}\n",
-            project_id=project_id,
+            f"project:\n  id: {project_name}\n",
+            project_name=project_name,
         ):
             with mock_git_config():
-                task_id = task_new(project_id)
+                task_id = task_new(project_name)
 
                 log_content = "2026-03-05T12:00:00Z stdout line\n"
 
@@ -1647,7 +1647,7 @@ class TestTaskArchive:
                     "terok_executor.AgentRunner.capture_logs",
                     new=fake_capture,
                 ):
-                    log_file = capture_task_logs(project_id, task_id, "run")
+                    log_file = capture_task_logs(project_name, task_id, "run")
 
                 assert log_file is not None
                 assert "stdout line" in log_file.read_text()
@@ -1658,19 +1658,19 @@ class TestTaskArchive:
         way through AgentRunner.capture_logs)."""
         from terok.lib.orchestration.tasks import capture_task_logs
 
-        project_id = "proj_capture2"
+        project_name = "proj_capture2"
         with project_env(
-            f"project:\n  id: {project_id}\n",
-            project_id=project_id,
+            f"project:\n  id: {project_name}\n",
+            project_name=project_name,
         ):
             with mock_git_config():
-                task_id = task_new(project_id)
+                task_id = task_new(project_name)
 
                 with unittest.mock.patch(
                     "terok_executor.AgentRunner.capture_logs",
                     return_value=False,
                 ):
-                    result = capture_task_logs(project_id, task_id, "run")
+                    result = capture_task_logs(project_name, task_id, "run")
 
                 assert result is None
 
@@ -1688,7 +1688,7 @@ class TestTaskDeleteWarnings:
     def _delete_with_mocks(
         self,
         mock_runtime,
-        project_id: str = "proj_warn",
+        project_name: str = "proj_warn",
         *,
         container_results: list | None = None,
         rmtree_side_effect: BaseException | None = None,
@@ -1703,11 +1703,11 @@ class TestTaskDeleteWarnings:
         ]
 
         with project_env(
-            f"project:\n  id: {project_id}\n",
-            project_id=project_id,
+            f"project:\n  id: {project_name}\n",
+            project_name=project_name,
         ):
             with mock_git_config():
-                task_id = task_new(project_id)
+                task_id = task_new(project_name)
 
                 patches = [
                     unittest.mock.patch(
@@ -1739,11 +1739,11 @@ class TestTaskDeleteWarnings:
                             unittest.mock.patch.object(Path, "unlink", _guarded_unlink)
                         )
 
-                    return task_delete(project_id, task_id)
+                    return task_delete(project_name, task_id)
 
     def test_clean_delete_returns_empty_warnings(self, mock_runtime) -> None:
         """Normal deletion returns TaskDeleteResult with no warnings."""
-        result = self._delete_with_mocks(mock_runtime, project_id="proj_warn1")
+        result = self._delete_with_mocks(mock_runtime, project_name="proj_warn1")
         assert isinstance(result, TaskDeleteResult)
         assert result.warnings == []
 
@@ -1751,7 +1751,7 @@ class TestTaskDeleteWarnings:
         """Failed container removal adds a warning and keeps port claimed."""
         result = self._delete_with_mocks(
             mock_runtime,
-            project_id="proj_warn3",
+            project_name="proj_warn3",
             container_results=[
                 {"name": "proj-cli-1", "removed": True},
                 {"name": "proj-web-1", "removed": False, "error": "locked"},
@@ -1765,7 +1765,7 @@ class TestTaskDeleteWarnings:
         """Failed workspace rmtree adds a warning."""
         result = self._delete_with_mocks(
             mock_runtime,
-            project_id="proj_warn4",
+            project_name="proj_warn4",
             rmtree_side_effect=PermissionError("busy"),
         )
         assert any("Workspace removal" in w for w in result.warnings)
@@ -1774,7 +1774,7 @@ class TestTaskDeleteWarnings:
         """Failed metadata unlink adds a warning."""
         result = self._delete_with_mocks(
             mock_runtime,
-            project_id="proj_warn5",
+            project_name="proj_warn5",
             unlink_side_effect=PermissionError("read-only"),
         )
         assert any("Metadata removal" in w for w in result.warnings)
@@ -1783,7 +1783,7 @@ class TestTaskDeleteWarnings:
         """Multiple failures from different steps all appear in warnings."""
         result = self._delete_with_mocks(
             mock_runtime,
-            project_id="proj_warn6",
+            project_name="proj_warn6",
             container_results=[
                 {"name": "c1", "removed": False, "error": "timeout"},
             ],
@@ -1833,7 +1833,7 @@ class TestArchiveListing:
         from terok.lib.orchestration.tasks import list_archived_tasks, tasks_archive_dir
 
         pid = "proj_arc_skip"
-        with project_env(f"project:\n  id: {pid}\n", project_id=pid):
+        with project_env(f"project:\n  id: {pid}\n", project_name=pid):
             root = tasks_archive_dir(pid)
             root.mkdir(parents=True)
             (root / "stray-file.txt").write_text("not a dir")
@@ -1850,7 +1850,7 @@ class TestArchiveListing:
         from terok.lib.orchestration.tasks import task_archive_list, tasks_archive_dir
 
         pid = "proj_arc_fmt"
-        with project_env(f"project:\n  id: {pid}\n", project_id=pid):
+        with project_env(f"project:\n  id: {pid}\n", project_name=pid):
             entry = tasks_archive_dir(pid) / "20260103T120000Z_k3v8h_fix-bug"
             entry.mkdir(parents=True)
             (entry / "task.json").write_text(
@@ -1868,7 +1868,7 @@ class TestArchiveListing:
         from terok.lib.orchestration.tasks import task_archive_logs
 
         pid = "proj_arc_nodir"
-        with project_env(f"project:\n  id: {pid}\n", project_id=pid):
+        with project_env(f"project:\n  id: {pid}\n", project_name=pid):
             assert task_archive_logs(pid, "anything") is None
 
 
@@ -1880,7 +1880,7 @@ class TestGetTaskMeta:
         from terok.lib.orchestration.tasks import get_task_meta
 
         pid = "proj_gtm_unknown"
-        with project_env(f"project:\n  id: {pid}\n", project_id=pid):
+        with project_env(f"project:\n  id: {pid}\n", project_name=pid):
             with pytest.raises(SystemExit, match="Unknown task"):
                 get_task_meta(pid, "g1v2h")
 
@@ -1889,7 +1889,7 @@ class TestGetTaskMeta:
         from terok.lib.orchestration.tasks import get_task_meta
 
         pid = "proj_gtm_live"
-        with project_env(f"project:\n  id: {pid}\n", project_id=pid), mock_git_config():
+        with project_env(f"project:\n  id: {pid}\n", project_name=pid), mock_git_config():
             task_id = task_new(pid)
             meta_dir = tasks_meta_dir(pid)
             meta = read_task_meta(meta_dir, task_id)
@@ -1907,7 +1907,7 @@ class TestGetTaskMeta:
         from terok.lib.orchestration.tasks import get_task_meta
 
         pid = "proj_gtm_nomode"
-        with project_env(f"project:\n  id: {pid}\n", project_id=pid), mock_git_config():
+        with project_env(f"project:\n  id: {pid}\n", project_name=pid), mock_git_config():
             task_id = task_new(pid)  # fresh task — mode is None
             tm = get_task_meta(pid, task_id)
             assert tm.mode is None
@@ -1944,7 +1944,7 @@ class TestMetaMutations:
         from terok.lib.orchestration.tasks import mark_task_deleting, tasks_meta_dir
 
         pid = "proj_mtd"
-        with project_env(f"project:\n  id: {pid}\n", project_id=pid), mock_git_config():
+        with project_env(f"project:\n  id: {pid}\n", project_name=pid), mock_git_config():
             task_id = task_new(pid)
             mark_task_deleting(pid, task_id)
             assert read_task_meta(tasks_meta_dir(pid), task_id)["deleting"] is True
@@ -1954,7 +1954,7 @@ class TestMetaMutations:
         from terok.lib.orchestration.tasks import mark_task_deleting
 
         pid = "proj_mtd_missing"
-        with project_env(f"project:\n  id: {pid}\n", project_id=pid):
+        with project_env(f"project:\n  id: {pid}\n", project_name=pid):
             mark_task_deleting(pid, "g1v2h")  # must not raise
 
     def test_mark_deleting_swallows_write_errors(self) -> None:
@@ -1962,7 +1962,7 @@ class TestMetaMutations:
         from terok.lib.orchestration.tasks import mark_task_deleting
 
         pid = "proj_mtd_err"
-        with project_env(f"project:\n  id: {pid}\n", project_id=pid), mock_git_config():
+        with project_env(f"project:\n  id: {pid}\n", project_name=pid), mock_git_config():
             task_id = task_new(pid)
             with unittest.mock.patch(
                 "terok.lib.orchestration.tasks.meta.write_task_meta",
@@ -1975,5 +1975,5 @@ class TestMetaMutations:
         from terok.lib.orchestration.tasks import update_task_exit_code
 
         pid = "proj_uec_missing"
-        with project_env(f"project:\n  id: {pid}\n", project_id=pid):
+        with project_env(f"project:\n  id: {pid}\n", project_name=pid):
             update_task_exit_code(pid, "g1v2h", 0)  # must not raise

--- a/tests/unit/lib/test_unattended.py
+++ b/tests/unit/lib/test_unattended.py
@@ -53,7 +53,7 @@ class TaskRunnerResult:
 
 def make_project_config(
     *,
-    project_id: str,
+    project_name: str,
     root: Path,
     tasks_root: Path,
     gate_path: Path,
@@ -63,7 +63,7 @@ def make_project_config(
     from terok.lib.core.projects import ProjectConfig
 
     return ProjectConfig(
-        id=project_id,
+        name=project_name,
         security_class="online",
         upstream_url=None,
         default_branch="main",
@@ -91,7 +91,7 @@ def runner_env_vars(base: Path, config_file: Path) -> dict[str, str]:
     }
 
 
-def task_paths(base: Path, project_id: str, task_id: str = "1") -> tuple[Path, Path]:
+def task_paths(base: Path, project_name: str, task_id: str = "1") -> tuple[Path, Path]:
     """Return ``(agent_config_dir, meta_path)`` for a task.
 
     agent_config_dir lives under sandbox-live (container-writable),
@@ -100,12 +100,12 @@ def task_paths(base: Path, project_id: str, task_id: str = "1") -> tuple[Path, P
     sandbox_live = base / "sandbox-live"
     state = base / "state"
     return (
-        sandbox_live / "tasks" / project_id / task_id / "agent-config",
-        state / "projects" / project_id / "tasks" / f"{task_id}_dossier.json",
+        sandbox_live / "tasks" / project_name / task_id / "agent-config",
+        state / "projects" / project_name / "tasks" / f"{task_id}_dossier.json",
     )
 
 
-def write_runner_project(base: Path, project_id: str, extra_yml: str = "") -> Path:
+def write_runner_project(base: Path, project_name: str, extra_yml: str = "") -> Path:
     """Write a minimal project config and matching global config file for task runners."""
     config_base = base / "config"
     projects_root = config_base / "projects"
@@ -115,13 +115,13 @@ def write_runner_project(base: Path, project_id: str, extra_yml: str = "") -> Pa
     config_file.write_text(f"credentials:\n  dir: {envs_dir}\n", encoding="utf-8")
     write_project(
         projects_root,
-        project_id,
-        f"project:\n  id: {project_id}\n  security_class: online\n{extra_yml}",
+        project_name,
+        f"project:\n  id: {project_name}\n  security_class: online\n{extra_yml}",
     )
     return config_file
 
 
-def read_task_meta(base: Path, project_id: str, task_id: str = "1") -> dict[str, object]:
+def read_task_meta(base: Path, project_name: str, task_id: str = "1") -> dict[str, object]:
     """Load merged task metadata for a task — wire-dossier + bookkeeping.
 
     Live tasks store the wire-dossier triple in JSON (the file shield
@@ -130,7 +130,7 @@ def read_task_meta(base: Path, project_id: str, task_id: str = "1") -> dict[str,
     """
     from terok.lib.orchestration.tasks import read_task_meta
 
-    meta_dir = task_paths(base, project_id, task_id)[1].parent
+    meta_dir = task_paths(base, project_name, task_id)[1].parent
     return read_task_meta(meta_dir, task_id) or {}
 
 
@@ -190,7 +190,7 @@ def run_headless_request(
 
 def run_followup_request(
     base: Path,
-    project_id: str,
+    project_name: str,
     task_id: str,
     prompt: str,
     *,
@@ -229,7 +229,7 @@ def run_followup_request(
     ):
         buffer = StringIO()
         with redirect_stdout(buffer):
-            task_followup_headless(project_id, task_id, prompt, follow=follow)
+            task_followup_headless(project_name, task_id, prompt, follow=follow)
     return TaskRunnerResult(output=buffer.getvalue(), run_mock=start_mock, wait_mock=wait_mock)
 
 
@@ -492,12 +492,12 @@ class TestTaskRunHeadless:
 class TestTaskFollowupHeadless:
     """Tests for task_followup_headless."""
 
-    def _create_completed_task(self, base: Path, project_id: str) -> str:
+    def _create_completed_task(self, base: Path, project_name: str) -> str:
         """Create a task via task_run_headless and return the task_id."""
         result = run_headless_request(
             base,
-            write_runner_project(base, project_id),
-            HeadlessRunRequest(project_id, "initial prompt"),
+            write_runner_project(base, project_name),
+            HeadlessRunRequest(project_name, "initial prompt"),
         )
         assert result.task_id is not None
         return result.task_id

--- a/tests/unit/lib/test_vault_helpers.py
+++ b/tests/unit/lib/test_vault_helpers.py
@@ -203,7 +203,7 @@ class TestGateSyncAuthNotConfigured:
 
         from terok.cli.commands.project import _cmd_gate_sync
 
-        args = MagicMock(project_id="proj", use_personal_ssh=False, force_reinit=False)
+        args = MagicMock(project_name="proj", use_personal_ssh=False, force_reinit=False)
         gate = MagicMock()
         gate.sync.side_effect = GateAuthNotConfigured("proj")
         with (

--- a/tests/unit/lib/test_wizard.py
+++ b/tests/unit/lib/test_wizard.py
@@ -18,8 +18,8 @@ from terok.lib.domain.wizards.new_project import (
     SECURITY_CLASSES,
     Question,
     _load_base_choices,
-    _slugify_project_id,
-    _validate_project_id,
+    _slugify_project_name,
+    _validate_project_name,
     collect_wizard_inputs,
     generate_config,
     prompt_agent_override,
@@ -47,7 +47,7 @@ def wizard_values(
     *,
     security_class: str = "online",
     base: str = "fedora",
-    project_id: str = "test-proj",
+    project_name: str = "test-proj",
     upstream_url: str = "https://github.com/user/repo.git",
     default_branch: str = "main",
     agents: str | None = None,
@@ -58,7 +58,7 @@ def wizard_values(
     values: dict[str, object] = {
         "security_class": security_class,
         "base": base,
-        "project_id": project_id,
+        "project_name": project_name,
         "upstream_url": upstream_url,
         "default_branch": default_branch,
         "user_snippet": user_snippet,
@@ -70,7 +70,7 @@ def wizard_values(
 
 
 @pytest.mark.parametrize(
-    ("project_id", "valid"),
+    ("project_name", "valid"),
     [
         pytest.param("myproject", True, id="simple"),
         pytest.param("my-project", True, id="hyphen"),
@@ -86,9 +86,9 @@ def wizard_values(
         pytest.param("default", False, id="reserved-default"),
     ],
 )
-def test_validate_project_id(project_id: str, valid: bool) -> None:
-    """Project ID validation accepts only the supported slug-like IDs."""
-    error = _validate_project_id(project_id)
+def test_validate_project_name(project_name: str, valid: bool) -> None:
+    """Project name validation accepts only the supported slug-like IDs."""
+    error = _validate_project_name(project_name)
     assert (error is None) is valid
 
 
@@ -98,14 +98,14 @@ def test_validate_project_id(project_id: str, valid: bool) -> None:
         pytest.param(
             # sec, base, pid, upstream, branch, snippet-y/N, creds-scope, override-agents-y/N
             ["1", "1", "myproj", "https://example.com/r.git", "main", "n", "1", "n"],
-            wizard_values(project_id="myproj", upstream_url="https://example.com/r.git"),
+            wizard_values(project_name="myproj", upstream_url="https://example.com/r.git"),
             id="collect-all-values-no-override",
         ),
         pytest.param(
             ["2", "1", "gkproj", "git@host:r.git", "", "n", "1", "n"],
             wizard_values(
                 security_class="gatekeeping",
-                project_id="gkproj",
+                project_name="gkproj",
                 upstream_url="git@host:r.git",
                 default_branch="",
             ),
@@ -115,7 +115,7 @@ def test_validate_project_id(project_id: str, valid: bool) -> None:
             ["1", "2", "proj", "https://example.com/r.git", "", "n", "1", "n"],
             wizard_values(
                 base="nvidia",
-                project_id="proj",
+                project_name="proj",
                 upstream_url="https://example.com/r.git",
                 default_branch="",
             ),
@@ -136,7 +136,7 @@ def test_validate_project_id(project_id: str, valid: bool) -> None:
             ],
             wizard_values(
                 base="nvidia",
-                project_id="proj",
+                project_name="proj",
                 upstream_url="https://example.com/r.git",
                 default_branch="dev",
                 agents="claude,vibe",
@@ -146,12 +146,12 @@ def test_validate_project_id(project_id: str, valid: bool) -> None:
         ),
         pytest.param(
             ["1", "1", "!!!", "good-id", "https://example.com/r.git", "main", "n", "1", "n"],
-            wizard_values(project_id="good-id", upstream_url="https://example.com/r.git"),
-            id="retry-invalid-project-id",
+            wizard_values(project_name="good-id", upstream_url="https://example.com/r.git"),
+            id="retry-invalid-project-name",
         ),
         pytest.param(
             ["1", "1", "proj", "", "main", "n", "1", "n"],
-            wizard_values(project_id="proj", upstream_url=""),
+            wizard_values(project_name="proj", upstream_url=""),
             id="empty-upstream-url-accepted",
         ),
     ],
@@ -185,8 +185,8 @@ def test_collect_wizard_inputs_cancellation_paths(
         assert collect_wizard_inputs() is None
 
 
-def test_collect_wizard_inputs_lowercases_project_id() -> None:
-    """Uppercase project IDs are normalised with a friendly note."""
+def test_collect_wizard_inputs_lowercases_project_name() -> None:
+    """Uppercase project names are normalised with a friendly note."""
     with (
         patch(
             "builtins.input",
@@ -196,7 +196,9 @@ def test_collect_wizard_inputs_lowercases_project_id() -> None:
     ):
         result = collect_wizard_inputs()
 
-    assert result == wizard_values(project_id="myproject", upstream_url="https://example.com/r.git")
+    assert result == wizard_values(
+        project_name="myproject", upstream_url="https://example.com/r.git"
+    )
     printed = [" ".join(str(arg) for arg in call.args) for call in mock_print.call_args_list]
     assert any("normalised to 'myproject'" in line for line in printed)
 
@@ -215,9 +217,9 @@ def test_collect_wizard_inputs_lowercases_project_id() -> None:
         pytest.param("terok pages", "terok-pages", id="the-field-report-case"),
     ],
 )
-def test_slugify_project_id(raw: str, expected: str) -> None:
-    """``_slugify_project_id`` meets users halfway without silently mangling intent."""
-    assert _slugify_project_id(raw) == expected
+def test_slugify_project_name(raw: str, expected: str) -> None:
+    """``_slugify_project_name`` meets users halfway without silently mangling intent."""
+    assert _slugify_project_name(raw) == expected
 
 
 def generate_into_tmp(values: dict[str, object]) -> tuple[str, str, str]:
@@ -238,7 +240,7 @@ def generate_into_tmp(values: dict[str, object]) -> tuple[str, str, str]:
         pytest.param(
             wizard_values(),
             [
-                'id: "test-proj"',
+                'name: "test-proj"',
                 "https://github.com/user/repo.git",
                 'default_branch: "main"',
                 'security_class: "online"',
@@ -248,7 +250,7 @@ def generate_into_tmp(values: dict[str, object]) -> tuple[str, str, str]:
         pytest.param(
             wizard_values(
                 security_class="gatekeeping",
-                project_id="gk-proj",
+                project_name="gk-proj",
                 upstream_url="git@github.com:user/repo.git",
                 default_branch="dev",
                 user_snippet="RUN apt-get update",
@@ -264,7 +266,7 @@ def generate_into_tmp(values: dict[str, object]) -> tuple[str, str, str]:
         pytest.param(
             wizard_values(
                 base="nvidia",
-                project_id="gpu-proj",
+                project_name="gpu-proj",
                 upstream_url="https://example.com/r.git",
             ),
             ["gpus: all", "nvcr.io/nvidia/"],
@@ -273,7 +275,7 @@ def generate_into_tmp(values: dict[str, object]) -> tuple[str, str, str]:
         pytest.param(
             wizard_values(
                 base="fedora",
-                project_id="fedora-proj",
+                project_name="fedora-proj",
                 upstream_url="https://example.com/r.git",
             ),
             ['base_image: "fedora:44"', 'security_class: "online"'],
@@ -282,7 +284,7 @@ def generate_into_tmp(values: dict[str, object]) -> tuple[str, str, str]:
         pytest.param(
             wizard_values(
                 base="podman",
-                project_id="podman-proj",
+                project_name="podman-proj",
                 upstream_url="https://example.com/r.git",
             ),
             ['base_image: "quay.io/podman/stable:latest"'],
@@ -294,7 +296,7 @@ def test_generate_config_templates(values: dict[str, object], expected_snippets:
     """Generated configs include the expected template-specific content."""
     config_name, project_dir_name, content = generate_into_tmp(values)
     assert config_name == "project.yml"
-    assert project_dir_name == values["project_id"]
+    assert project_dir_name == values["project_name"]
     for snippet in expected_snippets:
         assert snippet in content
 
@@ -307,13 +309,13 @@ def test_generate_config_replaces_all_placeholders() -> None:
                 wizard_values(
                     security_class=sec.slug,
                     base=base.slug,
-                    project_id=f"proj-{sec.slug}-{base.slug}",
+                    project_name=f"proj-{sec.slug}-{base.slug}",
                     upstream_url="https://example.com/r.git",
                     user_snippet="RUN echo hi",
                 )
             )
             for placeholder in (
-                "{{PROJECT_ID}}",
+                "{{PROJECT_NAME}}",
                 "{{UPSTREAM_URL}}",
                 "{{DEFAULT_BRANCH}}",
                 "{{USER_SNIPPET}}",
@@ -333,7 +335,7 @@ def test_generate_config_replaces_all_placeholders() -> None:
     ),
     [
         pytest.param(
-            wizard_values(project_id="proj1", upstream_url="https://example.com/r.git"),
+            wizard_values(project_name="proj1", upstream_url="https://example.com/r.git"),
             ["y", "y"],
             True,
             True,
@@ -342,7 +344,7 @@ def test_generate_config_replaces_all_placeholders() -> None:
             id="edit-and-init",
         ),
         pytest.param(
-            wizard_values(project_id="proj2", upstream_url="https://example.com/r.git"),
+            wizard_values(project_name="proj2", upstream_url="https://example.com/r.git"),
             ["n", "n"],
             True,
             True,
@@ -351,7 +353,7 @@ def test_generate_config_replaces_all_placeholders() -> None:
             id="skip-edit-and-init",
         ),
         pytest.param(
-            wizard_values(project_id="proj3", upstream_url="https://example.com/r.git"),
+            wizard_values(project_name="proj3", upstream_url="https://example.com/r.git"),
             ["n"],
             False,
             True,
@@ -360,7 +362,7 @@ def test_generate_config_replaces_all_placeholders() -> None:
             id="no-init-fn",
         ),
         pytest.param(
-            wizard_values(project_id="proj4", upstream_url="https://example.com/r.git"),
+            wizard_values(project_name="proj4", upstream_url="https://example.com/r.git"),
             KeyboardInterrupt,
             False,
             True,
@@ -411,7 +413,7 @@ def test_run_wizard(
             0 if user_answers and user_answers[0] in {"n", "no"} else 1
         )
     if expect_init:
-        init_fn.assert_called_once_with(collect_result["project_id"])
+        init_fn.assert_called_once_with(collect_result["project_name"])
     elif init_fn is not None:
         init_fn.assert_not_called()
 
@@ -444,7 +446,7 @@ class TestValidateAnswer:
 
     def test_required_rejects_empty(self) -> None:
         """A required question refuses empty input with the standard message."""
-        value, err = validate_answer(_q("project_id"), "")
+        value, err = validate_answer(_q("project_name"), "")
         assert err is not None
         assert "required" in err
 
@@ -455,29 +457,29 @@ class TestValidateAnswer:
         assert err is None
 
     def test_transform_runs_before_validation(self) -> None:
-        """Slugify + lowercase on project_id normalises before the regex check fires."""
-        value, err = validate_answer(_q("project_id"), "MyProject")
+        """Slugify + lowercase on project_name normalises before the regex check fires."""
+        value, err = validate_answer(_q("project_name"), "MyProject")
         assert value == "myproject"
         assert err is None
 
     def test_transform_slugifies_spaces_and_specials(self) -> None:
         """Whitespace turns into hyphens and stray punctuation is dropped."""
-        value, err = validate_answer(_q("project_id"), "My Fancy Project!!")
+        value, err = validate_answer(_q("project_name"), "My Fancy Project!!")
         assert value == "my-fancy-project"
         assert err is None
 
     def test_transform_collapses_hyphen_runs(self) -> None:
         """Consecutive delimiters collapse into one hyphen."""
-        value, err = validate_answer(_q("project_id"), "foo   ---   bar")
+        value, err = validate_answer(_q("project_name"), "foo   ---   bar")
         assert value == "foo-bar"
         assert err is None
 
     def test_validator_surfaces_error(self) -> None:
         """A slug that can't be salvaged by slugification surfaces the regex error."""
         # Only punctuation — nothing in the allowed alphabet survives.
-        value, err = validate_answer(_q("project_id"), "!!!")
+        value, err = validate_answer(_q("project_name"), "!!!")
         assert err is not None
-        assert "Invalid project ID" in err or "required" in err
+        assert "Invalid project name" in err or "required" in err
 
     def test_editor_kind_accepts_arbitrary_text(self) -> None:
         """Editor-style questions have no validator; any string goes through."""
@@ -488,13 +490,13 @@ class TestValidateAnswer:
 
     def test_surrounding_whitespace_is_stripped(self) -> None:
         """Leading/trailing whitespace is removed before validation and transform."""
-        value, err = validate_answer(_q("project_id"), "  MyProj  ")
+        value, err = validate_answer(_q("project_name"), "  MyProj  ")
         assert value == "myproj"
         assert err is None
 
     def test_all_whitespace_answer_counts_as_empty_for_required(self) -> None:
         """``'   '`` → required field rejected the same way an empty string is."""
-        value, err = validate_answer(_q("project_id"), "   ")
+        value, err = validate_answer(_q("project_name"), "   ")
         assert value == ""
         assert err is not None
         assert "required" in err
@@ -559,7 +561,7 @@ class TestRenderAndWrite:
 
     def test_render_project_yaml_matches_generate_output(self) -> None:
         """In-memory render must equal the file generate_config writes."""
-        values = wizard_values(project_id="renderp", upstream_url="https://example.com/r.git")
+        values = wizard_values(project_name="renderp", upstream_url="https://example.com/r.git")
         rendered = render_project_yaml(values)
         with tempfile.TemporaryDirectory() as td:
             with patch(

--- a/tests/unit/lib/test_wizard_templates.py
+++ b/tests/unit/lib/test_wizard_templates.py
@@ -29,7 +29,7 @@ def _render_template(path: Path, variables: dict) -> str:
 TEMPLATE_DIR: Traversable = resources.files("terok") / "resources" / "templates" / "projects"
 TEMPLATE_NAME = "project.yml.template"
 REQUIRED_PLACEHOLDERS: list[str] = [
-    "{{PROJECT_ID}}",
+    "{{PROJECT_NAME}}",
     "{{UPSTREAM_URL}}",
     "{{DEFAULT_BRANCH}}",
     "{{USER_SNIPPET | indent(4)}}",
@@ -42,7 +42,7 @@ REQUIRED_PLACEHOLDERS: list[str] = [
 def _full_variables(*, security_class: str, base: str, **overrides: str) -> dict[str, str]:
     """Build a complete variables dict for the unified template."""
     return {
-        "PROJECT_ID": overrides.get("project_id", "my-project"),
+        "PROJECT_NAME": overrides.get("project_name", "my-project"),
         "UPSTREAM_URL": overrides.get("upstream_url", "https://example.test/repo.git"),
         "DEFAULT_BRANCH": overrides.get("default_branch", "main"),
         "USER_SNIPPET": overrides.get("user_snippet", ""),
@@ -76,7 +76,7 @@ class TestProjectTemplate:
     @pytest.mark.parametrize("security_class", [c.slug for c in SECURITY_CLASSES])
     @pytest.mark.parametrize("base", [c.slug for c in BASES])
     def test_renders_for_every_combination(self, security_class: str, base: str) -> None:
-        rendered = _render(security_class, base, project_id=f"proj-{security_class}-{base}")
+        rendered = _render(security_class, base, project_name=f"proj-{security_class}-{base}")
         # Every placeholder must be substituted away.
         assert "{{" not in rendered
         assert "{%" not in rendered
@@ -140,8 +140,8 @@ class TestProjectTemplate:
     def test_raises_on_missing_variable(self) -> None:
         """A typo or forgotten variable surfaces at render time, not silently."""
         traversable = TEMPLATE_DIR / TEMPLATE_NAME
-        # Drop PROJECT_ID to trigger the StrictUndefined guard.
+        # Drop PROJECT_NAME to trigger the StrictUndefined guard.
         variables = _full_variables(security_class="online", base="ubuntu")
-        del variables["PROJECT_ID"]
+        del variables["PROJECT_NAME"]
         with resources.as_file(traversable) as path, pytest.raises(jinja2.UndefinedError):
             _render_template(path, variables)

--- a/tests/unit/lib/test_yaml_schema.py
+++ b/tests/unit/lib/test_yaml_schema.py
@@ -58,7 +58,7 @@ class RawProjectYamlTests(unittest.TestCase):
             "agent": {"model": "opus"},
         }
         raw = RawProjectYaml.model_validate(data)
-        self.assertEqual(raw.project.id, "myproj")
+        self.assertEqual(raw.project.name, "myproj")
         self.assertEqual(raw.project.security_class, "gatekeeping")
         self.assertEqual(raw.git.upstream_url, "https://example.com/repo.git")
         self.assertTrue(raw.ssh.use_personal)
@@ -158,17 +158,17 @@ class IsolationValidationTests(unittest.TestCase):
 
 
 class ProjectIdValidationTests(unittest.TestCase):
-    """Tests for the project.id field validator."""
+    """Tests for the project.name field validator."""
 
     def test_valid_id(self) -> None:
-        """Valid lowercase ID is accepted."""
+        """Valid lowercase name is accepted (legacy ``id`` key still read)."""
         s = RawProjectSection.model_validate({"id": "my-project_1"})
-        self.assertEqual(s.id, "my-project_1")
+        self.assertEqual(s.name, "my-project_1")
 
     def test_none_id(self) -> None:
-        """None ID is accepted (defaults to directory name)."""
+        """None name is accepted (defaults to directory name)."""
         s = RawProjectSection.model_validate({"id": None})
-        self.assertIsNone(s.id)
+        self.assertIsNone(s.name)
 
     def test_uppercase_rejected(self) -> None:
         """Uppercase IDs are rejected."""

--- a/tests/unit/lib/test_yaml_schema.py
+++ b/tests/unit/lib/test_yaml_schema.py
@@ -170,6 +170,18 @@ class ProjectIdValidationTests(unittest.TestCase):
         s = RawProjectSection.model_validate({"id": None})
         self.assertIsNone(s.name)
 
+    def test_legacy_id_and_name_map_to_name_and_description(self) -> None:
+        """Pre-rename ``id`` (slug) and ``name`` (display) map to name + description."""
+        s = RawProjectSection.model_validate({"id": "proj", "name": "Pretty Proj"})
+        self.assertEqual(s.name, "proj")
+        self.assertEqual(s.description, "Pretty Proj")
+
+    def test_new_name_and_description(self) -> None:
+        """New-form ``name`` (slug) and ``description`` pass through unchanged."""
+        s = RawProjectSection.model_validate({"name": "proj", "description": "Pretty Proj"})
+        self.assertEqual(s.name, "proj")
+        self.assertEqual(s.description, "Pretty Proj")
+
     def test_uppercase_rejected(self) -> None:
         """Uppercase IDs are rejected."""
         with self.assertRaises(ValidationError):

--- a/tests/unit/lib/test_yaml_schema.py
+++ b/tests/unit/lib/test_yaml_schema.py
@@ -157,8 +157,8 @@ class IsolationValidationTests(unittest.TestCase):
         self.assertEqual(s.isolation, "shared")
 
 
-class ProjectIdValidationTests(unittest.TestCase):
-    """Tests for the project.name field validator."""
+class ProjectNameLegacyMappingTests(unittest.TestCase):
+    """Tests for raw project identity key mapping."""
 
     def test_valid_id(self) -> None:
         """Valid lowercase name is accepted (legacy ``id`` key still read)."""
@@ -182,20 +182,20 @@ class ProjectIdValidationTests(unittest.TestCase):
         self.assertEqual(s.name, "proj")
         self.assertEqual(s.description, "Pretty Proj")
 
-    def test_uppercase_rejected(self) -> None:
-        """Uppercase IDs are rejected."""
-        with self.assertRaises(ValidationError):
-            RawProjectSection.model_validate({"id": "MyProject"})
+    def test_new_display_name_without_id_is_kept_for_loader(self) -> None:
+        """No-``id`` old display names are left intact for loader mismatch handling."""
+        s = RawProjectSection.model_validate({"name": "Pretty Project"})
+        self.assertEqual(s.name, "Pretty Project")
 
-    def test_path_separator_rejected(self) -> None:
-        """Path separators in IDs are rejected."""
-        with self.assertRaises(ValidationError):
-            RawProjectSection.model_validate({"id": "../escape"})
+    def test_uppercase_id_is_left_for_resolved_loader_validation(self) -> None:
+        """Raw schema maps legacy IDs; resolved project loading owns slug validation."""
+        s = RawProjectSection.model_validate({"id": "MyProject"})
+        self.assertEqual(s.name, "MyProject")
 
-    def test_absolute_path_rejected(self) -> None:
-        """Absolute paths as IDs are rejected."""
-        with self.assertRaises(ValidationError):
-            RawProjectSection.model_validate({"id": "/etc/passwd"})
+    def test_path_separator_id_is_left_for_resolved_loader_validation(self) -> None:
+        """Raw schema keeps path-looking legacy IDs so project loading can explain them."""
+        s = RawProjectSection.model_validate({"id": "../escape"})
+        self.assertEqual(s.name, "../escape")
 
 
 class NameCategoriesTests(unittest.TestCase):

--- a/tests/unit/test_error_surfacing.py
+++ b/tests/unit/test_error_surfacing.py
@@ -320,7 +320,7 @@ class TestProjectStateWarnings:
         from terok.lib.domain.project_state import get_project_state
 
         mock_project = MagicMock()
-        mock_project.id = "test-proj"
+        mock_project.name = "test-proj"
         mock_project.security_class = "online"
         mock_project.ssh_host_dir = None
         mock_project.gate_path = tmp_path / "nonexistent-gate"
@@ -351,7 +351,7 @@ class TestProjectStateWarnings:
         from terok.lib.domain.project_state import get_project_state
 
         mock_project = MagicMock()
-        mock_project.id = "test-proj"
+        mock_project.name = "test-proj"
         mock_project.security_class = "online"
         mock_project.ssh_host_dir = None
         gate_dir = tmp_path / "gate"
@@ -379,7 +379,7 @@ class TestProjectStateWarnings:
 
 
 class TestImageCleanupWarning:
-    """Cover _known_project_ids() exception logging."""
+    """Cover _known_project_names() exception logging."""
 
     @pytest.fixture(autouse=True)
     def _isolate_log(self, tmp_path: Path) -> None:
@@ -388,7 +388,7 @@ class TestImageCleanupWarning:
 
     def test_project_discovery_failure_logged(self) -> None:
         """Exception in list_projects() is caught and logged."""
-        from terok.lib.domain.image_cleanup import _known_project_ids
+        from terok.lib.domain.image_cleanup import _known_project_names
 
         with (
             patch(
@@ -397,7 +397,7 @@ class TestImageCleanupWarning:
             ),
             patch("terok.lib.util.logging_utils.log_warning") as mock_warn,
         ):
-            result = _known_project_ids()
+            result = _known_project_names()
 
         assert result is None
         mock_warn.assert_called_once()
@@ -430,7 +430,7 @@ class TestEnvironmentWarnings:
 
         mock_project = MagicMock()
         mock_project.security_class = "online"
-        mock_project.id = "test-proj"
+        mock_project.name = "test-proj"
         mock_project.gate_enabled = True
         mock_project.upstream_url = "https://example.com/repo.git"
         mock_project.default_branch = "main"

--- a/tests/unit/test_unified_layering_contracts.py
+++ b/tests/unit/test_unified_layering_contracts.py
@@ -243,7 +243,7 @@ def test_terok_task_slash_alias() -> None:
     Exercises the argparse layer plus
     [`_normalize_pt`][terok.cli.commands.task._normalize_pt] (which
     [`dispatch`][terok.cli.commands.task.dispatch] runs first) and
-    asserts the resulting ``(project_id, task_id)`` is the same for
+    asserts the resulting ``(project_name, task_id)`` is the same for
     both input forms.  Uses ``task stop`` as a representative verb
     that takes both positionals.
     """
@@ -260,8 +260,8 @@ def test_terok_task_slash_alias() -> None:
     slash = parser.parse_args(["task", "stop", "myproj/mytask"])
     _normalize_pt(slash)
 
-    assert (space.project_id, space.task_id) == ("myproj", "mytask")
-    assert (slash.project_id, slash.task_id) == ("myproj", "mytask")
+    assert (space.project_name, space.task_id) == ("myproj", "mytask")
+    assert (slash.project_name, slash.task_id) == ("myproj", "mytask")
 
 
 def test_lookup_container_by_pt_resolves_and_handles_misses() -> None:
@@ -314,31 +314,31 @@ def test_normalize_pt_rejects_path_traversal(slash_form: str) -> None:
 
     from terok.cli.commands.task import _normalize_pt
 
-    args = argparse.Namespace(project_id=slash_form, task_id=None)
+    args = argparse.Namespace(project_name=slash_form, task_id=None)
     with pytest.raises(SystemExit, match="(?i)invalid"):
         _normalize_pt(args)
 
 
 @pytest.mark.parametrize(
-    ("project_id", "task_id"),
+    ("project_name", "task_id"),
     [
         ("../escape", "a1b2c"),
-        ("MYPROJ", "a1b2c"),  # validate_project_id is lowercase-only
+        ("MYPROJ", "a1b2c"),  # validate_project_name is lowercase-only
         ("myproj", ".."),
         ("myproj", "evil/sub"),
         ("myproj", ""),
     ],
 )
-def test_lookup_container_by_pt_rejects_unsafe_ids(project_id: str, task_id: str) -> None:
+def test_lookup_container_by_pt_rejects_unsafe_ids(project_name: str, task_id: str) -> None:
     """`lookup_container_by_pt` returns None for any input that could traverse out of the task store."""
     from terok.lib.orchestration.tasks import lookup_container_by_pt
 
-    assert lookup_container_by_pt(project_id, task_id) is None
+    assert lookup_container_by_pt(project_name, task_id) is None
 
 
 @pytest.mark.parametrize("bad", ["", ".", "..", "../escape", "..hidden", "a/b", "a\\b"])
-def test_meta_path_builders_reject_unsafe_project_id(bad: str) -> None:
-    """The five ``tasks/meta.py`` path-builders raise on a path-unsafe project_id.
+def test_meta_path_builders_reject_unsafe_project_name(bad: str) -> None:
+    """The five ``tasks/meta.py`` path-builders raise on a path-unsafe project_name.
 
     Defense-in-depth: even if a caller smuggles past the CLI / resolver
     guards (``_normalize_pt``, ``lookup_container_by_pt``), the
@@ -347,7 +347,7 @@ def test_meta_path_builders_reject_unsafe_project_id(bad: str) -> None:
     [`tasks_meta_dir`][terok.lib.orchestration.tasks.meta.tasks_meta_dir],
     [`tasks_archive_dir`][terok.lib.orchestration.tasks.meta.tasks_archive_dir],
     and [`agent_config_dir`][terok.lib.orchestration.tasks.meta.agent_config_dir]
-    (the project_id-consuming builders).
+    (the project_name-consuming builders).
     """
     from terok.lib.orchestration.tasks.meta import (
         agent_config_dir,
@@ -356,9 +356,9 @@ def test_meta_path_builders_reject_unsafe_project_id(bad: str) -> None:
     )
 
     for builder in (tasks_meta_dir, tasks_archive_dir):
-        with pytest.raises(SystemExit, match="project_id"):
+        with pytest.raises(SystemExit, match="project_name"):
             builder(bad)
-    with pytest.raises(SystemExit, match="project_id"):
+    with pytest.raises(SystemExit, match="project_name"):
         agent_config_dir(bad, "a1b2c")
 
 

--- a/tests/unit/tui/test_askpass_gating.py
+++ b/tests/unit/tui/test_askpass_gating.py
@@ -56,7 +56,7 @@ class _FakeApp:
 def _new_screen() -> InitProgressScreen:
     """Construct a bare [`InitProgressScreen`][terok.tui.wizard_screens.InitProgressScreen] without Textual's setup machinery."""
     screen = InitProgressScreen.__new__(InitProgressScreen)
-    screen._project_id = "demo"
+    screen._project_name = "demo"
     return screen
 
 

--- a/tests/unit/tui/test_clearance_screen.py
+++ b/tests/unit/tui/test_clearance_screen.py
@@ -352,7 +352,7 @@ class TestClearanceTUIIntegration:
         task = widgets.TaskMeta(
             task_id="1", mode="cli", workspace="/w", web_port=None, container_state="running"
         )
-        screen = screens.TaskDetailsScreen(task=task, has_tasks=True, project_id="p")
+        screen = screens.TaskDetailsScreen(task=task, has_tasks=True, project_name="p")
         screen.dismiss = mock.Mock()
         screen.on_key(make_key_event("C"))
         screen.dismiss.assert_called_once_with("show_clearance")
@@ -360,7 +360,7 @@ class TestClearanceTUIIntegration:
     def test_task_details_shift_c_noop_without_tasks(self) -> None:
         """Pressing C without tasks does nothing."""
         screens, _ = import_screens()
-        screen = screens.TaskDetailsScreen(task=None, has_tasks=False, project_id="p")
+        screen = screens.TaskDetailsScreen(task=None, has_tasks=False, project_name="p")
         screen.dismiss = mock.Mock()
         screen.on_key(make_key_event("C"))
         screen.dismiss.assert_not_called()

--- a/tests/unit/tui/test_delete_resume.py
+++ b/tests/unit/tui/test_delete_resume.py
@@ -93,7 +93,7 @@ class TestDeleteGuard:
     def _ready_instance(self, app_class: type) -> Any:
         """Instance wired for a single ``action_delete_task`` call."""
         instance = _instance(app_class)
-        instance.current_project_id = "p1"
+        instance.current_project_name = "p1"
         instance._log_debug = mock.Mock()
         instance._update_task_details = mock.Mock()
         instance.query_one = mock.Mock(return_value=mock.Mock())
@@ -145,7 +145,7 @@ class TestInFlightBookkeeping:
         instance = app_class()
         instance.notify = mock.Mock()
         # A different current project so the handler returns before refresh_tasks.
-        instance.current_project_id = "other"
+        instance.current_project_name = "other"
         instance._deleting_tasks.add(("p1", "7"))
 
         worker = mock.Mock()

--- a/tests/unit/tui/test_detail_screens.py
+++ b/tests/unit/tui/test_detail_screens.py
@@ -24,14 +24,14 @@ from tests.unit.tui.tui_test_helpers import (
 )
 
 MOCK_WORKSPACE = str(MOCK_BASE / "ws")
-TEST_PROJECT_ID = "test-proj"
-TEST_PROJECT_ROOT = MOCK_CONFIG_ROOT / "projects" / TEST_PROJECT_ID
+TEST_PROJECT_NAME = "test-proj"
+TEST_PROJECT_ROOT = MOCK_CONFIG_ROOT / "projects" / TEST_PROJECT_NAME
 
 
 def make_project(**overrides: object) -> mock.Mock:
     """Return a project mock with sensible defaults for TUI rendering tests."""
     project = mock.Mock()
-    project.id = TEST_PROJECT_ID
+    project.name = TEST_PROJECT_NAME
     project.upstream_url = TEST_UPSTREAM_URL
     project.security_class = "online"
     project.agents = ["codex"]
@@ -60,7 +60,7 @@ def make_task_screen(*, has_tasks: bool, mode: str | None = None) -> object:
     """Build a TaskDetailsScreen with a mocked dismiss method."""
     screens, widgets = import_screens()
     task = None if mode is None else make_task(widgets, task_id="t1", mode=mode)
-    screen = screens.TaskDetailsScreen(task=task, has_tasks=has_tasks, project_id="p")
+    screen = screens.TaskDetailsScreen(task=task, has_tasks=has_tasks, project_name="p")
     screen.dismiss = mock.Mock()
     return screen
 
@@ -69,7 +69,7 @@ def render_task_details_text(**overrides: object) -> str:
     """Render task details and return plain text for substring assertions."""
     widgets = import_widgets()
     task = make_task(widgets, **overrides)
-    return str(widgets.render_task_details(task, project_id="proj1"))
+    return str(widgets.render_task_details(task, project_name="proj1"))
 
 
 def format_task_label(**overrides: object) -> str:
@@ -104,7 +104,7 @@ async def fake_push_screen(
 def make_creation_app(app_class: type) -> object:
     """Build a TUI app instance prepared for task-creation workflows."""
     instance = app_class()
-    instance.current_project_id = "proj1"
+    instance.current_project_name = "proj1"
     instance._last_selected_tasks = {}
     instance.notify = mock.Mock()
     instance.suspend = mock.Mock(return_value=contextlib.nullcontext())
@@ -149,7 +149,7 @@ class TestRenderHelpers:
 
         assert isinstance(result, Text)
         text_str = str(result)
-        assert TEST_PROJECT_ID in text_str
+        assert TEST_PROJECT_NAME in text_str
 
     def test_render_project_details_shows_config_path(self) -> None:
         widgets = import_widgets()
@@ -173,7 +173,7 @@ class TestRenderHelpers:
 
         task = make_task(widgets, task_id="42", backend="codex")
 
-        result = widgets.render_task_details(task, project_id="proj1")
+        result = widgets.render_task_details(task, project_name="proj1")
 
         assert isinstance(result, Text)
         text_str = str(result)
@@ -189,7 +189,7 @@ class TestRenderHelpers:
 
     def test_render_project_loading(self) -> None:
         widgets = import_widgets()
-        project = make_project(id="myproj", upstream_url=TEST_EGRESS_URL)
+        project = make_project(name="myproj", upstream_url=TEST_EGRESS_URL)
 
         result = widgets.render_project_loading(project, task_count=3)
 
@@ -208,7 +208,7 @@ class TestRenderHelpers:
     def test_render_task_details_unattended_mode(self) -> None:
         widgets = import_widgets()
         task = make_task(widgets, task_id="5", mode="run")
-        result = widgets.render_task_details(task, project_id="proj1")
+        result = widgets.render_task_details(task, project_name="proj1")
         assert isinstance(result, Text)
         text_str = str(result)
         assert "Unattended" in text_str
@@ -217,7 +217,7 @@ class TestRenderHelpers:
     def test_render_task_details_unattended_with_exit_code(self) -> None:
         widgets = import_widgets()
         task = make_task(widgets, task_id="5", mode="run", exit_code=0)
-        result = widgets.render_task_details(task, project_id="proj1")
+        result = widgets.render_task_details(task, project_name="proj1")
         text_str = str(result)
         assert "Exit code: 0" in text_str
 
@@ -229,7 +229,7 @@ class TestRenderHelpers:
 
         widgets = import_widgets()
         task = make_task(widgets, task_id="42", mode="toad", web_port=8123, web_token="t0k")
-        result = widgets.render_task_details(task, project_id="proj1", is_web=False)
+        result = widgets.render_task_details(task, project_name="proj1", is_web=False)
         # Render to a buffer with ``force_terminal`` so styles serialise
         # to ANSI; the plain ``str(result)`` projection drops styling.
         buf = io.StringIO()
@@ -246,7 +246,7 @@ class TestRenderHelpers:
 
         widgets = import_widgets()
         task = make_task(widgets, task_id="42", mode="toad", web_port=8123, web_token="t0k")
-        result = widgets.render_task_details(task, project_id="proj1", is_web=True)
+        result = widgets.render_task_details(task, project_name="proj1", is_web=True)
         buf = io.StringIO()
         Console(file=buf, width=80, force_terminal=True, color_system="standard").print(result)
         ansi = buf.getvalue()
@@ -345,7 +345,7 @@ class TestRenderHelpers:
         """Stopped containers with healthy hooks show 'ready', no warning."""
         widgets = import_widgets()
         task = make_task(widgets, task_id="99", shield_state="OFFLINE", container_state="exited")
-        text = str(widgets.render_task_details(task, project_id="proj1", shield_hooks_ok=True))
+        text = str(widgets.render_task_details(task, project_name="proj1", shield_hooks_ok=True))
         assert "ready" in text
         assert "offline" not in text
         assert "shield-security" not in text
@@ -354,7 +354,7 @@ class TestRenderHelpers:
         """Stopped containers with broken hooks still show offline warning."""
         widgets = import_widgets()
         task = make_task(widgets, task_id="99", shield_state="OFFLINE", container_state="exited")
-        text = str(widgets.render_task_details(task, project_id="proj1", shield_hooks_ok=False))
+        text = str(widgets.render_task_details(task, project_name="proj1", shield_hooks_ok=False))
         assert "offline" in text
         assert "shield-security" in text
         assert "ready" not in text
@@ -429,7 +429,7 @@ class TestScreenConstruction:
 
     def test_project_details_screen_construction(self) -> None:
         screens, _ = import_screens()
-        project = make_project(id="proj1")
+        project = make_project(name="proj1")
         staleness = mock.Mock()
 
         screen = screens.ProjectDetailsScreen(
@@ -454,7 +454,7 @@ class TestScreenConstruction:
     def test_project_details_action_set_agents_opens_modal(self) -> None:
         """``action_set_agents`` calls ``_open_agents_modal`` — keeps the wiring honest."""
         screens, _ = import_screens()
-        project = make_project(id="proj1")
+        project = make_project(name="proj1")
         screen = screens.ProjectDetailsScreen(project=project, state=None, task_count=0)
         screen._open_agents_modal = mock.Mock()
         screen.action_set_agents()
@@ -463,7 +463,7 @@ class TestScreenConstruction:
     def test_project_details_option_list_routes_set_agents(self) -> None:
         """Selecting the OptionList entry pushes the modal instead of dismissing."""
         screens, _ = import_screens()
-        project = make_project(id="proj1")
+        project = make_project(name="proj1")
         screen = screens.ProjectDetailsScreen(project=project, state=None, task_count=0)
         screen._open_agents_modal = mock.Mock()
         screen.dismiss = mock.Mock()
@@ -476,7 +476,7 @@ class TestScreenConstruction:
     def test_project_details_agents_modal_writes_selection(self) -> None:
         """A non-None selection from the modal lands in ``set_project_image_agents``."""
         screens, _ = import_screens()
-        project = make_project(id="proj1", agents="all")
+        project = make_project(name="proj1", agents="all")
         screen = screens.ProjectDetailsScreen(project=project, state=None, task_count=0)
         screen.notify = mock.Mock()
         with mock.patch("terok.lib.api.set_project_image_agents") as write_mock:
@@ -490,7 +490,7 @@ class TestScreenConstruction:
     def test_project_details_agents_modal_cancel_is_noop(self) -> None:
         """``None`` from the modal must NOT touch project.yml."""
         screens, _ = import_screens()
-        project = make_project(id="proj1", agents="all")
+        project = make_project(name="proj1", agents="all")
         screen = screens.ProjectDetailsScreen(project=project, state=None, task_count=0)
         screen.notify = mock.Mock()
         with mock.patch("terok.lib.api.set_project_image_agents") as write_mock:
@@ -505,12 +505,12 @@ class TestScreenConstruction:
         screen = screens.TaskDetailsScreen(
             task=task,
             has_tasks=True,
-            project_id="proj1",
+            project_name="proj1",
             image_old=False,
         )
         assert screen._task_meta == task
         assert screen._has_tasks
-        assert screen._project_id == "proj1"
+        assert screen._project_name == "proj1"
         assert not screen._image_old
 
     @pytest.mark.parametrize("screen_name", ["AuthActionsScreen", "UnattendedPromptScreen"])
@@ -757,7 +757,7 @@ class TestSSHKeyRegistration:
         """action_init_ssh dispatches the init_ssh worker action for the selection."""
         mixin = self._get_mixin()
         instance = mock.Mock(spec=mixin)
-        instance.current_project_id = "proj"
+        instance.current_project_name = "proj"
         run(mixin.action_init_ssh(instance))
         instance._run_console_action.assert_called_once_with(
             "terok.tui.worker_actions:init_ssh",
@@ -776,13 +776,13 @@ class TestSSHKeyRegistration:
         """
         mixin = self._get_mixin()
         instance = mock.Mock(spec=mixin)
-        instance.current_project_id = "proj"
+        instance.current_project_name = "proj"
         instance.push_screen = mock.AsyncMock()
         run(mixin._action_project_init(instance))
         instance.push_screen.assert_awaited_once()
         screen = instance.push_screen.call_args[0][0]
         assert type(screen).__name__ == "InitProgressScreen"
-        assert screen._project_id == "proj"
+        assert screen._project_name == "proj"
         assert screen._rendered_yaml is None
 
 
@@ -948,11 +948,11 @@ class TestActionAuth:
 
         return ProjectActionsMixin
 
-    def test_per_project_dispatches_auth_with_project_id(self) -> None:
+    def test_per_project_dispatches_auth_with_project_name(self) -> None:
         """``_action_auth`` is the project-details path — passes the selection."""
         mixin = self._get_mixin()
         instance = mock.Mock(spec=mixin)
-        instance.current_project_id = "myproj"
+        instance.current_project_name = "myproj"
         # ``_run_auth_flow`` is ``@work``-decorated — sync at call time despite
         # the async source.  Override the autospec'd AsyncMock so the call
         # doesn't leak an unawaited coroutine.
@@ -964,7 +964,7 @@ class TestActionAuth:
         """Without a selection ``_action_auth`` is a no-op — host-wide path is separate."""
         mixin = self._get_mixin()
         instance = mock.Mock(spec=mixin)
-        instance.current_project_id = None
+        instance.current_project_name = None
         # ``notify`` lives on the App parent, not the mixin spec — wire it
         # explicitly so the early-return path can call it without erroring.
         instance.notify = mock.Mock()
@@ -975,10 +975,10 @@ class TestActionAuth:
         instance.notify.assert_called_once()
 
     def test_host_wide_dispatches_auth_with_none(self) -> None:
-        """``_action_auth_host_wide`` ignores ``current_project_id`` by design."""
+        """``_action_auth_host_wide`` ignores ``current_project_name`` by design."""
         mixin = self._get_mixin()
         instance = mock.Mock(spec=mixin)
-        instance.current_project_id = "selected-but-irrelevant"
+        instance.current_project_name = "selected-but-irrelevant"
         instance._run_auth_flow = mock.Mock()
         run(mixin._action_auth_host_wide(instance, "claude"))
         instance._run_auth_flow.assert_called_once_with("claude", None)
@@ -1039,7 +1039,7 @@ class TestAuthFlow:
         with self._roster("claude", self._provider(oauth=True, api_key=True), oauth_enabled=True):
             run(mixin._run_auth_flow_body(instance, "claude", "proj"))
         instance.push_screen_wait.assert_awaited_once()
-        instance._auth_via_oauth.assert_awaited_once_with("claude", project_id="proj")
+        instance._auth_via_oauth.assert_awaited_once_with("claude", project_name="proj")
         instance._auth_via_api_key.assert_not_awaited()
 
     def test_both_modes_prompts_then_api_key(self) -> None:
@@ -1049,7 +1049,7 @@ class TestAuthFlow:
         instance.push_screen_wait.return_value = "api_key"
         with self._roster("claude", self._provider(oauth=True, api_key=True), oauth_enabled=True):
             run(mixin._run_auth_flow_body(instance, "claude", None))
-        instance._auth_via_api_key.assert_awaited_once_with("claude", project_id=None)
+        instance._auth_via_api_key.assert_awaited_once_with("claude", project_name=None)
         instance._auth_via_oauth.assert_not_awaited()
 
     def test_both_modes_cancel_dispatches_nothing(self) -> None:
@@ -1069,7 +1069,7 @@ class TestAuthFlow:
         with self._roster("claude", self._provider(oauth=True, api_key=False), oauth_enabled=True):
             run(mixin._run_auth_flow_body(instance, "claude", None))
         instance.push_screen_wait.assert_not_awaited()
-        instance._auth_via_oauth.assert_awaited_once_with("claude", project_id=None)
+        instance._auth_via_oauth.assert_awaited_once_with("claude", project_name=None)
 
     def test_api_key_only_skips_mode_screen(self) -> None:
         """An API-key-only provider goes straight to the key form — no mode prompt."""
@@ -1079,7 +1079,7 @@ class TestAuthFlow:
         with self._roster("blablador", info, oauth_enabled=True):
             run(mixin._run_auth_flow_body(instance, "blablador", None))
         instance.push_screen_wait.assert_not_awaited()
-        instance._auth_via_api_key.assert_awaited_once_with("blablador", project_id=None)
+        instance._auth_via_api_key.assert_awaited_once_with("blablador", project_name=None)
 
     def test_oauth_gated_off_falls_back_to_api_key(self) -> None:
         """A dual-mode provider with the OAuth gate closed uses API key, no prompt."""
@@ -1088,7 +1088,7 @@ class TestAuthFlow:
         with self._roster("claude", self._provider(oauth=True, api_key=True), oauth_enabled=False):
             run(mixin._run_auth_flow_body(instance, "claude", None))
         instance.push_screen_wait.assert_not_awaited()
-        instance._auth_via_api_key.assert_awaited_once_with("claude", project_id=None)
+        instance._auth_via_api_key.assert_awaited_once_with("claude", project_name=None)
 
     def test_oauth_only_but_gated_off_errors(self) -> None:
         """OAuth-only provider with the gate closed has no usable mode — it errors."""
@@ -1109,7 +1109,7 @@ class TestAuthFlow:
         instance.notify = mock.Mock()
         instance.push_screen_wait = mock.AsyncMock(return_value="sk-test-key")
         with mock.patch("terok.lib.api.store_api_key") as store:
-            run(mixin._auth_via_api_key(instance, "claude", project_id=None))
+            run(mixin._auth_via_api_key(instance, "claude", project_name=None))
         store.assert_called_once_with("claude", "sk-test-key", credential_set="default")
         instance.notify.assert_called_once()
 
@@ -1120,7 +1120,7 @@ class TestAuthFlow:
         instance.notify = mock.Mock()
         instance.push_screen_wait = mock.AsyncMock(return_value=None)
         with mock.patch("terok.lib.api.store_api_key") as store:
-            run(mixin._auth_via_api_key(instance, "claude", project_id=None))
+            run(mixin._auth_via_api_key(instance, "claude", project_name=None))
         store.assert_not_called()
 
     def test_api_key_store_failure_notifies_error(self) -> None:
@@ -1130,7 +1130,7 @@ class TestAuthFlow:
         instance.notify = mock.Mock()
         instance.push_screen_wait = mock.AsyncMock(return_value="sk")
         with mock.patch("terok.lib.api.store_api_key", side_effect=RuntimeError("vault locked")):
-            run(mixin._auth_via_api_key(instance, "claude", project_id=None))
+            run(mixin._auth_via_api_key(instance, "claude", project_name=None))
         assert instance.notify.call_args.kwargs.get("severity") == "error"
 
     # ---- _auth_via_oauth ----
@@ -1142,7 +1142,7 @@ class TestAuthFlow:
         instance.notify = mock.Mock()
         instance._launch_oauth_container = mock.AsyncMock()
         with mock.patch("terok.lib.api.find_host_auth_image", return_value=None):
-            run(mixin._auth_via_oauth(instance, "claude", project_id=None))
+            run(mixin._auth_via_oauth(instance, "claude", project_name=None))
         assert instance.notify.call_args.kwargs.get("severity") == "warning"
         instance._launch_oauth_container.assert_not_awaited()
 
@@ -1159,7 +1159,7 @@ class TestAuthFlow:
             mock.patch("terok.lib.api.Authenticator", return_value=authenticator),
             mock.patch("terok.lib.core.config.sandbox_live_mounts_dir", return_value=MOCK_BASE),
         ):
-            run(mixin._auth_via_oauth(instance, "claude", project_id=None))
+            run(mixin._auth_via_oauth(instance, "claude", project_name=None))
         authenticator.prepare_oauth.assert_called_once()
         instance._launch_oauth_container.assert_awaited_once_with(session)
 
@@ -1179,7 +1179,7 @@ class TestAuthFlow:
                 "terok.lib.api.resolve_credential_routing", return_value=(MOCK_BASE, "myproj")
             ),
         ):
-            run(mixin._auth_via_oauth(instance, "claude", project_id="myproj"))
+            run(mixin._auth_via_oauth(instance, "claude", project_name="myproj"))
         pci.assert_called_once_with("myproj")
         find_host.assert_not_called()
         # Per-project credential set reaches prepare_oauth.
@@ -1264,7 +1264,7 @@ class TestActionSelection:
         app_mod, app_class = import_app()
 
         instance = app_class()
-        instance.current_project_id = "proj1"
+        instance.current_project_name = "proj1"
         instance._last_selected_tasks = {}
         instance.notify = mock.Mock()
         instance._save_selection_state = mock.Mock()
@@ -1298,7 +1298,7 @@ class TestGateSyncAction:
         """With a selection, the action dispatches the sync_gate worker entrypoint."""
         mixin = self._get_mixin()
         instance = mock.Mock(spec=mixin)
-        instance.current_project_id = "proj1"
+        instance.current_project_name = "proj1"
         run(mixin._action_sync_gate(instance))
         instance._run_console_action.assert_called_once_with(
             "terok.tui.worker_actions:sync_gate",
@@ -1310,7 +1310,7 @@ class TestGateSyncAction:
         """No project selected — the action notifies and dispatches nothing."""
         mixin = self._get_mixin()
         instance = mock.Mock(spec=mixin)
-        instance.current_project_id = None
+        instance.current_project_name = None
         instance.notify = mock.Mock()
         run(mixin._action_sync_gate(instance))
         instance._run_console_action.assert_not_called()
@@ -1322,7 +1322,7 @@ class TestProjectScreenNoneState:
 
     def test_project_screen_stores_none_state(self) -> None:
         screens, _ = import_screens()
-        project = make_project(id="proj1")
+        project = make_project(name="proj1")
         screen = screens.ProjectDetailsScreen(project=project, state=None, task_count=3)
         assert screen._state is None
         assert screen._task_count == 3
@@ -1574,7 +1574,7 @@ class TestDeleteTaskResult:
         try:
             return app_class._delete_task(
                 instance,
-                kwargs.get("project_id", "proj1"),
+                kwargs.get("project_name", "proj1"),
                 kwargs.get("task_id", "3"),
                 kwargs.get("task_name", "fix-login"),
             )
@@ -1582,7 +1582,7 @@ class TestDeleteTaskResult:
             fn_globals["task_delete"] = orig
 
     def test_delete_task_success_returns_five_tuple(self) -> None:
-        """Successful deletion returns (project_id, task_id, task_name, None, [])."""
+        """Successful deletion returns (project_name, task_id, task_name, None, [])."""
         assert self._call_delete() == ("proj1", "3", "fix-login", None, [])
 
     def test_delete_task_error_returns_five_tuple(self) -> None:

--- a/tests/unit/tui/test_detail_screens.py
+++ b/tests/unit/tui/test_detail_screens.py
@@ -168,6 +168,24 @@ class TestRenderHelpers:
         assert isinstance(result, Text)
         assert "No project" in str(result)
 
+    def test_render_project_details_shows_description(self) -> None:
+        widgets = import_widgets()
+        project = make_project(description="A friendly summary")
+        state = {"ssh": True, "dockerfiles": True, "images": True, "gate": True}
+
+        result = widgets.render_project_details(project, state, task_count=5)
+
+        assert "A friendly summary" in str(result)
+
+    def test_render_project_details_omits_description_when_none(self) -> None:
+        widgets = import_widgets()
+        project = make_project(description=None)
+        state = {"ssh": True, "dockerfiles": True, "images": True, "gate": True}
+
+        result = widgets.render_project_details(project, state, task_count=5)
+
+        assert "Desc:" not in str(result)
+
     def test_render_task_details_returns_text(self) -> None:
         widgets = import_widgets()
 
@@ -204,6 +222,22 @@ class TestRenderHelpers:
 
         assert isinstance(result, Text)
         assert "No project" in str(result)
+
+    def test_render_project_loading_shows_description(self) -> None:
+        widgets = import_widgets()
+        project = make_project(description="Loading-time summary")
+
+        result = widgets.render_project_loading(project, task_count=1)
+
+        assert "Loading-time summary" in str(result)
+
+    def test_render_project_loading_omits_description_when_none(self) -> None:
+        widgets = import_widgets()
+        project = make_project(description=None)
+
+        result = widgets.render_project_loading(project, task_count=1)
+
+        assert "Desc:" not in str(result)
 
     def test_render_task_details_unattended_mode(self) -> None:
         widgets = import_widgets()

--- a/tests/unit/tui/test_list_widgets.py
+++ b/tests/unit/tui/test_list_widgets.py
@@ -1,0 +1,96 @@
+# SPDX-FileCopyrightText: 2026 Jiri Vyskocil
+# SPDX-License-Identifier: Apache-2.0
+
+"""Focused tests for project/task list widget identity plumbing."""
+
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+from terok.lib.api import BrokenProject
+from tests.unit.tui.tui_test_helpers import import_widgets
+
+
+def _wire_listview(widget: Any) -> tuple[list[Any], list[Any]]:
+    """Attach the tiny ListView surface the Textual stubs intentionally omit."""
+    appended: list[Any] = []
+    posted: list[Any] = []
+
+    def append(item: Any) -> None:
+        item.parent = widget
+        appended.append(item)
+
+    widget.append = append
+    widget.clear = appended.clear
+    widget.post_message = posted.append
+    return appended, posted
+
+
+def test_project_list_uses_project_names_for_rows_and_messages(tmp_path: Path) -> None:
+    """Healthy and broken project rows carry the canonical project name."""
+    widgets = import_widgets()
+    project_list = widgets.ProjectList()
+    rows, messages = _wire_listview(project_list)
+
+    healthy = SimpleNamespace(name="healthy", security_class="online", root=tmp_path / "healthy")
+    broken = BrokenProject(
+        name="broken",
+        config_path=tmp_path / "broken" / "project.yml",
+        error="project.name must match directory",
+    )
+
+    project_list.set_projects([healthy], [broken])
+
+    assert [row.project_name for row in rows] == ["broken", "healthy"]
+    assert [row.is_broken for row in rows] == [True, False]
+
+    project_list.select_project("broken")
+    assert project_list.index == 0
+    project_list.select_project("healthy")
+    assert project_list.index == 1
+
+    project_list._post_selected_project(rows[1])
+    assert messages[-1].project_name == "healthy"
+    assert messages[-1].is_broken is False
+
+
+def test_task_list_preserves_live_state_and_posts_current_project() -> None:
+    """Task rows keep live state across reloads and emit the owning project name."""
+    widgets = import_widgets()
+    task_list = widgets.TaskList()
+    rows, messages = _wire_listview(task_list)
+    task_list._label_width = lambda: 80
+
+    first_snapshot = widgets.TaskMeta(
+        task_id="t1", mode="cli", workspace="", web_port=None, container_state="running"
+    )
+    task_list.set_tasks("alpha", [first_snapshot])
+
+    refreshed_snapshot = widgets.TaskMeta(
+        task_id="t1", mode="cli", workspace="", web_port=None, container_state=None
+    )
+    task_list.set_tasks("alpha", [refreshed_snapshot])
+
+    assert task_list.tasks[0].container_state == "running"
+    assert rows[-1].project_name == "alpha"
+
+    task_list._post_selected_task(rows[-1])
+    assert messages[-1].project_name == "alpha"
+    assert messages[-1].task.task_id == "t1"
+
+
+def test_task_list_drops_stale_selection_messages() -> None:
+    """Stale rows from another project cannot update the current selection."""
+    widgets = import_widgets()
+    task_list = widgets.TaskList()
+    rows, messages = _wire_listview(task_list)
+    task_list._label_width = lambda: 80
+
+    task_list.set_tasks(
+        "alpha", [widgets.TaskMeta(task_id="t1", mode="cli", workspace="", web_port=None)]
+    )
+    task_list.project_name = "beta"
+
+    task_list._post_selected_task(rows[-1])
+
+    assert messages == []

--- a/tests/unit/tui/test_log_debug_exception_paths.py
+++ b/tests/unit/tui/test_log_debug_exception_paths.py
@@ -49,7 +49,7 @@ def test_render_project_details_handles_instructions_probe_failure() -> None:
     file present".  Covers project_state.py:159-162.
     """
     project = MagicMock()
-    project.id = "demo"
+    project.name = "demo"
     project.upstream_url = None
     project.security_class = "online"
     project.agents = []

--- a/tests/unit/tui/test_log_viewer.py
+++ b/tests/unit/tui/test_log_viewer.py
@@ -27,7 +27,7 @@ def make_log_viewer_screen(
     """Build a LogViewerScreen with captured posted output."""
     mod = import_log_viewer()
     ref = mod.TaskContainerRef(
-        project_id="p",
+        project_name="p",
         task_id="1",
         mode=mode,
         container_name="p-cli-1",
@@ -372,13 +372,13 @@ class TestLogViewerScreenConstruction:
     def test_construction_follow_mode(self) -> None:
         mod = import_log_viewer()
         ref = mod.TaskContainerRef(
-            project_id="proj1",
+            project_name="proj1",
             task_id="42",
             mode="run",
             container_name="proj1-run-42",
         )
         screen = mod.LogViewerScreen(ref, follow=True)
-        assert screen.project_id == "proj1"
+        assert screen.project_name == "proj1"
         assert screen.task_id == "42"
         assert screen.mode == "run"
         assert screen.container_name == "proj1-run-42"
@@ -387,7 +387,7 @@ class TestLogViewerScreenConstruction:
     def test_construction_static_mode(self) -> None:
         mod = import_log_viewer()
         ref = mod.TaskContainerRef(
-            project_id="proj1",
+            project_name="proj1",
             task_id="7",
             mode="cli",
             container_name="proj1-cli-7",
@@ -399,7 +399,7 @@ class TestLogViewerScreenConstruction:
     def test_construction_default_follow(self) -> None:
         mod = import_log_viewer()
         ref = mod.TaskContainerRef(
-            project_id="p",
+            project_name="p",
             task_id="1",
             mode="run",
             container_name="p-run-1",
@@ -410,7 +410,7 @@ class TestLogViewerScreenConstruction:
     def test_stop_event_initialized(self) -> None:
         mod = import_log_viewer()
         ref = mod.TaskContainerRef(
-            project_id="p",
+            project_name="p",
             task_id="1",
             mode="run",
             container_name="p-run-1",

--- a/tests/unit/tui/test_new_task_flow.py
+++ b/tests/unit/tui/test_new_task_flow.py
@@ -1332,7 +1332,7 @@ class TestFillInstalledAgents:
         instance._log_debug = mock.Mock()
 
         fake_project = mock.Mock()
-        fake_project.id = "proj1"
+        fake_project.name = "proj1"
         launch_screen = mock.Mock()
 
         with mock.patch(

--- a/tests/unit/tui/test_new_task_flow.py
+++ b/tests/unit/tui/test_new_task_flow.py
@@ -126,13 +126,13 @@ class TestTaskLaunchScreen:
         screens, _ = import_screens()
         screen = screens.TaskLaunchScreen(
             container_name="terok-p-cli-1",
-            project_id="p",
+            project_name="p",
             task_id="1",
             task_name="fix-bug",
             default_shell="claude",
         )
         assert screen._container_name == "terok-p-cli-1"
-        assert screen._project_id == "p"
+        assert screen._project_name == "p"
         assert screen._task_id == "1"
         assert screen._task_name == "fix-bug"
         assert screen._default_shell == "claude"
@@ -140,20 +140,20 @@ class TestTaskLaunchScreen:
 
     def test_construction_default_bash(self) -> None:
         screens, _ = import_screens()
-        screen = screens.TaskLaunchScreen(container_name="c", project_id="p", task_id="1")
+        screen = screens.TaskLaunchScreen(container_name="c", project_name="p", task_id="1")
         assert screen._default_shell == "bash"
         assert screen._task_name == "1"  # falls back to task_id
 
     def test_dismiss_returns_none(self) -> None:
         screens, _ = import_screens()
-        screen = screens.TaskLaunchScreen(container_name="c", project_id="p", task_id="1")
+        screen = screens.TaskLaunchScreen(container_name="c", project_name="p", task_id="1")
         screen.dismiss = mock.Mock()
         screen.action_dismiss_screen()
         screen.dismiss.assert_called_once_with(None)
 
     def test_dismiss_via_button(self) -> None:
         screens, _ = import_screens()
-        screen = screens.TaskLaunchScreen(container_name="c", project_id="p", task_id="1")
+        screen = screens.TaskLaunchScreen(container_name="c", project_name="p", task_id="1")
         screen.dismiss = mock.Mock()
         event = mock.Mock()
         event.button = mock.Mock()
@@ -166,14 +166,14 @@ class TestTaskLaunchScreen:
         screens, _ = import_screens()
         entry = mock.Mock()
         screen = screens.TaskLaunchScreen(
-            container_name="c", project_id="p", task_id="1", console_entry=entry
+            container_name="c", project_name="p", task_id="1", console_entry=entry
         )
         assert screen._console_entry is entry
 
     def test_console_entry_defaults_to_none(self) -> None:
         """Without a console_entry there is nothing to foreground — Show-log is omitted."""
         screens, _ = import_screens()
-        screen = screens.TaskLaunchScreen(container_name="c", project_id="p", task_id="1")
+        screen = screens.TaskLaunchScreen(container_name="c", project_name="p", task_id="1")
         assert screen._console_entry is None
 
     def test_show_log_button_opens_worker_log_view(self) -> None:
@@ -181,7 +181,7 @@ class TestTaskLaunchScreen:
         screens, _ = import_screens()
         entry = mock.Mock()
         screen = screens.TaskLaunchScreen(
-            container_name="c", project_id="p", task_id="1", console_entry=entry
+            container_name="c", project_name="p", task_id="1", console_entry=entry
         )
         screen.app = mock.Mock()
         event = mock.Mock()
@@ -193,7 +193,7 @@ class TestTaskLaunchScreen:
     def test_do_login_returns_agent_and_prompt(self) -> None:
         screens, _ = import_screens()
         screen = screens.TaskLaunchScreen(
-            container_name="c", project_id="p", task_id="1", task_name="fix-bug"
+            container_name="c", project_name="p", task_id="1", task_name="fix-bug"
         )
         screen.dismiss = mock.Mock()
 
@@ -215,7 +215,7 @@ class TestTaskLaunchScreen:
     def test_do_login_bash_keeps_prompt(self) -> None:
         screens, _ = import_screens()
         screen = screens.TaskLaunchScreen(
-            container_name="c", project_id="p", task_id="1", task_name="my-task"
+            container_name="c", project_name="p", task_id="1", task_name="my-task"
         )
         screen.dismiss = mock.Mock()
 
@@ -239,7 +239,7 @@ class TestTaskLaunchScreen:
     def test_do_login_bash_empty_prompt_is_none(self) -> None:
         screens, _ = import_screens()
         screen = screens.TaskLaunchScreen(
-            container_name="c", project_id="p", task_id="1", task_name="my-task"
+            container_name="c", project_name="p", task_id="1", task_name="my-task"
         )
         screen.dismiss = mock.Mock()
 
@@ -260,7 +260,7 @@ class TestTaskLaunchScreen:
 
     def test_login_button_blocked_when_not_ready(self) -> None:
         screens, _ = import_screens()
-        screen = screens.TaskLaunchScreen(container_name="c", project_id="p", task_id="1")
+        screen = screens.TaskLaunchScreen(container_name="c", project_name="p", task_id="1")
         screen._do_login = mock.Mock()
 
         assert not screen._container_ready
@@ -272,7 +272,7 @@ class TestTaskLaunchScreen:
 
     def test_login_button_allowed_when_ready(self) -> None:
         screens, _ = import_screens()
-        screen = screens.TaskLaunchScreen(container_name="c", project_id="p", task_id="1")
+        screen = screens.TaskLaunchScreen(container_name="c", project_name="p", task_id="1")
         screen._do_login = mock.Mock()
         screen._container_ready = True
 
@@ -288,7 +288,7 @@ class TestTaskLaunchScreen:
         the screen must treat it as a no-op (no insert, no submit).
         """
         screens, _ = import_screens()
-        screen = screens.TaskLaunchScreen(container_name="c", project_id="p", task_id="1")
+        screen = screens.TaskLaunchScreen(container_name="c", project_name="p", task_id="1")
 
         mock_textarea = mock.Mock()
         mock_textarea.text = "line1"
@@ -316,7 +316,7 @@ class TestTaskLaunchScreen:
     def test_on_key_enter_submits_when_ready_and_focused(self) -> None:
         """Enter (without Ctrl) submits when container ready and prompt has focus."""
         screens, _ = import_screens()
-        screen = screens.TaskLaunchScreen(container_name="c", project_id="p", task_id="1")
+        screen = screens.TaskLaunchScreen(container_name="c", project_name="p", task_id="1")
         screen._container_ready = True
         screen._do_login = mock.Mock()
 
@@ -344,7 +344,7 @@ class TestTaskLaunchScreen:
     def test_on_key_enter_noop_when_not_ready(self) -> None:
         """Enter does nothing when container is not ready, even with focus."""
         screens, _ = import_screens()
-        screen = screens.TaskLaunchScreen(container_name="c", project_id="p", task_id="1")
+        screen = screens.TaskLaunchScreen(container_name="c", project_name="p", task_id="1")
         screen._container_ready = False
         screen._do_login = mock.Mock()
 
@@ -372,7 +372,7 @@ class TestTaskLaunchScreen:
     def test_on_key_enter_noop_when_not_focused(self) -> None:
         """Enter does nothing when prompt doesn't have focus, even if ready."""
         screens, _ = import_screens()
-        screen = screens.TaskLaunchScreen(container_name="c", project_id="p", task_id="1")
+        screen = screens.TaskLaunchScreen(container_name="c", project_name="p", task_id="1")
         screen._container_ready = True
         screen._do_login = mock.Mock()
 
@@ -441,7 +441,7 @@ class TestTaskLaunchScreenLazyAgents:
     def test_build_agent_choices_loading_returns_bash_only(self) -> None:
         screens, _ = import_screens()
         screen = screens.TaskLaunchScreen(
-            container_name="c", project_id="p", task_id="1", installed=None
+            container_name="c", project_name="p", task_id="1", installed=None
         )
         assert screen._build_agent_choices() == [("bash", "bash")]
 
@@ -453,7 +453,7 @@ class TestTaskLaunchScreenLazyAgents:
         target = next(iter(AGENTS))
         screen = screens.TaskLaunchScreen(
             container_name="c",
-            project_id="p",
+            project_name="p",
             task_id="1",
             installed=frozenset({target}),
         )
@@ -468,7 +468,7 @@ class TestTaskLaunchScreenLazyAgents:
         target = next(iter(AGENTS))
         screen = screens.TaskLaunchScreen(
             container_name="c",
-            project_id="p",
+            project_name="p",
             task_id="1",
             default_shell=target,
             installed=None,
@@ -493,7 +493,7 @@ class TestTaskLaunchScreenLazyAgents:
         screens, _ = import_screens()
         screen = screens.TaskLaunchScreen(
             container_name="c",
-            project_id="p",
+            project_name="p",
             task_id="1",
             default_shell="not-installed-agent",
             installed=None,
@@ -513,7 +513,7 @@ class TestTaskLaunchScreenLazyAgents:
         """Calling set_installed before compose mounted the Select is a no-op."""
         screens, _ = import_screens()
         screen = screens.TaskLaunchScreen(
-            container_name="c", project_id="p", task_id="1", installed=None
+            container_name="c", project_name="p", task_id="1", installed=None
         )
         screen.query_one = mock.Mock(side_effect=RuntimeError("not mounted"))
         # Must not raise.
@@ -531,7 +531,7 @@ def _run_launch_with_prompt(agent: str, prompt: str | None) -> tuple[mock.Mock, 
     """Drive _on_launch_screen_result for *agent*/*prompt* and return mocks."""
     _, app_class = import_app()
     instance = app_class()
-    instance.current_project_id = "proj1"
+    instance.current_project_name = "proj1"
     instance.refresh_tasks = mock.AsyncMock()
     instance._launch_terminal_session = mock.AsyncMock()
 
@@ -641,7 +641,7 @@ class TestBackgroundLaunchCompletion:
     def _run_and_capture_on_complete(app_class, start_method: str):
         """Run a ``_start_*_task_background`` with dispatch mocked; return (instance, on_complete)."""
         instance = app_class()
-        instance.current_project_id = "proj1"
+        instance.current_project_name = "proj1"
         instance._last_selected_tasks = {}
         instance._save_selection_state = mock.Mock()
         instance.notify = mock.Mock()
@@ -805,7 +805,7 @@ class TestTaskLaunchScreenCompose:
     def test_compose_border_title_includes_name(self) -> None:
         screens, _ = import_screens()
         screen = screens.TaskLaunchScreen(
-            container_name="c", project_id="p", task_id="3", task_name="fix-auth"
+            container_name="c", project_name="p", task_id="3", task_name="fix-auth"
         )
         dialog = self._run_compose(screens, screen)
         assert dialog is not None
@@ -813,7 +813,7 @@ class TestTaskLaunchScreenCompose:
 
     def test_compose_border_title_fallback_to_id(self) -> None:
         screens, _ = import_screens()
-        screen = screens.TaskLaunchScreen(container_name="c", project_id="p", task_id="7")
+        screen = screens.TaskLaunchScreen(container_name="c", project_name="p", task_id="7")
         dialog = self._run_compose(screens, screen)
         assert dialog is not None
         assert dialog.border_title == "CLI Task 7 (7)"
@@ -822,7 +822,7 @@ class TestTaskLaunchScreenCompose:
         """While ``_installed is None`` the agent Select is rendered disabled."""
         screens, _ = import_screens()
         screen = screens.TaskLaunchScreen(
-            container_name="c", project_id="p", task_id="1", installed=None
+            container_name="c", project_name="p", task_id="1", installed=None
         )
         widgets = list(screen.compose())
         selects = [w for w in widgets if isinstance(w, screens.Select)]
@@ -842,7 +842,7 @@ class TestTaskLaunchScreenCompose:
         target = next(iter(AGENTS))
         screen = screens.TaskLaunchScreen(
             container_name="c",
-            project_id="p",
+            project_name="p",
             task_id="1",
             installed=frozenset({target}),
         )
@@ -1015,7 +1015,7 @@ class TestActionLoginTitle:
     def test_action_login_passes_unified_title(self) -> None:
         _, app_class = import_app()
         instance = app_class()
-        instance.current_project_id = "proj1"
+        instance.current_project_name = "proj1"
         instance.current_task = mock.Mock()
         instance.current_task.task_id = "5"
         instance.current_task.name = "fix-login-bug"
@@ -1042,7 +1042,7 @@ class TestActionLoginTitle:
     def test_action_login_falls_back_to_task_id_when_unnamed(self) -> None:
         _, app_class = import_app()
         instance = app_class()
-        instance.current_project_id = "proj1"
+        instance.current_project_name = "proj1"
         instance.current_task = mock.Mock()
         instance.current_task.task_id = "8"
         instance.current_task.name = ""
@@ -1067,7 +1067,7 @@ class TestActionLoginTitle:
     def test_action_login_no_task_notifies(self) -> None:
         _, app_class = import_app()
         instance = app_class()
-        instance.current_project_id = "proj1"
+        instance.current_project_name = "proj1"
         instance.current_task = None
         instance.notify = mock.Mock()
         instance._launch_terminal_session = mock.AsyncMock()
@@ -1082,7 +1082,7 @@ class TestActionLoginTitle:
         _, app_class = import_app()
         instance = app_class()
         instance.is_web = True
-        instance.current_project_id = "proj1"
+        instance.current_project_name = "proj1"
         instance.current_task = mock.Mock()
         instance.current_task.task_id = "5"
         instance.notify = mock.Mock()
@@ -1140,21 +1140,21 @@ class TestTaskLaunchScreenNamePropagation:
     def test_empty_name_falls_back_to_task_id(self) -> None:
         screens, _ = import_screens()
         screen = screens.TaskLaunchScreen(
-            container_name="c", project_id="p", task_id="42", task_name=""
+            container_name="c", project_name="p", task_id="42", task_name=""
         )
         assert screen._task_name == "42"
 
     def test_none_name_falls_back_to_task_id(self) -> None:
         screens, _ = import_screens()
         screen = screens.TaskLaunchScreen(
-            container_name="c", project_id="p", task_id="5", task_name=None
+            container_name="c", project_name="p", task_id="5", task_name=None
         )
         assert screen._task_name == "5"
 
     def test_explicit_name_preserved(self) -> None:
         screens, _ = import_screens()
         screen = screens.TaskLaunchScreen(
-            container_name="c", project_id="p", task_id="1", task_name="fix-login"
+            container_name="c", project_name="p", task_id="1", task_name="fix-login"
         )
         assert screen._task_name == "fix-login"
 
@@ -1162,7 +1162,7 @@ class TestTaskLaunchScreenNamePropagation:
         """The 6-tuple dismiss result includes task_name at position 2."""
         screens, _ = import_screens()
         screen = screens.TaskLaunchScreen(
-            container_name="ctr", project_id="proj", task_id="9", task_name="deploy-fix"
+            container_name="ctr", project_name="proj", task_id="9", task_name="deploy-fix"
         )
         screen.dismiss = mock.Mock()
 
@@ -1183,7 +1183,7 @@ class TestTaskLaunchScreenNamePropagation:
     def test_do_login_unnamed_task_uses_id(self) -> None:
         """When no task_name given, the result falls back to task_id."""
         screens, _ = import_screens()
-        screen = screens.TaskLaunchScreen(container_name="c", project_id="p", task_id="11")
+        screen = screens.TaskLaunchScreen(container_name="c", project_name="p", task_id="11")
         screen.dismiss = mock.Mock()
 
         mock_select = mock.Mock()
@@ -1212,7 +1212,7 @@ class TestStartCliTaskBackgroundPassesName:
     def test_task_name_forwarded_to_launch_screen(self) -> None:
         _, app_class = import_app()
         instance = app_class()
-        instance.current_project_id = "proj1"
+        instance.current_project_name = "proj1"
         instance._last_selected_tasks = {}
         instance._save_selection_state = mock.Mock()
         instance.notify = mock.Mock()
@@ -1241,7 +1241,7 @@ class TestStartCliTaskBackgroundPassesName:
         launch_screen = instance.push_screen.call_args[0][0]
         assert launch_screen._task_name == "deploy-hotfix"
         assert launch_screen._task_id == "7"
-        assert launch_screen._project_id == "proj1"
+        assert launch_screen._project_name == "proj1"
         assert launch_screen._default_shell == "claude"
         # Launch screen is pushed in the "loading" state so the prompt
         # TextArea is typeable immediately — the agent dropdown fills in
@@ -1266,7 +1266,7 @@ class TestStartCliTaskBackgroundLoadFailure:
     def test_launch_screen_finalised_when_load_project_fails(self) -> None:
         _, app_class = import_app()
         instance = app_class()
-        instance.current_project_id = "proj1"
+        instance.current_project_name = "proj1"
         instance._last_selected_tasks = {}
         instance._save_selection_state = mock.Mock()
         instance.notify = mock.Mock()
@@ -1359,7 +1359,7 @@ class TestOnLaunchScreenResultTitle:
     def test_bash_login_title_includes_task_name(self) -> None:
         _, app_class = import_app()
         instance = app_class()
-        instance.current_project_id = "proj1"
+        instance.current_project_name = "proj1"
         instance.refresh_tasks = mock.AsyncMock()
         instance._launch_terminal_session = mock.AsyncMock()
 
@@ -1380,7 +1380,7 @@ class TestOnLaunchScreenResultTitle:
     def test_agent_login_title_includes_task_name(self) -> None:
         _, app_class = import_app()
         instance = app_class()
-        instance.current_project_id = "proj1"
+        instance.current_project_name = "proj1"
         instance.refresh_tasks = mock.AsyncMock()
         instance._launch_terminal_session = mock.AsyncMock()
 
@@ -1423,7 +1423,7 @@ class TestOnLaunchScreenResultTitle:
     def test_unknown_agent_notifies(self) -> None:
         _, app_class = import_app()
         instance = app_class()
-        instance.current_project_id = "proj1"
+        instance.current_project_name = "proj1"
         instance.refresh_tasks = mock.AsyncMock()
         instance.notify = mock.Mock()
         instance._launch_terminal_session = mock.AsyncMock()

--- a/tests/unit/tui/test_polling.py
+++ b/tests/unit/tui/test_polling.py
@@ -35,22 +35,22 @@ def reset_notification_after_sync(staleness: GateStalenessInfo, *, notified: boo
     return False if not staleness.is_stale and not staleness.error else notified
 
 
-def maybe_auto_sync(project_id: str, cooldowns: dict[str, float], sync_calls: list[str]) -> None:
+def maybe_auto_sync(project_name: str, cooldowns: dict[str, float], sync_calls: list[str]) -> None:
     """Schedule auto-sync once per project per cooldown window."""
     now = time.time()
-    if now < cooldowns.get(project_id, 0):
+    if now < cooldowns.get(project_name, 0):
         return
-    cooldowns[project_id] = now + 300
-    sync_calls.append(project_id)
+    cooldowns[project_name] = now + 300
+    sync_calls.append(project_name)
 
 
 def apply_poll_result(
-    poll_project_id: str,
-    current_project_id: str,
+    poll_project_name: str,
+    current_project_name: str,
     staleness: GateStalenessInfo,
 ) -> GateStalenessInfo | None:
     """Return the poll result only when it still matches the currently selected project."""
-    return staleness if poll_project_id == current_project_id else None
+    return staleness if poll_project_name == current_project_name else None
 
 
 def test_staleness_notification_only_once() -> None:

--- a/tests/unit/tui/test_project_state_staleness.py
+++ b/tests/unit/tui/test_project_state_staleness.py
@@ -37,7 +37,7 @@ def test_staleness_checked_for_online_and_gatekeeping(security_class: str) -> No
         result = app.TerokTUI._load_project_state(mock.Mock(), "proj1")
 
     mock_gate.compare_vs_upstream.assert_called_once()
-    assert result.project_id == "proj1"
+    assert result.project_name == "proj1"
     assert result.project == project
     assert result.state == state
     assert result.staleness == staleness

--- a/tests/unit/tui/test_task_list_reconcile.py
+++ b/tests/unit/tui/test_task_list_reconcile.py
@@ -50,7 +50,7 @@ def _meta(
 def _instance(app_class: type, displayed: list[Any]) -> Any:
     """App wired with a fake task list and an async ``refresh_tasks`` spy."""
     instance = app_class()
-    instance.current_project_id = "p1"
+    instance.current_project_name = "p1"
     instance.current_task = None
     instance.refresh_tasks = mock.AsyncMock()
     task_list = mock.Mock()

--- a/tests/unit/tui/test_task_watcher_wiring.py
+++ b/tests/unit/tui/test_task_watcher_wiring.py
@@ -10,6 +10,7 @@ is covered against real inotify in ``test_task_watcher``.
 
 from __future__ import annotations
 
+import asyncio
 import types
 from typing import Any
 from unittest import mock
@@ -130,6 +131,42 @@ def test_stop_event_stream_closes_and_clears() -> None:
     instance._stop_container_event_stream()
     stream.close.assert_called_once()
     assert instance._container_event_stream is None
+
+
+def test_poll_container_status_queues_current_project() -> None:
+    _app_mod, app_class = import_app()
+    instance = app_class()
+    instance.current_project_name = "p1"
+    instance._queue_container_state_check = mock.Mock()
+    instance._poll_container_status()
+    instance._queue_container_state_check.assert_called_once_with("p1")
+
+
+def test_load_container_state_worker_sets_live_states() -> None:
+    _app_mod, app_class = import_app()
+    instance = app_class()
+    tasks = [types_ns(task_id="1", container_state=None), types_ns(task_id="2")]
+    states = {"1": "running", "2": "exited"}
+    with (
+        mock.patch("terok.lib.api.get_tasks", return_value=tasks),
+        mock.patch("terok.lib.api.get_all_task_states", return_value=states),
+    ):
+        project_name, refreshed = asyncio.run(instance._load_container_state_worker("p1"))
+    assert project_name == "p1"
+    assert refreshed == tasks
+    assert tasks[0].container_state == "running"
+    assert tasks[1].container_state == "exited"
+
+
+def test_load_container_state_worker_degrades_on_snapshot_error() -> None:
+    _app_mod, app_class = import_app()
+    instance = app_class()
+    instance._log_debug = mock.Mock()
+    with mock.patch("terok.lib.api.get_tasks", side_effect=RuntimeError("boom")):
+        project_name, refreshed = asyncio.run(instance._load_container_state_worker("p1"))
+    assert project_name == "p1"
+    assert refreshed == []
+    instance._log_debug.assert_called_once()
 
 
 class TestLifecycleWiring:

--- a/tests/unit/tui/test_task_watcher_wiring.py
+++ b/tests/unit/tui/test_task_watcher_wiring.py
@@ -75,7 +75,7 @@ def test_stop_cancels_pending_debounce() -> None:
 def _event_instance(app_class: type) -> Any:
     """App wired with debounce spies for the podman-event reaction."""
     instance = app_class()
-    instance.current_project_id = "p1"
+    instance.current_project_name = "p1"
     instance._watch_debounce = None
     instance._poll_container_status = mock.Mock()
     instance.set_timer = mock.Mock(return_value=mock.Mock())
@@ -137,7 +137,7 @@ class TestLifecycleWiring:
 
     def _app(self, app_class: type) -> Any:
         instance = app_class()
-        instance.current_project_id = "p1"
+        instance.current_project_name = "p1"
         instance._container_status_timer = None
         instance._task_watcher = None
         instance._container_event_stream = None
@@ -218,7 +218,7 @@ class TestLifecycleWiring:
     def test_resync_task_watches_syncs_to_current_paths(self) -> None:
         _app_mod, app_class = import_app()
         instance = app_class()
-        instance.current_project_id = "p1"
+        instance.current_project_name = "p1"
         instance._task_watcher = mock.Mock()
         instance._task_watch_paths = mock.Mock(return_value=["/meta", "/cfg/1"])
         instance._resync_task_watches()
@@ -227,7 +227,7 @@ class TestLifecycleWiring:
     def test_resync_task_watches_is_a_noop_without_a_watcher(self) -> None:
         _app_mod, app_class = import_app()
         instance = app_class()
-        instance.current_project_id = "p1"
+        instance.current_project_name = "p1"
         instance._task_watcher = None
         instance._resync_task_watches()  # must not raise
 

--- a/tests/unit/tui/test_wizard_screens.py
+++ b/tests/unit/tui/test_wizard_screens.py
@@ -71,16 +71,16 @@ async def test_wizard_form_cancel_dismisses_with_none() -> None:
 
 @pytest.mark.asyncio
 async def test_wizard_form_submit_blocks_on_validation_error() -> None:
-    """Empty required project_id surfaces the shared ``validate_answer`` message."""
+    """Empty required project_name surfaces the shared ``validate_answer`` message."""
     app = _WizardHost(WizardFormScreen())
     async with app.run_test() as pilot:
         await pilot.pause()
-        # Leave project_id empty and click Create — should NOT dismiss.
+        # Leave project_name empty and click Create — should NOT dismiss.
         await pilot.click("#wizard-form-create")
         await pilot.pause()
         screen = app.screen
         assert isinstance(screen, WizardFormScreen)
-        error_label = screen.query_one("#wizard-error-project_id", Label)
+        error_label = screen.query_one("#wizard-error-project_name", Label)
         rendered = error_label.render()
         assert "required" in str(rendered).lower()
     # Still showing the form when the test exited — no dismissal.
@@ -93,14 +93,14 @@ async def test_wizard_form_submit_returns_collected_dict() -> None:
     app = _WizardHost(WizardFormScreen())
     async with app.run_test() as pilot:
         await pilot.pause()
-        # Fill project_id so validation passes.
-        pid_input = app.screen.query_one("#wizard-field-project_id", Input)
+        # Fill project_name so validation passes.
+        pid_input = app.screen.query_one("#wizard-field-project_name", Input)
         pid_input.value = "demo-proj"
         # Leave upstream + branch + snippet empty (all optional).
         await pilot.click("#wizard-form-create")
         await pilot.pause()
     assert isinstance(app.result, dict)
-    assert app.result["project_id"] == "demo-proj"
+    assert app.result["project_name"] == "demo-proj"
     # First radio button is pre-selected on each choice; confirm it mapped
     # through to the slug, not the label.
     assert app.result["security_class"] == _question("security_class").resolve_choices()[0].slug
@@ -116,16 +116,16 @@ async def test_wizard_form_submit_returns_collected_dict() -> None:
 
 
 @pytest.mark.asyncio
-async def test_wizard_form_lowercases_project_id() -> None:
+async def test_wizard_form_lowercases_project_name() -> None:
     """``str.lower`` transform runs before validation on submit."""
     app = _WizardHost(WizardFormScreen())
     async with app.run_test() as pilot:
         await pilot.pause()
-        app.screen.query_one("#wizard-field-project_id", Input).value = "MixedCaseID"
+        app.screen.query_one("#wizard-field-project_name", Input).value = "MixedCaseID"
         await pilot.click("#wizard-form-create")
         await pilot.pause()
     assert isinstance(app.result, dict)
-    assert app.result["project_id"] == "mixedcaseid"
+    assert app.result["project_name"] == "mixedcaseid"
 
 
 @pytest.mark.asyncio
@@ -160,7 +160,7 @@ async def test_wizard_submit_includes_agents_only_when_overridden() -> None:
     app = _WizardHost(WizardFormScreen(initial={"agents": "claude"}))
     async with app.run_test() as pilot:
         await pilot.pause()
-        app.screen.query_one("#wizard-field-project_id", Input).value = "demo"
+        app.screen.query_one("#wizard-field-project_name", Input).value = "demo"
         await pilot.click("#wizard-form-create")
         await pilot.pause()
     assert isinstance(app.result, dict)
@@ -194,7 +194,7 @@ async def test_wizard_form_radio_selection_picks_other_option() -> None:
         sec_radioset = app.screen.query_one("#wizard-field-security_class", RadioSet)
         buttons = list(sec_radioset.query(RadioButton))
         buttons[1].value = True
-        app.screen.query_one("#wizard-field-project_id", Input).value = "p1"
+        app.screen.query_one("#wizard-field-project_name", Input).value = "p1"
         await pilot.click("#wizard-form-create")
         await pilot.pause()
     assert isinstance(app.result, dict)
@@ -310,7 +310,7 @@ def test_touched_wizard_yaml_survives_roundtrip() -> None:
     values = {
         "security_class": "online",
         "base": "ubuntu",
-        "project_id": "roundtrip",
+        "project_name": "roundtrip",
         "upstream_url": "",
         "default_branch": "main",
         "agents": "all",
@@ -405,7 +405,7 @@ async def test_form_prefill_populates_widgets() -> None:
     initial = {
         "security_class": _question("security_class").resolve_choices()[1].slug,  # second choice
         "base": _question("base").resolve_choices()[2].slug,
-        "project_id": "kept-from-back",
+        "project_name": "kept-from-back",
         "upstream_url": "https://example.com/r.git",
         "default_branch": "dev",
         "user_snippet": "RUN echo hi",
@@ -414,7 +414,7 @@ async def test_form_prefill_populates_widgets() -> None:
     async with app.run_test() as pilot:
         await pilot.pause()
         # Text and editor fields carry the prefill verbatim.
-        assert app.screen.query_one("#wizard-field-project_id", Input).value == "kept-from-back"
+        assert app.screen.query_one("#wizard-field-project_name", Input).value == "kept-from-back"
         assert (
             app.screen.query_one("#wizard-field-upstream_url", Input).value
             == "https://example.com/r.git"

--- a/tests/unit/tui/test_worker_actions.py
+++ b/tests/unit/tui/test_worker_actions.py
@@ -203,7 +203,7 @@ def test_selinux_switch_to_tcp_writes_services_mode(tmp_path) -> None:
 
 
 def test_task_restart_and_stop_delegate_to_facade() -> None:
-    """``task_restart`` / ``task_stop`` forward ``(project_id, task_id)`` to the facade."""
+    """``task_restart`` / ``task_stop`` forward ``(project_name, task_id)`` to the facade."""
     with mock.patch("terok.lib.api.task_restart") as m_restart:
         worker_actions.task_restart("proj", "tid")
     m_restart.assert_called_once_with("proj", "tid")
@@ -213,14 +213,14 @@ def test_task_restart_and_stop_delegate_to_facade() -> None:
 
 
 def test_start_cli_container_delegates_to_task_run_cli() -> None:
-    """``start_cli_container`` forwards ``(project_id, task_id)`` to ``task_run_cli``."""
+    """``start_cli_container`` forwards ``(project_name, task_id)`` to ``task_run_cli``."""
     with mock.patch("terok.lib.api.task_run_cli") as m:
         worker_actions.start_cli_container("proj", "tid")
     m.assert_called_once_with("proj", "tid")
 
 
 def test_start_toad_container_delegates_to_task_run_toad() -> None:
-    """``start_toad_container`` forwards ``(project_id, task_id)`` to ``task_run_toad``."""
+    """``start_toad_container`` forwards ``(project_name, task_id)`` to ``task_run_toad``."""
     with mock.patch("terok.lib.api.task_run_toad") as m:
         worker_actions.start_toad_container("proj", "tid")
     m.assert_called_once_with("proj", "tid")


### PR DESCRIPTION
Renames the project slug `project_id` → `project_name` repo-wide ("ID" reads as a unique/numeric key; it's really a name).

In `project.yml`: the slug key `id` → `name`, and the old display-only `name` → `description` — now propagated into `ProjectConfig` and shown in the TUI project-details panel and `terok project list`.

Back-compat for existing projects: a legacy `id:` key is read as `name`, and any old `name:` as `description`. Tasks get a clean break (no shim).

The `terok_executor` `launch_prepared` kwarg stays `project_id` (external API), fed `project.name`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)