### PR TITLE
fix(tasks): restart a task container after host reboot

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -923,61 +923,58 @@ toml = ["tomli ; python_full_version <= \"3.11.0a6\""]
 
 [[package]]
 name = "cryptography"
-version = "48.0.0"
+version = "49.0.0"
 description = "cryptography is a package which provides cryptographic recipes and primitives to Python developers."
 optional = false
 python-versions = "!=3.9.0,!=3.9.1,>=3.9"
 groups = ["main"]
 files = [
-    {file = "cryptography-48.0.0-cp311-abi3-macosx_10_9_universal2.whl", hash = "sha256:0c558d2cdffd8f4bbb30fc7134c74d2ca9a476f830bb053074498fbc86f41ed6"},
-    {file = "cryptography-48.0.0-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:f5333311663ea94f75dd408665686aaf426563556bb5283554a3539177e03b8c"},
-    {file = "cryptography-48.0.0-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7995ef305d7165c3f11ae07f2517e5a4f1d5c18da1376a0a9ed496336b69e5f3"},
-    {file = "cryptography-48.0.0-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:40ba1f85eaa6959837b1d51c9767e230e14612eea4ef110ee8854ada22da1bf5"},
-    {file = "cryptography-48.0.0-cp311-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:369a6348999f94bbd53435c894377b20ab95f25a9065c283570e70150d8abc3c"},
-    {file = "cryptography-48.0.0-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:a0e692c683f4df67815a2d258b324e66f4738bd7a96a218c826dce4f4bd05d8f"},
-    {file = "cryptography-48.0.0-cp311-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:18349bbc56f4743c8b12dc32e2bccb2cf83ee8b69a3bba74ef8ae857e26b3d25"},
-    {file = "cryptography-48.0.0-cp311-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:7e8eac43dfca5c4cccc6dad9a80504436fca53bb9bc3100a2386d730fbe6b602"},
-    {file = "cryptography-48.0.0-cp311-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:9ccdac7d40688ecb5a3b4a604b8a88c8002e3442d6c60aead1db2a89a041560c"},
-    {file = "cryptography-48.0.0-cp311-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:bd72e68b06bb1e96913f97dd4901119bc17f39d4586a5adf2d3e47bc2b9d58b5"},
-    {file = "cryptography-48.0.0-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:59baa2cb386c4f0b9905bd6eb4c2a79a69a128408fd31d32ca4d7102d4156321"},
-    {file = "cryptography-48.0.0-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:9249e3cd978541d665967ac2cb2787fd6a62bddf1e75b3e347a594d7dacf4f74"},
-    {file = "cryptography-48.0.0-cp311-abi3-win32.whl", hash = "sha256:9c459db21422be75e2809370b829a87eb37f74cd785fc4aa9ea1e5f43b47cda4"},
-    {file = "cryptography-48.0.0-cp311-abi3-win_amd64.whl", hash = "sha256:5b012212e08b8dd5edc78ef54da83dd9892fd9105323b3993eff6bea65dc21d7"},
-    {file = "cryptography-48.0.0-cp314-cp314t-macosx_10_9_universal2.whl", hash = "sha256:3cb07a3ed6431663cd321ea8a000a1314c74211f823e4177fefa2255e057d1ec"},
-    {file = "cryptography-48.0.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:8c7378637d7d88016fa6791c159f698b3d3eed28ebf844ac36b9dc04a14dae18"},
-    {file = "cryptography-48.0.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:cc90c0b39b2e3c65ef52c804b72e3c58f8a04ab2a1871272798e5f9572c17d20"},
-    {file = "cryptography-48.0.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:76341972e1eff8b4bea859f09c0d3e64b96ce931b084f9b9b7db8ef364c30eff"},
-    {file = "cryptography-48.0.0-cp314-cp314t-manylinux_2_28_ppc64le.whl", hash = "sha256:55b7718303bf06a5753dcdccf2f3945cf18ad7bffde41b61226e4db31ab89a9c"},
-    {file = "cryptography-48.0.0-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:a64697c641c7b1b2178e573cbc31c7c6684cd56883a478d75143dbb7118036db"},
-    {file = "cryptography-48.0.0-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:561215ea3879cb1cbbf272867e2efda62476f240fb58c64de6b393ae19246741"},
-    {file = "cryptography-48.0.0-cp314-cp314t-manylinux_2_34_aarch64.whl", hash = "sha256:ad64688338ed4bc1a6618076ba75fd7194a5f1797ac60b47afe926285adb3166"},
-    {file = "cryptography-48.0.0-cp314-cp314t-manylinux_2_34_ppc64le.whl", hash = "sha256:906cbf0670286c6e0044156bc7d4af9cbb0ef6db9f73e52c3ec56ba6bdde5336"},
-    {file = "cryptography-48.0.0-cp314-cp314t-manylinux_2_34_x86_64.whl", hash = "sha256:ea8990436d914540a40ab24b6a77c0969695ed52f4a4874c5137ccf7045a7057"},
-    {file = "cryptography-48.0.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:c18684a7f0cc9a3cb60328f496b8e3372def7c5d2df39ac267878b05565aaaae"},
-    {file = "cryptography-48.0.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:9be5aafa5736574f8f15f262adc81b2a9869e2cfe9014d52a44633905b40d52c"},
-    {file = "cryptography-48.0.0-cp314-cp314t-win32.whl", hash = "sha256:c17dfe85494deaeddc5ce251aebd1d60bbe6afc8b62071bb0b469431a000124f"},
-    {file = "cryptography-48.0.0-cp314-cp314t-win_amd64.whl", hash = "sha256:27241b1dc9962e056062a8eef1991d02c3a24569c95975bd2322a8a52c6e5e12"},
-    {file = "cryptography-48.0.0-cp39-abi3-macosx_10_9_universal2.whl", hash = "sha256:58d00498e8933e4a194f3076aee1b4a97dfec1a6da444535755822fe5d8b0b86"},
-    {file = "cryptography-48.0.0-cp39-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:614d0949f4790582d2cc25553abd09dd723025f0c0e7c67376a1d77196743d6e"},
-    {file = "cryptography-48.0.0-cp39-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7ce4bfae76319a532a2dc68f82cc32f5676ee792a983187dac07183690e5c66f"},
-    {file = "cryptography-48.0.0-cp39-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:2eb992bbd4661238c5a397594c83f5b4dc2bc5b848c365c8f991b6780efcc5c7"},
-    {file = "cryptography-48.0.0-cp39-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:22a5cb272895dce158b2cacdfdc3debd299019659f42947dbdac6f32d68fe832"},
-    {file = "cryptography-48.0.0-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:2b4d59804e8408e2fea7d1fbaf218e5ec984325221db76e6a241a9abd6cdd95c"},
-    {file = "cryptography-48.0.0-cp39-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:984a20b0f62a26f48a3396c72e4bc34c66e356d356bf370053066b3b6d54634a"},
-    {file = "cryptography-48.0.0-cp39-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:5a5ed8fde7a1d09376ca0b40e68cd59c69fe23b1f9768bd5824f54681626032a"},
-    {file = "cryptography-48.0.0-cp39-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:8cd666227ef7af430aa5914a9910e0ddd703e75f039cef0825cd0da71b6b711a"},
-    {file = "cryptography-48.0.0-cp39-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:9071196d81abc88b3516ac8cdfad32e2b66dd4a5393a8e68a961e9161ddc6239"},
-    {file = "cryptography-48.0.0-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:1e2d54c8be6152856a36f0882ab231e70f8ec7f14e93cf87db8a2ed056bf160c"},
-    {file = "cryptography-48.0.0-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:a5da777e32ffed6f85a7b2b3f7c5cbc88c146bfcd0a1d7baf5fcc6c52ee35dd4"},
-    {file = "cryptography-48.0.0-cp39-abi3-win32.whl", hash = "sha256:77a2ccbbe917f6710e05ba9adaa25fb5075620bf3ea6fb751997875aff4ae4bd"},
-    {file = "cryptography-48.0.0-cp39-abi3-win_amd64.whl", hash = "sha256:16cd65b9330583e4619939b3a3843eec1e6e789744bb01e7c7e2e62e33c239c8"},
-    {file = "cryptography-48.0.0-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:84cf79f0dc8b36ac5da873481716e87aef31fcfa0444f9e1d8b4b2cece142855"},
-    {file = "cryptography-48.0.0-pp311-pypy311_pp73-manylinux_2_28_aarch64.whl", hash = "sha256:fdfef35d751d510fcef5252703621574364fec16418c4a1e5e1055248401054b"},
-    {file = "cryptography-48.0.0-pp311-pypy311_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:0890f502ddf7d9c6426129c3f49f5c0a39278ed7cd6322c8755ffca6ee675a13"},
-    {file = "cryptography-48.0.0-pp311-pypy311_pp73-manylinux_2_34_aarch64.whl", hash = "sha256:ecde28a596bead48b0cfd2a1b4416c3d43074c2d785e3a398d7ec1fc4d0f7fbb"},
-    {file = "cryptography-48.0.0-pp311-pypy311_pp73-manylinux_2_34_x86_64.whl", hash = "sha256:4defde8685ae324a9eb9d818717e93b4638ef67070ac9bc15b8ca85f63048355"},
-    {file = "cryptography-48.0.0-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:db63bf618e5dea46c07de12e900fe1cdd2541e6dc9dbae772a70b7d4d4765f6a"},
-    {file = "cryptography-48.0.0.tar.gz", hash = "sha256:5c3932f4436d1cccb036cb0eaef46e6e2db91035166f1ad6505c3c9d5a635920"},
+    {file = "cryptography-49.0.0-cp311-abi3-macosx_11_0_arm64.whl", hash = "sha256:966fe0e9c67490071f14c0d2b1cb2dfb3023c5ce39457343931415f08382f2db"},
+    {file = "cryptography-49.0.0-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:36d1709f992593689b45bda411498d62c6e365f2ca00b84657d4dadd24de16db"},
+    {file = "cryptography-49.0.0-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:0e959b578856a3924bc0cbb710fc12c387b9412a951389f3ca61704a9e25f325"},
+    {file = "cryptography-49.0.0-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:53ecee2e23f7169b6117e99fc8a944e5e50f79e69758a83b52a00cb98ab2b2d2"},
+    {file = "cryptography-49.0.0-cp311-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:2eda353d8a27bcbcaa4cbed18994a74ab4d19a2ca897db188ea269ab9b71419b"},
+    {file = "cryptography-49.0.0-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:2afe9051da7ae7bd5905da5a949280c7d2bb75682e188f650a9d0f2756b834c6"},
+    {file = "cryptography-49.0.0-cp311-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:0b82e28ee398a386f0807bba7884d30f25218855690f45115831bcce5d90822c"},
+    {file = "cryptography-49.0.0-cp311-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:ccac2bfebc306b862133e3bb71f3f6ee8bb525240089b2d952e4144b3a6d5da7"},
+    {file = "cryptography-49.0.0-cp311-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:d0527ce944105f257f605a827d6ebead966c752038b6e8656abb9c5edee6fc68"},
+    {file = "cryptography-49.0.0-cp311-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:cbc77da8c523d5abd028635ba850a6966fcee2c82e2bf65a41d1d8afe0f98be9"},
+    {file = "cryptography-49.0.0-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:b87e65d263b3e5d3bb92a57e2a6638e2f31110fa7aa890c7b2dbba42248d0a3f"},
+    {file = "cryptography-49.0.0-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:66ec79c3904820572d7e987abdf304281f141d37ad9a489b8e97066e7b9b6459"},
+    {file = "cryptography-49.0.0-cp311-abi3-win_amd64.whl", hash = "sha256:e5dfc1e64de5677cec922ffa8da89c546d0415bf6efdf081842e5d44c84e1f0e"},
+    {file = "cryptography-49.0.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:73a205dce83953d131a4aa1e0fd917a2fd1c5b1eef251e9d7152efefcbf5caf7"},
+    {file = "cryptography-49.0.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:196ecd6a36e4e9aa10270393bb98d8df88fccee0bf1e5128b91ae4eb4375896d"},
+    {file = "cryptography-49.0.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7abcee80084cda3f7691f3eb1ce480d8df49cec637b429aa35986c1de71738aa"},
+    {file = "cryptography-49.0.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:4ae387c9cb68ea569ca17e490d66d8142b81c3cc814bf179974b7d146e490bbb"},
+    {file = "cryptography-49.0.0-cp314-cp314t-manylinux_2_28_ppc64le.whl", hash = "sha256:f37d847238971164fdbc68ade6f6574aecc9c0af714190e2083429ff68f4ce9d"},
+    {file = "cryptography-49.0.0-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:c2bc30226390d60ea19d9f82b19db005fe0452154a23c1c410c12ea801e43561"},
+    {file = "cryptography-49.0.0-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:07cab27cc7b7e0fd28e5e26bb9eeedde5c135c868b46de4a27845abe94af6122"},
+    {file = "cryptography-49.0.0-cp314-cp314t-manylinux_2_34_aarch64.whl", hash = "sha256:b20133d204d2bb56ba047642199603876c872026ca53e79c35b83772ab2cc505"},
+    {file = "cryptography-49.0.0-cp314-cp314t-manylinux_2_34_ppc64le.whl", hash = "sha256:b970c6da94d5bb18629db453d14f2a1300f6bf59b61e9b82377931ef95504866"},
+    {file = "cryptography-49.0.0-cp314-cp314t-manylinux_2_34_x86_64.whl", hash = "sha256:d8ecde755e2e91bf773fc94e8c9d730cd7f2007004cb492263a794ec3899a1c8"},
+    {file = "cryptography-49.0.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:e3fb64c420688e5319ae25113a354015abbd8dffbfbc41781a1ea66fc7622ac3"},
+    {file = "cryptography-49.0.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:32703d93296f5c1f4b53349ad3a250c2cae0fdecd3a3dd5d47e616d8d616af27"},
+    {file = "cryptography-49.0.0-cp314-cp314t-win_amd64.whl", hash = "sha256:33cd0565932807baddb67b96dbee92f2c374b5c89dee09fd74079aeb8c8dba61"},
+    {file = "cryptography-49.0.0-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:ec5e529fb80935c94fe7b729f9972b50e351a0e6b50aa294fd5cabb109fcc29a"},
+    {file = "cryptography-49.0.0-cp39-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:f78ff2c9ed8dc2d036b0f4d640e22522213d047c1b14e61205a7e55c80a494d4"},
+    {file = "cryptography-49.0.0-cp39-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:35b151772baff2c74cba7fa290ceaff4c3b11c0c881eb93eb5dbc05a7cfbba18"},
+    {file = "cryptography-49.0.0-cp39-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:0f21641cf4b30fca7aee061ced0ec7ad7b073518088b7c9969a297c0ae796c69"},
+    {file = "cryptography-49.0.0-cp39-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:9e82dcc8e56052715fb18b2429e3bca4823b1629136a2084fc45a9a5cecb9b64"},
+    {file = "cryptography-49.0.0-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:6f2debedf9ca60cf1d5bd466475638af5130f89965605cd818484d19987d3a21"},
+    {file = "cryptography-49.0.0-cp39-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:8c25ceb16df5b9435f3f6a9829204985b0e0cbee3b48aacd432c7d2c850b44d9"},
+    {file = "cryptography-49.0.0-cp39-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:28d8b15e6275f12c8a207dc309dfa957903c927d08d0cc937ee3f63f200693cc"},
+    {file = "cryptography-49.0.0-cp39-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:6fc361c34fb6aac015ce19435876635e5c6d21db31998b0920f675f131e043b8"},
+    {file = "cryptography-49.0.0-cp39-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:2400ef9c9e2299a25614eb1dea3db54a69b1349efd043bfac9c67630d136df36"},
+    {file = "cryptography-49.0.0-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:67e1d20ad9ef3a563c59ef22e7a8a0b8210bd26604369ea4a30a7c66aefe504e"},
+    {file = "cryptography-49.0.0-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:42b0684e0e40cf26122427802486f6d93aea593612603a94fbf260c7eb1e9c1b"},
+    {file = "cryptography-49.0.0-cp39-abi3-win_amd64.whl", hash = "sha256:026ac7423e6fa66872d3bf889be5974507da3944f866f704fa200eadacd00001"},
+    {file = "cryptography-49.0.0-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:fc1e275c2f1d97b1a6450b8b0ea3ebfa6e087a611c2b26cb2404d48588abab7b"},
+    {file = "cryptography-49.0.0-pp311-pypy311_pp73-manylinux_2_28_aarch64.whl", hash = "sha256:c83782480a4a9da4d0feb51950131ba32e12e70813848b3343f6e18c28a66838"},
+    {file = "cryptography-49.0.0-pp311-pypy311_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:b39efa323140595abd3ecca8529d321ae50f55f3aa3ba9cc81ea56a6011953d5"},
+    {file = "cryptography-49.0.0-pp311-pypy311_pp73-manylinux_2_34_aarch64.whl", hash = "sha256:b47db11c2c3525083296069b98ac5221907455e989ae0c2e3008bde851921615"},
+    {file = "cryptography-49.0.0-pp311-pypy311_pp73-manylinux_2_34_x86_64.whl", hash = "sha256:084ef1af862eb07ec46d25f68689f2102a9fc0e05ce7b80f14f5fe51e4eef0f6"},
+    {file = "cryptography-49.0.0-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:be9fcb48a55f023493482827d4f459bd263cc20efde64f204b97c123201850c6"},
+    {file = "cryptography-49.0.0.tar.gz", hash = "sha256:f89660a348f4f78a92366240a61404e337586ef7f5909a2fef59ca88ef505493"},
 ]
 
 [package.dependencies]
@@ -3642,16 +3639,14 @@ name = "terok-sandbox"
 version = "0.3.0"
 description = "Hardened Podman container runner with gate server and shield integration"
 optional = false
-python-versions = "<4.0,>=3.12"
+python-versions = ">=3.12,<4.0"
 groups = ["main"]
-files = [
-    {file = "terok_sandbox-0.3.0-py3-none-any.whl", hash = "sha256:54739389a0c13be67b5a86ad79d1e9cba852d33ba685b75f2f4f2604e36e4f14"},
-    {file = "terok_sandbox-0.3.0.tar.gz", hash = "sha256:9c3ebace7016586a671fbf741d960c7e0dec19bfc031933ed6a6eb6424b8de2b"},
-]
+files = []
+develop = false
 
 [package.dependencies]
 aiohttp = ">=3.14.1"
-cryptography = ">=46.0.7"
+cryptography = ">=49.0.0"
 jinja2 = ">=3.1"
 keyring = ">=25.0"
 packaging = ">=24"
@@ -3663,6 +3658,12 @@ sqlcipher3 = ">=0.6.2"
 terok-clearance = ">=0.7.1,<0.8.0"
 terok-shield = ">=0.7.1,<0.8.0"
 terok-util = ">=0.2.0,<0.3.0"
+
+[package.source]
+type = "git"
+url = "https://github.com/sliwowitz/terok-sandbox.git"
+reference = "fix/restart-runtime-dir-after-reboot"
+resolved_reference = "842fc020936a593947d5e53c060bd345295be597"
 
 [[package]]
 name = "terok-shield"
@@ -4551,4 +4552,4 @@ propcache = ">=0.2.1"
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.12,<3.15"
-content-hash = "789d6e8561fe1e4a33c443fc7630aaaa3fb19a19b92bab7732e1ce485934ae35"
+content-hash = "582bd63b61dee0c5d5e770bae85494691ac027c7a7cfa28343b88467b691c349"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,10 @@ dependencies = [
     # writer; sandbox 0.3.0 ships it plus remove_container_state /
     # make_stray_sidecar_check.
     "terok-executor>=0.2.1,<0.3.0",
-    "terok-sandbox>=0.3.0,<0.4.0",
+    # PR-chain pin: needs terok-sandbox's ensure_container_runtime_dir
+    # (terok-ai/terok-sandbox#396) to rebuild the /run/terok bind source on
+    # restart.  Unreleased — re-pin to its 0.3.x release range once it ships.
+    "terok-sandbox @ git+https://github.com/sliwowitz/terok-sandbox.git@fix/restart-runtime-dir-after-reboot",
     "terok-shield>=0.7.1,<0.8.0",
     "terok-clearance>=0.7.1,<0.8.0",
     "terok-util>=0.2.0,<0.3.0",

--- a/src/terok/lib/orchestration/container_exec.py
+++ b/src/terok/lib/orchestration/container_exec.py
@@ -10,7 +10,10 @@ poisoned git hooks or scripts executing with host privileges.
 
 from subprocess import TimeoutExpired
 
+from terok.lib.integrations.sandbox import Sandbox
+
 from ..core import runtime as _rt
+from ..core.config import make_sandbox_config
 from ..core.projects import load_project
 from ..core.task_state import container_name as _container_name
 from ..util.logging_utils import _log_debug
@@ -59,8 +62,12 @@ def container_git_diff(
             # commits, network calls, and other side effects.
             _log_debug(f"container_git_diff: refusing to restart exited headless container {cname}")
             return None
+        # Start through the sandbox facade so it rebuilds the /run/terok
+        # bind-mount source (wiped by a reboot, removed by the supervisor
+        # on every stop) — this temporary restart need not know that
+        # host-side precondition.
         try:
-            container.start()
+            Sandbox(make_sandbox_config(), runtime=runtime).start(cname)
         except (FileNotFoundError, RuntimeError) as exc:
             _log_debug(f"container_git_diff: temporary start({cname}) failed: {exc}")
             return None

--- a/src/terok/lib/orchestration/task_runners/container.py
+++ b/src/terok/lib/orchestration/task_runners/container.py
@@ -44,9 +44,16 @@ if TYPE_CHECKING:
 
 
 def _podman_start(project: ProjectConfig, cname: str) -> None:
-    """Start an existing container, raising SystemExit on failure."""
+    """Start an existing container, raising SystemExit on failure.
+
+    Routes through [`Sandbox.start`][terok_sandbox.Sandbox.start] so the
+    sandbox re-establishes the container's host-side scaffolding — the
+    ``/run/terok`` bind-mount source that a reboot wipes — as part of the
+    start.  terok stays ignorant of that precondition; "start an existing
+    container" is one sandbox call.
+    """
     try:
-        _rt.resolve_runtime(project).container(cname).start()
+        _sandbox(project).start(cname)
     except FileNotFoundError:
         raise SystemExit("podman not found; please install podman")
     except RuntimeError as exc:
@@ -222,17 +229,22 @@ def _run_container(
         raise SystemExit(str(exc)) from exc
 
 
-def _agent_runner(project: ProjectConfig) -> AgentRunner:
-    """Return an `AgentRunner` whose `Sandbox` is bound to *project*'s runtime.
+def _sandbox(project: ProjectConfig) -> Sandbox:
+    """Return a `Sandbox` bound to *project*'s resolved runtime.
 
-    Resolving the runtime here (rather than letting `Sandbox` default
-    to crun) is what makes ``run.runtime: krun`` actually take effect
-    on launch — `AgentRunner` then routes every podman invocation
-    through the matching backend.
+    Resolving the runtime here (rather than letting `Sandbox` default to
+    crun) is what makes ``run.runtime: krun`` take effect — the facade
+    then routes every podman invocation through the matching backend.
+    Shared by [`_agent_runner`][terok.lib.orchestration.task_runners.container._agent_runner]
+    (launch) and [`_podman_start`][terok.lib.orchestration.task_runners.container._podman_start]
+    (restart) so both speak to the same backend the same way.
     """
-    cfg = make_sandbox_config()
-    runtime = _rt.resolve_runtime(project)
-    return AgentRunner(sandbox=Sandbox(cfg, runtime=runtime))
+    return Sandbox(make_sandbox_config(), runtime=_rt.resolve_runtime(project))
+
+
+def _agent_runner(project: ProjectConfig) -> AgentRunner:
+    """Return an `AgentRunner` whose `Sandbox` is bound to *project*'s runtime."""
+    return AgentRunner(sandbox=_sandbox(project))
 
 
 def _project_runtime_flags(project: ProjectConfig, *, cname: str) -> list[str]:

--- a/tests/unit/lib/test_container_exec.py
+++ b/tests/unit/lib/test_container_exec.py
@@ -57,6 +57,25 @@ class TestContainerGitDiff:
         assert args[1] == ["git", "-C", "/workspace", "diff", "--stat", "HEAD@{1}..HEAD"]
         assert kwargs == {"timeout": 30}
 
+    def test_restart_rebuilds_runtime_dir(self, mock_runtime) -> None:
+        """The temporary restart rebuilds the /run/terok bind source first.
+
+        Mirrors the host-reboot case: the per-container runtime dir is gone,
+        so the temporary start would fail on the missing mount source unless
+        ``container_git_diff`` recreates it (mode 0700) before starting.
+        """
+        from terok.lib.core.config import make_sandbox_config
+
+        mock_runtime.container.return_value.state = "exited"
+        mock_runtime.exec.return_value = ExecResult(exit_code=0, stdout="d", stderr="")
+        run_dir = make_sandbox_config().runtime_dir / "run" / "proj-cli-7"
+        assert not run_dir.exists()
+
+        container_git_diff("proj", "7", "cli", "HEAD")
+
+        assert run_dir.is_dir()
+        assert (run_dir.stat().st_mode & 0o777) == 0o700
+
     def test_exited_headless_container_not_restarted(self, mock_runtime) -> None:
         """Exited headless (run mode) containers must not be restarted."""
         mock_runtime.container.return_value.state = "exited"

--- a/tests/unit/lib/test_task_runner_internals.py
+++ b/tests/unit/lib/test_task_runner_internals.py
@@ -97,6 +97,29 @@ class TestPodmanStart:
         with pytest.raises(SystemExit):
             _podman_start(Mock(), "test-ctr")
 
+    def test_ensures_runtime_dir_before_start(self, mock_runtime) -> None:
+        """The /run/terok bind source is rebuilt (mode 0700) before start.
+
+        After a host reboot the per-container runtime dir is wiped; without
+        recreating it ``podman start`` fails on the missing mount source.
+        The dir must exist *at* start time, so the check rides the mocked
+        start call.
+        """
+        from terok.lib.core.config import make_sandbox_config
+        from terok.lib.orchestration.task_runners.container import _podman_start
+
+        cname = "terok-cli-reboot"
+        run_dir = make_sandbox_config().runtime_dir / "run" / cname
+        assert not run_dir.exists()
+
+        def _check_dir_ready() -> None:
+            assert run_dir.is_dir(), "runtime dir must exist before podman start"
+            assert (run_dir.stat().st_mode & 0o777) == 0o700
+
+        mock_runtime.container.return_value.start.side_effect = _check_dir_ready
+        _podman_start(Mock(), cname)
+        mock_runtime.container.return_value.start.assert_called_once()
+
 
 # ── _apply_shield_policy ─────────────────────────────────
 


### PR DESCRIPTION
## Problem

Restarting a task (e.g. **task restart** in the TUI) fails **after a host reboot**: `podman start` can't find `/run/user/<uid>/terok/sandbox/run/terok-<…>`, the per-container runtime directory.

That dir is the host-side **bind-mount source** for the in-container `/run/terok` socket dir. It lives on the `$XDG_RUNTIME_DIR` tmpfs (wiped on logout/reboot) and the supervisor `rmtree`s it on **every** stop, so by restart time it is routinely gone. A plain stop→start survives because podman recreates the leaf while its parent lives; a **reboot wipes the whole `…/run` chain**, and the start then fails on the missing mount source.

The dir holds only transient sockets — the bug is the missing **mount point**, not misplaced persistent data, so nothing needs to move to the state root. Other reboot-wiped state is already handled (clearance sockets recreated by the supervisor; shield re-applied post-start; vault re-unlocked by design).

## Fix

Route every (re)start of an existing container through **`Sandbox.start()`**, which now re-establishes the host-side scaffolding (the `/run/terok` bind source) as part of the start — so terok no longer has to know that precondition exists. One sandbox call = "start an existing container, correctly."

- `_podman_start` — the shared helper behind task restart and CLI/headless/toad resume — now calls `_sandbox(project).start(cname)`.
- `container_git_diff` — the temporary restart used to diff a stopped container — starts via the facade too.
- `_sandbox(project)` centralises the project-bound `Sandbox` construction shared by launch (`_agent_runner`) and restart.

The dir-rebuild itself lives in **terok-sandbox#396** (`Sandbox.start` + `SandboxConfig.ensure_container_runtime_dir`); this PR is purely the rewire. The terok adapter is untouched — no sandbox helper leaks into terok.

## Tests

- `TestPodmanStart::test_ensures_runtime_dir_before_start` — the dir exists (mode 0700) **at** start time (the assertion rides the mocked start call, proving ordering).
- `TestContainerGitDiff::test_restart_rebuilds_runtime_dir` — the temp restart rebuilds the dir.

Full unit suite green (2708 passed), incl. host **Integration tests**; lint / format / tach / import-linter / mypy / docstrings / bandit / reuse all pass.

---
## PR chain

1. **terok-ai/terok-sandbox#396** — hardens `Sandbox.start()` to rebuild the `/run/terok` bind source. **Merged + released as 0.3.1.**
2. **this PR** — routes terok's restart paths through it.

`pyproject.toml` now pins the released `terok-sandbox>=0.3.1,<0.4.0` (the 0.3.1 floor guarantees the fixed `Sandbox.start()`). No terok-executor change — executor 0.2.1 already admits 0.3.1 via its `<0.4.0` range. **Ready to merge + release.**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed container restart behavior to ensure required host runtime bind scaffolding is re-established after reboot.
  * Added safeguards so missing runtime directories are rebuilt with correct permissions before container start.

* **Chores**
  * Updated the sandbox dependency pin to a temporary branch version to support the reboot/restart rebuild workflow.

* **Tests**
  * Added unit coverage for runtime directory reconstruction on restart and for verifying the directory exists with correct mode at container start.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

