### PR TITLE
feat(tui): preserve initial prompt when CLI launch modal is dismissed

### DIFF
--- a/src/terok/tui/screens.py
+++ b/src/terok/tui/screens.py
@@ -1268,13 +1268,17 @@ else:  # pragma: no cover - stub TextArea in test envs
     _SubmittablePromptArea = TextArea  # type: ignore[assignment,misc]
 
 
-class TaskLaunchScreen(screen.ModalScreen["tuple[str, str, str, str, str, str | None] | None"]):
+class TaskLaunchScreen(
+    screen.ModalScreen["tuple[str, str, str, str, str | None, str | None] | None"]
+):
     """Post-creation modal for CLI tasks: agent selection + optional prompt.
 
     Dismisses with ``(project_name, task_id, task_name, container_name,
-    agent, prompt)`` on Login, or ``None`` on Dismiss.  The full launch
-    context is captured at creation time so the callback is immune to
-    selection changes.
+    agent, prompt)``.  ``agent`` is the chosen shell/agent on Login and
+    ``None`` on Dismiss — but the *prompt* travels either way, so a prompt
+    typed before dismissing is preserved for the next manual ``login``
+    rather than lost.  The full launch context is captured at creation time
+    so the callback is immune to selection changes.
     """
 
     BINDINGS = [
@@ -1572,11 +1576,29 @@ class TaskLaunchScreen(screen.ModalScreen["tuple[str, str, str, str, str, str | 
         if event.button.id == "btn-login":
             self._do_login()
         elif event.button.id == "btn-dismiss":
-            self.dismiss(None)
+            self._dismiss_keeping_prompt()
         elif event.button.id == "btn-show-log" and self._console_entry is not None:
             from .worker_log_screen import WorkerLogScreen
 
             self.app.push_screen(WorkerLogScreen(self._console_entry))
+
+    def _build_result(
+        self, agent: str | None
+    ) -> "tuple[str, str, str, str, str | None, str | None]":
+        """Bundle the launch context with *agent* and the prompt typed so far.
+
+        *agent* is the chosen shell/agent on Login, or ``None`` on Dismiss;
+        the prompt travels either way (stripped, or ``None`` when blank).
+        """
+        prompt = self.query_one("#launch-prompt", TextArea).text.strip() or None
+        return (
+            self._project_name,
+            self._task_id,
+            self._task_name,
+            self._container_name,
+            agent,
+            prompt,
+        )
 
     def _do_login(self) -> None:
         """Dismiss with launch context + selected agent and optional prompt."""
@@ -1587,22 +1609,21 @@ class TaskLaunchScreen(screen.ModalScreen["tuple[str, str, str, str, str, str | 
         if isinstance(agent, NoSelection):
             self.app.notify("Pick an agent first.")
             return
-        prompt_input = self.query_one("#launch-prompt", TextArea)
-        prompt = prompt_input.text.strip() or None
-        self.dismiss(
-            (
-                self._project_name,
-                self._task_id,
-                self._task_name,
-                self._container_name,
-                str(agent),
-                prompt,
-            )
-        )
+        self.dismiss(self._build_result(str(agent)))
+
+    def _dismiss_keeping_prompt(self) -> None:
+        """Dismiss without logging in, but hand back the prompt typed so far.
+
+        The container is already starting in the background, so a ``None``
+        agent tells the callback to persist the prompt (where the agent
+        wrapper and login banner read it) and refresh — rather than launch a
+        terminal.  The prompt then greets the user on their next ``login``.
+        """
+        self.dismiss(self._build_result(None))
 
     def action_dismiss_screen(self) -> None:
-        """Dismiss the launch screen without logging in."""
-        self.dismiss(None)
+        """Dismiss the launch screen without logging in (prompt is preserved)."""
+        self._dismiss_keeping_prompt()
 
     def on_unmount(self) -> None:
         """Clean up the polling timer."""

--- a/src/terok/tui/task_actions.py
+++ b/src/terok/tui/task_actions.py
@@ -62,11 +62,17 @@ _INITIAL_PROMPT_FILENAME = "initial-prompt.txt"
 
 
 def _save_initial_prompt(project_name: str, task_id: str, prompt: str | None) -> None:
-    """Persist the user's initial prompt to the task's mounted agent-config dir."""
+    """Persist the user's initial prompt to the task's mounted agent-config dir.
+
+    Saved on Login *and* on Dismiss — and Dismiss can land before the
+    background container start has populated the agent-config dir, so create
+    it here rather than assume the runner got there first.
+    """
     if not prompt:
         return
-    path = agent_config_dir(project_name, task_id) / _INITIAL_PROMPT_FILENAME
-    path.write_text(prompt + "\n", encoding="utf-8")
+    config_dir = agent_config_dir(project_name, task_id)
+    config_dir.mkdir(parents=True, exist_ok=True)
+    (config_dir / _INITIAL_PROMPT_FILENAME).write_text(prompt + "\n", encoding="utf-8")
 
 
 def _login_title(project_name: str, task_id: str, task_name: str) -> str:
@@ -283,18 +289,35 @@ class TaskActionsMixin(_MixinBase):
         launch_screen.set_installed(installed)
 
     async def _on_launch_screen_result(
-        self, result: "tuple[str, str, str, str, str, str | None] | None"
+        self, result: "tuple[str, str, str, str, str | None, str | None] | None"
     ) -> None:
         """Handle the result from TaskLaunchScreen.
 
         The result carries the full launch context captured at creation time
         so it is immune to ``self.current_task`` changes while the modal is open.
+        A ``None`` *agent* means the user dismissed the modal: the prompt is
+        still persisted (so it greets them on the next ``login``) but no
+        terminal is launched.
         """
         if result is None:
             await self.refresh_tasks()
             return
 
         pid, tid, task_name, cname, agent, prompt = result
+
+        # Stash the prompt where the agent wrappers (terok-executor) and the
+        # interactive bash banner can pick it up — on Login *and* on Dismiss,
+        # since the container is already starting either way.  Bash displays it
+        # after `hilfe --kurz`; the per-provider wrapper consumes it one-shot on
+        # bare invocation and renames the file so subsequent runs --resume the
+        # saved session instead of replaying the prompt.
+        _save_initial_prompt(pid, tid, prompt)
+
+        # Dismissed without choosing an agent: the prompt is saved for the next
+        # manual login, and there is no terminal session to open.
+        if agent is None:
+            await self.refresh_tasks()
+            return
 
         # All agents (including bash) launch interactively inside tmux so the
         # user can re-attach later with 'login'.  The base command is always
@@ -304,13 +327,6 @@ class TaskActionsMixin(_MixinBase):
         except SystemExit as e:
             self.notify(str(e))
             return
-
-        # Stash the prompt where the agent wrappers (terok-executor) and the
-        # interactive bash banner can pick it up.  Bash displays it after
-        # `hilfe --kurz`; the per-provider wrapper consumes it one-shot on
-        # bare invocation and renames the file so subsequent runs --resume
-        # the saved session instead of replaying the prompt.
-        _save_initial_prompt(pid, tid, prompt)
 
         if agent == "bash":
             cmd = base_cmd

--- a/tests/unit/tui/test_new_task_flow.py
+++ b/tests/unit/tui/test_new_task_flow.py
@@ -144,22 +144,53 @@ class TestTaskLaunchScreen:
         assert screen._default_shell == "bash"
         assert screen._task_name == "1"  # falls back to task_id
 
-    def test_dismiss_returns_none(self) -> None:
+    def test_dismiss_keeps_prompt_with_null_agent(self) -> None:
+        """Dismiss hands back the typed prompt with a ``None`` agent — not lost."""
         screens, _ = import_screens()
-        screen = screens.TaskLaunchScreen(container_name="c", project_name="p", task_id="1")
+        screen = screens.TaskLaunchScreen(
+            container_name="c", project_name="p", task_id="1", task_name="fix-bug"
+        )
         screen.dismiss = mock.Mock()
-        screen.action_dismiss_screen()
-        screen.dismiss.assert_called_once_with(None)
+        mock_textarea = mock.Mock()
+        mock_textarea.text = "half-typed thought"
+        screen.query_one = lambda selector, cls=None: mock_textarea
 
-    def test_dismiss_via_button(self) -> None:
+        screen.action_dismiss_screen()
+        screen.dismiss.assert_called_once_with(
+            ("p", "1", "fix-bug", "c", None, "half-typed thought")
+        )
+
+    def test_dismiss_via_button_keeps_prompt(self) -> None:
         screens, _ = import_screens()
-        screen = screens.TaskLaunchScreen(container_name="c", project_name="p", task_id="1")
+        screen = screens.TaskLaunchScreen(
+            container_name="c", project_name="p", task_id="1", task_name="fix-bug"
+        )
         screen.dismiss = mock.Mock()
+        mock_textarea = mock.Mock()
+        mock_textarea.text = "half-typed thought"
+        screen.query_one = lambda selector, cls=None: mock_textarea
+
         event = mock.Mock()
         event.button = mock.Mock()
         event.button.id = "btn-dismiss"
         screen.on_button_pressed(event)
-        screen.dismiss.assert_called_once_with(None)
+        screen.dismiss.assert_called_once_with(
+            ("p", "1", "fix-bug", "c", None, "half-typed thought")
+        )
+
+    def test_dismiss_blank_prompt_is_none(self) -> None:
+        """A blank prompt still dismisses cleanly — agent and prompt both None."""
+        screens, _ = import_screens()
+        screen = screens.TaskLaunchScreen(
+            container_name="c", project_name="p", task_id="1", task_name="fix-bug"
+        )
+        screen.dismiss = mock.Mock()
+        mock_textarea = mock.Mock()
+        mock_textarea.text = "   "
+        screen.query_one = lambda selector, cls=None: mock_textarea
+
+        screen.action_dismiss_screen()
+        screen.dismiss.assert_called_once_with(("p", "1", "fix-bug", "c", None, None))
 
     def test_console_entry_stored_when_provided(self) -> None:
         """The background-container-start entry is held for the Show-log button."""
@@ -594,7 +625,7 @@ class TestTaskLaunchScreenLazyAgents:
 # ---------------------------------------------------------------------------
 
 
-def _run_launch_with_prompt(agent: str, prompt: str | None) -> tuple[mock.Mock, mock.Mock]:
+def _run_launch_with_prompt(agent: str | None, prompt: str | None) -> tuple[mock.Mock, mock.Mock]:
     """Drive _on_launch_screen_result for *agent*/*prompt* and return mocks."""
     _, app_class = import_app()
     instance = app_class()
@@ -650,6 +681,36 @@ class TestLaunchCmdShape:
         cmd = launch.call_args[0][0]
         assert cmd == ["podman", "exec", "-it", "c"]
         save.assert_called_once_with("proj1", "5", "first message")
+
+    def test_dismiss_saves_prompt_without_launching(self) -> None:
+        # A None agent means the user dismissed: the prompt is still persisted
+        # for the next manual login, but no terminal session is opened.
+        launch, save = _run_launch_with_prompt(None, "saved for later")
+        save.assert_called_once_with("proj1", "5", "saved for later")
+        launch.assert_not_called()
+
+
+class TestSaveInitialPrompt:
+    """The real _save_initial_prompt — file contract for the agent wrappers."""
+
+    def _save_fn(self) -> Any:
+        _, app_class = import_app()
+        return app_class._on_launch_screen_result.__globals__
+
+    def test_creates_missing_config_dir(self, tmp_path: Any) -> None:
+        # Dismiss can fire before the background runner has made the dir.
+        g = self._save_fn()
+        config_dir = tmp_path / "p" / "1" / "agent-config"
+        with mock.patch.dict(g, {"agent_config_dir": mock.Mock(return_value=config_dir)}):
+            g["_save_initial_prompt"]("p", "1", "remember this")
+        assert (config_dir / "initial-prompt.txt").read_text() == "remember this\n"
+
+    def test_blank_prompt_writes_nothing(self, tmp_path: Any) -> None:
+        g = self._save_fn()
+        config_dir = tmp_path / "p" / "1" / "agent-config"
+        with mock.patch.dict(g, {"agent_config_dir": mock.Mock(return_value=config_dir)}):
+            g["_save_initial_prompt"]("p", "1", None)
+        assert not config_dir.exists()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem

Pressing **Dismiss** in the new-task CLI launch modal (`TaskLaunchScreen`) discarded whatever initial prompt the user had typed. Since the container is already starting in the background the moment the modal opens, that prompt can simply be recorded and made available to the task on the next manual `login`.

## Change

- **Dismiss now preserves the prompt.** Both the Esc binding and the Dismiss button route through `_dismiss_keeping_prompt()`, which hands back the full launch context with a `None` agent. A `None` agent is the callback's signal to *save-and-refresh* rather than open a terminal.
- The prompt travels the **same `initial-prompt.txt` path the Login flow already uses** — consumed one-shot by the terok-executor agent wrappers, and shown by the bash login banner. No new delivery mechanism.
- `_save_initial_prompt` now creates the `agent-config` dir if missing, because Dismiss can land before the background container-start runner has populated it.
- `_do_login` and `_dismiss_keeping_prompt` share a single `_build_result(agent)` helper, so the launch-context tuple shape is defined in one place.

## Tests

`tests/unit/tui/test_new_task_flow.py` — dismiss-keeps-prompt (action + button), blank-prompt-is-`None`, callback saves-without-launching, and direct coverage of `_save_initial_prompt` (dir creation + blank no-op). Full TUI suite green (780 passed); `ruff check`/`format` clean.

## Follow-up (not in this PR)

A reviewer flagged that the `agent-config` dir is created in two layers (here on Dismiss, and in the orchestration runner on container start). A deeper fix would create the dir at `task_new()` time, retiring the TUI-side `mkdir` and the race entirely — but that touches the orchestration layer and all task modes, so it's left as a separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Task launch modal now preserves typed prompts when dismissed without selecting an agent, allowing you to resume where you left off.
  * Prompts are consistently saved regardless of login or dismissal workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->