### PR TITLE
fix(tui): make the Enter hint track focus and login readiness

### DIFF
--- a/src/terok/tui/screens.py
+++ b/src/terok/tui/screens.py
@@ -118,6 +118,17 @@ def _visible_agents(installed: frozenset[str] | None) -> list[str]:
     return [name for name in AGENTS if name in installed]
 
 
+# A border subtitle is assembled from independent hint segments; the
+# focus- and readiness-dependent ones evaluate to ``None`` and drop out, so the
+# rendered hint never promises a key that wouldn't do what it says right now.
+_HINT_SEP = " · "
+
+
+def _join_hints(*segments: str | None) -> str:
+    """Join the present hint segments with the standard separator, dropping blanks."""
+    return _HINT_SEP.join(segment for segment in segments if segment)
+
+
 # ---------------------------------------------------------------------------
 # Project Details Screen
 # ---------------------------------------------------------------------------
@@ -775,12 +786,26 @@ class UnattendedPromptScreen(screen.ModalScreen[str | None]):
                 yield Button("Cancel", id="btn-cancel", variant="default")
                 yield Button("Run ▶", id="btn-run", variant="primary")
         dialog.border_title = "Unattended Prompt"
-        dialog.border_subtitle = "Enter to run · Ctrl+J newline · Esc cancel"
 
     def on_mount(self) -> None:
         """Focus the text area for immediate typing."""
         area = self.query_one("#prompt-area", TextArea)
         area.focus()
+        self._refresh_hint()
+
+    def on_descendant_focus(self, event: events.DescendantFocus) -> None:
+        """Refresh the Enter hint whenever focus moves between the dialog's controls."""
+        self._refresh_hint()
+
+    def _refresh_hint(self) -> None:
+        """Rebuild the border subtitle to match what Enter does for the focused control."""
+        prompt_focused = self.focused is not None and self.focused.id == "prompt-area"
+        subtitle = _join_hints(
+            "Ctrl+J newline" if prompt_focused else None,
+            "Esc cancel",
+            "Enter to run" if prompt_focused else None,
+        )
+        self.query_one("#unattended-dialog", Vertical).border_subtitle = subtitle
 
     def on_key(self, event: events.Key) -> None:
         """Submit on Enter (bubbled from the prompt area); modifiers add newlines.
@@ -1363,7 +1388,6 @@ class TaskLaunchScreen(screen.ModalScreen["tuple[str, str, str, str, str, str | 
                 yield Button("Dismiss", id="btn-dismiss", variant="default")
                 yield Button("Login", id="btn-login", variant="primary", disabled=True)
         dialog.border_title = f"CLI Task {self._task_id} ({self._task_name})"
-        dialog.border_subtitle = "Enter to login · Ctrl+J newline · Esc dismiss"
 
     def _build_agent_choices(self) -> list[tuple[str, str]]:
         """Build the (label, value) list for the agent Select.
@@ -1412,8 +1436,41 @@ class TaskLaunchScreen(screen.ModalScreen["tuple[str, str, str, str, str, str | 
 
         prompt = self.query_one("#launch-prompt", TextArea)
         prompt.focus()
+        self._refresh_hint()
         self._start_time = time.monotonic()
         self._poll_timer = self.set_interval(1.5, self._poll_status)
+
+    def on_descendant_focus(self, event: events.DescendantFocus) -> None:
+        """Refresh the Enter hint whenever focus moves between the dialog's controls."""
+        self._refresh_hint()
+
+    def _enter_hint(self) -> str | None:
+        """What Enter does for the focused control right now, or ``None`` when nothing.
+
+        Enter reaches login only from the prompt, and only once the container is
+        ready — until then it's a dimmed, hourglassed promise that brightens in
+        place the moment login goes live. On the agent ``Select`` Enter expands the
+        dropdown; on the action buttons it activates the focused one, whose own
+        caption already says what that is — so those drop the segment rather than
+        echo the label.
+        """
+        focused = self.focused
+        focused_id = focused.id if focused else None
+        if focused_id == "launch-prompt":
+            return "Enter login" if self._container_ready else "[dim]Enter login ⌛[/dim]"
+        if focused_id == "login-agent":
+            return "Enter shows agent list"
+        return None
+
+    def _refresh_hint(self) -> None:
+        """Rebuild the border subtitle for the current focus and readiness state."""
+        prompt_focused = self.focused is not None and self.focused.id == "launch-prompt"
+        subtitle = _join_hints(
+            "Ctrl+J newline" if prompt_focused else None,
+            "Esc dismiss",
+            self._enter_hint(),
+        )
+        self.query_one("#launch-dialog", Vertical).border_subtitle = subtitle
 
     def on_key(self, event: events.Key) -> None:
         """Submit on Enter (bubbled from the prompt) once the container is ready.
@@ -1494,6 +1551,7 @@ class TaskLaunchScreen(screen.ModalScreen["tuple[str, str, str, str, str, str | 
             status_widget.update("Status: Container ready")
             self._container_ready = True
             self.query_one("#btn-login", Button).disabled = False
+            self._refresh_hint()
             if self._poll_timer:
                 self._poll_timer.stop()
                 self._poll_timer = None

--- a/tests/unit/tui/test_new_task_flow.py
+++ b/tests/unit/tui/test_new_task_flow.py
@@ -431,6 +431,73 @@ class TestUnattendedPromptOnKey:
 
 
 # ---------------------------------------------------------------------------
+# Focus-/readiness-aware Enter hint
+# ---------------------------------------------------------------------------
+
+
+class TestTaskLaunchScreenHint:
+    """The border subtitle promises only what Enter actually does right now."""
+
+    @staticmethod
+    def _screen(focused_id: str | None, *, ready: bool):
+        screens, _ = import_screens()
+        screen = screens.TaskLaunchScreen(container_name="c", project_name="p", task_id="1")
+        screen._container_ready = ready
+        screen.focused = None if focused_id is None else types.SimpleNamespace(id=focused_id)
+        return screen
+
+    def test_enter_hint_prompt_ready_logs_in(self) -> None:
+        assert self._screen("launch-prompt", ready=True)._enter_hint() == "Enter login"
+
+    def test_enter_hint_prompt_pending_is_dimmed_with_hourglass(self) -> None:
+        hint = self._screen("launch-prompt", ready=False)._enter_hint()
+        assert "[dim]" in hint and "Enter login" in hint and "⌛" in hint
+
+    def test_enter_hint_agent_select_describes_the_dropdown(self) -> None:
+        assert self._screen("login-agent", ready=True)._enter_hint() == "Enter shows agent list"
+
+    def test_enter_hint_button_is_omitted(self) -> None:
+        assert self._screen("btn-dismiss", ready=True)._enter_hint() is None
+
+    def test_refresh_hint_prompt_ready_subtitle(self) -> None:
+        screen = self._screen("launch-prompt", ready=True)
+        dialog = mock.Mock()
+        screen.query_one = lambda *a, **k: dialog
+        screen._refresh_hint()
+        assert dialog.border_subtitle == "Ctrl+J newline · Esc dismiss · Enter login"
+
+    def test_refresh_hint_on_button_drops_newline_and_enter(self) -> None:
+        screen = self._screen("btn-login", ready=True)
+        dialog = mock.Mock()
+        screen.query_one = lambda *a, **k: dialog
+        screen._refresh_hint()
+        assert dialog.border_subtitle == "Esc dismiss"
+
+
+class TestUnattendedPromptHint:
+    """Unattended-prompt subtitle shows Enter only while the prompt holds focus."""
+
+    @staticmethod
+    def _screen(focused_id: str | None):
+        screens, _ = import_screens()
+        screen = screens.UnattendedPromptScreen()
+        screen.focused = None if focused_id is None else types.SimpleNamespace(id=focused_id)
+        dialog = mock.Mock()
+        screen.query_one = lambda *a, **k: dialog
+        return screen, dialog
+
+    def test_prompt_focus_shows_enter_to_run(self) -> None:
+        screen, dialog = self._screen("prompt-area")
+        screen._refresh_hint()
+        assert dialog.border_subtitle == "Ctrl+J newline · Esc cancel · Enter to run"
+
+    def test_button_focus_omits_enter(self) -> None:
+        screen, dialog = self._screen("btn-cancel")
+        screen._refresh_hint()
+        assert dialog.border_subtitle == "Esc cancel"
+
+
+# ---------------------------------------------------------------------------
 # TaskLaunchScreen — lazy agent dropdown
 # ---------------------------------------------------------------------------
 

--- a/tests/unit/tui/tui_test_helpers.py
+++ b/tests/unit/tui/tui_test_helpers.py
@@ -57,8 +57,12 @@ def build_textual_stubs() -> dict[str, types.ModuleType]:
     class Resize:
         pass
 
+    class DescendantFocus:
+        pass
+
     events_mod.Key = Key
     events_mod.Resize = Resize
+    events_mod.DescendantFocus = DescendantFocus
 
     screen_mod = types.ModuleType("textual.screen")
 


### PR DESCRIPTION
## Problem

The CLI launch modal (`TaskLaunchScreen`) and the unattended-prompt modal (`UnattendedPromptScreen`) showed a **static** border hint — `Enter to login` / `Enter to run` — that is only true under one condition: the prompt holds focus (and, for launch, the container is ready). The hint lies when:

- focus is on the agent `Select` (Enter expands the dropdown),
- focus is on an action button (Enter activates *that* button — at worst **Dismiss**),
- the container hasn't finished init yet (Enter is swallowed entirely).

## Change

A single `_refresh_hint()` per screen rebuilds the border subtitle from `(focus, readiness)`, driven by two triggers already present:

- `on_descendant_focus` — focus moved between controls,
- the readiness flip already observed in `TaskLaunchScreen._poll_status` (where the Login button is enabled) — one added call.

Behavior:

- **Enter segment moves last** so the stable hints (`Esc`, `Ctrl+J`) anchor the left edge and only the right end varies.
- `Ctrl+J newline` is shown **only on the prompt**, where it actually does something.
- On the agent `Select`, the hint becomes `Enter shows agent list`; on the action buttons it's **dropped** (the focused button's own label already says what Enter does).
- While the container is still starting, the prompt's hint shows **dimmed with a trailing ⌛** and brightens **in place** to solid `Enter login` the instant login goes live — same words, nothing shifts.

`TaskLaunchScreen` subtitle by context:

| Focus | Container | Subtitle |
|---|---|---|
| Prompt | ready | `Ctrl+J newline · Esc dismiss · Enter login` |
| Prompt | not ready | `Ctrl+J newline · Esc dismiss · [dim]Enter login ⌛[/dim]` |
| Agent `Select` | — | `Esc dismiss · Enter shows agent list` |
| any button | — | `Esc dismiss` |

(`⌛` U+231B is natively wide with no VS16, per the project emoji rule; Textual's `render_str` parses `[dim]…[/dim]` as content markup.)

## Tests

- New `TestTaskLaunchScreenHint` and `TestUnattendedPromptHint` cover `_enter_hint`/`_refresh_hint` per focus + readiness.
- The textual `events` test stub gains `DescendantFocus` (screens.py has no `from __future__ import annotations`, so the new handler annotation is evaluated at import — same reason `Key`/`Resize` are stubbed).
- `tests/unit/tui` — all green; ruff + docstring coverage pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)