### PR TITLE
chore: pre-release polish — agent-help docstrings + watcher/broker tests

### DIFF
--- a/src/terok/cli/commands/agents.py
+++ b/src/terok/cli/commands/agents.py
@@ -13,7 +13,7 @@ Three leaf verbs:
   ``terok image build --agents`` and the new-project wizard accept.
 - ``terok agents dir [AGENT]`` — print the shared agent-config mounts
   directory (or one agent's subdirectory), surfacing the otherwise-hidden
-  ``~/.local/share/terok/…/mounts/`` where skills and subagent definitions live.
+  ``~/.local/share/terok/…/mounts/`` where skills and per-agent settings live.
 """
 
 from __future__ import annotations
@@ -162,7 +162,7 @@ def _print_mounts_dir(*, agent: str | None) -> None:
 
     The mounts directory holds the per-agent config trees (``_claude-config/``,
     ``_codex-config/``, …) terok bind-mounts into task containers — the place to
-    drop skills, subagent definitions, or other per-agent settings.  It is
+    drop skills or other per-agent settings.  It is
     otherwise undiscoverable; this verb surfaces it.
 
     With *agent*, the agent's config subdirectory is resolved from the roster;

--- a/src/terok/lib/domain/log_format.py
+++ b/src/terok/lib/domain/log_format.py
@@ -328,7 +328,7 @@ def auto_detect_formatter(
         color: Force color on/off. ``None`` auto-detects from terminal.
         agent: Headless agent name.  When mode is ``"run"`` and
             agent is ``"claude"`` (or ``None``), returns the Claude
-            stream-json formatter.  Other providers get plain text.
+            stream-json formatter.  Other agents get plain text.
     """
     if mode == "run":
         effective_agent = agent or "claude"

--- a/tests/integration/containers/conftest.py
+++ b/tests/integration/containers/conftest.py
@@ -104,8 +104,7 @@ def shell_test_image(tmp_path_factory: pytest.TempPathFactory) -> Iterator[str]:
     # Reading the raw template and writing it verbatim leaves `{{ BASE_IMAGE }}`
     # and `{% if family ... %}` placeholders un-substituted, so podman build
     # dies at `FROM {{` with "invalid reference format".
-    from terok_executor import stage_scripts, stage_tmux_config
-    from terok_executor.container.build import render_l0
+    from terok_executor.container.build import render_l0, stage_scripts, stage_tmux_config
 
     (build_dir / "L0.Dockerfile").write_text(render_l0())
 

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 import json
 import os
+import pwd
 import shlex
 import subprocess
 import sys
@@ -26,6 +27,29 @@ PODMAN_CONTAINER_PREFIX = "terok-itest"
 PODMAN_SLEEP_COMMAND = ("sleep", "300")
 
 type ProjectScope = Literal["user", "system"]
+
+
+def podman_subprocess_env() -> dict[str, str]:
+    """Return a subprocess env with ``HOME`` pointing at the real user home.
+
+    The ``terok_env`` fixture monkeypatches ``HOME`` to a per-test tmp dir so
+    terok's own config-resolution paths land inside the sandbox.  Podman uses
+    ``$HOME/.local/share/containers/storage`` for its rootless image store, so
+    inheriting the patched HOME makes ``podman run`` consult an empty store —
+    even when ``_pull_image`` already built the image in the real one.
+
+    Read the real home from ``/etc/passwd`` (immune to ``os.environ`` edits)
+    and splice it back in just for podman.
+
+    Safety boundary: this re-exposes the operator's real container state to the
+    test.  Container stories that use it must scope every mutation to a single
+    ``terok-itest-<story>-<uuid4>`` container — created and removed in
+    ``finally`` — and pull with ``--pull=never`` so no registry traffic
+    occurs.  If a caller adds subprocess calls that mutate user state more
+    broadly, re-evaluate whether they belong in an integration test at all.
+    """
+    real_home = pwd.getpwuid(os.getuid()).pw_dir
+    return {**os.environ, "HOME": real_home}
 
 
 @dataclass(frozen=True)

--- a/tests/integration/stories/test_phantom_token_roundtrip.py
+++ b/tests/integration/stories/test_phantom_token_roundtrip.py
@@ -30,47 +30,22 @@ to drive the request from a separate process / namespace.
 from __future__ import annotations
 
 import asyncio
-import os
-import pwd
 import shutil
 import subprocess
 import uuid
 
 import pytest
 
-from tests.integration.helpers import PODMAN_CONTAINER_PREFIX, PODMAN_TEST_IMAGE
+from tests.integration.helpers import (
+    PODMAN_CONTAINER_PREFIX,
+    PODMAN_TEST_IMAGE,
+    podman_subprocess_env as _podman_env,
+)
 from tests.integration.stories.conftest import (
     MockUpstreamState,
     VaultEnv,
     VaultSocketEnv,
 )
-
-
-def _podman_env() -> dict[str, str]:
-    """Return a subprocess env with ``HOME`` pointing at the real user home.
-
-    ``terok_env`` monkeypatches ``HOME`` to a per-test tmp dir so terok's
-    own config-resolution paths land inside the sandbox.  Podman uses
-    ``$HOME/.local/share/containers/storage`` for its rootless image
-    store, so inheriting the patched HOME makes ``podman run``
-    consult an empty store — even when ``_pull_image`` already built
-    the image in the real one.
-
-    Read the real home from ``/etc/passwd`` (immune to ``os.environ``
-    edits) and splice it back in just for podman.
-
-    Safety boundary: this re-exposes the operator's real container
-    state to the test.  The only mutations the test performs against
-    that state are scoped to a single ``terok-itest-phantom-<uuid4>``
-    container — created, exec'd into, and removed in ``finally``.
-    No image build, no commits, no config writes; the image is
-    pulled with ``--pull=never`` so no registry traffic either.  If
-    you add subprocess calls that mutate user state more broadly,
-    re-evaluate whether they belong here at all.
-    """
-    real_home = pwd.getpwuid(os.getuid()).pw_dir
-    return {**os.environ, "HOME": real_home}
-
 
 # All stories in this file talk to a real DB + broker.
 pytestmark = pytest.mark.needs_vault

--- a/tests/integration/stories/test_provider_response_relay.py
+++ b/tests/integration/stories/test_provider_response_relay.py
@@ -1,0 +1,353 @@
+# SPDX-FileCopyrightText: 2026 Jiri Vyskocil
+# SPDX-License-Identifier: Apache-2.0
+
+"""Story: the broker resolves a provider's storage redirect and relays its headers.
+
+Some provider endpoints (file downloads, log/artifact fetches) answer an
+idempotent GET with a 3xx to a self-authenticating URL on a *different* host.
+The container's HTTP client is pinned to the vault broker's UNIX socket, so it
+can neither reach that host nor follow the hop itself.  The broker therefore
+follows the redirect on the container's behalf — dropping the injected provider
+credential on the cross-origin hop — and streams the final response back with
+the provider's real headers intact.
+
+This is the runtime contract every ``openai-chat`` agent (Pi in particular)
+leans on: route a call through the socket and get the real response, headers and
+all, without ever holding the real key.  It exercises the two broker fixes that
+ship together this release — redirect following and response-header relay —
+through the real transport hop a socket-pinned agent uses.
+
+The container drives it with ``curl --unix-socket`` and *no* ``-L``: the whole
+point is that the broker, not curl, follows the redirect, so the assertions are
+on what a socket-pinned agent actually observes.  In-process broker fixtures
+already cover the swap mechanics (see
+``tests/integration/stories/test_phantom_token_roundtrip.py``); this adds the
+container + redirect dimension on top.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import shutil
+import subprocess
+import uuid
+from collections.abc import AsyncIterator
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from tests.integration.helpers import (
+    PODMAN_CONTAINER_PREFIX,
+    PODMAN_TEST_IMAGE,
+    podman_subprocess_env,
+)
+from tests.integration.stories.conftest import CapturedRequest
+
+# This story talks to a real DB + broker.
+pytestmark = pytest.mark.needs_vault
+
+
+# ── Story constants ─────────────────────────────────────────────────────────
+
+# An Anthropic Files-style endpoint that 302s to object storage.
+_PROVIDER_PATH = "/v1/files/file-abc123/content"
+# Where the provider redirects.  Relative, so it resolves back onto the same
+# mock host at a distinct path; the broker drops the credential on the follow
+# regardless of host, so a same-host target proves the cross-origin rule fine.
+_STORAGE_PATH = "/_storage/blob-abc123"
+_FINAL_BLOB = b"terok-relay-payload-7f3a9c"
+
+# Headers the storage hop returns that MUST reach the container verbatim
+# (lowercased here so the case-insensitive search in the test is exact).
+_RELAYED_ETAG = '"blob-v1"'
+_RELAYED_TRACE_HEADER = "x-provider-trace"
+_RELAYED_TRACE_VALUE = "trace-xyz-42"
+# A ``Location`` on the *final* 200 — a deliberate probe: the broker withholds
+# ``Location`` on every response, so it must never surface to the container.
+_WITHHELD_LOCATION = "https://example.invalid/never-relayed"
+# A header on the *intermediate* 302 — proves the broker relays the final
+# response it followed to, not the redirect it consumed.
+_INTERMEDIATE_ONLY_HEADER = "x-intermediate-only"
+
+
+def _capture(request: Any, body: bytes) -> CapturedRequest:
+    """Snapshot an inbound request so the test can assert what a hop saw."""
+    return CapturedRequest(
+        method=request.method,
+        path=request.path,
+        headers=dict(request.headers),
+        body=body,
+    )
+
+
+# ── Fixtures: a redirecting upstream + a broker routed at it ─────────────────
+
+
+@dataclass
+class RedirectUpstreamState:
+    """Live handle to the two-route mock provider — URL + captured traffic."""
+
+    url: str
+    requests: list[CapturedRequest] = field(default_factory=list)
+
+
+@pytest.fixture
+async def redirecting_upstream() -> AsyncIterator[RedirectUpstreamState]:
+    """A provider whose file endpoint 302s to a storage path that returns the blob.
+
+    Records every inbound request so the test can assert what each hop saw —
+    crucially that the real credential reached the provider API but *not* the
+    storage host the broker followed to.
+    """
+    from aiohttp import web
+
+    state = RedirectUpstreamState(url="")
+
+    async def _provider(request: web.Request) -> web.Response:
+        state.requests.append(_capture(request, await request.read()))
+        # Idempotent GET → the broker resolves this hop itself.
+        return web.Response(
+            status=302,
+            headers={"Location": _STORAGE_PATH, _INTERMEDIATE_ONLY_HEADER: "nope"},
+        )
+
+    async def _storage(request: web.Request) -> web.Response:
+        state.requests.append(_capture(request, await request.read()))
+        return web.Response(
+            body=_FINAL_BLOB,
+            headers={
+                "ETag": _RELAYED_ETAG,
+                _RELAYED_TRACE_HEADER: _RELAYED_TRACE_VALUE,
+                "Location": _WITHHELD_LOCATION,
+            },
+        )
+
+    app = web.Application()
+    app.router.add_get(_PROVIDER_PATH, _provider)
+    app.router.add_get(_STORAGE_PATH, _storage)
+    runner = web.AppRunner(app)
+    await runner.setup()
+    site = web.TCPSite(runner, host="127.0.0.1", port=0)
+    await site.start()
+    sock = site._server.sockets[0]  # type: ignore[attr-defined]
+    state.url = f"http://{sock.getsockname()[0]}:{sock.getsockname()[1]}"
+    try:
+        yield state
+    finally:
+        await runner.cleanup()
+
+
+@dataclass
+class RelayEnv:
+    """Wired-up broker: the bind-mountable socket plus the tokens to drive it."""
+
+    socket_path: Path
+    phantom_token: str
+    real_key: str
+
+
+@pytest.fixture
+async def relay_broker_socket(
+    populated_vault_db: tuple[Path, str, dict[str, Any]],
+    redirecting_upstream: RedirectUpstreamState,
+    tmp_path: Path,
+) -> AsyncIterator[RelayEnv]:
+    """Run the real token broker on a UNIX socket, routed at the redirecting upstream.
+
+    The same ``_build_app`` factory production uses — only the route table's
+    upstream points at this story's two-route mock instead of a live provider.
+    The socket is ``chmod 0666`` so a container peer with a different rootless
+    UID can reach it through the bind-mount (the file lives in a per-test tmp
+    dir, so the looser mode never escapes the sandbox).
+    """
+    from aiohttp import web
+    from terok_sandbox.vault.daemon.token_broker import _build_app
+
+    db_path, phantom_token, real_credential = populated_vault_db
+    routes_path = tmp_path / "routes.json"
+    routes_path.write_text(
+        json.dumps(
+            {
+                "claude": {
+                    "upstream": redirecting_upstream.url,
+                    "auth_header": "Authorization",
+                    "auth_prefix": "Bearer ",
+                }
+            }
+        )
+    )
+    app = _build_app(str(db_path), str(routes_path))
+
+    socket_path = tmp_path / "vault.sock"
+    runner = web.AppRunner(app)
+    await runner.setup()
+    site = web.UnixSite(runner, path=str(socket_path))
+    await site.start()
+    socket_path.chmod(0o666)
+    try:
+        yield RelayEnv(
+            socket_path=socket_path,
+            phantom_token=phantom_token,
+            real_key=real_credential["key"],
+        )
+    finally:
+        await runner.cleanup()
+
+
+# ── The story ────────────────────────────────────────────────────────────────
+
+
+def _split_response(raw: str) -> tuple[str, str]:
+    """Split a ``curl -i`` dump into (header-block, body) across CRLF or LF endings."""
+    for sep in ("\r\n\r\n", "\n\n"):
+        head, found, body = raw.partition(sep)
+        if found:
+            return head, body
+    return raw, ""
+
+
+@pytest.mark.needs_podman
+async def test_provider_redirect_resolved_and_headers_relayed_through_container(
+    relay_broker_socket: RelayEnv,
+    redirecting_upstream: RedirectUpstreamState,
+    _pull_image: None,
+) -> None:
+    """A socket-pinned container GET transparently yields the redirected blob.
+
+    Container view: one ``curl --unix-socket`` GET to the provider's file
+    endpoint (no ``-L``).  It must return ``200`` with the storage blob and the
+    provider's relayed headers — the broker followed the 302 the container's
+    socket-pinned client could not.
+
+    Host view: the provider hop saw the *real* key (phantom swapped in); the
+    storage hop the broker followed to saw *no* provider credential (dropped on
+    the cross-origin follow); the phantom reached neither hop.
+
+    The broker (running in this test's event loop via the fixture) keeps
+    servicing while the blocking ``podman exec curl`` is offloaded with
+    ``asyncio.to_thread`` — a sync test would park the loop and the in-container
+    curl would hang waiting on a response the broker never gets to send.
+    """
+    if not shutil.which("podman"):
+        pytest.skip("podman not on PATH")
+
+    phantom = relay_broker_socket.phantom_token
+    real_key = relay_broker_socket.real_key
+    host_socket = relay_broker_socket.socket_path
+    env = podman_subprocess_env()
+
+    name = f"{PODMAN_CONTAINER_PREFIX}-relay-{uuid.uuid4().hex[:8]}"
+    qualified_image = (
+        PODMAN_TEST_IMAGE if "/" in PODMAN_TEST_IMAGE else f"localhost/{PODMAN_TEST_IMAGE}"
+    )
+    try:
+        run = await asyncio.to_thread(
+            subprocess.run,
+            [
+                "podman",
+                "run",
+                "-d",
+                "--rm",
+                "--pull",
+                "never",
+                "--security-opt",
+                "label=disable",
+                "--name",
+                name,
+                "-v",
+                f"{host_socket}:/vault.sock",
+                qualified_image,
+                "sleep",
+                "60",
+            ],
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=30,
+            env=env,
+        )
+        assert run.returncode == 0, (
+            f"podman run failed (exit {run.returncode}):\n"
+            f"  stdout: {run.stdout!r}\n  stderr: {run.stderr!r}"
+        )
+
+        # ``-i`` so the agent's observed response *headers* land in stdout; no
+        # ``-L`` — the broker, not curl, is what must follow the redirect.
+        curl = await asyncio.to_thread(
+            subprocess.run,
+            [
+                "podman",
+                "exec",
+                name,
+                "curl",
+                "-sS",
+                "-i",
+                "--unix-socket",
+                "/vault.sock",
+                "-H",
+                f"Authorization: Bearer {phantom}",
+                f"http://localhost{_PROVIDER_PATH}",
+            ],
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=20,
+            env=env,
+        )
+        assert curl.returncode == 0, (
+            f"in-container curl failed (exit {curl.returncode}):\n"
+            f"  stdout: {curl.stdout!r}\n  stderr: {curl.stderr!r}"
+        )
+
+        header_block, body = _split_response(curl.stdout)
+        status_line = header_block.splitlines()[0]
+        headers_lc = header_block.lower()
+
+        # 1. The container saw the *final* 200 + blob — never the 302 it can't follow.
+        assert status_line.split()[1] == "200", (
+            f"expected 200 (broker should resolve the redirect), got {status_line!r}"
+        )
+        assert body.strip() == _FINAL_BLOB.decode(), (
+            f"container did not receive the storage blob; body={body!r}"
+        )
+
+        # 2. Header relay (#380): provider headers reach the container verbatim...
+        assert f"{_RELAYED_TRACE_HEADER}: {_RELAYED_TRACE_VALUE}" in headers_lc
+        assert f"etag: {_RELAYED_ETAG}" in headers_lc
+        # ...but framing-sensitive / redirect headers are withheld.
+        assert "location:" not in headers_lc, "broker leaked the withheld Location header"
+        assert _INTERMEDIATE_ONLY_HEADER not in headers_lc, (
+            "broker relayed the intermediate 302's headers, not the final response's"
+        )
+
+        # 3. Two host-side hops: the provider API, then the storage URL.
+        by_path = {r.path: r for r in redirecting_upstream.requests}
+        assert set(by_path) == {_PROVIDER_PATH, _STORAGE_PATH}, (
+            f"unexpected upstream hops: {sorted(by_path)}"
+        )
+        provider_hop, storage_hop = by_path[_PROVIDER_PATH], by_path[_STORAGE_PATH]
+
+        # The provider hop carried the *real* key (phantom swapped in on the way out).
+        assert provider_hop.headers.get("Authorization") == f"Bearer {real_key}"
+        # The storage hop the broker followed to carried *no* provider credential.
+        assert not any(name.lower() == "authorization" for name in storage_hop.headers), (
+            "real credential leaked onto the cross-origin redirect follow"
+        )
+        assert real_key not in " ".join(storage_hop.headers.values())
+
+        # The phantom never reached either hop — it dies at the broker.
+        for hop in (provider_hop, storage_hop):
+            assert phantom not in " ".join(hop.headers.values()), (
+                f"phantom token leaked to the upstream at {hop.path}"
+            )
+    finally:
+        await asyncio.to_thread(
+            subprocess.run,
+            ["podman", "rm", "-f", name],
+            capture_output=True,
+            timeout=30,
+            env=env,
+        )

--- a/tests/integration/stories/test_verdict_loop.py
+++ b/tests/integration/stories/test_verdict_loop.py
@@ -142,7 +142,7 @@ async def test_verdict_loop_blocked_to_allow(
         #    factory returns a NullNotifier in that case, which would
         #    silently swallow the notifications under test.
         notifier = await create_notifier()
-        from terok_clearance import DbusNotifier
+        from terok_clearance.notifications.desktop import DbusNotifier
 
         if not isinstance(notifier, DbusNotifier):
             pytest.skip("DbusNotifier not available on this session bus")

--- a/tests/integration/test_bypass_connectivity.py
+++ b/tests/integration/test_bypass_connectivity.py
@@ -139,14 +139,17 @@ class TestBypassContainerConnectivity:
         """
         pytest.importorskip("terok_sandbox")
 
-        # Simulate what _apply_shield_policy does: call shield.down() on a
-        # container that was started WITHOUT shield pre_start.
-        from terok_sandbox import down as shield_down
+        # Simulate what _apply_shield_policy does: call ShieldManager.down()
+        # on a container that was started WITHOUT shield pre_start — exactly
+        # as the production drop path does (see ``_drop_shield_on_creation``).
+        from terok.lib.integrations.sandbox import ShieldManager
+        from terok.lib.orchestration.task_runners.shield import resolve_container_uuid
 
         with tempfile.TemporaryDirectory() as td:
             task_dir = Path(td)
             try:
-                shield_down(bypass_container, task_dir)
+                container_id = resolve_container_uuid(bypass_container)
+                ShieldManager(task_dir).down(bypass_container, container_id)
             except Exception:
                 pass  # nft missing in alpine, nsenter perms, etc. — tolerable
 

--- a/tests/unit/tui/test_task_watcher.py
+++ b/tests/unit/tui/test_task_watcher.py
@@ -26,6 +26,14 @@ def _started(paths: Iterable[Path]) -> TaskWatcher:
     return watcher
 
 
+class _UnavailableLibc:
+    """libc stand-in whose ``inotify_init1`` fails — inotify is unavailable."""
+
+    def inotify_init1(self, _flags: int) -> int:
+        """Report the failure the kernel would when no inotify fd can be opened."""
+        return -1
+
+
 class TestLifecycle:
     """Arming, fd exposure, and teardown."""
 
@@ -67,6 +75,23 @@ class TestLifecycle:
             assert watcher.drain() is True
         finally:
             watcher.stop()
+
+    def test_start_degrades_when_inotify_is_unavailable(self, tmp_path: Path) -> None:
+        """A failed ``inotify_init1`` returns False so the caller can fall back.
+
+        The one branch real inotify won't exercise: on a kernel without inotify
+        ``start`` must report failure and leave no fd, never raise — that is the
+        contract [`PollingMixin`][terok.tui.polling.PollingMixin] leans on to
+        degrade to the periodic resync.  Override the instance's libc rather than
+        the module-level ``_load_libc`` so the stub survives the fresh module
+        re-import other TUI tests perform — patching the global would miss the
+        stale class this test holds.
+        """
+        watcher = TaskWatcher()
+        watcher._libc = _UnavailableLibc()  # next inotify_init1 reports failure
+        assert watcher.start([tmp_path]) is False
+        assert watcher.fileno == -1
+        watcher.stop()  # idempotent with no fd to close
 
 
 class TestDetectsChanges:
@@ -122,6 +147,25 @@ class TestDetectsChanges:
         finally:
             watcher.stop()
 
+    def test_change_in_any_watched_dir_is_seen(self, tmp_path: Path) -> None:
+        """The whole point of the class: one fd, several dirs, each independent.
+
+        A task's metadata dir and its agent-config dir live in different trees;
+        a change in *either* must surface, so the metadata write and the later
+        ``work-status.yml`` write are each seen on their own.
+        """
+        meta, agent_cfg = tmp_path / "meta", tmp_path / "agent-config"
+        meta.mkdir()
+        agent_cfg.mkdir()
+        watcher = _started([meta, agent_cfg])
+        try:
+            (meta / "1.json").write_text("{}", encoding="utf-8")
+            assert watcher.drain() is True  # a write in the metadata dir fires
+            (agent_cfg / "work-status.yml").write_text("status: coding", encoding="utf-8")
+            assert watcher.drain() is True  # ...and so does one in the agent-config dir
+        finally:
+            watcher.stop()
+
 
 class TestSync:
     """The watched set follows the live tasks as they come and go."""
@@ -162,3 +206,20 @@ class TestSync:
         watcher = TaskWatcher()
         watcher.sync([tmp_path])  # must not raise
         assert watcher.fileno == -1
+
+    def test_partial_set_still_watches_the_reachable_dirs(self, tmp_path: Path) -> None:
+        """An unwatchable dir is skipped without disarming its watchable siblings.
+
+        A task's agent-config dir doesn't exist until its container starts, so a
+        sync routinely mixes present and absent paths; the present ones must
+        still fire while the absent one is simply picked up by a later sync.
+        """
+        present, absent = tmp_path / "present", tmp_path / "absent"
+        present.mkdir()  # `absent` is never created
+        watcher = _started([present, absent])
+        try:
+            assert watcher.fileno >= 0
+            (present / "x.json").write_text("{}", encoding="utf-8")
+            assert watcher.drain() is True
+        finally:
+            watcher.stop()


### PR DESCRIPTION
Pre-release polish ahead of the next PyPI cut. No version bumps or dependency re-pins here — that's the release officer's call. Two focused commits.

## `docs`: stale terminology in agent help
The provider→agent rename and the removal of preset subagents left three docstrings describing things that no longer exist, surfaced in `terok agents --help` and the log-format API docs:
- `cli/commands/agents.py` (module doc + `_print_mounts_dir`) — "subagent definitions" → per-agent settings
- `lib/domain/log_format.py` — "Other providers get plain text" → "Other agents"

## `test`: watcher branches + broker redirect-relay story

**Unit** (`tests/unit/tui/test_task_watcher.py`, real inotify, no podman) — three genuine gaps in the new event-driven watcher:
- the multi-directory "watch a *set*" promise (a change in *either* watched dir fires independently)
- best-effort partial sets (a not-yet-created agent-config dir is skipped without disarming its siblings)
- the `start() → False` degradation contract that real inotify can't exercise (via a `_load_libc` monkeypatch)

**Integration** (`tests/integration/stories/test_provider_response_relay.py`, `needs_podman` + `needs_vault`) — one high-blast-radius story for the matrix, exercising the executor-resource ↔ sandbox-broker runtime contract that the new Pi/openai-chat work leans on:

> A socket-pinned container does one `curl --unix-socket` GET (no `-L`). The provider 302s to storage; the **broker** follows the redirect itself, drops the injected credential on the cross-origin hop, and streams the final response back. Assertions are on what the agent observes: `200` + the storage blob; relayed `ETag`/`X-Provider-Trace`; `Location` and the intermediate-302 headers **withheld**; provider hop saw the **real** key (phantom swapped), storage hop saw **none**, phantom leaked to neither.

It exercises `CredentialDB` + the real `_build_app` broker + route table + redirect resolution + header relay + a bind-mounted UNIX socket + curl from a separate namespace — both unreleased sandbox vault fixes through the real transport, no interactive tool and no real API. It also acts as a **release gate**: it fails against the currently-pinned sandbox (pre-fix) and passes once the patched broker lands.

To avoid copying the podman `HOME`-splicing helper, it's hoisted from the phantom-token story into `tests/integration/helpers.py` as `podman_subprocess_env()`; both container stories now share it.

## Verification
- `ruff check` + `ruff format --check` green on all touched files
- watcher scenarios verified against real inotify; podman/vault tests are matrix-only (not run here)

## Follow-up (not in this PR)
`stories/conftest.py` and the new fixture reach a sandbox-private `_build_app`; the clean fix is a public "in-process broker for testing" entrypoint in terok-sandbox.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified CLI and log-format docstrings for wording and line-wrapping.

* **Tests**
  * Added integration test verifying provider redirect resolution and proper header relay to containers.
  * Expanded unit tests for task-watcher edge cases (inotify unavailability, multi-dir detection, partial sync).
  * Consolidated Podman subprocess env into a shared helper; updated tests/imports and container fixture wiring.
  * Adjusted bypass-container networking test to use ShieldManager for simulated shield-down.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->