### PR TITLE
feat(task): graceful missing-id error + `task status --verbose` debug locations

### DIFF
--- a/src/terok/cli/commands/task.py
+++ b/src/terok/cli/commands/task.py
@@ -281,6 +281,15 @@ def register(
 
     t_status = tsub.add_parser("status", help="Show actual container state vs metadata")
     _add_project_task_args(t_status)
+    t_status.add_argument(
+        "-v",
+        "--verbose",
+        action="store_true",
+        help=(
+            "Also show on-host debug locations: container ID, mounts, and the "
+            "supervisor log / wrapper / PID / sidecar paths (for sending logs to support)"
+        ),
+    )
 
     t_revoke = tsub.add_parser(
         "revoke-credentials",
@@ -660,6 +669,26 @@ def _cmd_task_audit_credentials(project_name: str, task_id: str, args: argparse.
         print(f"{ts}  {provider:10s} {method:6s} {status} {outcome:25s} {duration}ms  {path}")
 
 
+def _resolve_required_task_id(args: argparse.Namespace) -> str:
+    """Resolve the ``task_id`` positional, or exit with a usage error.
+
+    The positional is ``nargs="?"`` so the ``proj/task`` slash form
+    parses as a single argument — which means a verb that *requires* a
+    task ID can still reach dispatch with ``task_id is None`` (the user
+    gave only the project). Surface that as an actionable usage error
+    rather than crashing in prefix resolution on a ``None`` input.
+    """
+    pid = args.project_name
+    if getattr(args, "task_id", None) is None:
+        cmd = args.task_cmd
+        raise SystemExit(
+            f"Missing task ID — `terok task {cmd}` needs one.\n"
+            f"  Usage: terok task {cmd} <project> <task_id>  (or <project>/<task_id>)\n"
+            f"  List tasks: terok task list {pid}"
+        )
+    return resolve_task_id(pid, args.task_id)
+
+
 def _dispatch_task_sub(args: argparse.Namespace) -> bool:
     """Dispatch ``task <subcommand>`` to the right handler."""
     # ``task run`` creates a new task (no task_id to resolve yet).
@@ -674,7 +703,9 @@ def _dispatch_task_sub(args: argparse.Namespace) -> bool:
 
     pid = args.project_name
     require_project_exists(pid)
-    tid = resolve_task_id(pid, args.task_id) if hasattr(args, "task_id") else ""
+    # ``list`` carries no ``task_id`` positional (project-only); every other
+    # verb here requires one and gets a clean error when it's missing.
+    tid = _resolve_required_task_id(args) if hasattr(args, "task_id") else ""
     if args.task_cmd == "list":
         task_list(
             pid,
@@ -713,7 +744,7 @@ def _dispatch_task_sub(args: argparse.Namespace) -> bool:
     elif args.task_cmd == "rename":
         task_rename(pid, tid, args.name)
     elif args.task_cmd == "status":
-        task_status(pid, tid)
+        task_status(pid, tid, verbose=getattr(args, "verbose", False))
     elif args.task_cmd == "revoke-credentials":
         _cmd_task_revoke_credentials(pid, tid)
     elif args.task_cmd == "audit-credentials":

--- a/src/terok/lib/integrations/sandbox.py
+++ b/src/terok/lib/integrations/sandbox.py
@@ -26,6 +26,7 @@ from terok_sandbox import (  # noqa: F401 — re-exported public API
     DEFAULT_SSH_HOST,
     SERVICES_TCP_OPTOUT_YAML,
     CheckVerdict,
+    ContainerDiagnostics,
     ContainerRuntime,
     CredentialDB,
     DoctorCheck,
@@ -65,6 +66,7 @@ from terok_sandbox import (  # noqa: F401 — re-exported public API
     check_selinux_status,
     claim_port,
     clear_redundant_session_file,
+    container_diagnostics,
     ensure_infra_keypair,
     gate_use_personal_ssh_default,
     handle_vault_seal,
@@ -103,6 +105,7 @@ from terok_sandbox.supervisor.install import (  # noqa: F401 — re-exported
 
 __all__ = [
     "CheckVerdict",
+    "ContainerDiagnostics",
     "ContainerRuntime",
     "CredentialDB",
     "DEFAULT_GUEST_SSHD_PORT",
@@ -142,6 +145,7 @@ __all__ = [
     "check_gpu_available",
     "check_selinux_status",
     "claim_port",
+    "container_diagnostics",
     "ensure_infra_keypair",
     "gate_use_personal_ssh_default",
     "handle_vault_seal",

--- a/src/terok/lib/orchestration/tasks/lifecycle.py
+++ b/src/terok/lib/orchestration/tasks/lifecycle.py
@@ -17,7 +17,7 @@ from pathlib import Path
 from terok_util import ensure_dir
 
 from terok.lib.integrations.executor import AgentRunner
-from terok.lib.integrations.sandbox import remove_container_state
+from terok.lib.integrations.sandbox import container_diagnostics, remove_container_state
 
 from ...core import runtime as _rt
 from ...core.config import make_sandbox_config
@@ -581,8 +581,14 @@ def task_stop(project_name: str, task_id: str, *, timeout: int | None = None) ->
     _task_stop(load_project(project_name), task_id, timeout=timeout)
 
 
-def task_status(project_name: str, task_id: str) -> None:
-    """Show live task status with container state diagnostics."""
+def task_status(project_name: str, task_id: str, *, verbose: bool = False) -> None:
+    """Show live task status with container state diagnostics.
+
+    With *verbose*, append the on-host debug locations — container ID,
+    bind mounts, and the supervisor log / wrapper / PID / sidecar paths
+    — so an operator can point a human at the right file to send back
+    instead of hand-rolling a ``podman inspect`` incantation.
+    """
     project = load_project(project_name)
     meta_dir = tasks_meta_dir(project.name)
     meta = read_task_meta(meta_dir, task_id)
@@ -597,10 +603,12 @@ def task_status(project_name: str, task_id: str) -> None:
 
     # Query live container state
     cname = None
+    container = None
     cs = None
     if mode:
         cname = container_name(project.name, mode, task_id)
-        cs = _rt.resolve_runtime(project).container(cname).state
+        container = _rt.resolve_runtime(project).container(cname)
+        cs = container.state
 
     # Build TaskMeta for effective_status / mode_emoji computation
     task = TaskMeta(
@@ -652,6 +660,63 @@ def task_status(project_name: str, task_id: str) -> None:
         print(f"  Work status:     {ws.status}")
         if ws.message:
             print(f"  Work message:    {ws.message}")
+
+    if verbose:
+        cid = container.id if container is not None else None
+        mounts = container.mounts if container is not None else []
+        _print_status_diagnostics(project_name, task_id, cname, cid, mounts)
+
+
+def _print_status_diagnostics(
+    project_name: str,
+    task_id: str,
+    cname: str | None,
+    cid: str | None,
+    mounts: list[tuple[str, str]],
+) -> None:
+    """Append the on-host debug locations for ``task status --verbose``.
+
+    Resolves the supervisor/sidecar artifact paths through sandbox's
+    [`container_diagnostics`][terok_sandbox.diagnostics.container_diagnostics]
+    so the layout stays sandbox-owned.  The log and PID file key on the
+    podman container *ID* (read live); the sidecar keys on the container
+    *name*, so it — and the install-global wrapper — resolve even when
+    the container has been removed and no ID is available.
+    """
+
+    def row(label: str, value: str) -> None:
+        """Print one ``label: value`` line, 17-wide to match the main status body."""
+        print(f"  {label + ':':<17}{value}")
+
+    print()
+    print("  ── Debug locations ──")
+    if cname is None:
+        print("  (no container — task has no run mode recorded)")
+        return
+
+    # ``Container`` itself is already printed in the main body above; start
+    # the debug block with what's new (the full ID).
+    row("Container ID", cid or "(not found — container removed)")
+    if mounts:
+        print("  Mounts:")
+        for src, dest in mounts:
+            print(f"    {src} → {dest}")
+
+    diag = container_diagnostics(cid or "", cname)
+    row("Sidecar", _path_with_presence(diag.sidecar))
+    row("Wrapper", str(diag.wrapper))
+    if cid:
+        row("Supervisor log", _path_with_presence(diag.log))
+        row("Supervisor PID", _path_with_presence(diag.pid))
+    else:
+        row("Supervisor log", "(needs a live or exited container to resolve the ID)")
+
+    row("Live logs", f"terok task logs {project_name} {task_id}")
+
+
+def _path_with_presence(path: Path) -> str:
+    """Render *path*, flagging when the file isn't on disk yet."""
+    return str(path) if path.exists() else f"{path}  (not present)"
 
 
 def wait_for_container_exit(

--- a/tests/unit/cli/test_cli_task_dispatch.py
+++ b/tests/unit/cli/test_cli_task_dispatch.py
@@ -36,7 +36,7 @@ _ROUTES = [
     ("delete", {}, "task_delete", mock.call(_PROJ, _TID)),
     ("stop", {"timeout": 9}, "task_stop", mock.call(_PROJ, _TID, timeout=9)),
     ("rename", {"name": "renamed"}, "task_rename", mock.call(_PROJ, _TID, "renamed")),
-    ("status", {}, "task_status", mock.call(_PROJ, _TID)),
+    ("status", {"verbose": False}, "task_status", mock.call(_PROJ, _TID, verbose=False)),
 ]
 
 
@@ -65,6 +65,27 @@ def test_new_skips_task_id_resolution() -> None:
         assert task_mod._dispatch_task_sub(args) is True
     new.assert_called_once_with(_PROJ, name=None)
     resolve.assert_not_called()
+
+
+@pytest.mark.parametrize("cmd", ["status", "stop", "rename", "delete", "logs"])
+def test_missing_task_id_exits_gracefully(cmd: str) -> None:
+    """A task-id-requiring verb with no task id exits with an actionable message.
+
+    Regression: ``task_id`` is ``nargs="?"`` (for the ``proj/task`` slash
+    form), so omitting it leaves ``task_id=None`` — which used to crash in
+    ``resolve_task_id(None)`` instead of telling the user what to do.
+    """
+    args = _ns(task_cmd=cmd, project_name=_PROJ, task_id=None)
+    with (
+        mock.patch.object(task_mod, "require_project_exists"),
+        mock.patch.object(task_mod, "resolve_task_id") as resolve,
+        pytest.raises(SystemExit) as exc,
+    ):
+        task_mod._dispatch_task_sub(args)
+    resolve.assert_not_called()
+    msg = str(exc.value)
+    assert "Missing task ID" in msg
+    assert f"terok task list {_PROJ}" in msg
 
 
 def test_archive_routes_to_archive_dispatch() -> None:

--- a/tests/unit/lib/test_container_lifecycle.py
+++ b/tests/unit/lib/test_container_lifecycle.py
@@ -235,6 +235,52 @@ def test_task_status_reports_live_container_state() -> None:
     assert "stopped" in output
 
 
+def test_task_status_verbose_shows_debug_locations() -> None:
+    """``status --verbose`` appends container ID, mounts, and supervisor paths."""
+    project_name = "proj_status_v"
+    with project_env(project_config(project_name), project_name=project_name) as ctx:
+        task_id = create_task_with_mode(ctx, project_name)
+
+        container = _mock_container(state="exited")
+        container.id = "abc123def456"
+        container.mounts = [("/host/work", "/workspace")]
+        runtime_mock = Mock(spec=PodmanRuntime)
+        runtime_mock.container.return_value = container
+        with (
+            mock_git_config(),
+            patch("terok.lib.core.runtime.resolve_runtime", return_value=runtime_mock),
+        ):
+            output = capture_stdout(task_status, project_name, task_id, verbose=True)
+
+    assert "Debug locations" in output
+    assert "abc123def456" in output  # full container ID
+    assert "/host/work → /workspace" in output  # mount projection
+    assert f"supervisor-{'abc123def456'}.pid" in output  # PID file keyed on ID
+    assert f"terok task logs {project_name} {task_id}" in output  # the logs hint
+
+
+def test_task_status_verbose_handles_removed_container() -> None:
+    """With no live container ID, ID-keyed paths degrade but name-keyed ones resolve."""
+    project_name = "proj_status_gone"
+    with project_env(project_config(project_name), project_name=project_name) as ctx:
+        task_id = create_task_with_mode(ctx, project_name)
+
+        container = _mock_container(state=None)
+        container.id = None  # container removed — no ID to inspect
+        container.mounts = []
+        runtime_mock = Mock(spec=PodmanRuntime)
+        runtime_mock.container.return_value = container
+        with (
+            mock_git_config(),
+            patch("terok.lib.core.runtime.resolve_runtime", return_value=runtime_mock),
+        ):
+            output = capture_stdout(task_status, project_name, task_id, verbose=True)
+
+    assert "container removed" in output
+    assert "Sidecar:" in output  # name-keyed → still resolvable
+    assert "needs a live or exited container" in output  # ID-keyed log unavailable
+
+
 def test_get_task_container_state_returns_none_without_mode() -> None:
     """Task container lookup is skipped when no mode is configured."""
     assert get_task_container_state("proj", "1", None) is None


### PR DESCRIPTION
Two `terok task` reporting fixes.

## 1. Bug: missing task ID crashes

`task_id` is `nargs="?"` (so the `proj/task` slash form parses as one positional), which means a verb that *requires* a task ID could reach dispatch with `task_id=None` and crash:

```
terok task status terok
...
AttributeError: 'NoneType' object has no attribute 'replace'
```

Now it exits with an actionable message:

```
Missing task ID — `terok task status` needs one.
  Usage: terok task status <project> <task_id>  (or <project>/<task_id>)
  List tasks: terok task list terok
```

## 2. `terok task status -v/--verbose` — debug locations

`task status` is CLI-only (no TUI consumer), so it's extended in place. `-v` appends the on-host debug locations so an operator can tell a human *"send me the file at this path"* instead of pasting a multi-line `podman inspect` snippet:

```
  ── Debug locations ──
  Container ID:    9f3c1ab2de45cafe9f3c1ab2de45cafe
  Mounts:
    /home/me/code/terok → /workspace
  Sidecar:         …/sandbox/sidecar/terok-cli-w9xk3.json
  Wrapper:         …/sandbox/supervisor_wrapper.py
  Supervisor log:  …/sandbox/logs/9f3c1ab2….log
  Supervisor PID:  …/sandbox/pids/supervisor-9f3c1ab2….pid
  Live logs:       terok task logs terok w9xk3
```

Degrades gracefully when the container has been removed (no ID → name-keyed sidecar/wrapper still resolve). Paths come from sandbox's `container_diagnostics()` (import-linter clean — no direct `terok_sandbox` reach).

## Tests

New regression tests for the missing-id error (parametrised across verbs) and the verbose block (live + removed-container variants). `make lint`, import-linter (5/5 kept), and docstr-coverage (96.9%) green locally.

## Dependency

Needs `container_diagnostics` + `Container.id`/`mounts` from terok-ai/terok-sandbox#400 (merged, released as **terok-sandbox 0.3.2a1**). Rebased onto current `master`, which already URL-pins the `0.3.2a1` / `0.2.2a1` alpha wheels — so this branch resolves against the functionality with no further pin changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)