### PR TITLE
test(matrix): non-systemd + Mageia slots; nft + e2e test fixes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,10 @@ jobs:
         with:
           args: format --check
 
+      - name: ASCII-only pyproject
+        run: |
+          ! LC_ALL=C grep -nP '[^\x00-\x7F]' pyproject.toml
+
   docstring-coverage:
     if: github.repository == 'terok-ai/terok'
     runs-on: ubuntu-latest

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -218,13 +218,18 @@ version:
 - **Third-party, major 0 (`0.y.z`)** → pin to an **exact patch**
   (`pkg==0.y.z`). Pre-1.0 packages promise no compatibility across either
   minors *or* patches, so a floating range invites silent breakage.
-- **Third-party, major ≥ 1** → pin by **range** (e.g. `pkg>=2.6`), trusting
-  the package to honour semver. If a specific `>=1` dependency is known to
-  break semver, tighten it deliberately.
-- **Sibling `terok-*` deps** → **exempt**: keep ranges (or their
-  release-wheel URL pin). We guarantee patch-level API stability across the
-  sibling packages, so a `0.y` range there will not silently break — do
-  *not* exact-pin them (it would fight the multi-repo release/PR-chain flow).
+- **Third-party, major ≥ 1** → **compatible-release at the tested
+  baseline**: `pkg~=X.Y` where `X.Y` is the locked major.minor (floor =
+  what we test against, cap = next major). Use the patch-series form
+  `pkg~=X.Y.Z` only where a specific patch floor is required — note the
+  PEP 440 truncation rule: the cap is one level above the last written
+  component (`~=2.13` → `<3`, `~=8.2.5` → `<8.3`). Prefer `~=` over a
+  hand-rolled `>=,<` pair: it states the baseline as one fact with the
+  ceiling derived by construction, so the bounds cannot drift apart.
+- **Sibling `terok-*` deps** → `~=0.y.z` (or their release-wheel URL pin).
+  We guarantee patch-level API stability across the sibling packages, so
+  the patch-series form is exactly right — do *not* exact-pin them (it
+  would fight the multi-repo release/PR-chain flow).
 
 Dev / test / docs / tooling dependencies (the `[tool.poetry.group.*]` groups)
 are **exempt** — they are not shipped to installers and exact-pinning them is

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -207,3 +207,37 @@ gh pr create --repo terok-ai/terok --base master --head sliwowitz:feat/my-featur
 - `pyproject.toml`: Project configuration and dependencies
 - `tach.toml`: Module boundary rules (enforced in CI)
 
+
+## Dependency Pinning & `pyproject.toml` Hygiene
+
+**Version pinning policy.** Runtime/production dependencies — those pulled in
+by a plain `pip install` / `pipx install` of this package (the
+`[project].dependencies` table) — are pinned by the dependency's major
+version:
+
+- **Third-party, major 0 (`0.y.z`)** → pin to an **exact patch**
+  (`pkg==0.y.z`). Pre-1.0 packages promise no compatibility across either
+  minors *or* patches, so a floating range invites silent breakage.
+- **Third-party, major ≥ 1** → pin by **range** (e.g. `pkg>=2.6`), trusting
+  the package to honour semver. If a specific `>=1` dependency is known to
+  break semver, tighten it deliberately.
+- **Sibling `terok-*` deps** → **exempt**: keep ranges (or their
+  release-wheel URL pin). We guarantee patch-level API stability across the
+  sibling packages, so a `0.y` range there will not silently break — do
+  *not* exact-pin them (it would fight the multi-repo release/PR-chain flow).
+
+Dev / test / docs / tooling dependencies (the `[tool.poetry.group.*]` groups)
+are **exempt** — they are not shipped to installers and exact-pinning them is
+an unwarranted maintenance burden the developers can absorb. After changing
+any pin, run `poetry lock` and commit `pyproject.toml` and `poetry.lock`
+together.
+
+**No comments in `pyproject.toml`.** Do **not** add comments to
+`pyproject.toml`, with the single exception of the standing dependency-pinning
+policy note above the `dependencies` table. In particular **never** add a
+comment about a dependency that is temporarily pinned to a git branch during a
+multi-repo PR chain, and never mention the PR-chain workflow in
+`pyproject.toml` at all. Cross-repo merges are performed by a script that does
+not understand comments, so any stray dev-cycle comment is carried straight
+into a production release. Keep such rationale in commit messages, PR
+descriptions, or this file.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -237,12 +237,13 @@ an unwarranted maintenance burden the developers can absorb. After changing
 any pin, run `poetry lock` and commit `pyproject.toml` and `poetry.lock`
 together.
 
-**No comments in `pyproject.toml`.** Do **not** add comments to
-`pyproject.toml`, with the single exception of the standing dependency-pinning
-policy note above the `dependencies` table. In particular **never** add a
-comment about a dependency that is temporarily pinned to a git branch during a
-multi-repo PR chain, and never mention the PR-chain workflow in
-`pyproject.toml` at all. Cross-repo merges are performed by a script that does
-not understand comments, so any stray dev-cycle comment is carried straight
-into a production release. Keep such rationale in commit messages, PR
-descriptions, or this file.
+**Comment discipline in `pyproject.toml`.** The dependency tables stay
+comment-free and self-documenting, apart from the standing policy pointer
+above them. **Never** comment on why a dependency -- especially a sibling
+`terok-*` package -- is pinned a certain way, and never mention dev-cycle
+state (temporary git-branch pins, the multi-repo PR chain): cross-repo
+merges are performed by a script that does not understand comments, so any
+such note is carried straight into a production release. Keep pin
+rationale in commit messages, PR descriptions, or this file. Ordinary
+explanatory comments in `[tool.*]` sections are fine. `pyproject.toml`
+stays ASCII-only.

--- a/Makefile
+++ b/Makefile
@@ -73,7 +73,7 @@ test-integration-podman:
 test-integration-map:
 	poetry run python docs/test_map.py
 
-# Multi-distro integration test matrix (Debian 12/13, Ubuntu 24.04/26.04, Fedora 43/44, podman:stable)
+# Multi-distro integration test matrix (Debian 12/13, Ubuntu 24.04/26.04, Fedora 43/44, Alpine (non-systemd), nix, podman:stable)
 #   NO_CACHE=1 make test-matrix           — force full image rebuild
 #   BUILD_ONLY=1 make test-matrix         — build images only
 #   SCOPE=host-only make test-matrix      — run only needs_host_features tests

--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,7 @@ all: check
 
 # Run linter and format checker (fast, run before commits)
 lint:
+	@if LC_ALL=C grep -nP '[^\x00-\x7F]' pyproject.toml; then echo "pyproject.toml must be ASCII-only"; exit 1; fi
 	mkdir -p $(REPORTS_DIR)
 	poetry run ruff check --exit-zero --output-format=json --output-file=$(RUFF_REPORT) .
 	poetry run ruff check .

--- a/poetry.lock
+++ b/poetry.lock
@@ -4551,4 +4551,4 @@ propcache = ">=0.2.1"
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.12,<3.15"
-content-hash = "2fcc106c562c42c87956fb26390ef062442b24ba08c23dbfb7b5abea9a41fea6"
+content-hash = "a6b2132e76bf69777b0248cd5a98fc94927470fc061c59442b1dc102300ee145"

--- a/poetry.lock
+++ b/poetry.lock
@@ -4551,4 +4551,4 @@ propcache = ">=0.2.1"
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.12,<3.15"
-content-hash = "e5ac3f16ecde340693674efc1ac818337486cecf307c64765cafaf360bf07a5d"
+content-hash = "5c86b39d4fbd70f890bba5c79f7a6ef8172ef226be3b1449894cdc70450cacc9"

--- a/poetry.lock
+++ b/poetry.lock
@@ -4551,4 +4551,4 @@ propcache = ">=0.2.1"
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.12,<3.15"
-content-hash = "a6b2132e76bf69777b0248cd5a98fc94927470fc061c59442b1dc102300ee145"
+content-hash = "5c86b39d4fbd70f890bba5c79f7a6ef8172ef226be3b1449894cdc70450cacc9"

--- a/poetry.lock
+++ b/poetry.lock
@@ -4551,4 +4551,4 @@ propcache = ">=0.2.1"
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.12,<3.15"
-content-hash = "5c86b39d4fbd70f890bba5c79f7a6ef8172ef226be3b1449894cdc70450cacc9"
+content-hash = "e5ac3f16ecde340693674efc1ac818337486cecf307c64765cafaf360bf07a5d"

--- a/poetry.lock
+++ b/poetry.lock
@@ -4551,4 +4551,4 @@ propcache = ">=0.2.1"
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.12,<3.15"
-content-hash = "5c86b39d4fbd70f890bba5c79f7a6ef8172ef226be3b1449894cdc70450cacc9"
+content-hash = "667c417c68592b3a77c3fdde50a28ce94060f5d9785fbc1525e5d1313aa0955a"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,10 +17,7 @@ keywords = ["podman", "containers", "tasks", "developer-tools", "cli"]
 requires-python = ">=3.12,<3.15"
 dynamic = ["version", "classifiers"]
 # Dependency pins follow the policy in AGENTS.md ("Dependency Pinning &
-# pyproject.toml Hygiene").  Keep the dependency tables comment-free and
-# self-documenting -- in particular, never note here why a sibling
-# terok-* package is pinned a certain way, nor any transient dev-cycle
-# state: a comment-blind release script would ship such notes.
+# pyproject.toml Hygiene").  Keep the dependency list comment-free.
 dependencies = [
     "pydantic~=2.13",
     "ruamel.yaml==0.19.1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ dynamic = ["version", "classifiers"]
 dependencies = [
     "pydantic>=2.6",
     "ruamel.yaml==0.19.1",
-    "textual[syntax]==8.2.5",
+    "textual[syntax]~=8.2.5",
     "argcomplete>=3.1",
     "requests>=2.31",
     "rich>=13.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,31 +17,32 @@ keywords = ["podman", "containers", "tasks", "developer-tools", "cli"]
 requires-python = ">=3.12,<3.15"
 dynamic = ["version", "classifiers"]
 # ── Dependency pinning policy (see AGENTS.md) ───────────────────────
-# Third-party runtime deps at major 0 (0.y.z) are pinned to an exact
-# patch: pre-1.0 packages guarantee nothing across minors OR patches.
-# Major >= 1 deps use ranges (semver).  Sibling terok-* deps are exempt
-# — we guarantee patch-level API stability, so they keep ranges (or a
-# release-wheel URL pin).  Dev/test/docs groups are exempt.  This is the
-# ONLY comment permitted in this file — never add dev-cycle notes here,
-# and never mention temporary git-branch pins or the multi-repo PR chain
-# (a merge script rewrites deps and would leak such comments into a
-# production release).
+# Runtime deps use compatible-release pins at the tested baseline:
+# third-party major 0 → exact (==0.y.z; pre-1.0 guarantees nothing);
+# third-party major >= 1 → ~=X.Y (locked-minor floor, next-major cap;
+# ~=X.Y.Z patch-series only where a specific patch floor is required);
+# sibling terok-* → ~=0.y.z or a release-wheel URL pin (patch-level API
+# stability is guaranteed across siblings).  Dev/test/docs groups keep
+# simple floors.  This is the ONLY comment permitted in this file —
+# never add dev-cycle notes here, and never mention temporary git-branch
+# pins or the multi-repo PR chain (a merge script rewrites deps and
+# would leak such comments into a production release).
 dependencies = [
-    "pydantic>=2.6",
+    "pydantic~=2.13",
     "ruamel.yaml==0.19.1",
     "textual[syntax]~=8.2.5",
-    "argcomplete>=3.1",
-    "requests>=2.31",
-    "rich>=13.0",
-    "platformdirs>=4.5.1",
-    "unique-namer>=1.3",
-    "textual-serve>=1.1.0",
-    "jinja2>=3.1",
+    "argcomplete~=3.7",
+    "requests~=2.34",
+    "rich~=15.0",
+    "platformdirs~=4.10",
+    "unique-namer~=1.6",
+    "textual-serve~=1.1",
+    "jinja2~=3.1",
     "terok-executor @ https://github.com/terok-ai/terok-executor/releases/download/v0.2.2a1/terok_executor-0.2.2a1-py3-none-any.whl",
     "terok-sandbox @ https://github.com/terok-ai/terok-sandbox/releases/download/v0.3.2a1/terok_sandbox-0.3.2a1-py3-none-any.whl",
-    "terok-shield>=0.7.1,<0.8.0",
-    "terok-clearance>=0.7.1,<0.8.0",
-    "terok-util>=0.2.0,<0.3.0",
+    "terok-shield~=0.7.1",
+    "terok-clearance~=0.7.2",
+    "terok-util~=0.2.0",
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ dynamic = ["version", "classifiers"]
 dependencies = [
     "pydantic>=2.6",
     "ruamel.yaml==0.19.1",
-    "textual[syntax]>=8.2.5,<8.3",
+    "textual[syntax]~=8.2.5",
     "argcomplete>=3.1",
     "requests>=2.31",
     "rich>=13.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,17 +16,9 @@ maintainers = [
 keywords = ["podman", "containers", "tasks", "developer-tools", "cli"]
 requires-python = ">=3.12,<3.15"
 dynamic = ["version", "classifiers"]
-# ── Dependency pinning policy (see AGENTS.md) ───────────────────────
-# Runtime deps use compatible-release pins at the tested baseline:
-# third-party major 0 → exact (==0.y.z; pre-1.0 guarantees nothing);
-# third-party major >= 1 → ~=X.Y (locked-minor floor, next-major cap;
-# ~=X.Y.Z patch-series only where a specific patch floor is required);
-# sibling terok-* → ~=0.y.z or a release-wheel URL pin (patch-level API
-# stability is guaranteed across siblings).  Dev/test/docs groups keep
-# simple floors.  This is the ONLY comment permitted in this file —
-# never add dev-cycle notes here, and never mention temporary git-branch
-# pins or the multi-repo PR chain (a merge script rewrites deps and
-# would leak such comments into a production release).
+# Dependency pins follow the policy in AGENTS.md ("Dependency Pinning &
+# pyproject.toml Hygiene").  No other comments belong in this file — a
+# comment-blind release script would carry them into a production release.
 dependencies = [
     "pydantic~=2.13",
     "ruamel.yaml==0.19.1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,9 +16,19 @@ maintainers = [
 keywords = ["podman", "containers", "tasks", "developer-tools", "cli"]
 requires-python = ">=3.12,<3.15"
 dynamic = ["version", "classifiers"]
+# ── Dependency pinning policy (see AGENTS.md) ───────────────────────
+# Third-party runtime deps at major 0 (0.y.z) are pinned to an exact
+# patch: pre-1.0 packages guarantee nothing across minors OR patches.
+# Major >= 1 deps use ranges (semver).  Sibling terok-* deps are exempt
+# — we guarantee patch-level API stability, so they keep ranges (or a
+# release-wheel URL pin).  Dev/test/docs groups are exempt.  This is the
+# ONLY comment permitted in this file — never add dev-cycle notes here,
+# and never mention temporary git-branch pins or the multi-repo PR chain
+# (a merge script rewrites deps and would leak such comments into a
+# production release).
 dependencies = [
     "pydantic>=2.6",
-    "ruamel.yaml>=0.18",
+    "ruamel.yaml==0.19.1",
     "textual[syntax]==8.2.5",
     "argcomplete>=3.1",
     "requests>=2.31",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,8 +17,10 @@ keywords = ["podman", "containers", "tasks", "developer-tools", "cli"]
 requires-python = ">=3.12,<3.15"
 dynamic = ["version", "classifiers"]
 # Dependency pins follow the policy in AGENTS.md ("Dependency Pinning &
-# pyproject.toml Hygiene").  No other comments belong in this file — a
-# comment-blind release script would carry them into a production release.
+# pyproject.toml Hygiene").  Keep the dependency tables comment-free and
+# self-documenting -- in particular, never note here why a sibling
+# terok-* package is pinned a certain way, nor any transient dev-cycle
+# state: a comment-blind release script would ship such notes.
 dependencies = [
     "pydantic~=2.13",
     "ruamel.yaml==0.19.1",
@@ -104,7 +106,7 @@ pytest = ">=9.1.1"
 pytest-asyncio = ">=1.4.0"
 pytest-cov = ">=4.0"
 
-# Optional group — only the matrix runner pulls this in.  Adding
+# Optional group -- only the matrix runner pulls this in.  Adding
 # python-dbusmock here (rather than to "test") keeps CI's default
 # ``poetry install`` clean: dbus-python (the transitive of
 # python-dbusmock) has no wheel and needs system-level libdbus-1-dev
@@ -185,7 +187,7 @@ quote-style = "double"
 indent-style = "space"
 docstring-code-format = true
 
-# Static type checking — see `make typecheck`.
+# Static type checking -- see `make typecheck`.
 [tool.mypy]
 python_version = "3.12"
 files = ["src/terok"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ dynamic = ["version", "classifiers"]
 dependencies = [
     "pydantic>=2.6",
     "ruamel.yaml==0.19.1",
-    "textual[syntax]~=8.2.5",
+    "textual[syntax]>=8.2.5,<8.3",
     "argcomplete>=3.1",
     "requests>=2.31",
     "rich>=13.0",

--- a/tests/containers/Containerfile.alpine
+++ b/tests/containers/Containerfile.alpine
@@ -1,0 +1,52 @@
+# SPDX-FileCopyrightText: 2026 Jiri Vyskocil
+# SPDX-License-Identifier: Apache-2.0
+
+# Alpine (OpenRC, musl) — the non-systemd matrix slot.
+#
+# Purpose: prove the full terok stack (per-container supervisor sidecar,
+# vault, git gate, clearance varlink hub) runs on a host with NO systemd
+# at all — the floor case for OpenRC servers (Gentoo/Alpine), runit/s6
+# images, and SLURM interactive jobs.  See terok-ai/terok#959 and #1113.
+#
+# Deliberately does NOT install systemd (the debian/fedora slots do).
+# The run-matrix.sh preflight asserts systemd is absent here, so the
+# slot can never silently regress into testing a systemd host.
+#
+# Alpine ships Python 3.12 natively; uv is used only for a fast,
+# ensurepip-independent venv (Alpine's stdlib venv ships no bundled
+# pip).  The uv binary in the official image is a static musl build.
+FROM docker.io/library/alpine:3.21
+
+# musl toolchain (build-base + *-dev) lets poetry build any dependency
+# without a musllinux wheel (notably dbus-python, built via meson
+# against dbus-dev + glib-dev).  bind-tools provides dig for the gate's
+# DNS probes; openssh-client for the SSH signer path; bash is required
+# by the harness (busybox sh is not bash).
+RUN apk add --no-cache \
+    podman slirp4netns nftables fuse-overlayfs crun \
+    shadow shadow-uidmap \
+    python3 \
+    git curl ca-certificates bind-tools bash openssh-client \
+    dbus \
+    build-base python3-dev dbus-dev glib-dev pkgconf meson libffi-dev
+
+COPY --from=ghcr.io/astral-sh/uv:latest /uv /usr/local/bin/uv
+
+# ── Rootless podman nesting setup (mirrors the debian/fedora slots) ──
+# Subordinate UID/GID ranges MUST stay within 0-65535 so they fit inside
+# the outer rootless-podman container's user-namespace mapping.
+RUN useradd -m -s /bin/bash testrunner \
+    && uid=$(id -u testrunner) \
+    && printf "testrunner:1:%d\ntestrunner:%d:%d\n" \
+        $((uid - 1)) $((uid + 1)) $((65535 - uid)) > /etc/subuid \
+    && cp /etc/subuid /etc/subgid \
+    && chmod 4755 /usr/bin/newuidmap /usr/bin/newgidmap \
+    && mkdir -p /etc/containers \
+    && printf '[storage]\ndriver = "overlay"\n\n[storage.options.overlay]\nmount_program = "/usr/bin/fuse-overlayfs"\nmountopt = "nodev,fsync=0"\n' \
+        > /etc/containers/storage.conf \
+    && printf '[engine]\ncgroup_manager = "cgroupfs"\nevents_logger = "file"\n\n# Disable per-container kernel keyring — prevents keyring leak / EDQUOT\n[containers]\nkeyring = false\n' \
+        > /etc/containers/containers.conf \
+    && mkdir -p /run/user/$uid \
+    && chown testrunner:testrunner /run/user/$uid
+
+WORKDIR /src

--- a/tests/containers/Containerfile.alpine
+++ b/tests/containers/Containerfile.alpine
@@ -49,7 +49,7 @@ RUN useradd -m -s /bin/bash testrunner \
     && mkdir -p /etc/containers \
     && printf '[storage]\ndriver = "overlay"\n\n[storage.options.overlay]\nmount_program = "/usr/bin/fuse-overlayfs"\nmountopt = "nodev,fsync=0"\n' \
         > /etc/containers/storage.conf \
-    && printf '[engine]\ncgroup_manager = "cgroupfs"\nevents_logger = "file"\n\n# Disable per-container kernel keyring — prevents keyring leak / EDQUOT\n[containers]\nkeyring = false\n' \
+    && printf '[engine]\ncgroup_manager = "cgroupfs"\nevents_logger = "file"\n\n# Disable per-container kernel keyring — prevents keyring leak / EDQUOT\n[containers]\nkeyring = false\n\n# On AppArmor hosts the passt profile attaches to the container pasta by\n# pathname (profiles are not container-namespaced) and denies its netns\n# and sysctl reads (dmesg: profile="passt" DENIED); slirp4netns is\n# unaffected.\n[network]\ndefault_rootless_network_cmd = "slirp4netns"\n' \
         > /etc/containers/containers.conf \
     && mkdir -p /run/user/$uid \
     && chown testrunner:testrunner /run/user/$uid

--- a/tests/containers/Containerfile.alpine
+++ b/tests/containers/Containerfile.alpine
@@ -17,6 +17,11 @@
 # pip).  The uv binary in the official image is a static musl build.
 FROM docker.io/library/alpine:3.21
 
+# Ownership label: a Containerfile LABEL propagates into every
+# intermediate layer image, so the harness teardown can prune exactly
+# its own dangling generations (value = the harness IMAGE_PREFIX).
+LABEL "io.terok.matrix-test"="terok-test"
+
 # musl toolchain (build-base + *-dev) lets poetry build any dependency
 # without a musllinux wheel (notably dbus-python, built via meson
 # against dbus-dev + glib-dev).  bind-tools provides dig for the gate's

--- a/tests/containers/Containerfile.alpine
+++ b/tests/containers/Containerfile.alpine
@@ -30,19 +30,6 @@ RUN apk add --no-cache \
     dbus \
     build-base python3-dev dbus-dev glib-dev pkgconf meson libffi-dev
 
-# textual[syntax] pulls tree-sitter grammar packages.  On aarch64-musl no
-# grammar wheels are published, so pip builds them from sdist — but the
-# grammar sdists omit the generated-parser headers (upstream packaging bug:
-# src/parser.c #includes "tree_sitter/parser.h" which is not shipped).
-# Vendor those headers onto the system include path where the grammars'
-# quoted include will find them, so the sdist builds succeed.
-ARG TS_HEADERS_REF=v0.25.0
-RUN mkdir -p /usr/include/tree_sitter \
-    && for h in parser alloc array; do \
-        curl -fsSL "https://raw.githubusercontent.com/tree-sitter/tree-sitter/${TS_HEADERS_REF}/lib/src/${h}.h" \
-            -o "/usr/include/tree_sitter/${h}.h"; \
-    done
-
 COPY --from=ghcr.io/astral-sh/uv:latest /uv /usr/local/bin/uv
 
 # ── Rootless podman nesting setup (mirrors the debian/fedora slots) ──

--- a/tests/containers/Containerfile.alpine
+++ b/tests/containers/Containerfile.alpine
@@ -23,7 +23,7 @@ FROM docker.io/library/alpine:3.21
 # DNS probes; openssh-client for the SSH signer path; bash is required
 # by the harness (busybox sh is not bash).
 RUN apk add --no-cache \
-    podman slirp4netns nftables fuse-overlayfs crun \
+    podman slirp4netns nftables dnsmasq fuse-overlayfs crun \
     shadow shadow-uidmap \
     python3 \
     git curl ca-certificates bind-tools bash openssh-client \

--- a/tests/containers/Containerfile.alpine
+++ b/tests/containers/Containerfile.alpine
@@ -30,6 +30,19 @@ RUN apk add --no-cache \
     dbus \
     build-base python3-dev dbus-dev glib-dev pkgconf meson libffi-dev
 
+# textual[syntax] pulls tree-sitter grammar packages.  On aarch64-musl no
+# grammar wheels are published, so pip builds them from sdist — but the
+# grammar sdists omit the generated-parser headers (upstream packaging bug:
+# src/parser.c #includes "tree_sitter/parser.h" which is not shipped).
+# Vendor those headers onto the system include path where the grammars'
+# quoted include will find them, so the sdist builds succeed.
+ARG TS_HEADERS_REF=v0.25.0
+RUN mkdir -p /usr/include/tree_sitter \
+    && for h in parser alloc array; do \
+        curl -fsSL "https://raw.githubusercontent.com/tree-sitter/tree-sitter/${TS_HEADERS_REF}/lib/src/${h}.h" \
+            -o "/usr/include/tree_sitter/${h}.h"; \
+    done
+
 COPY --from=ghcr.io/astral-sh/uv:latest /uv /usr/local/bin/uv
 
 # ── Rootless podman nesting setup (mirrors the debian/fedora slots) ──

--- a/tests/containers/Containerfile.alpine
+++ b/tests/containers/Containerfile.alpine
@@ -31,7 +31,7 @@ RUN apk add --no-cache \
     podman slirp4netns nftables dnsmasq fuse-overlayfs crun \
     shadow shadow-uidmap \
     python3 \
-    git curl ca-certificates bind-tools bash openssh-client \
+    git git-daemon curl ca-certificates bind-tools bash openssh-client \
     dbus \
     build-base python3-dev dbus-dev glib-dev pkgconf meson libffi-dev
 

--- a/tests/containers/Containerfile.debian12
+++ b/tests/containers/Containerfile.debian12
@@ -5,7 +5,7 @@
 FROM docker.io/library/debian:12
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    podman slirp4netns nftables uidmap fuse-overlayfs crun \
+    podman slirp4netns nftables dnsmasq-base uidmap fuse-overlayfs crun \
     python3 python3-venv \
     git curl ca-certificates dnsutils openssh-client \
     dbus gcc python3-dev libdbus-1-dev libglib2.0-dev pkg-config meson \

--- a/tests/containers/Containerfile.debian12
+++ b/tests/containers/Containerfile.debian12
@@ -4,6 +4,11 @@
 # Debian 12 (Bookworm) — podman 4.3.1, slirp4netns only
 FROM docker.io/library/debian:12
 
+# Ownership label: a Containerfile LABEL propagates into every
+# intermediate layer image, so the harness teardown can prune exactly
+# its own dangling generations (value = the harness IMAGE_PREFIX).
+LABEL "io.terok.matrix-test"="terok-test"
+
 RUN apt-get update && apt-get install -y --no-install-recommends \
     podman slirp4netns nftables dnsmasq-base uidmap fuse-overlayfs crun \
     python3 python3-venv \

--- a/tests/containers/Containerfile.debian13
+++ b/tests/containers/Containerfile.debian13
@@ -5,7 +5,7 @@
 FROM docker.io/library/debian:trixie
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    podman passt slirp4netns nftables uidmap fuse-overlayfs crun \
+    podman passt slirp4netns nftables dnsmasq-base uidmap fuse-overlayfs crun \
     python3 python3-pip python3-venv \
     git curl ca-certificates dnsutils openssh-client \
     dbus gcc python3-dev libdbus-1-dev libglib2.0-dev pkg-config meson \

--- a/tests/containers/Containerfile.debian13
+++ b/tests/containers/Containerfile.debian13
@@ -4,6 +4,11 @@
 # Debian 13 (Trixie) — podman 5.4.x, pasta default
 FROM docker.io/library/debian:trixie
 
+# Ownership label: a Containerfile LABEL propagates into every
+# intermediate layer image, so the harness teardown can prune exactly
+# its own dangling generations (value = the harness IMAGE_PREFIX).
+LABEL "io.terok.matrix-test"="terok-test"
+
 RUN apt-get update && apt-get install -y --no-install-recommends \
     podman passt slirp4netns nftables dnsmasq-base uidmap fuse-overlayfs crun \
     python3 python3-pip python3-venv \

--- a/tests/containers/Containerfile.fedora43
+++ b/tests/containers/Containerfile.fedora43
@@ -4,6 +4,11 @@
 # Fedora 43 — podman 5.8.x, pasta default, modern everything
 FROM registry.fedoraproject.org/fedora:43
 
+# Ownership label: a Containerfile LABEL propagates into every
+# intermediate layer image, so the harness teardown can prune exactly
+# its own dangling generations (value = the harness IMAGE_PREFIX).
+LABEL "io.terok.matrix-test"="terok-test"
+
 RUN dnf install -y \
     podman passt nftables dnsmasq slirp4netns fuse-overlayfs crun \
     python3 python3-pip \

--- a/tests/containers/Containerfile.fedora43
+++ b/tests/containers/Containerfile.fedora43
@@ -5,7 +5,7 @@
 FROM registry.fedoraproject.org/fedora:43
 
 RUN dnf install -y \
-    podman passt nftables slirp4netns fuse-overlayfs crun \
+    podman passt nftables dnsmasq slirp4netns fuse-overlayfs crun \
     python3 python3-pip \
     git curl bind-utils openssh-clients \
     dbus-daemon gcc python3-devel dbus-devel glib2-devel pkgconf meson \

--- a/tests/containers/Containerfile.fedora44
+++ b/tests/containers/Containerfile.fedora44
@@ -5,7 +5,7 @@
 FROM registry.fedoraproject.org/fedora:44
 
 RUN dnf install -y \
-    podman passt nftables slirp4netns fuse-overlayfs crun \
+    podman passt nftables dnsmasq slirp4netns fuse-overlayfs crun \
     python3 python3-pip \
     git curl bind-utils \
     dbus-daemon gcc python3-devel dbus-devel glib2-devel pkgconf meson \

--- a/tests/containers/Containerfile.fedora44
+++ b/tests/containers/Containerfile.fedora44
@@ -12,7 +12,7 @@ LABEL "io.terok.matrix-test"="terok-test"
 RUN dnf install -y \
     podman passt nftables dnsmasq slirp4netns fuse-overlayfs crun \
     python3 python3-pip \
-    git curl bind-utils \
+    git curl bind-utils openssh-clients \
     dbus-daemon gcc python3-devel dbus-devel glib2-devel pkgconf meson \
     && dnf clean all
 

--- a/tests/containers/Containerfile.fedora44
+++ b/tests/containers/Containerfile.fedora44
@@ -4,6 +4,11 @@
 # Fedora 44 — podman 5.x line, pasta default, looking forward
 FROM registry.fedoraproject.org/fedora:44
 
+# Ownership label: a Containerfile LABEL propagates into every
+# intermediate layer image, so the harness teardown can prune exactly
+# its own dangling generations (value = the harness IMAGE_PREFIX).
+LABEL "io.terok.matrix-test"="terok-test"
+
 RUN dnf install -y \
     podman passt nftables dnsmasq slirp4netns fuse-overlayfs crun \
     python3 python3-pip \

--- a/tests/containers/Containerfile.mageia
+++ b/tests/containers/Containerfile.mageia
@@ -13,6 +13,11 @@
 # names differ from Fedora).
 FROM docker.io/mageia:9
 
+# Ownership label: a Containerfile LABEL propagates into every
+# intermediate layer image, so the harness teardown can prune exactly
+# its own dangling generations (value = the harness IMAGE_PREFIX).
+LABEL "io.terok.matrix-test"="terok-test"
+
 # Known 64K-page-kernel incompatibility: Mageia 9's aarch64 bind userland
 # (jemalloc built for 4K pages) SIGABRTs on 64K-page hosts (e.g. the
 # nvidia-64k DGX kernels) — dig dies before sending a query, so

--- a/tests/containers/Containerfile.mageia
+++ b/tests/containers/Containerfile.mageia
@@ -13,6 +13,11 @@
 # names differ from Fedora).
 FROM docker.io/mageia:9
 
+# Known 64K-page-kernel incompatibility: Mageia 9's aarch64 bind userland
+# (jemalloc built for 4K pages) SIGABRTs on 64K-page hosts (e.g. the
+# nvidia-64k DGX kernels) — dig dies before sending a query, so
+# dig-dependent paths rely on shield's getent fallback there.
+
 # Mageia 9 has no fuse-overlayfs package (only mga10/cauldron do), so the
 # inner rootless podman uses the vfs storage driver — reliable when nested
 # (no overlay-on-overlay), just slower.

--- a/tests/containers/Containerfile.mageia
+++ b/tests/containers/Containerfile.mageia
@@ -18,7 +18,7 @@ FROM docker.io/mageia:9
 # (no overlay-on-overlay), just slower.
 
 RUN dnf install -y \
-        podman slirp4netns nftables crun \
+        podman slirp4netns nftables dnsmasq crun \
         shadow-utils \
         python3 \
         git curl ca-certificates bind-utils bash openssh-clients \

--- a/tests/containers/Containerfile.mageia
+++ b/tests/containers/Containerfile.mageia
@@ -1,0 +1,44 @@
+# SPDX-FileCopyrightText: 2026 Jiri Vyskocil
+# SPDX-License-Identifier: Apache-2.0
+
+# Mageia (systemd, glibc, rpm) — broadens rpm-distro coverage beyond
+# Fedora after a recently-reported Mageia issue.  Being glibc, terok is
+# exercised full-featured (tree-sitter grammars install from wheels).
+#
+# Mageia uses systemd — this is NOT a non-systemd slot; the run-matrix.sh
+# preflight only records the init system here.
+#
+# NOTE: Mageia package names / base tag are best-effort and may need
+# adjustment on the first matrix run (dnf is available on Mageia; some
+# names differ from Fedora).
+FROM docker.io/mageia:9
+
+RUN dnf install -y \
+        podman slirp4netns nftables fuse-overlayfs crun \
+        shadow-utils \
+        python3 \
+        git curl ca-certificates bind-utils bash openssh-clients \
+        dbus dbus-devel glib2-devel pkgconf meson gcc python3-devel libffi-devel \
+    && dnf clean all
+
+# Mageia 9 ships Python < 3.12 — use uv to get a 3.12 interpreter (mirrors
+# the debian12 slot).
+COPY --from=ghcr.io/astral-sh/uv:latest /uv /usr/local/bin/uv
+RUN uv python install 3.12
+
+# ── Rootless podman nesting setup (mirrors the debian/fedora slots) ──
+RUN useradd -m testrunner \
+    && uid=$(id -u testrunner) \
+    && printf "testrunner:1:%d\ntestrunner:%d:%d\n" \
+        $((uid - 1)) $((uid + 1)) $((65535 - uid)) > /etc/subuid \
+    && cp /etc/subuid /etc/subgid \
+    && chmod 4755 /usr/bin/newuidmap /usr/bin/newgidmap \
+    && mkdir -p /etc/containers \
+    && printf '[storage]\ndriver = "overlay"\n\n[storage.options.overlay]\nmount_program = "/usr/bin/fuse-overlayfs"\nmountopt = "nodev,fsync=0"\n' \
+        > /etc/containers/storage.conf \
+    && printf '[engine]\ncgroup_manager = "cgroupfs"\nevents_logger = "file"\n\n# Disable per-container kernel keyring — prevents keyring leak / EDQUOT\n[containers]\nkeyring = false\n' \
+        > /etc/containers/containers.conf \
+    && mkdir -p /run/user/$uid \
+    && chown testrunner:testrunner /run/user/$uid
+
+WORKDIR /src

--- a/tests/containers/Containerfile.mageia
+++ b/tests/containers/Containerfile.mageia
@@ -13,8 +13,12 @@
 # names differ from Fedora).
 FROM docker.io/mageia:9
 
+# Mageia 9 has no fuse-overlayfs package (only mga10/cauldron do), so the
+# inner rootless podman uses the vfs storage driver — reliable when nested
+# (no overlay-on-overlay), just slower.
+
 RUN dnf install -y \
-        podman slirp4netns nftables fuse-overlayfs crun \
+        podman slirp4netns nftables crun \
         shadow-utils \
         python3 \
         git curl ca-certificates bind-utils bash openssh-clients \
@@ -34,7 +38,7 @@ RUN useradd -m testrunner \
     && cp /etc/subuid /etc/subgid \
     && chmod 4755 /usr/bin/newuidmap /usr/bin/newgidmap \
     && mkdir -p /etc/containers \
-    && printf '[storage]\ndriver = "overlay"\n\n[storage.options.overlay]\nmount_program = "/usr/bin/fuse-overlayfs"\nmountopt = "nodev,fsync=0"\n' \
+    && printf '[storage]\ndriver = "vfs"\n' \
         > /etc/containers/storage.conf \
     && printf '[engine]\ncgroup_manager = "cgroupfs"\nevents_logger = "file"\n\n# Disable per-container kernel keyring — prevents keyring leak / EDQUOT\n[containers]\nkeyring = false\n' \
         > /etc/containers/containers.conf \

--- a/tests/containers/Containerfile.nix
+++ b/tests/containers/Containerfile.nix
@@ -26,9 +26,16 @@ FROM docker.io/nixos/nix:latest
 #
 # ``--extra-experimental-features`` turns on flakes (off by default in
 # nix 2.18-).
+#
+# ``nftables`` provides the real ``nft`` binary.  terok's shield requires
+# nftables at runtime, so the unit suite (which constructs a real Shield
+# via the task-runner code path) needs it present — the same as the
+# podman matrix slots, which install nftables in their images.  Providing
+# the real tool keeps the tests honest instead of stubbing it out.
 RUN nix --extra-experimental-features 'nix-command flakes' \
         profile add \
-        nixpkgs#gawk
+        nixpkgs#gawk \
+        nixpkgs#nftables
 
 # ``python312`` and ``python312Packages.pip`` are *separate* derivations
 # that don't share a site-packages; installing them side-by-side leaves

--- a/tests/containers/Containerfile.nix
+++ b/tests/containers/Containerfile.nix
@@ -13,6 +13,11 @@
 
 FROM docker.io/nixos/nix:latest
 
+# Ownership label: a Containerfile LABEL propagates into every
+# intermediate layer image, so the harness teardown can prune exactly
+# its own dangling generations (value = the harness IMAGE_PREFIX).
+LABEL "io.terok.matrix-test"="terok-test"
+
 # Pre-populate the system profile with what the tests need at runtime:
 # wrapped python + pip and awk.  Bash and git-minimal already ship in
 # the base image's profile; adding ``nixpkgs#bash`` or ``nixpkgs#git``

--- a/tests/containers/Containerfile.podman
+++ b/tests/containers/Containerfile.podman
@@ -6,6 +6,11 @@
 # (subuid/subgid, storage.conf, containers.conf, setuid newuidmap).
 FROM quay.io/podman/stable:latest
 
+# Ownership label: a Containerfile LABEL propagates into every
+# intermediate layer image, so the harness teardown can prune exactly
+# its own dangling generations (value = the harness IMAGE_PREFIX).
+LABEL "io.terok.matrix-test"="terok-test"
+
 RUN dnf install -y \
     nftables dnsmasq python3 python3-pip \
     git curl bind-utils openssh-clients \

--- a/tests/containers/Containerfile.podman
+++ b/tests/containers/Containerfile.podman
@@ -7,7 +7,7 @@
 FROM quay.io/podman/stable:latest
 
 RUN dnf install -y \
-    nftables python3 python3-pip \
+    nftables dnsmasq python3 python3-pip \
     git curl bind-utils openssh-clients \
     dbus-daemon gcc python3-devel dbus-devel glib2-devel pkgconf meson \
     && dnf clean all

--- a/tests/containers/Containerfile.ubuntu2404
+++ b/tests/containers/Containerfile.ubuntu2404
@@ -4,6 +4,11 @@
 # Ubuntu 24.04 (Noble) — podman 4.9.x, slirp4netns + pasta available
 FROM docker.io/library/ubuntu:24.04
 
+# Ownership label: a Containerfile LABEL propagates into every
+# intermediate layer image, so the harness teardown can prune exactly
+# its own dangling generations (value = the harness IMAGE_PREFIX).
+LABEL "io.terok.matrix-test"="terok-test"
+
 RUN apt-get update && apt-get install -y --no-install-recommends \
     podman slirp4netns passt nftables dnsmasq-base uidmap fuse-overlayfs crun \
     python3 python3-pip python3-venv \

--- a/tests/containers/Containerfile.ubuntu2404
+++ b/tests/containers/Containerfile.ubuntu2404
@@ -5,7 +5,7 @@
 FROM docker.io/library/ubuntu:24.04
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    podman slirp4netns passt nftables uidmap fuse-overlayfs crun \
+    podman slirp4netns passt nftables dnsmasq-base uidmap fuse-overlayfs crun \
     python3 python3-pip python3-venv \
     git curl ca-certificates dnsutils openssh-client \
     dbus gcc python3-dev libdbus-1-dev libglib2.0-dev pkg-config meson \

--- a/tests/containers/Containerfile.ubuntu2604
+++ b/tests/containers/Containerfile.ubuntu2604
@@ -4,6 +4,11 @@
 # Ubuntu 26.04 (Resolute) — next LTS, pulls in a newer podman than 24.04
 FROM docker.io/library/ubuntu:26.04
 
+# Ownership label: a Containerfile LABEL propagates into every
+# intermediate layer image, so the harness teardown can prune exactly
+# its own dangling generations (value = the harness IMAGE_PREFIX).
+LABEL "io.terok.matrix-test"="terok-test"
+
 RUN apt-get update && apt-get install -y --no-install-recommends \
     podman slirp4netns passt nftables dnsmasq-base uidmap fuse-overlayfs crun \
     python3 python3-pip python3-venv \

--- a/tests/containers/Containerfile.ubuntu2604
+++ b/tests/containers/Containerfile.ubuntu2604
@@ -12,7 +12,7 @@ LABEL "io.terok.matrix-test"="terok-test"
 RUN apt-get update && apt-get install -y --no-install-recommends \
     podman slirp4netns passt nftables dnsmasq-base uidmap fuse-overlayfs crun \
     python3 python3-pip python3-venv \
-    git curl ca-certificates dnsutils \
+    git curl ca-certificates dnsutils openssh-client \
     dbus gcc python3-dev libdbus-1-dev libglib2.0-dev pkg-config meson \
     && rm -rf /var/lib/apt/lists/*
 

--- a/tests/containers/Containerfile.ubuntu2604
+++ b/tests/containers/Containerfile.ubuntu2604
@@ -5,7 +5,7 @@
 FROM docker.io/library/ubuntu:26.04
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    podman slirp4netns passt nftables uidmap fuse-overlayfs crun \
+    podman slirp4netns passt nftables dnsmasq-base uidmap fuse-overlayfs crun \
     python3 python3-pip python3-venv \
     git curl ca-certificates dnsutils \
     dbus gcc python3-dev libdbus-1-dev libglib2.0-dev pkg-config meson \

--- a/tests/containers/Containerfile.void
+++ b/tests/containers/Containerfile.void
@@ -1,0 +1,49 @@
+# SPDX-FileCopyrightText: 2026 Jiri Vyskocil
+# SPDX-License-Identifier: Apache-2.0
+
+# Void Linux (runit, glibc) — a non-systemd glibc matrix slot.
+#
+# Purpose: prove the full terok stack runs on a non-systemd host that is
+# *glibc* (unlike the musl Alpine slot) — the shape of the real
+# non-systemd targets (Gentoo/OpenRC, SLURM nodes).  Being glibc, the
+# textual[syntax] tree-sitter grammars install from manylinux wheels, so
+# terok is exercised full-featured here.  See terok-ai/terok#959, #1113.
+#
+# Deliberately non-systemd (runit).  The run-matrix.sh preflight asserts
+# systemd is absent for this slot.
+#
+# NOTE: Void package names are best-effort and may need adjustment on the
+# first matrix run (Void uses xbps; -devel suffixes; base-devel for the
+# toolchain).
+FROM ghcr.io/void-linux/void-glibc:latest
+
+# Sync + self-update xbps first (rolling release), then install deps.  The
+# musl toolchain equivalents here are glibc; build tooling (base-devel +
+# *-devel) covers dbus-python (built via meson against dbus/glib) and any
+# other sdist.  bind-utils provides dig; openssh the ssh client.
+RUN xbps-install -Suy xbps \
+    && xbps-install -Sy \
+        podman slirp4netns nftables fuse-overlayfs crun \
+        shadow \
+        python3 python3-devel \
+        git curl ca-certificates bind-utils bash openssh \
+        dbus dbus-devel glib-devel pkgconf meson base-devel libffi-devel
+
+COPY --from=ghcr.io/astral-sh/uv:latest /uv /usr/local/bin/uv
+
+# ── Rootless podman nesting setup (mirrors the debian/fedora slots) ──
+RUN useradd -m -s /bin/bash testrunner \
+    && uid=$(id -u testrunner) \
+    && printf "testrunner:1:%d\ntestrunner:%d:%d\n" \
+        $((uid - 1)) $((uid + 1)) $((65535 - uid)) > /etc/subuid \
+    && cp /etc/subuid /etc/subgid \
+    && chmod 4755 /usr/bin/newuidmap /usr/bin/newgidmap \
+    && mkdir -p /etc/containers \
+    && printf '[storage]\ndriver = "overlay"\n\n[storage.options.overlay]\nmount_program = "/usr/bin/fuse-overlayfs"\nmountopt = "nodev,fsync=0"\n' \
+        > /etc/containers/storage.conf \
+    && printf '[engine]\ncgroup_manager = "cgroupfs"\nevents_logger = "file"\n\n# Disable per-container kernel keyring — prevents keyring leak / EDQUOT\n[containers]\nkeyring = false\n' \
+        > /etc/containers/containers.conf \
+    && mkdir -p /run/user/$uid \
+    && chown testrunner:testrunner /run/user/$uid
+
+WORKDIR /src

--- a/tests/containers/Containerfile.void
+++ b/tests/containers/Containerfile.void
@@ -23,7 +23,7 @@ FROM ghcr.io/void-linux/void-glibc:latest
 # other sdist.  bind-utils provides dig; openssh the ssh client.
 RUN xbps-install -Suy xbps \
     && xbps-install -Sy \
-        podman slirp4netns nftables fuse-overlayfs crun \
+        podman slirp4netns nftables dnsmasq fuse-overlayfs crun \
         shadow util-linux findutils \
         python3 python3-devel \
         git curl ca-certificates bind-utils bash openssh \
@@ -41,7 +41,7 @@ RUN useradd -m -s /bin/bash testrunner \
     && mkdir -p /etc/containers \
     && printf '[storage]\ndriver = "overlay"\n\n[storage.options.overlay]\nmount_program = "/usr/bin/fuse-overlayfs"\nmountopt = "nodev,fsync=0"\n' \
         > /etc/containers/storage.conf \
-    && printf '[engine]\ncgroup_manager = "cgroupfs"\nevents_logger = "file"\n\n# Disable per-container kernel keyring — prevents keyring leak / EDQUOT\n[containers]\nkeyring = false\n\n# Void ships an unpatched passt whose pasta cannot join the parent netns\n# inside this nested userns (build-time RUN dies with a Permission denied\n# on /proc/<pid>/ns/net); slirp4netns works, as on the older-podman slots.\n[network]\ndefault_rootless_network_cmd = "slirp4netns"\n' \
+    && printf '[engine]\ncgroup_manager = "cgroupfs"\nevents_logger = "file"\n\n# Disable per-container kernel keyring — prevents keyring leak / EDQUOT\n[containers]\nkeyring = false\n\n# On AppArmor hosts the passt profile attaches to the container pasta by\n# pathname (profiles are not container-namespaced) and denies the netns\n# and sysctl reads that Void pasta needs during nested build RUN steps\n# (dmesg: profile="passt" DENIED). slirp4netns is unaffected, as on the\n# older-podman slots.\n[network]\ndefault_rootless_network_cmd = "slirp4netns"\n' \
         > /etc/containers/containers.conf \
     && mkdir -p /run/user/$uid \
     && chown testrunner:testrunner /run/user/$uid

--- a/tests/containers/Containerfile.void
+++ b/tests/containers/Containerfile.void
@@ -17,6 +17,11 @@
 # toolchain).
 FROM ghcr.io/void-linux/void-glibc:latest
 
+# Ownership label: a Containerfile LABEL propagates into every
+# intermediate layer image, so the harness teardown can prune exactly
+# its own dangling generations (value = the harness IMAGE_PREFIX).
+LABEL "io.terok.matrix-test"="terok-test"
+
 # Sync + self-update xbps first (rolling release), then install deps.  The
 # musl toolchain equivalents here are glibc; build tooling (base-devel +
 # *-devel) covers dbus-python (built via meson against dbus/glib) and any

--- a/tests/containers/Containerfile.void
+++ b/tests/containers/Containerfile.void
@@ -24,7 +24,7 @@ FROM ghcr.io/void-linux/void-glibc:latest
 RUN xbps-install -Suy xbps \
     && xbps-install -Sy \
         podman slirp4netns nftables fuse-overlayfs crun \
-        shadow \
+        shadow util-linux findutils \
         python3 python3-devel \
         git curl ca-certificates bind-utils bash openssh \
         dbus dbus-devel glib-devel pkgconf meson base-devel libffi-devel

--- a/tests/containers/Containerfile.void
+++ b/tests/containers/Containerfile.void
@@ -41,7 +41,7 @@ RUN useradd -m -s /bin/bash testrunner \
     && mkdir -p /etc/containers \
     && printf '[storage]\ndriver = "overlay"\n\n[storage.options.overlay]\nmount_program = "/usr/bin/fuse-overlayfs"\nmountopt = "nodev,fsync=0"\n' \
         > /etc/containers/storage.conf \
-    && printf '[engine]\ncgroup_manager = "cgroupfs"\nevents_logger = "file"\n\n# Disable per-container kernel keyring — prevents keyring leak / EDQUOT\n[containers]\nkeyring = false\n' \
+    && printf '[engine]\ncgroup_manager = "cgroupfs"\nevents_logger = "file"\n\n# Disable per-container kernel keyring — prevents keyring leak / EDQUOT\n[containers]\nkeyring = false\n\n# Void ships an unpatched passt whose pasta cannot join the parent netns\n# inside this nested userns (build-time RUN dies with a Permission denied\n# on /proc/<pid>/ns/net); slirp4netns works, as on the older-podman slots.\n[network]\ndefault_rootless_network_cmd = "slirp4netns"\n' \
         > /etc/containers/containers.conf \
     && mkdir -p /run/user/$uid \
     && chown testrunner:testrunner /run/user/$uid

--- a/tests/containers/run-matrix.sh
+++ b/tests/containers/run-matrix.sh
@@ -96,10 +96,10 @@ declare -A EXPECTED_VERSIONS=(
     [ubuntu2604]="5.7.0"
     [debian13]="5.4.2"
     [fedora43]="5.8.2"
-    [fedora44]="5.8.2"
+    [fedora44]="5.8.3"
     [podman]="latest"
     [nix]="n/a"
-    [alpine]="5.3.1"
+    [alpine]="5.3.2"
 )
 
 # Print "expected podman X.Y.Z" for distros with a version pin, or
@@ -217,7 +217,7 @@ run_tests() {
 
     # Three-phase flow:
     #   Phase 1: tests that do NOT need hooks
-    #   Phase 2: install global hooks via terok shield install-hooks --user
+    #   Phase 2: install global hooks via terok shield install-hooks
     #   Phase 3: tests that need hooks
     #
     # Privileged mode gives the outer container the capabilities needed
@@ -316,7 +316,7 @@ run_tests() {
                 # ── Phase 2: install global hooks ──
                 echo \"\"
                 echo \"--- phase 2: installing shield hooks ---\"
-                poetry run terok shield install-hooks --user
+                poetry run terok shield install-hooks
 
                 # Verify hooks are detectable — fail fast if setup did not work
                 poetry run python3 -c \"

--- a/tests/containers/run-matrix.sh
+++ b/tests/containers/run-matrix.sh
@@ -63,7 +63,31 @@ declare -A DISTROS=(
     [podman]="podman"
     [nix]="nix"
     [alpine]="alpine"
+    [void]="void"
+    [mageia]="mageia"
 )
+
+# Host architecture — some slots can't run on every arch (see slot_skip_reason).
+HOST_ARCH="$(uname -m)"
+
+# Slots that are non-systemd (OpenRC/runit/musl): the run-time preflight
+# hard-fails these if systemd is unexpectedly present.
+declare -A NON_SYSTEMD_SLOTS=(
+    [alpine]=1
+    [void]=1
+)
+
+# Return a human reason if $1 cannot run on the current host, else nothing.
+# ``alpine`` is musl: textual[syntax]'s tree-sitter grammars have musllinux
+# wheels for x86_64 but NOT aarch64, and the sdists don't build against the
+# pinned core — so Alpine is x86_64-only for terok.  It is skipped (not
+# failed) on aarch64.  See terok-ai/terok#959 discussion.
+slot_skip_reason() {
+    local name="$1"
+    if [[ "$name" == "alpine" && ( "$HOST_ARCH" == "aarch64" || "$HOST_ARCH" == "arm64" ) ]]; then
+        printf 'musl+aarch64 has no tree-sitter grammar wheels (textual[syntax]); Alpine is x86_64-only for terok'
+    fi
+}
 
 # The ``nix`` slot runs the same flavour the GitHub-Actions host CI
 # does — full unit suite plus host-only integration tests — but under
@@ -83,6 +107,8 @@ declare -A SLOT_KIND=(
     [podman]="podman"
     [nix]="nix"
     [alpine]="podman"
+    [void]="podman"
+    [mageia]="podman"
 )
 
 # Expected podman versions — pinned to the exact distro-shipped point
@@ -100,6 +126,8 @@ declare -A EXPECTED_VERSIONS=(
     [podman]="latest"
     [nix]="n/a"
     [alpine]="5.3.2"
+    [void]="latest"
+    [mageia]="latest"
 )
 
 # Print "expected podman X.Y.Z" for distros with a version pin, or
@@ -147,6 +175,8 @@ declare -A TEST_USERS=(
     [podman]="podman"
     [nix]="testrunner"
     [alpine]="testrunner"
+    [void]="testrunner"
+    [mageia]="testrunner"
 )
 
 usage() {
@@ -238,14 +268,14 @@ run_tests() {
             chown -R $test_user:$test_user $WORKSPACE_DIR
 
             # ── Non-systemd proof ──
-            # The alpine slot must run on a genuinely systemd-free host;
-            # fail loudly if a future base image regresses that.  Other
-            # slots just record their init system in the log.
+            # Non-systemd slots (alpine/void) must run on a genuinely
+            # systemd-free host; fail loudly if a future base image regresses
+            # that.  Other slots just record their init system in the log.
             echo \"--- init system: PID1=\$(cat /proc/1/comm 2>/dev/null || echo unknown) ---\"
             if command -v systemctl >/dev/null 2>&1 || [ -d /run/systemd/system ]; then
                 echo \"systemd: present\"
-                if [ \"$name\" = alpine ]; then
-                    echo \"FATAL: 'alpine' is the non-systemd slot but systemd was detected\" >&2
+                if [ \"${NON_SYSTEMD_SLOTS[$name]:-}\" = 1 ]; then
+                    echo \"FATAL: '$name' is a non-systemd slot but systemd was detected\" >&2
                     exit 1
                 fi
             else
@@ -502,7 +532,12 @@ done
 
 warn_keyring
 
+SKIPPED=()
+
 for target in "${TARGETS[@]}"; do
+    if [[ -n "$(slot_skip_reason "$target")" ]]; then
+        continue
+    fi
     build_image "$target"
 done
 
@@ -515,6 +550,12 @@ PASSED=()
 FAILED=()
 
 for target in "${TARGETS[@]}"; do
+    skip_reason="$(slot_skip_reason "$target")"
+    if [[ -n "$skip_reason" ]]; then
+        echo -e "${C_YELLOW}==> Skipping ${C_BOLD}$target${C_YELLOW} on ${HOST_ARCH}: ${skip_reason}${C_RESET}"
+        SKIPPED+=("$target")
+        continue
+    fi
     case "${SLOT_KIND[$target]}" in
         nix) runner=run_nix_tests ;;
         *) runner=run_tests ;;
@@ -530,6 +571,9 @@ echo ""
 echo -e "${C_BOLD}===== Matrix Summary =====${C_RESET}"
 for target in "${PASSED[@]}"; do
     echo -e "  ${C_GREEN}PASS${C_RESET}: $target $(version_summary "$target")"
+done
+for target in "${SKIPPED[@]}"; do
+    echo -e "  ${C_YELLOW}SKIP${C_RESET}: $target ($(slot_skip_reason "$target"))"
 done
 for target in "${FAILED[@]}"; do
     echo -e "  ${C_RED}FAIL${C_RESET}: $target $(version_summary "$target")"

--- a/tests/containers/run-matrix.sh
+++ b/tests/containers/run-matrix.sh
@@ -253,7 +253,7 @@ run_tests() {
     #
     # Privileged mode gives the outer container the capabilities needed
     # for nested podman, but tests run as uid 1000 (rootless podman).
-    podman run --rm --name "$ctr_name" \
+    podman run --rm --replace --name "$ctr_name" \
         -e TERM=xterm \
         --privileged \
         --security-opt label=disable \
@@ -412,7 +412,7 @@ run_nix_tests() {
     echo -e "${C_CYAN}==> Testing ${C_BOLD}$name${C_CYAN} ($(version_expectation "$name"))${C_RESET}"
     echo ""
 
-    podman run --rm --name "$ctr_name" \
+    podman run --rm --replace --name "$ctr_name" \
         -e TERM=xterm \
         --security-opt label=disable \
         -v "$REPO_ROOT:$SOURCE_MOUNT:ro,Z" \

--- a/tests/containers/run-matrix.sh
+++ b/tests/containers/run-matrix.sh
@@ -186,6 +186,7 @@ usage() {
     echo "  --build-only   Build images without running tests"
     echo "  --no-cache     Rebuild images from scratch (ignore layer cache)"
     echo "  --list         List available distros"
+    echo "  --keep-dangling  Skip the teardown prune of this harness's dangling layers"
     echo "  -h, --help     Show this help"
     echo ""
     echo "Default: install full infrastructure, run all integration tests."
@@ -501,6 +502,7 @@ os.execvp('/tmp/run-nix-tests.sh', ['/tmp/run-nix-tests.sh'])
 BUILD_ONLY=false
 LIST_ONLY=false
 NO_CACHE=false
+KEEP_DANGLING=false
 TARGETS=()
 
 while [[ $# -gt 0 ]]; do
@@ -508,6 +510,7 @@ while [[ $# -gt 0 ]]; do
         --build-only) BUILD_ONLY=true ;;
         --no-cache) NO_CACHE=true ;;
         --list) LIST_ONLY=true ;;
+        --keep-dangling) KEEP_DANGLING=true ;;
         -h|--help) usage; exit 0 ;;
         *) TARGETS+=("$1") ;;
     esac
@@ -592,6 +595,21 @@ done
 for target in "${FAILED[@]}"; do
     echo -e "  ${C_RED}FAIL${C_RESET}: $target $(version_summary "$target")"
 done
+
+
+# Teardown hygiene: dangling generations of exactly THIS harness's images
+# (Containerfile LABEL ownership) are pruned at idle IO priority — small
+# per-run increments instead of an hours-long backlog.  Opt out with
+# --keep-dangling.
+if ! $KEEP_DANGLING; then
+    echo ""
+    echo -e "${C_DIM}Pruning this harness's dangling image generations (idle io)…${C_RESET}"
+    prune=(podman image prune -f --filter "label=io.terok.matrix-test=$IMAGE_PREFIX")
+    command -v nice >/dev/null && prune=(nice -n19 "${prune[@]}")
+    command -v ionice >/dev/null && prune=(ionice -c3 "${prune[@]}")
+    pruned=$("${prune[@]}" | wc -l) || true
+    echo -e "${C_DIM}pruned ${pruned:-0} image record(s)${C_RESET}"
+fi
 
 if [[ ${#FAILED[@]} -gt 0 ]]; then
     exit 1

--- a/tests/containers/run-matrix.sh
+++ b/tests/containers/run-matrix.sh
@@ -297,7 +297,9 @@ run_tests() {
                 set -e
                 export XDG_RUNTIME_DIR=/run/user/\$(id -u)
                 export TEROK_MATRIX=1
-                export TEROK_EXPECT=podman,nft,dnsmasq,dig,getent,git,ssh-keygen,internet,hooks
+                # Image-capability contract only: hooks are phase state,
+                # appended below once phase 2 has installed and verified them.
+                export TEROK_EXPECT=podman,nft,dnsmasq,dig,getent,git,ssh-keygen,internet
 
                 cd $WORKSPACE_DIR
 
@@ -360,6 +362,9 @@ print(\\\"Shield hooks verified.\\\")
 \"
 
                 # ── Phase 3: tests with hooks ──
+                # Hooks are installed and verified now — from here on their
+                # absence would be a real breakage, so the contract grows.
+                export TEROK_EXPECT=\${TEROK_EXPECT},hooks
                 echo \"\"
                 echo \"--- phase 3: tests with hooks ---\"
                 poetry run pytest tests/integration/ -v --tb=short -m \"needs_hooks\"

--- a/tests/containers/run-matrix.sh
+++ b/tests/containers/run-matrix.sh
@@ -253,6 +253,7 @@ run_tests() {
     # Privileged mode gives the outer container the capabilities needed
     # for nested podman, but tests run as uid 1000 (rootless podman).
     podman run --rm --name "$ctr_name" \
+        -e TERM=xterm \
         --privileged \
         --security-opt label=disable \
         --device /dev/fuse:rw \
@@ -404,6 +405,7 @@ run_nix_tests() {
     echo ""
 
     podman run --rm --name "$ctr_name" \
+        -e TERM=xterm \
         --security-opt label=disable \
         -v "$REPO_ROOT:$SOURCE_MOUNT:ro,Z" \
         -v "$RESULTS_DIR:/results:rw,Z" \

--- a/tests/containers/run-matrix.sh
+++ b/tests/containers/run-matrix.sh
@@ -51,6 +51,8 @@ else
 fi
 
 # Target distros: name -> Containerfile suffix
+# ``alpine`` is the non-systemd slot (OpenRC/musl) — it proves the full
+# stack runs with no systemd at all.  See terok-ai/terok#959, #1113.
 declare -A DISTROS=(
     [debian12]="debian12"
     [ubuntu2404]="ubuntu2404"
@@ -60,6 +62,7 @@ declare -A DISTROS=(
     [fedora44]="fedora44"
     [podman]="podman"
     [nix]="nix"
+    [alpine]="alpine"
 )
 
 # The ``nix`` slot runs the same flavour the GitHub-Actions host CI
@@ -79,6 +82,7 @@ declare -A SLOT_KIND=(
     [fedora44]="podman"
     [podman]="podman"
     [nix]="nix"
+    [alpine]="podman"
 )
 
 # Expected podman versions — pinned to the exact distro-shipped point
@@ -95,6 +99,7 @@ declare -A EXPECTED_VERSIONS=(
     [fedora44]="5.8.2"
     [podman]="latest"
     [nix]="n/a"
+    [alpine]="5.3.1"
 )
 
 # Print "expected podman X.Y.Z" for distros with a version pin, or
@@ -141,6 +146,7 @@ declare -A TEST_USERS=(
     [fedora44]="testrunner"
     [podman]="podman"
     [nix]="testrunner"
+    [alpine]="testrunner"
 )
 
 usage() {
@@ -230,6 +236,21 @@ run_tests() {
             # ── Prepare workspace (as root) ──
             cp -a $SOURCE_MOUNT $WORKSPACE_DIR
             chown -R $test_user:$test_user $WORKSPACE_DIR
+
+            # ── Non-systemd proof ──
+            # The alpine slot must run on a genuinely systemd-free host;
+            # fail loudly if a future base image regresses that.  Other
+            # slots just record their init system in the log.
+            echo \"--- init system: PID1=\$(cat /proc/1/comm 2>/dev/null || echo unknown) ---\"
+            if command -v systemctl >/dev/null 2>&1 || [ -d /run/systemd/system ]; then
+                echo \"systemd: present\"
+                if [ \"$name\" = alpine ]; then
+                    echo \"FATAL: 'alpine' is the non-systemd slot but systemd was detected\" >&2
+                    exit 1
+                fi
+            else
+                echo \"systemd: absent — non-systemd host confirmed\"
+            fi
 
             # Strip IPv6 zone-ID nameservers — they reference host interfaces
             # (e.g. eno1) that don't exist inside the container, causing dig

--- a/tests/containers/run-matrix.sh
+++ b/tests/containers/run-matrix.sh
@@ -533,12 +533,19 @@ done
 warn_keyring
 
 SKIPPED=()
+# A slot whose image fails to build is recorded and reported as FAILED, but
+# does NOT abort the whole matrix — so one run surfaces every distro's issues
+# instead of stopping at the first bad build.
+declare -A BUILD_FAILED_MAP=()
 
 for target in "${TARGETS[@]}"; do
     if [[ -n "$(slot_skip_reason "$target")" ]]; then
         continue
     fi
-    build_image "$target"
+    if ! build_image "$target"; then
+        echo -e "${C_RED}==> Build FAILED for ${C_BOLD}$target${C_RED} — recording and continuing${C_RESET}" >&2
+        BUILD_FAILED_MAP[$target]=1
+    fi
 done
 
 if $BUILD_ONLY; then
@@ -554,6 +561,11 @@ for target in "${TARGETS[@]}"; do
     if [[ -n "$skip_reason" ]]; then
         echo -e "${C_YELLOW}==> Skipping ${C_BOLD}$target${C_YELLOW} on ${HOST_ARCH}: ${skip_reason}${C_RESET}"
         SKIPPED+=("$target")
+        continue
+    fi
+    if [[ -n "${BUILD_FAILED_MAP[$target]:-}" ]]; then
+        echo -e "${C_RED}==> $target: FAIL (image build failed)${C_RESET}" >&2
+        FAILED+=("$target")
         continue
     fi
     case "${SLOT_KIND[$target]}" in

--- a/tests/containers/run-matrix.sh
+++ b/tests/containers/run-matrix.sh
@@ -296,6 +296,8 @@ run_tests() {
             su - $test_user -c '
                 set -e
                 export XDG_RUNTIME_DIR=/run/user/\$(id -u)
+                export TEROK_MATRIX=1
+                export TEROK_EXPECT=podman,nft,dnsmasq,dig,getent,git,ssh-keygen,internet,hooks
 
                 cd $WORKSPACE_DIR
 

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -111,6 +111,64 @@ hooks_unavailable = pytest.mark.skipif(
 )
 
 
+# ── Matrix capability contract ───────────────────────────────────────
+# The skip guards above are for dev machines, where a missing binary is
+# a host limitation.  Inside the matrix the harness built the image, so
+# every capability it declares (TEROK_EXPECT, exported by run-matrix.sh)
+# is a contract: absence fails the whole session up front instead of
+# dissolving into skips that read as green.
+
+# sbin fallback mirrors shield's find_nft: Debian-family login shells
+# omit /usr/sbin from PATH.  Self-contained on purpose — the installed
+# terok_shield wheel may predate its own sbin-aware helper.
+_SBIN_DIRS = ("/usr/sbin", "/sbin")
+
+
+def _which_sbin_aware(name: str) -> bool:
+    return any(shutil.which(name, path=path) for path in (None, *_SBIN_DIRS))
+
+
+def _internet_reachable() -> bool:
+    host, port = _target_host_port(ALLOWED_TARGET_HTTP)
+    try:
+        with socket.create_connection((host, port), timeout=5):
+            return True
+    except OSError:
+        return False
+
+
+_CAPABILITY_PROBES = {
+    "podman": lambda: _has("podman"),
+    "nft": lambda: bool(_find_nft()),
+    "dnsmasq": lambda: _which_sbin_aware("dnsmasq"),
+    "dig": lambda: _has("dig"),
+    "getent": lambda: _has("getent"),
+    "git": lambda: _has("git"),
+    "ssh-keygen": lambda: _has("ssh-keygen"),
+    "hooks": _hooks_available,
+    "internet": _internet_reachable,
+}
+
+
+def pytest_sessionstart(session: pytest.Session) -> None:
+    """Fail the whole session when the matrix capability contract is broken."""
+    expected = {cap for cap in os.environ.get("TEROK_EXPECT", "").split(",") if cap}
+    if not expected:
+        return
+    unknown = expected - _CAPABILITY_PROBES.keys()
+    if unknown:
+        pytest.exit(
+            f"TEROK_EXPECT names unknown capabilities: {sorted(unknown)}", returncode=3
+        )
+    missing = sorted(cap for cap in expected if not _CAPABILITY_PROBES[cap]())
+    if missing:
+        pytest.exit(
+            "matrix capability contract broken — expected but missing: "
+            + ", ".join(missing),
+            returncode=3,
+        )
+
+
 def _reset_layered_config_caches() -> None:
     """Clear terok/sandbox config caches after tests rewrite config files."""
     import terok_sandbox.config as _sandbox_config

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -157,14 +157,11 @@ def pytest_sessionstart(session: pytest.Session) -> None:
         return
     unknown = expected - _CAPABILITY_PROBES.keys()
     if unknown:
-        pytest.exit(
-            f"TEROK_EXPECT names unknown capabilities: {sorted(unknown)}", returncode=3
-        )
+        pytest.exit(f"TEROK_EXPECT names unknown capabilities: {sorted(unknown)}", returncode=3)
     missing = sorted(cap for cap in expected if not _CAPABILITY_PROBES[cap]())
     if missing:
         pytest.exit(
-            "matrix capability contract broken — expected but missing: "
-            + ", ".join(missing),
+            "matrix capability contract broken — expected but missing: " + ", ".join(missing),
             returncode=3,
         )
 

--- a/tests/integration/containers/conftest.py
+++ b/tests/integration/containers/conftest.py
@@ -106,7 +106,10 @@ def shell_test_image(tmp_path_factory: pytest.TempPathFactory) -> Iterator[str]:
     # dies at `FROM {{` with "invalid reference format".
     from terok_executor.container.build import render_l0, stage_scripts, stage_tmux_config
 
-    (build_dir / "L0.Dockerfile").write_text(render_l0())
+    # Fully-qualified base image: nested rootless podman in the matrix images
+    # has no unqualified-search-registries, so a short name like ``fedora:44``
+    # (executor's default) fails to resolve.
+    (build_dir / "L0.Dockerfile").write_text(render_l0("registry.fedoraproject.org/fedora:44"))
 
     # Stage scripts (executor's own + sandbox bridge overlays) and tmux
     # config into the build context.  Using executor's `stage_scripts()`

--- a/tests/integration/test_container_e2e.py
+++ b/tests/integration/test_container_e2e.py
@@ -14,7 +14,6 @@ Outbound internet is needed for the egress checks.
 
 from __future__ import annotations
 
-import json
 import subprocess
 import threading
 import uuid
@@ -85,15 +84,15 @@ def _strip_zone_id_nameservers(container: str) -> None:
 # ── In-process gate server ────────────────────────────────
 
 
-def _start_gate_server(base_path: Path, token_file: Path, port: int) -> threading.Thread:
+def _start_gate_server(base_path: Path, token: str, scope: str, port: int) -> threading.Thread:
     """Start the gate HTTP server in a daemon thread on *port*."""
     from terok_sandbox.gate.server import (
-        TokenStore,
         _make_handler_class,
+        _SingleTokenStore,
         _ThreadingHTTPServer,
     )
 
-    token_store = TokenStore(token_file)
+    token_store = _SingleTokenStore(token, scope)
     handler_class = _make_handler_class(base_path, token_store)
     server = _ThreadingHTTPServer((LOCALHOST, port), handler_class)
     thread = threading.Thread(target=server.serve_forever, daemon=True)
@@ -123,17 +122,12 @@ def gate_env(tmp_path: Path) -> dict:
     repo_path = base_path / f"{project_name}.git"
     create_bare_repo_with_branches(repo_path, default_branch="main", other_branches=[])
 
-    # Write token file
+    # Mint the single token the per-container gate will accept (scope = project)
     token = uuid.uuid4().hex
-    token_file = tmp_path / "tokens.json"
-    token_file.write_text(
-        json.dumps({token: {"scope": project_name, "task": "1"}}),
-        encoding="utf-8",
-    )
 
     # Start gate server on a free port
     port = _find_free_port()
-    _start_gate_server(base_path, token_file, port)
+    _start_gate_server(base_path, token, project_name, port)
 
     return {
         "project_name": project_name,

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -149,32 +149,6 @@ def _mock_infrastructure() -> Iterator[None]:
 
 
 @pytest.fixture(autouse=True)
-def _stub_nft_binary(
-    tmp_path_factory: pytest.TempPathFactory, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    """Guarantee an ``nft`` binary is resolvable so shield construction never fails.
-
-    ``terok_shield``'s ``SubprocessRunner`` resolves ``nft`` at construction
-    and raises ``NftNotFoundError`` when it is absent, so any unit test that
-    builds a real ``ShieldManager(...).shield`` (e.g. via
-    ``_apply_auth_protect_denies``) fails on a host without nftables — such as
-    the ``nix`` matrix slot.  The unit suite never runs an actual nft command
-    (deny sets are empty or mocked), so a no-op stub on ``PATH`` suffices;
-    hosts that already ship a real ``nft`` are left untouched.
-    """
-    import os
-    import shutil
-
-    if shutil.which("nft"):
-        return
-    bindir = tmp_path_factory.mktemp("stub-bin")
-    nft = bindir / "nft"
-    nft.write_text("#!/bin/sh\nexit 0\n")
-    nft.chmod(0o755)
-    monkeypatch.setenv("PATH", f"{bindir}{os.pathsep}{os.environ['PATH']}")
-
-
-@pytest.fixture(autouse=True)
 def _stub_credential_db(tmp_path_factory: pytest.TempPathFactory) -> Iterator[None]:
     """Stub ``SandboxConfig.open_credential_db`` so tests never hit the resolution chain.
 

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -149,6 +149,32 @@ def _mock_infrastructure() -> Iterator[None]:
 
 
 @pytest.fixture(autouse=True)
+def _stub_nft_binary(
+    tmp_path_factory: pytest.TempPathFactory, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Guarantee an ``nft`` binary is resolvable so shield construction never fails.
+
+    ``terok_shield``'s ``SubprocessRunner`` resolves ``nft`` at construction
+    and raises ``NftNotFoundError`` when it is absent, so any unit test that
+    builds a real ``ShieldManager(...).shield`` (e.g. via
+    ``_apply_auth_protect_denies``) fails on a host without nftables — such as
+    the ``nix`` matrix slot.  The unit suite never runs an actual nft command
+    (deny sets are empty or mocked), so a no-op stub on ``PATH`` suffices;
+    hosts that already ship a real ``nft`` are left untouched.
+    """
+    import os
+    import shutil
+
+    if shutil.which("nft"):
+        return
+    bindir = tmp_path_factory.mktemp("stub-bin")
+    nft = bindir / "nft"
+    nft.write_text("#!/bin/sh\nexit 0\n")
+    nft.chmod(0o755)
+    monkeypatch.setenv("PATH", f"{bindir}{os.pathsep}{os.environ['PATH']}")
+
+
+@pytest.fixture(autouse=True)
 def _stub_credential_db(tmp_path_factory: pytest.TempPathFactory) -> Iterator[None]:
     """Stub ``SandboxConfig.open_credential_db`` so tests never hit the resolution chain.
 


### PR DESCRIPTION
Part of the multi-repo **non-systemd matrix** work (refs terok-ai/terok#959, #1113).

Adds distro slots to `tests/containers/run-matrix.sh`: **Alpine** (musl/OpenRC, non-systemd; x86_64-only — skipped on aarch64 where tree-sitter has no musl wheels), **Void** (glibc/runit, non-systemd), and **Mageia** (glibc/systemd/rpm). Generalizes the non-systemd preflight assertion and makes per-slot image-build failures non-fatal. Also carries the dep-pinning-policy change.

Fixes: real nftables in the nix image (drop the unit stub); e2e gate test uses the current `_SingleTokenStore` sandbox API; qualified L0 base image (`registry.fedoraproject.org/fedora:44`) for nested rootless podman.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded the test matrix with additional Linux environments, including non-systemd and Alpine-based variants.
  * Added broader support for running container tests across more distro combinations.

* **Bug Fixes**
  * Improved dependency handling by tightening runtime package version rules.
  * Updated container setups so required networking tools are available in more test environments.

* **Tests**
  * Made matrix runs more resilient: build failures no longer stop other test slots, and results now report passed, failed, and skipped cases more clearly.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->