### PR TITLE
feat(setup): expose --passphrase-tier and declare the setup invocation

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,10 @@ terok setup                             # idempotent; safe to re-run after upgra
 `setup` installs the shield OCI hooks, the XDG desktop entry for the TUI, and shell
 completions for your detected shell.
 
+Interactive runs prompt for where the credentials-DB passphrase is
+stored; non-interactive hosts without systemd-creds must choose with
+`terok setup --passphrase-tier <keyring|session-file|config>`.
+
 To remove everything later:
 
 ```bash

--- a/docs/index.md
+++ b/docs/index.md
@@ -95,6 +95,10 @@ terok setup
 D-Bus clearance bridge, the XDG desktop entry for the TUI, and shell
 completions for your detected shell.  Idempotent — safe to re-run.
 
+Interactive runs prompt for where the credentials-DB passphrase is
+stored; non-interactive hosts without systemd-creds must choose with
+`terok setup --passphrase-tier <keyring|session-file|config>`.
+
 ### First project
 
 Launch the TUI:

--- a/src/terok/cli/commands/setup.py
+++ b/src/terok/cli/commands/setup.py
@@ -97,6 +97,15 @@ def register(subparsers: argparse._SubParsersAction[argparse.ArgumentParser]) ->
             "``rpm``).  Auto-detected from the base image name otherwise."
         ),
     )
+    p_setup.add_argument(
+        "--passphrase-tier",
+        default=None,
+        help=(
+            "Force credentials-DB passphrase storage to a specific tier "
+            "(``systemd-creds`` | ``keyring`` | ``session-file`` | "
+            "``config``); required on a non-TTY host without systemd-creds."
+        ),
+    )
 
 
 def dispatch(args: argparse.Namespace) -> bool:
@@ -108,6 +117,7 @@ def dispatch(args: argparse.Namespace) -> bool:
         install_desktop_entry=getattr(args, "install_desktop_entry", False),
         with_images=getattr(args, "with_images", None),
         family=getattr(args, "family", None),
+        passphrase_tier=getattr(args, "passphrase_tier", None),
     )
     return True
 
@@ -121,6 +131,7 @@ def cmd_setup(
     install_desktop_entry: bool = False,
     with_images: str | None = None,
     family: str | None = None,
+    passphrase_tier: str | None = None,
 ) -> None:
     """Install the sandbox stack + desktop entry; optionally pre-build one L0/L1 pair.
 
@@ -148,7 +159,7 @@ def cmd_setup(
 
     sandbox_failed = False
     try:
-        ensure_sandbox_ready()
+        ensure_sandbox_ready(passphrase_tier=passphrase_tier)
     except SystemExit as exc:
         sandbox_failed = True
         if exc.code:

--- a/src/terok/cli/main.py
+++ b/src/terok/cli/main.py
@@ -14,6 +14,7 @@ import argparse
 import sys
 
 from terok.lib.api.vault import NoPassphraseError as _NoPassphraseError
+from terok.lib.core.config import declare_setup_invocation
 
 from ..lib.core.config import set_experimental
 from ..lib.core.version import format_version_string, get_version_info
@@ -90,6 +91,7 @@ def main(prog: str = "terok") -> None:
       split exists so ``terok`` can evolve richer UX while ``terokctl``
       preserves backwards compatibility.
     """
+    declare_setup_invocation()
     # Fast-path: bare ``terok`` in a terminal launches the TUI.  Scripts
     # piping ``terok`` get the argparse usage error instead — the TTY
     # check keeps the convenience shortcut from surprising automation.

--- a/src/terok/lib/core/config.py
+++ b/src/terok/lib/core/config.py
@@ -31,6 +31,20 @@ namespace if they prefer."""
 # ---------- Prefix & roots ----------
 
 
+#: Declares, for the sandbox layer's re-run hints, the invocation under
+#: which sandbox setup is embedded in this front-end (protocol shared by
+#: string with terok-sandbox — only the front-end knows its own verbs).
+SETUP_INVOCATION_ENV = "TEROK_SETUP_INVOCATION"
+
+#: This front-end's spelling of the setup invocation.
+SETUP_INVOCATION = "terok setup"
+
+
+def declare_setup_invocation() -> None:
+    """Publish the setup spelling for sandbox-composed hints."""
+    os.environ.setdefault(SETUP_INVOCATION_ENV, SETUP_INVOCATION)
+
+
 def get_prefix() -> Path:
     """
     Minimal prefix helper used primarily for pip/venv installs.

--- a/src/terok/tui/app.py
+++ b/src/terok/tui/app.py
@@ -2081,6 +2081,9 @@ if _HAS_TEXTUAL:
         is already running; ``--new-session`` opts out and starts a parallel,
         tmux-named session instead.
         """
+        from terok.lib.core.config import declare_setup_invocation
+
+        declare_setup_invocation()
         args = _build_arg_parser().parse_args()
         set_experimental(args.experimental)
 

--- a/src/terok/tui/serve.py
+++ b/src/terok/tui/serve.py
@@ -57,6 +57,9 @@ _SCRYPT_PREFIX = "scrypt"
 
 def main() -> None:
     """Run the terok-web server, or update the stored password and exit."""
+    from terok.lib.core.config import declare_setup_invocation
+
+    declare_setup_invocation()
     args = _argparser().parse_args()
     path = _password_path()
 

--- a/tach.toml
+++ b/tach.toml
@@ -884,6 +884,7 @@ expose = [
     "get_shield_on_task_restart",
     "get_public_host",
     "make_sandbox_config",
+    "declare_setup_invocation",
     "SHIELD_SECURITY_HINT",
 ]
 from = ["terok.lib.core.config"]

--- a/tests/unit/cli/test_cli_setup_global.py
+++ b/tests/unit/cli/test_cli_setup_global.py
@@ -44,6 +44,7 @@ def test_dispatch_invokes_cmd_setup_with_flag() -> None:
         install_desktop_entry=False,
         with_images=None,
         family=None,
+        passphrase_tier=None,
     )
 
 
@@ -65,6 +66,7 @@ def test_dispatch_forwards_install_desktop_entry() -> None:
         install_desktop_entry=True,
         with_images=None,
         family=None,
+        passphrase_tier=None,
     )
 
 
@@ -86,6 +88,7 @@ def test_dispatch_forwards_with_images_and_family() -> None:
         install_desktop_entry=False,
         with_images="fedora:43",
         family="rpm",
+        passphrase_tier=None,
     )
 
 


### PR DESCRIPTION
Fixes the user report: the first terok run's host-service initialization can hit sandbox's non-TTY passphrase-tier guard, whose hint says to pass `--passphrase-tier` — a flag `terok` never exposed, and a hint prefixed `terok-sandbox setup:`, a binary the user never typed.

- `terok setup` gains `--passphrase-tier` (`systemd-creds` | `keyring` | `session-file` | `config`), forwarded through `ensure_sandbox_ready`'s existing kwargs pass-through; the sandbox aggregator fail-fast validates the value. Works with the currently pinned sandbox wheel.
- All three front-end entries (CLI, TUI, web) declare `TEROK_SETUP_INVOCATION="terok setup"` — the generic mechanism from terok-ai/terok-sandbox#419: sandbox-composed re-run hints must name an invocation the consuming front-end actually exposes, and only the front-end knows under which of its verbs the provisioning is embedded, so the spelling is **declared by the consumer**, not derived from argv. The env-var name is the whole contract (no import, no version coupling); until the next sandbox release the hint keeps its current `terok-sandbox setup` spelling, which also remains a valid remedy forever.
- README/index gain a one-line note about the flag for non-interactive hosts.

Companions: terok-ai/terok-sandbox#419 (hint rendering), terok-ai/terok-executor#429 (same flag + declaration for `terok-executor setup`).

Setup CLI + TUI setup-flow tests updated and green (28/28 locally).

🤖 Generated with [Claude Code](https://claude.com/claude-code)