### PR TITLE
fix(ci): stop PR docs builds from evicting queued master deploys

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -36,10 +36,14 @@ on:
         type: boolean
         default: false
 
-# Allow only one concurrent deployment
+# Concurrency is per ref: GitHub keeps only the newest *pending* run
+# per group, so a shared group let PR builds silently evict queued
+# master deploys. Superseded PR builds are cancelled outright; pushes
+# never are. Actual Pages deployments are serialized by the job-level
+# group inside publish-versioned-docs.yml.
 concurrency:
-  group: "pages"
-  cancel-in-progress: false
+  group: docs-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 permissions:
   contents: read


### PR DESCRIPTION
## Problem

`docs.yml` shares one workflow-level concurrency group (`"pages"`) across every ref. GitHub keeps only the newest **pending** run per group, so a PR push while a master deploy is queued silently cancels that deploy. This just bit us: after #1123 merged, the `feat/shared-matrix-engine` PR build evicted three queued master deploys, and the logo fix never reached the site until a manual `workflow_dispatch`.

## Fix

- `group: docs-${{ github.ref }}` — PR builds and master deploys queue independently; two quick master pushes still coalesce to the newest (desired: each deploy publishes the full tree).
- `cancel-in-progress: ${{ github.event_name == 'pull_request' }}` — superseded PR builds are cancelled outright (feedback-only); master/tag runs never are.

Deploy serialization doesn't regress: the actual Pages deployment is already guarded by the job-level `versioned-docs-${{ github.repository }}` group inside `publish-versioned-docs.yml` (workflow-level concurrency is ignored under `workflow_call` anyway).

## Note

All six sibling repos (mkdocs-terok, terok-util, terok-sandbox, terok-executor, terok-shield, terok-clearance) carry the identical `group: "pages"` stanza in their docs.yml and are exposed to the same eviction — same one-line fix applies if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
