### PR TITLE
feat(sickbay): add --system flag for host-wide checks only

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -884,6 +884,7 @@ terok sickbay                    # check all projects
 terok sickbay myproject          # check one project
 terok sickbay myproject 3        # check one task
 terok sickbay --fix              # auto-reconcile (run missed hooks)
+terok sickbay --system           # host-wide checks only; skip the per-container walk (fast)
 ```
 
 ### Example: task lifecycle logging

--- a/src/terok/cli/commands/sickbay.py
+++ b/src/terok/cli/commands/sickbay.py
@@ -63,6 +63,11 @@ def register(subparsers: argparse._SubParsersAction[argparse.ArgumentParser]) ->
     add_project_name(p, nargs="?", metavar="project", help="Scope to a single project")
     add_task_id(p, nargs="?", metavar="task", help="Scope to a single task")
     p.add_argument("--fix", action="store_true", help="Auto-remediate issues")
+    p.add_argument(
+        "--system",
+        action="store_true",
+        help="Only host-wide checks; skip the per-container walk (fast)",
+    )
 
 
 def dispatch(args: argparse.Namespace) -> bool:
@@ -71,12 +76,18 @@ def dispatch(args: argparse.Namespace) -> bool:
         return False
     project_name = getattr(args, "project_name", None)
     task_id = getattr(args, "task_id", None)
+    system_only = getattr(args, "system", False)
+    # --system runs only the host-wide checks, so a project/task scope is a
+    # contradiction in terms — reject it rather than silently ignoring one.
+    if system_only and (project_name or task_id):
+        sys.exit("error: --system runs host-wide checks only; drop the project/task argument")
     if project_name and task_id:
         task_id = resolve_task_id(project_name, task_id)
     _cmd_sickbay(
         project_name=project_name,
         task_id=task_id,
         fix=getattr(args, "fix", False),
+        system_only=system_only,
     )
     return True
 
@@ -601,6 +612,7 @@ def _cmd_sickbay(
     project_name: str | None = None,
     task_id: str | None = None,
     fix: bool = False,
+    system_only: bool = False,
 ) -> None:
     """Run health checks and report results, streaming progress line-by-line."""
     reporter = CheckReporter()
@@ -612,22 +624,28 @@ def _cmd_sickbay(
             reporter.end(status, detail)
         # Visual separator between host-wide checks and per-project /
         # per-task rows that follow — same intent as ``terok setup``'s
-        # blank line between stage groups.
-        print()
+        # blank line between stage groups.  ``--system`` prints no such
+        # rows, so the separator would just dangle.
+        if not system_only:
+            print()
 
-    for status, label, detail in _check_unfired_hooks(project_name, task_id, fix=fix):
-        reporter.emit(status, label, detail)
-    for status, label, detail in _check_shield_annotations(project_name, task_id):
-        reporter.emit(status, label, detail)
+    # The per-container walk resolves podman state for every task — the slow
+    # part sickbay is known for.  ``--system`` runs only the host-wide checks
+    # above and falls straight through to the exit-code summary.
+    if not system_only:
+        for status, label, detail in _check_unfired_hooks(project_name, task_id, fix=fix):
+            reporter.emit(status, label, detail)
+        for status, label, detail in _check_shield_annotations(project_name, task_id):
+            reporter.emit(status, label, detail)
 
-    _stream_containers(project_name, task_id, fix=fix, reporter=reporter)
+        _stream_containers(project_name, task_id, fix=fix, reporter=reporter)
 
-    # Single-task summary: ``ok (consistent)`` iff every check for this
-    # task came back clean.  Globals aren't run in the ``task_id`` scope,
-    # so the reporter's worst-status at this point covers exactly the
-    # three task-scoped check sets.
-    if task_id and reporter.worst_status == "ok":
-        reporter.emit("ok", f"Task {project_name}/{task_id}", "consistent")
+        # Single-task summary: ``ok (consistent)`` iff every check for this
+        # task came back clean.  Globals aren't run in the ``task_id`` scope,
+        # so the reporter's worst-status at this point covers exactly the
+        # three task-scoped check sets.
+        if task_id and reporter.worst_status == "ok":
+            reporter.emit("ok", f"Task {project_name}/{task_id}", "consistent")
 
     if reporter.worst_status == "error":
         sys.exit(2)

--- a/src/terok/cli/commands/sickbay.py
+++ b/src/terok/cli/commands/sickbay.py
@@ -10,6 +10,13 @@ Scoping:
 - ``terok sickbay`` — all projects
 - ``terok sickbay <project>`` — single project
 - ``terok sickbay <project> <task>`` — single task
+- ``terok sickbay --system`` — host-wide checks only (shield, vault,
+  recovery, ssh signer, selinux, default agents); skips the slow
+  per-container walk.  Mutually exclusive with a project/task scope.
+
+``--fix`` is orthogonal to scope and auto-remediates (e.g. unfired
+post_stop hooks); it has no effect under ``--system``, which runs no
+container-level checks.  Exit codes are unchanged by either flag.
 
 Exit codes:
 - 0: all checks passed

--- a/tests/unit/cli/test_sickbay.py
+++ b/tests/unit/cli/test_sickbay.py
@@ -799,6 +799,71 @@ class TestSickbayDispatch:
         containers.assert_not_called()
 
 
+class TestCmdSickbayFullRun:
+    """The non-``--system`` path: host checks, then the per-container walk."""
+
+    @staticmethod
+    def _patch_walk(sb, *, hooks=(), annotations=()):
+        """Patch the three per-container walk helpers with canned results."""
+        return (
+            unittest.mock.patch.object(sb, "_check_unfired_hooks", return_value=list(hooks)),
+            unittest.mock.patch.object(
+                sb, "_check_shield_annotations", return_value=list(annotations)
+            ),
+            unittest.mock.patch.object(sb, "_stream_containers"),
+        )
+
+    def test_full_run_streams_walk_after_globals(self, capsys: pytest.CaptureFixture[str]) -> None:
+        """A plain run prints the separator, emits walk rows, and runs the container doctor."""
+        from terok.cli.commands import sickbay as sb
+
+        walk_hooks, walk_annos, stream = self._patch_walk(
+            sb,
+            hooks=[("warn", "Hooks", "unfired post_stop")],
+            annotations=[("ok", "Shield annotation", "matches")],
+        )
+        with (
+            unittest.mock.patch.object(
+                sb, "_GLOBAL_CHECKS", [("Fake", lambda: ("ok", "Fake", "fine"))]
+            ),
+            walk_hooks,
+            walk_annos,
+            stream as containers,
+            pytest.raises(SystemExit) as exc,  # a "warn" row forces exit 1
+        ):
+            sb._cmd_sickbay()
+        assert exc.value.code == 1
+        containers.assert_called_once()
+        out = capsys.readouterr().out
+        assert "unfired post_stop" in out
+
+    def test_single_task_emits_consistent_summary(self, capsys: pytest.CaptureFixture[str]) -> None:
+        """A clean single-task run appends the ``consistent`` summary line."""
+        from terok.cli.commands import sickbay as sb
+
+        h, a, s = self._patch_walk(sb)
+        with h, a, s:
+            sb._cmd_sickbay(project_name="alpha", task_id="t1")
+        assert "Task alpha/t1" in capsys.readouterr().out
+
+    def test_error_row_exits_2(self) -> None:
+        """An ``error`` from any check sets exit code 2."""
+        from terok.cli.commands import sickbay as sb
+
+        h, a, s = self._patch_walk(sb)
+        with (
+            unittest.mock.patch.object(
+                sb, "_GLOBAL_CHECKS", [("Bad", lambda: ("error", "Bad", "boom"))]
+            ),
+            h,
+            a,
+            s,
+            pytest.raises(SystemExit) as exc,
+        ):
+            sb._cmd_sickbay()
+        assert exc.value.code == 2
+
+
 class TestCheckUnfiredHooks:
     """``_check_unfired_hooks`` walks projects and flags pending post_stop hooks."""
 

--- a/tests/unit/cli/test_sickbay.py
+++ b/tests/unit/cli/test_sickbay.py
@@ -746,14 +746,57 @@ class TestSickbayDispatch:
 
         from terok.cli.commands import sickbay as sb
 
-        args = argparse.Namespace(cmd="sickbay", project_name="alpha", task_id="1", fix=True)
+        args = argparse.Namespace(
+            cmd="sickbay", project_name="alpha", task_id="1", fix=True, system=False
+        )
         with (
             unittest.mock.patch.object(sb, "resolve_task_id", return_value="full-id") as resolve,
             unittest.mock.patch.object(sb, "_cmd_sickbay") as run,
         ):
             assert sb.dispatch(args) is True
         resolve.assert_called_once_with("alpha", "1")
-        run.assert_called_once_with(project_name="alpha", task_id="full-id", fix=True)
+        run.assert_called_once_with(
+            project_name="alpha", task_id="full-id", fix=True, system_only=False
+        )
+
+    def test_system_flag_skips_scope_and_walk(self) -> None:
+        import argparse
+
+        from terok.cli.commands import sickbay as sb
+
+        args = argparse.Namespace(
+            cmd="sickbay", project_name=None, task_id=None, fix=False, system=True
+        )
+        with unittest.mock.patch.object(sb, "_cmd_sickbay") as run:
+            assert sb.dispatch(args) is True
+        run.assert_called_once_with(project_name=None, task_id=None, fix=False, system_only=True)
+
+    def test_system_with_scope_is_rejected(self) -> None:
+        import argparse
+
+        from terok.cli.commands import sickbay as sb
+
+        args = argparse.Namespace(
+            cmd="sickbay", project_name="alpha", task_id=None, fix=False, system=True
+        )
+        with pytest.raises(SystemExit):
+            sb.dispatch(args)
+
+    def test_system_only_runs_globals_and_skips_container_walk(self) -> None:
+        from terok.cli.commands import sickbay as sb
+
+        with (
+            unittest.mock.patch.object(
+                sb, "_GLOBAL_CHECKS", [("Fake", lambda: ("ok", "Fake", "fine"))]
+            ),
+            unittest.mock.patch.object(sb, "_check_unfired_hooks") as hooks,
+            unittest.mock.patch.object(sb, "_check_shield_annotations") as annotations,
+            unittest.mock.patch.object(sb, "_stream_containers") as containers,
+        ):
+            sb._cmd_sickbay(system_only=True)
+        hooks.assert_not_called()
+        annotations.assert_not_called()
+        containers.assert_not_called()
 
 
 class TestCheckUnfiredHooks:


### PR DESCRIPTION
`terok sickbay` walks every container to resolve podman state — the slow part that makes it impractical as a quick health probe. `--system` runs only the host-wide checks (shield, vault, recovery, ssh signer, selinux, default agents) and skips the per-container walk entirely.

- Mutually exclusive with a project/task scope (a host-wide run can't be scoped to one task).
- Falls through to the same exit-code summary as a full run.

~10 LoC + 4 tests (dispatch flag, scope rejection, walk-skipped). Independent of the vault/panic work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a `--system` option to sickbay to run host-wide checks only (faster diagnostics); mutually exclusive with project/task scoping and causes `--fix` to be ignored.

* **Documentation**
  * Help and docs updated to describe the `--system` flag and its behavior.

* **Tests**
  * Expanded test coverage for `--system` behavior and exit-code semantics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->