### PR TITLE
feat(docs): versioned docs publishing + fix cross-repo API links

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -201,14 +201,12 @@ jobs:
           name: docs-site
           path: site/
 
-  # TODO(repin): point at the mkdocs-terok release tag (@vX.Y.Z) once
-  # terok-ai/mkdocs-terok#95 ships in a release.
   publish:
     if: github.repository == 'terok-ai/terok' && (github.ref == 'refs/heads/master' || inputs.release)
     needs: build
     permissions:
       contents: write
-    uses: terok-ai/mkdocs-terok/.github/workflows/publish-versioned-docs.yml@master
+    uses: sliwowitz/mkdocs-terok/.github/workflows/publish-versioned-docs.yml@feat/versioned-docs
     with:
       version: ${{ needs.build.outputs.version }}
       title: ${{ needs.build.outputs.title }}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -167,48 +167,13 @@ jobs:
           name: docs-site
           path: site/
 
-  # A release call ships the built site as an immutable snapshot asset on
-  # the tag's GitHub release; the assembler serves it as /<minor>/ from
-  # here on.  Final vX.Y.Z tags only: alphas never reach pypi-publish, so
-  # a non-final ref here is a mis-dispatch and fails loudly.
-  attach:
-    if: inputs.release
+  publish:
+    if: github.repository == 'terok-ai/terok' && (github.ref == 'refs/heads/master' || inputs.release)
     needs: build
-    runs-on: ubuntu-latest
     permissions:
       contents: write
-    steps:
-      - name: Require a final release tag
-        run: |
-          set -euo pipefail
-          if [[ ! "$GITHUB_REF_NAME" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-            echo "Release docs publish requires a final v*.*.* tag ref (got: $GITHUB_REF_NAME)" >&2
-            exit 1
-          fi
-
-      - uses: actions/download-artifact@v8
-        with:
-          name: docs-site
-          path: site
-
-      - name: Upload snapshot to the release
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          set -euo pipefail
-          tar -czf docs-site.tar.gz -C site .
-          gh release upload "$GITHUB_REF_NAME" docs-site.tar.gz --clobber --repo "$GITHUB_REPOSITORY"
-
-  # Runs after attach on the release path so the fresh snapshot is in the
-  # release list; attach is skipped on master pushes.
-  publish:
-    if: >-
-      !cancelled() && needs.build.result == 'success' &&
-      (needs.attach.result == 'success' || needs.attach.result == 'skipped') &&
-      github.repository == 'terok-ai/terok' && (github.ref == 'refs/heads/master' || inputs.release)
-    needs: [build, attach]
-    permissions:
-      contents: read
       pages: write
       id-token: write
     uses: sliwowitz/mkdocs-terok/.github/workflows/publish-versioned-docs.yml@feat/versioned-docs
+    with:
+      release: ${{ inputs.release == true }}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -161,14 +161,14 @@ jobs:
         run: poetry run properdocs build --strict
 
       - name: Upload site for versioned publish
-        if: github.ref == 'refs/heads/master' || inputs.release
+        if: github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/')
         uses: actions/upload-artifact@v7
         with:
           name: docs-site
           path: site/
 
   publish:
-    if: github.repository == 'terok-ai/terok' && (github.ref == 'refs/heads/master' || inputs.release)
+    if: github.repository == 'terok-ai/terok' && (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/'))
     needs: build
     permissions:
       contents: write

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -174,6 +174,6 @@ jobs:
       contents: write
       pages: write
       id-token: write
-    uses: terok-ai/mkdocs-terok/.github/workflows/publish-versioned-docs.yml@v0.7.2a1
+    uses: terok-ai/mkdocs-terok/.github/workflows/publish-versioned-docs.yml@v0.7.2
     with:
       release: ${{ inputs.release == true }}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -49,10 +49,6 @@ jobs:
   build:
     if: github.repository == 'terok-ai/terok'
     runs-on: ubuntu-latest
-    outputs:
-      version: ${{ steps.target.outputs.version }}
-      title: ${{ steps.target.outputs.title }}
-      aliases: ${{ steps.target.outputs.aliases }}
     steps:
       - uses: actions/checkout@v7
 
@@ -164,36 +160,6 @@ jobs:
       - name: Build documentation
         run: poetry run properdocs build --strict
 
-      # Master pushes refresh /dev/; a release call (release.yml, on the
-      # tag ref) lands in /<minor>/ titled with the full version and moves
-      # the `latest` alias.  Only final vX.Y.Z tags qualify: alphas never
-      # reach pypi-publish, so a non-final ref here is a mis-dispatch and
-      # fails loudly rather than minting a docs version.
-      - name: Compute versioned-docs target
-        id: target
-        env:
-          RELEASE: ${{ inputs.release || false }}
-        run: |
-          set -euo pipefail
-          if [[ "$RELEASE" == "true" ]]; then
-            if [[ ! "$GITHUB_REF_NAME" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-              echo "Release docs publish requires a final v*.*.* tag ref (got: $GITHUB_REF_NAME)" >&2
-              exit 1
-            fi
-            full="${GITHUB_REF_NAME#v}"
-            {
-              echo "version=${full%.*}"
-              echo "title=$full"
-              echo "aliases=latest"
-            } >> "$GITHUB_OUTPUT"
-          else
-            {
-              echo "version=dev"
-              echo "title="
-              echo "aliases="
-            } >> "$GITHUB_OUTPUT"
-          fi
-
       - name: Upload site for versioned publish
         if: github.ref == 'refs/heads/master' || inputs.release
         uses: actions/upload-artifact@v7
@@ -201,13 +167,48 @@ jobs:
           name: docs-site
           path: site/
 
-  publish:
-    if: github.repository == 'terok-ai/terok' && (github.ref == 'refs/heads/master' || inputs.release)
+  # A release call ships the built site as an immutable snapshot asset on
+  # the tag's GitHub release; the assembler serves it as /<minor>/ from
+  # here on.  Final vX.Y.Z tags only: alphas never reach pypi-publish, so
+  # a non-final ref here is a mis-dispatch and fails loudly.
+  attach:
+    if: inputs.release
     needs: build
+    runs-on: ubuntu-latest
     permissions:
       contents: write
+    steps:
+      - name: Require a final release tag
+        run: |
+          set -euo pipefail
+          if [[ ! "$GITHUB_REF_NAME" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "Release docs publish requires a final v*.*.* tag ref (got: $GITHUB_REF_NAME)" >&2
+            exit 1
+          fi
+
+      - uses: actions/download-artifact@v8
+        with:
+          name: docs-site
+          path: site
+
+      - name: Upload snapshot to the release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          tar -czf docs-site.tar.gz -C site .
+          gh release upload "$GITHUB_REF_NAME" docs-site.tar.gz --clobber --repo "$GITHUB_REPOSITORY"
+
+  # Runs after attach on the release path so the fresh snapshot is in the
+  # release list; attach is skipped on master pushes.
+  publish:
+    if: >-
+      !cancelled() && needs.build.result == 'success' &&
+      (needs.attach.result == 'success' || needs.attach.result == 'skipped') &&
+      github.repository == 'terok-ai/terok' && (github.ref == 'refs/heads/master' || inputs.release)
+    needs: [build, attach]
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
     uses: sliwowitz/mkdocs-terok/.github/workflows/publish-versioned-docs.yml@feat/versioned-docs
-    with:
-      version: ${{ needs.build.outputs.version }}
-      title: ${{ needs.build.outputs.title }}
-      aliases: ${{ needs.build.outputs.aliases }}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -161,14 +161,14 @@ jobs:
         run: poetry run properdocs build --strict
 
       - name: Upload site for versioned publish
-        if: github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/')
+        if: github.ref == 'refs/heads/master' || inputs.release
         uses: actions/upload-artifact@v7
         with:
           name: docs-site
           path: site/
 
   publish:
-    if: github.repository == 'terok-ai/terok' && (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/'))
+    if: github.repository == 'terok-ai/terok' && (github.ref == 'refs/heads/master' || inputs.release)
     needs: build
     permissions:
       contents: write

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -165,9 +165,10 @@ jobs:
         run: poetry run properdocs build --strict
 
       # Master pushes refresh /dev/; a release call (release.yml, on the
-      # tag ref) lands in /<minor>/ titled with the full version.  Only
-      # final releases take the `latest` alias — an alpha must not become
-      # the site default.
+      # tag ref) lands in /<minor>/ titled with the full version and moves
+      # the `latest` alias.  Only final vX.Y.Z tags qualify: alphas never
+      # reach pypi-publish, so a non-final ref here is a mis-dispatch and
+      # fails loudly rather than minting a docs version.
       - name: Compute versioned-docs target
         id: target
         env:
@@ -175,19 +176,15 @@ jobs:
         run: |
           set -euo pipefail
           if [[ "$RELEASE" == "true" ]]; then
-            if [[ ! "$GITHUB_REF_NAME" =~ ^v[0-9]+\.[0-9]+\.[0-9]+ ]]; then
-              echo "Release docs publish requires a v*.*.* tag ref (got: $GITHUB_REF_NAME)" >&2
+            if [[ ! "$GITHUB_REF_NAME" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+              echo "Release docs publish requires a final v*.*.* tag ref (got: $GITHUB_REF_NAME)" >&2
               exit 1
             fi
             full="${GITHUB_REF_NAME#v}"
-            aliases=""
-            if [[ "$full" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-              aliases="latest"
-            fi
             {
               echo "version=${full%.*}"
               echo "title=$full"
-              echo "aliases=$aliases"
+              echo "aliases=latest"
             } >> "$GITHUB_OUTPUT"
           else
             {

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -26,6 +26,15 @@ on:
   pull_request:
     branches: [master]
   workflow_dispatch:
+  # release.yml calls this after a successful PyPI publish: the same build
+  # runs on the tag ref and lands in the versioned tree as /<minor>/ with
+  # the `latest` alias (final releases only), instead of /dev/.
+  workflow_call:
+    inputs:
+      release:
+        description: "Publish as the release version derived from the tag ref (instead of dev)"
+        type: boolean
+        default: false
 
 # Allow only one concurrent deployment
 concurrency:
@@ -40,6 +49,10 @@ jobs:
   build:
     if: github.repository == 'terok-ai/terok'
     runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.target.outputs.version }}
+      title: ${{ steps.target.outputs.title }}
+      aliases: ${{ steps.target.outputs.aliases }}
     steps:
       - uses: actions/checkout@v7
 
@@ -151,27 +164,55 @@ jobs:
       - name: Build documentation
         run: poetry run properdocs build --strict
 
-      - name: Setup Pages
-        if: github.repository == 'terok-ai/terok' && github.ref == 'refs/heads/master'
-        uses: actions/configure-pages@v6
+      # Master pushes refresh /dev/; a release call (release.yml, on the
+      # tag ref) lands in /<minor>/ titled with the full version.  Only
+      # final releases take the `latest` alias — an alpha must not become
+      # the site default.
+      - name: Compute versioned-docs target
+        id: target
+        env:
+          RELEASE: ${{ inputs.release || false }}
+        run: |
+          set -euo pipefail
+          if [[ "$RELEASE" == "true" ]]; then
+            if [[ ! "$GITHUB_REF_NAME" =~ ^v[0-9]+\.[0-9]+\.[0-9]+ ]]; then
+              echo "Release docs publish requires a v*.*.* tag ref (got: $GITHUB_REF_NAME)" >&2
+              exit 1
+            fi
+            full="${GITHUB_REF_NAME#v}"
+            aliases=""
+            if [[ "$full" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+              aliases="latest"
+            fi
+            {
+              echo "version=${full%.*}"
+              echo "title=$full"
+              echo "aliases=$aliases"
+            } >> "$GITHUB_OUTPUT"
+          else
+            {
+              echo "version=dev"
+              echo "title="
+              echo "aliases="
+            } >> "$GITHUB_OUTPUT"
+          fi
 
-      - name: Upload artifact
-        if: github.ref == 'refs/heads/master'
-        uses: actions/upload-pages-artifact@v5
+      - name: Upload site for versioned publish
+        if: github.ref == 'refs/heads/master' || inputs.release
+        uses: actions/upload-artifact@v7
         with:
-          path: site
+          name: docs-site
+          path: site/
 
-  deploy:
-    if: github.repository == 'terok-ai/terok' && github.ref == 'refs/heads/master'
+  # TODO(repin): point at the mkdocs-terok release tag (@vX.Y.Z) once
+  # terok-ai/mkdocs-terok#95 ships in a release.
+  publish:
+    if: github.repository == 'terok-ai/terok' && (github.ref == 'refs/heads/master' || inputs.release)
     needs: build
-    runs-on: ubuntu-latest
     permissions:
-      pages: write
-      id-token: write
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
-    steps:
-      - name: Deploy to GitHub Pages
-        id: deployment
-        uses: actions/deploy-pages@v5
+      contents: write
+    uses: terok-ai/mkdocs-terok/.github/workflows/publish-versioned-docs.yml@master
+    with:
+      version: ${{ needs.build.outputs.version }}
+      title: ${{ needs.build.outputs.title }}
+      aliases: ${{ needs.build.outputs.aliases }}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -174,6 +174,6 @@ jobs:
       contents: write
       pages: write
       id-token: write
-    uses: terok-ai/mkdocs-terok/.github/workflows/publish-versioned-docs.yml@v0.7.2
+    uses: terok-ai/mkdocs-terok/.github/workflows/publish-versioned-docs.yml@v0.7.3
     with:
       release: ${{ inputs.release == true }}

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -174,6 +174,6 @@ jobs:
       contents: write
       pages: write
       id-token: write
-    uses: sliwowitz/mkdocs-terok/.github/workflows/publish-versioned-docs.yml@feat/versioned-docs
+    uses: terok-ai/mkdocs-terok/.github/workflows/publish-versioned-docs.yml@v0.7.2a1
     with:
       release: ${{ inputs.release == true }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,6 +63,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+    outputs:
+      prerelease: ${{ steps.classify.outputs.prerelease }}
     steps:
       # No triggering-actor check on github-release: tag creation is already
       # gated by the v*.*.* tag-creation ruleset on the org (release-officers
@@ -93,6 +95,19 @@ jobs:
         with:
           files: dist/*
           prerelease: ${{ steps.classify.outputs.prerelease }}
+
+  # A gh-only (prerelease) release still refreshes the dev docs — the
+  # branch push yielded its deploy to the release pipeline — while final
+  # tags leave the deployment to the pypi path's versioned publish.
+  docs-dev:
+    needs: github-release
+    if: needs.github-release.outputs.prerelease == 'true'
+    permissions:
+      contents: write
+      actions: read
+      pages: write
+      id-token: write
+    uses: ./.github/workflows/docs.yml
 
   pypi-publish:
     needs: build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -128,6 +128,8 @@ jobs:
     permissions:
       contents: write
       actions: read
+      pages: write
+      id-token: write
     uses: ./.github/workflows/docs.yml
     with:
       release: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,8 +63,6 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-    outputs:
-      prerelease: ${{ steps.classify.outputs.prerelease }}
     steps:
       # No triggering-actor check on github-release: tag creation is already
       # gated by the v*.*.* tag-creation ruleset on the org (release-officers
@@ -95,19 +93,6 @@ jobs:
         with:
           files: dist/*
           prerelease: ${{ steps.classify.outputs.prerelease }}
-
-  # A gh-only (prerelease) release still refreshes the dev docs — the
-  # branch push yielded its deploy to the release pipeline — while final
-  # tags leave the deployment to the pypi path's versioned publish.
-  docs-dev:
-    needs: github-release
-    if: needs.github-release.outputs.prerelease == 'true'
-    permissions:
-      contents: write
-      actions: read
-      pages: write
-      id-token: write
-    uses: ./.github/workflows/docs.yml
 
   pypi-publish:
     needs: build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -120,6 +120,18 @@ jobs:
         with:
           attestations: true
 
+  # Versioned docs exist only for what users can `pip install`: publish
+  # the /<minor>/ snapshot (and move `latest`) strictly after the PyPI
+  # upload succeeded.  gh-only and testpypi targets deliberately skip this.
+  docs-version:
+    needs: pypi-publish
+    permissions:
+      contents: write
+      actions: read
+    uses: ./.github/workflows/docs.yml
+    with:
+      release: true
+
   testpypi-publish:
     needs: build
     if: github.event_name == 'workflow_dispatch' && inputs.target == 'testpypi'

--- a/poetry.lock
+++ b/poetry.lock
@@ -2066,23 +2066,20 @@ properdocs = ">=1.6.5"
 
 [[package]]
 name = "mkdocs-terok"
-version = "0.7.2a1"
+version = "0.7.2"
 description = "Shared ProperDocs documentation generators for terok projects"
 optional = false
-python-versions = ">=3.12,<4.0"
+python-versions = "<4.0,>=3.12"
 groups = ["docs"]
 files = [
-    {file = "mkdocs_terok-0.7.2a1-py3-none-any.whl", hash = "sha256:867e6bef283978c186bf8573e8ef5d951a31bee2b692fd0ac8282b358129329a"},
+    {file = "mkdocs_terok-0.7.2-py3-none-any.whl", hash = "sha256:699429790abccd79189a99ff4f2e576ae8b8bf890e91d38da29fd10fe5f270cc"},
+    {file = "mkdocs_terok-0.7.2.tar.gz", hash = "sha256:bde77d4568c87eb3b3eab19a5989688dee44df1662619fa3e95c778d2e8190ef"},
 ]
 
 [package.dependencies]
 properdocs = ">=1.6.7,<1.7.0"
 PyYAML = ">=6.0,<7.0"
 squarify = "0.4.4"
-
-[package.source]
-type = "url"
-url = "https://github.com/terok-ai/mkdocs-terok/releases/download/v0.7.2a1/mkdocs_terok-0.7.2a1-py3-none-any.whl"
 
 [[package]]
 name = "mkdocstrings"
@@ -4541,4 +4538,4 @@ propcache = ">=0.2.1"
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.12,<3.15"
-content-hash = "57bfb2320282dacfd7080066fcc3fec463a4c1839b42b0530cba8c1095165f8f"
+content-hash = "987ee08780e439acfbad99cf0d7c52f951741b9908f11891fb77ef601f976791"

--- a/poetry.lock
+++ b/poetry.lock
@@ -2066,13 +2066,14 @@ properdocs = ">=1.6.5"
 
 [[package]]
 name = "mkdocs-terok"
-version = "0.7.1"
+version = "0.7.2a1"
 description = "Shared ProperDocs documentation generators for terok projects"
 optional = false
 python-versions = ">=3.12,<4.0"
 groups = ["docs"]
-files = []
-develop = false
+files = [
+    {file = "mkdocs_terok-0.7.2a1-py3-none-any.whl", hash = "sha256:867e6bef283978c186bf8573e8ef5d951a31bee2b692fd0ac8282b358129329a"},
+]
 
 [package.dependencies]
 properdocs = ">=1.6.7,<1.7.0"
@@ -2080,10 +2081,8 @@ PyYAML = ">=6.0,<7.0"
 squarify = "0.4.4"
 
 [package.source]
-type = "git"
-url = "https://github.com/sliwowitz/mkdocs-terok.git"
-reference = "feat/versioned-docs"
-resolved_reference = "5d523291b6e24f1c572bbe135996a0d29d79dd07"
+type = "url"
+url = "https://github.com/terok-ai/mkdocs-terok/releases/download/v0.7.2a1/mkdocs_terok-0.7.2a1-py3-none-any.whl"
 
 [[package]]
 name = "mkdocstrings"
@@ -4542,4 +4541,4 @@ propcache = ">=0.2.1"
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.12,<3.15"
-content-hash = "0157e8472e612239283f93e0cee181d0285f51087f25a6a1ceacf8cc5153c409"
+content-hash = "57bfb2320282dacfd7080066fcc3fec463a4c1839b42b0530cba8c1095165f8f"

--- a/poetry.lock
+++ b/poetry.lock
@@ -2069,17 +2069,21 @@ name = "mkdocs-terok"
 version = "0.7.1"
 description = "Shared ProperDocs documentation generators for terok projects"
 optional = false
-python-versions = "<4.0,>=3.12"
+python-versions = ">=3.12,<4.0"
 groups = ["docs"]
-files = [
-    {file = "mkdocs_terok-0.7.1-py3-none-any.whl", hash = "sha256:71f51c8d2d241a808e527ede731983157e817864ab6065a7e74cf84021215e2e"},
-    {file = "mkdocs_terok-0.7.1.tar.gz", hash = "sha256:cdb5715dfa82395bcd61c005603091910924a7609178c6dca26eea814cdf6667"},
-]
+files = []
+develop = false
 
 [package.dependencies]
-properdocs = ">=1.6.7"
-PyYAML = ">=6.0"
-squarify = ">=0.4"
+properdocs = ">=1.6.7,<1.7.0"
+PyYAML = ">=6.0,<7.0"
+squarify = "0.4.4"
+
+[package.source]
+type = "git"
+url = "https://github.com/sliwowitz/mkdocs-terok.git"
+reference = "feat/versioned-docs"
+resolved_reference = "5d523291b6e24f1c572bbe135996a0d29d79dd07"
 
 [[package]]
 name = "mkdocstrings"
@@ -4538,4 +4542,4 @@ propcache = ">=0.2.1"
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.12,<3.15"
-content-hash = "5e27efd6cb9bf0012f90de2d39f51323c0290954442544f8c4ac0fc11181c061"
+content-hash = "0157e8472e612239283f93e0cee181d0285f51087f25a6a1ceacf8cc5153c409"

--- a/poetry.lock
+++ b/poetry.lock
@@ -2066,14 +2066,14 @@ properdocs = ">=1.6.5"
 
 [[package]]
 name = "mkdocs-terok"
-version = "0.7.2"
+version = "0.7.3"
 description = "Shared ProperDocs documentation generators for terok projects"
 optional = false
 python-versions = "<4.0,>=3.12"
 groups = ["docs"]
 files = [
-    {file = "mkdocs_terok-0.7.2-py3-none-any.whl", hash = "sha256:699429790abccd79189a99ff4f2e576ae8b8bf890e91d38da29fd10fe5f270cc"},
-    {file = "mkdocs_terok-0.7.2.tar.gz", hash = "sha256:bde77d4568c87eb3b3eab19a5989688dee44df1662619fa3e95c778d2e8190ef"},
+    {file = "mkdocs_terok-0.7.3-py3-none-any.whl", hash = "sha256:3c628aecc2201e86c5573b0e19d412b602f2534ab49a4c745f2fdd1304b4af04"},
+    {file = "mkdocs_terok-0.7.3.tar.gz", hash = "sha256:67129d19a623dfe6c8acdcef4b2bf8485ea7a38e8de9abf0d51c8f59e9f5a2a4"},
 ]
 
 [package.dependencies]
@@ -4538,4 +4538,4 @@ propcache = ">=0.2.1"
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.12,<3.15"
-content-hash = "987ee08780e439acfbad99cf0d7c52f951741b9908f11891fb77ef601f976791"
+content-hash = "67fec2b0d528e4a541e678210ed57325db99a3078aec8fa7aff052be343a8406"

--- a/properdocs.yml
+++ b/properdocs.yml
@@ -47,11 +47,11 @@ plugins:
           # at the docs-inventories bucket instead of the sibling Pages site.
           inventories:
             - https://docs.python.org/3/objects.inv
-            - { url: "https://raw.githubusercontent.com/terok-ai/docs-inventories/master/terok-executor/objects.inv", base_url: "https://terok-ai.github.io/terok-executor/" }
-            - { url: "https://raw.githubusercontent.com/terok-ai/docs-inventories/master/terok-sandbox/objects.inv", base_url: "https://terok-ai.github.io/terok-sandbox/" }
-            - { url: "https://raw.githubusercontent.com/terok-ai/docs-inventories/master/terok-shield/objects.inv", base_url: "https://terok-ai.github.io/terok-shield/" }
-            - { url: "https://raw.githubusercontent.com/terok-ai/docs-inventories/master/terok-clearance/objects.inv", base_url: "https://terok-ai.github.io/terok-clearance/" }
-            - { url: "https://raw.githubusercontent.com/terok-ai/docs-inventories/master/terok-util/objects.inv", base_url: "https://terok-ai.github.io/terok-util/" }
+            - { url: "https://raw.githubusercontent.com/terok-ai/docs-inventories/master/terok-executor/objects.inv", base_url: "https://terok-ai.github.io/terok-executor/dev/" }
+            - { url: "https://raw.githubusercontent.com/terok-ai/docs-inventories/master/terok-sandbox/objects.inv", base_url: "https://terok-ai.github.io/terok-sandbox/dev/" }
+            - { url: "https://raw.githubusercontent.com/terok-ai/docs-inventories/master/terok-shield/objects.inv", base_url: "https://terok-ai.github.io/terok-shield/dev/" }
+            - { url: "https://raw.githubusercontent.com/terok-ai/docs-inventories/master/terok-clearance/objects.inv", base_url: "https://terok-ai.github.io/terok-clearance/dev/" }
+            - { url: "https://raw.githubusercontent.com/terok-ai/docs-inventories/master/terok-util/objects.inv", base_url: "https://terok-ai.github.io/terok-util/dev/" }
           options:
             docstring_style: google
             show_source: true

--- a/properdocs.yml
+++ b/properdocs.yml
@@ -42,13 +42,16 @@ plugins:
   - mkdocstrings:
       handlers:
         python:
+          # Sibling entries carry an explicit base_url: the .inv URIs are
+          # relative, so without it mkdocstrings would aim cross-repo links
+          # at the docs-inventories bucket instead of the sibling Pages site.
           inventories:
             - https://docs.python.org/3/objects.inv
-            - https://raw.githubusercontent.com/terok-ai/docs-inventories/master/terok-executor/objects.inv
-            - https://raw.githubusercontent.com/terok-ai/docs-inventories/master/terok-sandbox/objects.inv
-            - https://raw.githubusercontent.com/terok-ai/docs-inventories/master/terok-shield/objects.inv
-            - https://raw.githubusercontent.com/terok-ai/docs-inventories/master/terok-clearance/objects.inv
-            - https://raw.githubusercontent.com/terok-ai/docs-inventories/master/terok-util/objects.inv
+            - { url: "https://raw.githubusercontent.com/terok-ai/docs-inventories/master/terok-executor/objects.inv", base_url: "https://terok-ai.github.io/terok-executor/" }
+            - { url: "https://raw.githubusercontent.com/terok-ai/docs-inventories/master/terok-sandbox/objects.inv", base_url: "https://terok-ai.github.io/terok-sandbox/" }
+            - { url: "https://raw.githubusercontent.com/terok-ai/docs-inventories/master/terok-shield/objects.inv", base_url: "https://terok-ai.github.io/terok-shield/" }
+            - { url: "https://raw.githubusercontent.com/terok-ai/docs-inventories/master/terok-clearance/objects.inv", base_url: "https://terok-ai.github.io/terok-clearance/" }
+            - { url: "https://raw.githubusercontent.com/terok-ai/docs-inventories/master/terok-util/objects.inv", base_url: "https://terok-ai.github.io/terok-util/" }
           options:
             docstring_style: google
             show_source: true
@@ -122,6 +125,11 @@ nav:
   - API Reference: reference/
 
 extra:
+  # "mike" names the versions.json contract, not the tool: the versioned
+  # tree on gh-pages is maintained by mkdocs_terok.versions via the
+  # publish-versioned-docs.yml reusable workflow.
+  version:
+    provider: mike
   social:
     - icon: fontawesome/brands/github
       link: https://github.com/terok-ai/terok

--- a/properdocs.yml
+++ b/properdocs.yml
@@ -125,8 +125,8 @@ nav:
   - API Reference: reference/
 
 extra:
-  # "mike" names the versions.json contract, not the tool: the versioned
-  # tree on gh-pages is maintained by mkdocs_terok.versions via the
+  # "mike" names the versions.json contract, not the tool: the deployed
+  # versioned tree is assembled by mkdocs_terok.versions via the
   # publish-versioned-docs.yml reusable workflow.
   version:
     provider: mike

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -127,7 +127,7 @@ mkdocstrings = {extras = ["python"], version = ">=0.26"}
 mkdocs-gen-files = ">=0.5"
 mkdocs-literate-nav = ">=0.6"
 mkdocs-section-index = ">=0.3"
-mkdocs-terok = "^0.7.2"
+mkdocs-terok = "^0.7.3"
 
 
 [tool.pytest.ini_options]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -127,7 +127,7 @@ mkdocstrings = {extras = ["python"], version = ">=0.26"}
 mkdocs-gen-files = ">=0.5"
 mkdocs-literate-nav = ">=0.6"
 mkdocs-section-index = ">=0.3"
-mkdocs-terok = {url = "https://github.com/terok-ai/mkdocs-terok/releases/download/v0.7.2a1/mkdocs_terok-0.7.2a1-py3-none-any.whl"}
+mkdocs-terok = "^0.7.2"
 
 
 [tool.pytest.ini_options]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -127,7 +127,7 @@ mkdocstrings = {extras = ["python"], version = ">=0.26"}
 mkdocs-gen-files = ">=0.5"
 mkdocs-literate-nav = ">=0.6"
 mkdocs-section-index = ">=0.3"
-mkdocs-terok = {git = "https://github.com/sliwowitz/mkdocs-terok.git", branch = "feat/versioned-docs"}
+mkdocs-terok = {url = "https://github.com/terok-ai/mkdocs-terok/releases/download/v0.7.2a1/mkdocs_terok-0.7.2a1-py3-none-any.whl"}
 
 
 [tool.pytest.ini_options]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -127,7 +127,7 @@ mkdocstrings = {extras = ["python"], version = ">=0.26"}
 mkdocs-gen-files = ">=0.5"
 mkdocs-literate-nav = ">=0.6"
 mkdocs-section-index = ">=0.3"
-mkdocs-terok = "^0.7"
+mkdocs-terok = {git = "https://github.com/sliwowitz/mkdocs-terok.git", branch = "feat/versioned-docs"}
 
 
 [tool.pytest.ini_options]


### PR DESCRIPTION
Part of the family-wide versioned-docs rollout (machinery: terok-ai/mkdocs-terok#95 + #97). Users landing from a PyPI install get docs matching their version via Material's version chooser: master merges refresh `/dev/`, each PyPI release serves a frozen `/<minor>/` snapshot, and the newest 6 minors stay served while older versions remain downloadable from their release assets. Full model and rationale: [Versioned Docs Publishing](https://terok-ai.github.io/mkdocs-terok/dev/versioned-docs/).

## What changes

- **properdocs.yml** — `extra.version.provider: mike` (the `versions.json` contract the chooser reads — not the tool); sibling inventory entries become `{ url, base_url }` mappings pointing cross-repo API links at the siblings' `/dev/` docs. **Fixes a live bug**: relative `.inv` URIs resolve against the inventory's own URL, so those links currently 404 into `raw.githubusercontent.com`.
- **docs.yml** — the build job is untouched and uploads the built site as the `docs-site` artifact; a `publish` job hands it to mkdocs-terok's `publish-versioned-docs.yml@v0.7.3` reusable workflow, which owns assembly, deploy, and the one-deployment-per-commit handling.
- **release.yml** — a `docs-version` job (`needs: pypi-publish`) publishes the versioned snapshot: only what ships to PyPI mints a docs version; gh-only releases and alphas don't.
- **pyproject.toml / poetry.lock** — `mkdocs-terok = "^0.7.3"` from PyPI.

Repo settings (already configured): Pages source is "GitHub Actions"; the `github-pages` environment allows `v*` tag deployments (release deploys run on the tag ref).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
