### PR TITLE
docs: Acknowledgements heading + borderless CASUS/HZDR logo table

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,13 +30,27 @@ Python packages.
   <img src="https://terok-ai.github.io/terok/img/architecture.svg" alt="terok ecosystem at a glance">
 </p>
 
-<p align="right">
-Terok was started at the <a href="https://www.casus.science/">Center for Advanced Systems Understanding (CASUS)</a> <br>
-an institute of <a href="https://www.hzdr.de/">Helmholtz-Zentrum Dresden-Rossendorf (HZDR)</a> <br>
-    <a href="https://www.casus.science"><img src="docs/casus-logo.svg" alt="CASUS" width="120"></a> &nbsp; &nbsp;
-    <a href="https://www.hzdr.de"><img src="docs/hzdr-logo.svg" alt="HZDR" width="120"></a> <br>
-    <a href="https://helmholtz.software/software/terok">see also HELMHOLTZ.software</a>
-</p>
+## Acknowledgements
+
+<table border="0" style="border: none;">
+<tr style="border: none;">
+<td valign="top" style="border: none;">
+<a href="https://www.casus.science"><img src="docs/casus-logo.svg" alt="CASUS" width="120"></a>
+<br>
+<a href="https://www.hzdr.de"><img src="docs/hzdr-logo.svg" alt="HZDR" width="120"></a>
+</td>
+<td valign="top" style="border: none;">
+Terok was started at the
+<br><a href="https://www.casus.science/">Center for Advanced Systems Understanding (CASUS)</a>, an institute of
+<br><a href="https://www.hzdr.de/">Helmholtz-Zentrum Dresden-Rossendorf (HZDR)</a> at the end of 2025.
+<br>
+<br>See also
+<br><a href="https://helmholtz.software/software/terok">Terok at HELMHOLTZ.software</a> and the
+<br><a href="https://www.casus.science/scientific-computing-core-agentic-ai-for-coding/">topic page</a> at the
+<br><a href="https://www.casus.science/scientific-computing-core/">Scientific Computing Core (SCC) group</a> of CASUS.
+</td>
+</tr>
+</table>
 
 
 ## What you get

--- a/docs/index.md
+++ b/docs/index.md
@@ -15,21 +15,27 @@ Python packages.
 
 ![terok ecosystem at a glance](img/architecture.svg)
 
-## Origin
+## Acknowledgements
 
-<p>
-Terok was started at the <a href="https://www.casus.science/">Center for Advanced Systems Understanding (CASUS)</a>,
-an institute of <a href="https://www.hzdr.de/">Helmholtz-Zentrum Dresden-Rossendorf (HZDR)</a> in the end of 2025.
-</p>
-
-<a href="https://www.casus.science"><img src="casus-logo.svg" alt="CASUS" width="120"></a> &nbsp; &nbsp;
-<a href="https://www.hzdr.de"><img src="hzdr-logo.svg" alt="HZDR" width="120"></a> <br>
-
-<p>
-See also <a href="https://helmholtz.software/software/terok">Terok at HELMHOLTZ.software</a> and 
-the <a href="https://www.casus.science/scientific-computing-core-agentic-ai-for-coding/">topic page</a> at the 
-<a href="https://www.casus.science/scientific-computing-core/">Scientific Computing Core (SCC) group</s> of CASUS.
-</p>
+<table border="0" style="border: none;">
+<tr style="border: none;">
+<td valign="top" style="border: none;">
+<a href="https://www.casus.science"><img src="casus-logo.svg" alt="CASUS" width="120"></a>
+<br>
+<a href="https://www.hzdr.de"><img src="hzdr-logo.svg" alt="HZDR" width="120"></a>
+</td>
+<td valign="top" style="border: none;">
+Terok was started at the
+<br><a href="https://www.casus.science/">Center for Advanced Systems Understanding (CASUS)</a>, an institute of
+<br><a href="https://www.hzdr.de/">Helmholtz-Zentrum Dresden-Rossendorf (HZDR)</a> at the end of 2025.
+<br>
+<br>See also
+<br><a href="https://helmholtz.software/software/terok">Terok at HELMHOLTZ.software</a> and the
+<br><a href="https://www.casus.science/scientific-computing-core-agentic-ai-for-coding/">topic page</a> at the
+<br><a href="https://www.casus.science/scientific-computing-core/">Scientific Computing Core (SCC) group</a> of CASUS.
+</td>
+</tr>
+</table>
 
 
 ## What you get


### PR DESCRIPTION
Follow-up to #1077 (now merged). Two things:

**1. Address the CodeRabbit review on #1077** (in `docs/index.md`):
- "in the end of 2025" → "at the end of 2025"
- fix the malformed `</s>` closing tag on the SCC group link → `</a>`

**2. Reformat the CASUS/HZDR attribution** in both `README.md` and `docs/index.md`:
- Put it under an **`## Acknowledgements`** heading (replacing the bare right-aligned block in the README and the `## Origin` heading in the docs).
- Lay it out as a **borderless two-column table**: the CASUS and HZDR logos stacked in the left cell (one per line), the attribution text in the right cell with a line break before each link so the long text wraps cleanly. Inline `border: none` keeps it borderless on the docs site (GitHub strips inline styles, so cells may show GitHub's default faint border there).

Both files now use the same, richer (CodeRabbit-corrected) wording. README still renders for PyPI (`readme_renderer` passes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated README and documentation with a new "Acknowledgements" section.
  * Redesigned acknowledgements layout using an HTML table featuring organization logos and attribution information.
  * Added updated links to related project resources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->