### PR TITLE
docs(readme): absolute URLs for CASUS/HZDR logos so they render on PyPI

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,9 +35,9 @@ Python packages.
 <table border="0" style="border: none;">
 <tr style="border: none;">
 <td valign="top" style="border: none;">
-<a href="https://www.casus.science"><img src="docs/casus-logo.svg" alt="CASUS" width="120"></a>
+<a href="https://www.casus.science"><img src="https://terok-ai.github.io/terok/casus-logo.svg" alt="CASUS" width="120"></a>
 <br>
-<a href="https://www.hzdr.de"><img src="docs/hzdr-logo.svg" alt="HZDR" width="120"></a>
+<a href="https://www.hzdr.de"><img src="https://terok-ai.github.io/terok/hzdr-logo.svg" alt="HZDR" width="120"></a>
 </td>
 <td valign="top" style="border: none;">
 Terok was started at the


### PR DESCRIPTION
The CASUS/HZDR logos didn't render on PyPI because they used **relative** image
paths (`docs/casus-logo.svg`). PyPI's README renderer only shows images served
from **absolute** URLs — which is why the terok logo and the architecture
diagram (both pointing at `https://terok-ai.github.io/terok/...`) render fine
but the acknowledgement logos came up broken.

This points the two logos at the same published GitHub Pages location:

- `https://terok-ai.github.io/terok/casus-logo.svg`
- `https://terok-ai.github.io/terok/hzdr-logo.svg`

(both verified live, HTTP 200). `docs/index.md` is left untouched — its relative
paths resolve correctly on the docs site.

Follow-up to #1079.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated logo references in the Acknowledgements section of README to use more reliable external URLs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->