### PR TITLE
feat(restart): keep container on plain restart, make image upgrade opt-in

### DIFF
--- a/docs/container-lifecycle.md
+++ b/docs/container-lifecycle.md
@@ -86,15 +86,20 @@ All three persist independently and survive:
 |---------|---------------------------|---------------------------|------------------------|
 | `task run` | Always creates a fresh task + container (new ID) | Always creates a fresh task + container (new ID) | Always creates a fresh task + container (new ID) |
 | `task stop` | `podman stop` | Error: not running | Error: not running |
-| `task restart` | `podman stop`, then resume — or recreate in place on `--fresh` / image drift | Resume (`podman start`) — or recreate in place on `--fresh` / image drift | Recreates the container in place (same task ID, name, workspace) |
+| `task restart` | `podman stop`, then resume as-is (warns on image drift) — or recreate on `--recreate` | Resume (`podman start`) as-is (warns on image drift) — or recreate on `--recreate` | Recreates the container in place (same task ID, name, workspace) |
 | `task status`  | Shows state            | Shows state     | Shows "not found"      |
 | `task delete` | `podman rm -f` + cleanup | `podman rm -f` + cleanup | Cleanup only |
 
 `task restart` is a resume-or-recreate ladder: it resumes the existing
-container when it can, and otherwise warns and recreates it through the
-normal launch path (workspace kept, fresh tokens).  Headless tasks are the
-exception — recreating would replay their original prompt, so a missing
-container is an error there.
+container when it can — keeping it as-is even when the project image was
+rebuilt underneath it, so a long-running task keeps its in-container
+state.  A stale image is only *warned* about (pointing at recreate +
+restart), not upgraded.  When the resume rung is gone — the container no
+longer exists, or podman refuses to start it — it recreates through the
+normal launch path (workspace kept, fresh tokens).  `--recreate` skips
+straight to that rung, the explicit upgrade that picks up a rebuilt
+image.  Headless tasks are the exception — recreating would replay their
+original prompt, so a missing container is an error there.
 
 ### Container Naming
 
@@ -184,14 +189,16 @@ Container's build-context hash ≠ current build hash
         │
         ▼
   User should: terok project build <project>
-               then: terok task restart <project> <task>
+               then: terok task restart <project> <task> --recreate
 ```
 
 Staleness is detected by comparing per-layer build-context hashes
 (`build_manifest.json`, with the `terok.build_context_hash` image label
-as fallback) — not raw image IDs.  `task restart` probes for image drift
-and recreates the container in place automatically; `--fresh` forces it.
-The workspace is kept either way — no need to delete the task.
+as fallback) — not raw image IDs.  A plain `task restart` resumes the
+container as-is and *warns* when the image has drifted, leaving a
+long-running task on its existing image; `--recreate` picks up the
+rebuilt image by recreating the container in place.  The workspace is
+kept either way — no need to delete the task.
 
 ---
 

--- a/docs/developer.md
+++ b/docs/developer.md
@@ -161,14 +161,17 @@ Containers follow podman's own lifecycle, split across the three layers:
 - **terok** owns tasks (container + workspace + metadata).  The mode
   runners (`task_runners/cli.py`, `toad.py`) only ever *create*;
   everything that brings a container back goes through one ladder in
-  `task_runners/restart.py`: resume the existing container, else warn
-  and recreate it in place through the normal launch path (same names,
+  `task_runners/restart.py`: resume the existing container, else
+  recreate it in place through the normal launch path (same names,
   fresh tokens, config re-read, per-task settings from metadata).
-  `task_restart` is the ladder's bounce flavor (stop-if-running first,
-  `--fresh` forces recreate, an image-ID drift probe triggers it
-  automatically); `ensure_task_running` is the attach flavor (a running
-  container is reported, never disturbed).  Headless tasks never take
-  the recreate rung — that would replay their original prompt.
+  `task_restart` is the ladder's bounce flavor (stop-if-running first);
+  a plain restart resumes the container as-is and an image-ID drift
+  probe only *warns* that the image is stale (long-running tasks keep
+  their in-container state), while `--recreate` (`fresh=True`) forces
+  the recreate rung to pick up a rebuilt image.  `ensure_task_running`
+  is the attach flavor (a running container is reported, never
+  disturbed).  Headless tasks never take the recreate rung — that would
+  replay their original prompt.
 
 Invariants: the task workspace is never re-seeded on relaunch (the
 new-task-marker protocol decides), podman is the source of truth for

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -394,8 +394,8 @@ terok task logs myproj v9krt --raw        # Raw podman output
 
 # Stop or restart a task
 terok task stop myproj v9krt
-terok task restart myproj v9krt           # Resume; recreates in place if it can't
-terok task restart myproj v9krt --fresh   # Force recreate (e.g. rebuilt image)
+terok task restart myproj v9krt             # Resume as-is; warns if the image drifted
+terok task restart myproj v9krt --recreate  # Recreate to pick up a rebuilt image
 
 # Delete a task
 terok task delete myproj v9krt

--- a/src/terok/cli/commands/task.py
+++ b/src/terok/cli/commands/task.py
@@ -261,14 +261,15 @@ def register(
 
     t_restart = tsub.add_parser(
         "restart",
-        help="Restart a task's container (stop if running, then start; "
-        "recreates in place when the container can't be resumed)",
+        help="Restart a task's container (stop if running, then resume in "
+        "place; the container is kept as-is even when the project image was "
+        "rebuilt — a stale image is warned about, not upgraded)",
     )
     t_restart.add_argument(
-        "--fresh",
+        "--recreate",
         action="store_true",
-        help="Skip the resume and recreate the container (e.g. after an image "
-        "rebuild); the workspace is kept as-is",
+        help="Recreate the container instead of resuming it, picking up a "
+        "rebuilt project image; the workspace is kept as-is",
     )
     _add_project_task_args(t_restart)
 
@@ -742,7 +743,7 @@ def _dispatch_task_sub(args: argparse.Namespace) -> bool:
         task_stop(pid, tid, timeout=getattr(args, "timeout", None))
     elif args.task_cmd == "restart":
         _setup_verdict_or_exit()
-        task_restart(pid, tid, fresh=args.fresh)
+        task_restart(pid, tid, fresh=args.recreate)
     elif args.task_cmd == "followup":
         _setup_verdict_or_exit()
         task_followup_headless(

--- a/src/terok/lib/orchestration/task_runners/restart.py
+++ b/src/terok/lib/orchestration/task_runners/restart.py
@@ -46,7 +46,7 @@ def task_restart(project_name: str, task_id: str, *, fresh: bool = False) -> Non
     container in place — kept as-is even when the project image was
     rebuilt underneath it, so a long-running task keeps its in-container
     state.  A stale image is only *warned* about, not acted on (see
-    [`_warn_if_stale_image`][terok.lib.orchestration.task_runners.restart._warn_if_stale_image]).
+    ``_warn_if_stale_image``).
     When the resume rung is gone — the container no longer exists or
     podman refuses to start it — recreate the container through the
     normal launch path: same task and container name, workspace reused
@@ -154,8 +154,7 @@ def _recreate_reason(container_state: str | None, *, fresh: bool) -> str | None:
 
     Image drift is deliberately *not* a reason: a plain restart keeps a
     long-running task's container as-is and only warns about the stale
-    image (see
-    [`_warn_if_stale_image`][terok.lib.orchestration.task_runners.restart._warn_if_stale_image]).
+    image (see ``_warn_if_stale_image``).
     Picking up a rebuilt image is the explicit job of *fresh* — the
     "recreate + restart" the caller asked for.
     """

--- a/src/terok/lib/orchestration/task_runners/restart.py
+++ b/src/terok/lib/orchestration/task_runners/restart.py
@@ -43,14 +43,19 @@ def task_restart(project_name: str, task_id: str, *, fresh: bool = False) -> Non
     """Bring a task's container back to running: stop if running, then start.
 
     The start is a best-effort ladder.  First rung: resume the existing
-    container in place.  When that rung is gone — the container no longer
-    exists, podman refuses to start it, or its image no longer matches
-    the current project image — warn and recreate the container through
-    the normal launch path: same task and container name, workspace
-    reused as-is (never re-seeded), project config re-read, tokens
-    minted fresh, per-task settings carried over from the saved
-    metadata.  *fresh* skips straight to the recreate rung (e.g. to pick
-    up a rebuilt image).
+    container in place — kept as-is even when the project image was
+    rebuilt underneath it, so a long-running task keeps its in-container
+    state.  A stale image is only *warned* about, not acted on (see
+    [`_warn_if_stale_image`][terok.lib.orchestration.task_runners.restart._warn_if_stale_image]).
+    When the resume rung is gone — the container no longer exists or
+    podman refuses to start it — recreate the container through the
+    normal launch path: same task and container name, workspace reused
+    as-is (never re-seeded), project config re-read, tokens minted fresh,
+    per-task settings carried over from the saved metadata.
+
+    *fresh* skips straight to the recreate rung — the explicit
+    "recreate + restart" that picks up a rebuilt image, upgrading a task
+    that a plain restart deliberately left on its old image.
 
     Headless tasks (mode ``run``) only ever take the resume rung:
     recreating one would replay its original prompt against the
@@ -120,7 +125,7 @@ def _make_running(
     if bounce:
         print(f"Restarting task {project_name}/{task_id} ({mode})...")
 
-    reason = _recreate_reason(project, mode, cname, container_state, fresh=fresh)
+    reason = _recreate_reason(container_state, fresh=fresh)
 
     if container_state is not None:
         _validate_restart_preconditions(project, task_id, mode, meta, cname)
@@ -144,23 +149,47 @@ def _make_running(
     )
 
 
-def _recreate_reason(
-    project: ProjectConfig, mode: str, cname: str, container_state: str | None, *, fresh: bool
-) -> str | None:
+def _recreate_reason(container_state: str | None, *, fresh: bool) -> str | None:
     """First reason the resume rung can't be taken, or ``None`` to resume.
 
-    Headless tasks skip the image-drift probe: they have no recreate
-    rung (the refusal in
-    [`_recreate_in_place`][terok.lib.orchestration.task_runners.restart._recreate_in_place]),
-    so flagging drift would only turn a working resume into an error.
+    Image drift is deliberately *not* a reason: a plain restart keeps a
+    long-running task's container as-is and only warns about the stale
+    image (see
+    [`_warn_if_stale_image`][terok.lib.orchestration.task_runners.restart._warn_if_stale_image]).
+    Picking up a rebuilt image is the explicit job of *fresh* — the
+    "recreate + restart" the caller asked for.
     """
     if fresh:
-        return "--fresh requested"
+        return "recreate requested"
     if container_state is None:
         return "the container no longer exists"
+    return None
+
+
+def _warn_if_stale_image(project: ProjectConfig, task_id: str, mode: str, cname: str) -> None:
+    """Print a highlighted warning when a resumed container's image is stale.
+
+    A plain restart keeps the existing container even when the project
+    image was rebuilt underneath it — long-running tasks depend on their
+    in-container state and prefer stability over an upgrade.  This makes
+    the reuse a *visible* choice rather than silent staleness: it names
+    the drift and points at the recreate + restart that would pick up the
+    new image.  Headless tasks (mode ``run``) are skipped — they have no
+    recreate rung to point at.
+    """
     if mode == "run":
-        return None
-    return _image_drift(project, cname)
+        return
+    drift = _image_drift(project, cname)
+    if drift is None:
+        return
+    print(
+        _yellow(
+            f"Warning: task {task_id} restarted on an OUTDATED image ({drift}).\n"
+            f"  The container was reused as-is.  Recreate + restart to upgrade it "
+            f"to the rebuilt image (TUI: R;  CLI: terok task restart --recreate).",
+            _supports_color(),
+        )
+    )
 
 
 def _image_drift(project: ProjectConfig, cname: str) -> str | None:
@@ -248,6 +277,7 @@ def _start_and_report_restart(
     )
     _apply_shield_policy(project, cname, task_dir, is_restart=True)
 
+    _warn_if_stale_image(project, task_id, mode, cname)
     print(f"Restarted task {task_id}: {_green(cname, _supports_color())}")
     _print_reach_footer(project, task_id, mode, cname, meta)
 

--- a/src/terok/tui/app.py
+++ b/src/terok/tui/app.py
@@ -173,6 +173,7 @@ if _HAS_TEXTUAL:
         "task_start_unattended": "_action_task_start_unattended",
         "delete": "action_delete_task",
         "restart": "_action_restart_task",
+        "recreate": "_action_recreate_task",
         "followup": "_action_task_followup",
         "diff_head": "action_copy_diff_head",
         "diff_prev": "action_copy_diff_prev",

--- a/src/terok/tui/screens.py
+++ b/src/terok/tui/screens.py
@@ -1823,6 +1823,7 @@ class TaskDetailsScreen(screen.Screen[str | None]):
                 options.append(Option("view \\[f]ormatted logs", id="follow_logs"))
             options.append(None)
             options.append(Option("\\[r]estart container", id="restart"))
+            options.append(Option("\\[R]ecreate + restart  (pick up new image)", id="recreate"))
             options.append(Option("s\\[t]op container", id="stop"))
             if (
                 self._task_meta
@@ -1901,6 +1902,7 @@ class TaskDetailsScreen(screen.Screen[str | None]):
         # Shift keys (uppercase) — U always available, others require tasks
         shift_map: dict[str, str] = {
             "U": "task_start_unattended",
+            "R": "recreate",
             "H": "diff_head",
             "P": "diff_prev",
             "X": "delete",
@@ -1909,7 +1911,7 @@ class TaskDetailsScreen(screen.Screen[str | None]):
             "C": "show_clearance",
         }
         if key in shift_map:
-            if key in ("H", "P", "X", "D", "W", "C") and not self._has_tasks:
+            if key in ("R", "H", "P", "X", "D", "W", "C") and not self._has_tasks:
                 return
             self.dismiss(shift_map[key])
             event.stop()

--- a/src/terok/tui/task_actions.py
+++ b/src/terok/tui/task_actions.py
@@ -626,8 +626,7 @@ class TaskActionsMixin(_MixinBase):
 
         Keeps the container as-is even when the project image was
         rebuilt; a stale image is warned about, not upgraded.  Use
-        [`_action_recreate_task`][terok.tui.task_actions.TaskActionsMixin._action_recreate_task]
-        to pick up a rebuilt image.
+        ``_action_recreate_task`` to pick up a rebuilt image.
         """
         if not self.current_project_name or not self.current_task:
             self.notify("No task selected.")

--- a/src/terok/tui/task_actions.py
+++ b/src/terok/tui/task_actions.py
@@ -622,7 +622,13 @@ class TaskActionsMixin(_MixinBase):
         )
 
     async def _action_restart_task(self) -> None:
-        """Restart a task container (stops it first if running)."""
+        """Restart a task container in place (stops it first if running).
+
+        Keeps the container as-is even when the project image was
+        rebuilt; a stale image is warned about, not upgraded.  Use
+        [`_action_recreate_task`][terok.tui.task_actions.TaskActionsMixin._action_recreate_task]
+        to pick up a rebuilt image.
+        """
         if not self.current_project_name or not self.current_task:
             self.notify("No task selected.")
             return
@@ -633,6 +639,21 @@ class TaskActionsMixin(_MixinBase):
             pid,
             tid,
             title=f"Restarting task {tid}",
+            refresh="tasks",
+        )
+
+    async def _action_recreate_task(self) -> None:
+        """Recreate + restart a task container, picking up a rebuilt image."""
+        if not self.current_project_name or not self.current_task:
+            self.notify("No task selected.")
+            return
+        pid = self.current_project_name
+        tid = self.current_task.task_id
+        self._run_console_action(
+            "terok.tui.worker_actions:task_recreate",
+            pid,
+            tid,
+            title=f"Recreating task {tid}",
             refresh="tasks",
         )
 

--- a/src/terok/tui/worker_actions.py
+++ b/src/terok/tui/worker_actions.py
@@ -238,10 +238,29 @@ def selinux_switch_to_tcp() -> None:
 
 
 def task_restart(project_name: str, task_id: str) -> None:
-    """Restart *task_id*'s container (stopping it first if running)."""
+    """Restart *task_id*'s container (stopping it first if running).
+
+    Resumes the container in place, keeping it as-is even when the
+    project image was rebuilt — a stale image is warned about, not
+    upgraded.  Use [`task_recreate`][terok.tui.worker_actions.task_recreate]
+    to pick up a rebuilt image.
+    """
     from terok.lib.api import task_restart as _task_restart
 
     _task_restart(project_name, task_id)
+
+
+def task_recreate(project_name: str, task_id: str) -> None:
+    """Recreate + restart *task_id*'s container, picking up a rebuilt image.
+
+    The recreate flavor of [`task_restart`][terok.tui.worker_actions.task_restart]:
+    tears the container down and relaunches it into the same name and
+    workspace, upgrading a task that a plain restart left on its old
+    image.
+    """
+    from terok.lib.api import task_restart as _task_restart
+
+    _task_restart(project_name, task_id, fresh=True)
 
 
 def task_stop(project_name: str, task_id: str) -> None:

--- a/tests/unit/lib/test_container_lifecycle.py
+++ b/tests/unit/lib/test_container_lifecycle.py
@@ -389,7 +389,7 @@ def test_ensure_task_running_launches_missing_container() -> None:
 
 
 def test_task_restart_fresh_skips_resume_and_recreates() -> None:
-    """``--fresh`` tears a healthy running container down and relaunches it."""
+    """``--recreate`` (fresh) tears a healthy running container down and relaunches it."""
     project_name = "proj_restart_fresh"
     with project_env(project_config(project_name), project_name=project_name) as ctx:
         task_id = create_task_with_mode(ctx, project_name)
@@ -412,13 +412,21 @@ def test_task_restart_fresh_skips_resume_and_recreates() -> None:
         run_cli.assert_called_once()
 
 
-def test_task_restart_image_drift_recreates() -> None:
-    """A container built from a superseded project image takes the recreate rung."""
+def test_task_restart_image_drift_warns_and_resumes() -> None:
+    """A container on a superseded image is resumed as-is, with a stale-image warning.
+
+    A plain restart keeps a long-running task's container rather than
+    upgrading it: it starts the existing container and only warns that
+    the image is out of date, pointing at recreate + restart.
+    """
     project_name = "proj_restart_drift"
     with project_env(project_config(project_name), project_name=project_name) as ctx:
         task_id = create_task_with_mode(ctx, project_name)
 
+        container_name = f"{project_name}-cli-{task_id}"
         container = _mock_container(state="exited")
+        container.login_command.return_value = ["podman", "exec", "-it", container_name, "bash"]
+        container.start.side_effect = lambda: setattr(container, "state", "running")
         runtime_mock = _mock_runtime(container)
         rebuilt = Mock()
         rebuilt.id = "img-rebuilt"
@@ -431,9 +439,38 @@ def test_task_restart_image_drift_recreates() -> None:
         ):
             output = capture_stdout(task_restart, project_name, task_id)
 
+        assert "OUTDATED image" in output
         assert "rebuilt" in output
+        assert "--recreate" in output
+        container.start.assert_called_once()
+        sandbox.return_value.rm.assert_not_called()
+        run_cli.assert_not_called()
+        assert "Restarted" in output
+
+
+def test_task_restart_recreate_on_image_drift_upgrades() -> None:
+    """``--recreate`` (fresh) tears the container down and relaunches on the new image."""
+    project_name = "proj_restart_drift_recreate"
+    with project_env(project_config(project_name), project_name=project_name) as ctx:
+        task_id = create_task_with_mode(ctx, project_name)
+        container_name = f"{project_name}-cli-{task_id}"
+
+        container = _mock_container(state="exited")
+        runtime_mock = _mock_runtime(container)
+        rebuilt = Mock()
+        rebuilt.id = "img-rebuilt"
+        runtime_mock.image.return_value = rebuilt
+        with (
+            mock_git_config(),
+            patch("terok.lib.core.runtime.resolve_runtime", return_value=runtime_mock),
+            patch("terok.lib.orchestration.task_runners.restart._sandbox") as sandbox,
+            patch("terok.lib.orchestration.task_runners.restart.task_run_cli") as run_cli,
+        ):
+            output = capture_stdout(task_restart, project_name, task_id, fresh=True)
+
+        assert "Recreating" in output
         container.start.assert_not_called()
-        sandbox.return_value.rm.assert_called_once()
+        sandbox.return_value.rm.assert_called_once_with([container_name])
         run_cli.assert_called_once()
 
 

--- a/tests/unit/tui/test_worker_actions.py
+++ b/tests/unit/tui/test_worker_actions.py
@@ -204,6 +204,13 @@ def test_task_restart_and_stop_delegate_to_facade() -> None:
     m_stop.assert_called_once_with("proj", "tid")
 
 
+def test_task_recreate_delegates_with_fresh() -> None:
+    """``task_recreate`` forwards to the facade with ``fresh=True`` (recreate rung)."""
+    with mock.patch("terok.lib.api.task_restart") as m_restart:
+        worker_actions.task_recreate("proj", "tid")
+    m_restart.assert_called_once_with("proj", "tid", fresh=True)
+
+
 def test_start_cli_container_delegates_to_task_run_cli() -> None:
     """``start_cli_container`` forwards ``(project_name, task_id)`` to ``task_run_cli``."""
     with mock.patch("terok.lib.api.task_run_cli") as m:


### PR DESCRIPTION
A plain `task restart` now resumes the existing container as-is even when the project image was rebuilt underneath it, and only warns that the image is stale — pointing at recreate + restart to upgrade. This suits long-running tasks that depend on in-container state and prefer stability until they choose to upgrade; short-lived tasks are unaffected, as new tasks always start from the current image.

Recreating the container to pick up a rebuilt image is now an explicit choice:

- TUI: `r` restarts in place, `R` recreates + restarts.
- CLI: `terok task restart` resumes, `--recreate` (renamed from `--fresh`) upgrades.

Image drift is dropped as a recreate reason; the recreate rung is taken only when resume is impossible (container gone / start fails) or the caller asks for it.