### PR TITLE
deps: pin terok-sandbox to released 0.3.1 (drop PR-chain branch pin)

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -3636,13 +3636,15 @@ tomli-w = ">=1.0"
 
 [[package]]
 name = "terok-sandbox"
-version = "0.3.0"
+version = "0.3.1"
 description = "Hardened Podman container runner with gate server and shield integration"
 optional = false
-python-versions = ">=3.12,<4.0"
+python-versions = "<4.0,>=3.12"
 groups = ["main"]
-files = []
-develop = false
+files = [
+    {file = "terok_sandbox-0.3.1-py3-none-any.whl", hash = "sha256:df18ad21af47e0743c9600d01e02236b2cc590cfe07a9624a8da07615302a60e"},
+    {file = "terok_sandbox-0.3.1.tar.gz", hash = "sha256:1b55652a2b8bef7660f5fd66416719528b555a3fabab9a729f8cc36e9244df74"},
+]
 
 [package.dependencies]
 aiohttp = ">=3.14.1"
@@ -3658,12 +3660,6 @@ sqlcipher3 = ">=0.6.2"
 terok-clearance = ">=0.7.1,<0.8.0"
 terok-shield = ">=0.7.1,<0.8.0"
 terok-util = ">=0.2.0,<0.3.0"
-
-[package.source]
-type = "git"
-url = "https://github.com/sliwowitz/terok-sandbox.git"
-reference = "fix/restart-runtime-dir-after-reboot"
-resolved_reference = "842fc020936a593947d5e53c060bd345295be597"
 
 [[package]]
 name = "terok-shield"
@@ -4552,4 +4548,4 @@ propcache = ">=0.2.1"
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.12,<3.15"
-content-hash = "582bd63b61dee0c5d5e770bae85494691ac027c7a7cfa28343b88467b691c349"
+content-hash = "7e0d4a20af73e46e96d370e23a0d94440a856146bb4fd9a2f3e79841797b6d16"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,10 +31,7 @@ dependencies = [
     # writer; sandbox 0.3.0 ships it plus remove_container_state /
     # make_stray_sidecar_check.
     "terok-executor>=0.2.1,<0.3.0",
-    # PR-chain pin: needs terok-sandbox's ensure_container_runtime_dir
-    # (terok-ai/terok-sandbox#396) to rebuild the /run/terok bind source on
-    # restart.  Unreleased — re-pin to its 0.3.x release range once it ships.
-    "terok-sandbox @ git+https://github.com/sliwowitz/terok-sandbox.git@fix/restart-runtime-dir-after-reboot",
+    "terok-sandbox>=0.3.1,<0.4.0",
     "terok-shield>=0.7.1,<0.8.0",
     "terok-clearance>=0.7.1,<0.8.0",
     "terok-util>=0.2.0,<0.3.0",


### PR DESCRIPTION
I misclicked on merge and accidentally merged a branch from an open PR chain. The CI caught the wrong git dependency, but the commit already landed. Re-pinning to a PyPi release.