### PR TITLE
chore: drop the stale Floors comment from pyproject deps

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,9 +27,6 @@ dependencies = [
     "unique-namer>=1.3",
     "textual-serve>=1.1.0",
     "jinja2>=3.1",
-    # Floors: executor 0.2.1 routes the sidecar through sandbox's canonical
-    # writer; sandbox 0.3.0 ships it plus remove_container_state /
-    # make_stray_sidecar_check.
     "terok-executor>=0.2.1,<0.3.0",
     "terok-sandbox>=0.3.1,<0.4.0",
     "terok-shield>=0.7.1,<0.8.0",


### PR DESCRIPTION
Removes the multi-line `# Floors:` comment above the sibling pins in `pyproject.toml`. The floors are clear from the version ranges, and the note still referenced sandbox 0.3.0 (superseded by the 0.3.1 bump). Deps list is now bare pins, matching the rest. No dependency change — `poetry check --lock` stays green (comment-only, content-hash unaffected).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed outdated inline documentation from project configuration files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->