### PR TITLE
fix(docs): restore README logo URLs at the versioned site root

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -174,6 +174,10 @@ jobs:
       contents: write
       pages: write
       id-token: write
-    uses: terok-ai/mkdocs-terok/.github/workflows/publish-versioned-docs.yml@v0.7.3
+    uses: terok-ai/mkdocs-terok/.github/workflows/publish-versioned-docs.yml@v0.7.4
     with:
       release: ${{ inputs.release == true }}
+      # Brand assets hotlinked at the site root by the terok-* READMEs —
+      # rendered on GitHub and in immutable, already-published PyPI
+      # descriptions — so the versioned tree must keep serving them there.
+      root-assets: terok-logo-w.svg terok-logo-b.svg casus-logo.svg hzdr-logo.svg img/architecture.svg


### PR DESCRIPTION
## Problem

Since the versioned docs publish (#1117), the served Pages tree contains only `dev/` + released minors + the chooser/redirect — the brand assets that used to sit at the site root now live only under version dirs. Every terok-* README hotlinks them at the root (`https://terok-ai.github.io/terok/terok-logo-b.svg`, `casus-logo.svg`, `hzdr-logo.svg`, `img/architecture.svg`), so the logos are broken on all GitHub repo pages and on PyPI — including the already-published, immutable terok-util description, which only a server-side fix can heal.

## Fix

Declare those five files as `root-assets` on the reusable publish workflow; mkdocs-terok copies them from the dev build back to the tree root on every deploy (terok-ai/mkdocs-terok#101). No README changes needed anywhere — the old URLs simply work again, retroactively for published PyPI pages.

## Depends on

**terok-ai/mkdocs-terok#101** shipped as **v0.7.4** — the workflow ref here is bumped to `@v0.7.4`, so the Documentation check stays red until that tag exists; re-run it after the mkdocs-terok release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)