### PR TITLE
fix(docs): lock mkdocs-terok 0.7.4 so the deploy gets the root-assets assembler

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -2066,14 +2066,14 @@ properdocs = ">=1.6.5"
 
 [[package]]
 name = "mkdocs-terok"
-version = "0.7.3"
+version = "0.7.4"
 description = "Shared ProperDocs documentation generators for terok projects"
 optional = false
 python-versions = "<4.0,>=3.12"
 groups = ["docs"]
 files = [
-    {file = "mkdocs_terok-0.7.3-py3-none-any.whl", hash = "sha256:3c628aecc2201e86c5573b0e19d412b602f2534ab49a4c745f2fdd1304b4af04"},
-    {file = "mkdocs_terok-0.7.3.tar.gz", hash = "sha256:67129d19a623dfe6c8acdcef4b2bf8485ea7a38e8de9abf0d51c8f59e9f5a2a4"},
+    {file = "mkdocs_terok-0.7.4-py3-none-any.whl", hash = "sha256:5bf8624f49c2e7d7354d1ac92f91ce8d5a487e2c1d7bb022808ca31bac4c6d7f"},
+    {file = "mkdocs_terok-0.7.4.tar.gz", hash = "sha256:27b9bb0f7a09960083722bff8b2f9098be91c61824ac0ed22848fe94e553178d"},
 ]
 
 [package.dependencies]


### PR DESCRIPTION
Completes #1123. The reusable workflow runs `mkdocs_terok.versions` from the **calling repo's locked docs environment** — the `@v0.7.4` workflow ref passes `--root-assets`, but the lockfile still resolved mkdocs-terok 0.7.3, whose assembler doesn't know the flag. The master docs deploy failed with:

```
python -m mkdocs_terok.versions: error: unrecognized arguments: --root-assets terok-logo-w.svg ...
```

`pyproject.toml`'s `^0.7.3` already covers 0.7.4, so this is a lock-only bump (`poetry update mkdocs-terok --lock`). After merge, the master deploy restores the README logo URLs at the site root.

🤖 Generated with [Claude Code](https://claude.com/claude-code)