### PR TITLE
fix(tui): keep Enter as Login on the task launch screen's agent select

### DIFF
--- a/src/terok/tui/screens.py
+++ b/src/terok/tui/screens.py
@@ -1280,6 +1280,26 @@ else:  # pragma: no cover - stub TextArea in test envs
     _SubmittablePromptArea = TextArea  # type: ignore[assignment,misc]
 
 
+if Select is not None:
+
+    class _LoginAgentSelect(Select):
+        """Agent dropdown where Enter confirms the dialog instead of expanding it.
+
+        The stock Select binds Enter alongside Space/Up/Down to "open the
+        option list", which makes Enter flip meaning as focus moves across
+        the launch dialog. Subclass bindings replace same-key bindings from
+        the base class, so Enter alone is rebound to the host screen's
+        ``login`` action — the same reflex as the prompt area beside it —
+        while Space/Up/Down keep expanding the list. Once the list is
+        expanded, focus sits on the overlay, whose own Enter binding
+        confirms the highlighted option before this one is consulted.
+        """
+
+        BINDINGS = [_modal_binding("enter", "screen.login", "Login")]
+else:  # pragma: no cover - stub Select in test envs
+    _LoginAgentSelect = Select  # type: ignore[assignment,misc]
+
+
 class TaskLaunchScreen(
     screen.ModalScreen["tuple[str, str, str, str, str | None, str | None] | None"]
 ):
@@ -1390,7 +1410,7 @@ class TaskLaunchScreen(
             choices = self._build_agent_choices()
             valid_values = {v for _, v in choices}
             login_value = self._default_shell if self._default_shell in valid_values else "bash"
-            yield Select(
+            yield _LoginAgentSelect(
                 choices,
                 value=login_value,
                 id="login-agent",
@@ -1460,29 +1480,32 @@ class TaskLaunchScreen(
         """Refresh the Enter hint whenever focus moves between the dialog's controls."""
         self._refresh_hint()
 
+    # Enter means "log in" on both of these widgets — via the bubbled key in
+    # ``on_key`` for the prompt (``_SubmittablePromptArea``) and via the
+    # ``screen.login`` binding for the agent select (``_LoginAgentSelect``).
+    _ENTER_LOGS_IN = frozenset({"launch-prompt", "login-agent"})
+
     def _enter_hint(self) -> str | None:
         """What Enter does for the focused control right now, or ``None`` when nothing.
 
-        Enter reaches login only from the prompt, and only once the container is
-        ready — until then it's a dimmed, hourglassed promise that brightens in
-        place the moment login goes live. On the agent ``Select`` Enter expands the
-        dropdown; on the action buttons it activates the focused one, whose own
-        caption already says what that is — so those drop the segment rather than
-        echo the label.
+        Enter reaches login from the prompt and from the collapsed agent select,
+        and only once the container is ready — until then it's a dimmed,
+        hourglassed promise that brightens in place the moment login goes live.
+        On the action buttons Enter activates the focused one, whose own caption
+        already says what that is — so those drop the segment rather than echo
+        the label.
         """
         focused = self.focused
-        focused_id = focused.id if focused else None
-        if focused_id == "launch-prompt":
+        if focused is not None and focused.id in self._ENTER_LOGS_IN:
             return "Enter login" if self._container_ready else "[dim]Enter login ⌛[/dim]"
-        if focused_id == "login-agent":
-            return "Enter shows agent list"
         return None
 
     def _refresh_hint(self) -> None:
         """Rebuild the border subtitle for the current focus and readiness state."""
-        prompt_focused = self.focused is not None and self.focused.id == "launch-prompt"
+        focused_id = self.focused.id if self.focused else None
         subtitle = _join_hints(
-            "Ctrl+J newline" if prompt_focused else None,
+            "Ctrl+J newline" if focused_id == "launch-prompt" else None,
+            "Space agent list" if focused_id == "login-agent" else None,
             "Esc dismiss",
             self._enter_hint(),
         )
@@ -1493,14 +1516,20 @@ class TaskLaunchScreen(
 
         Newline insertion (Ctrl+Enter / Shift+Enter / Ctrl+J) is owned by
         `_SubmittablePromptArea` and never reaches here; Tab still cycles
-        focus by default.
+        focus by default. Enter on the agent select arrives through the
+        ``screen.login`` binding (see ``action_login``), not this handler.
         """
-        # Only act on Enter while the prompt TextArea holds focus.
-        if not self.query_one("#launch-prompt", TextArea).has_focus:
+        focused = self.focused
+        if focused is None or focused.id != "launch-prompt":
             return
         if event.key == "enter" and self._container_ready:
             self._do_login()
             event.stop()
+
+    def action_login(self) -> None:
+        """Log in once the container is ready — Enter on the agent select lands here."""
+        if self._container_ready:
+            self._do_login()
 
     # If no container has appeared within this many wall-clock seconds, assume
     # the launch failed and surface a hint.  Wall-clock based (not tick count)

--- a/tests/unit/tui/test_new_task_flow.py
+++ b/tests/unit/tui/test_new_task_flow.py
@@ -311,122 +311,88 @@ class TestTaskLaunchScreen:
         screen.on_input_submitted(event)
         screen._do_login.assert_called_once()
 
+    @staticmethod
+    def _screen_focused_on(focused_id: str | None, *, ready: bool):
+        """Launch screen with mocked login and focus resting on *focused_id*."""
+        screens, _ = import_screens()
+        screen = screens.TaskLaunchScreen(container_name="c", project_name="p", task_id="1")
+        screen._container_ready = ready
+        screen._do_login = mock.Mock()
+        screen.focused = None if focused_id is None else types.SimpleNamespace(id=focused_id)
+        return screen
+
     def test_on_key_ctrl_enter_is_owned_by_the_widget(self) -> None:
         """The screen ignores Ctrl+Enter — newline insertion lives in the widget.
 
         ``_SubmittablePromptArea`` inserts the newline and stops the event, so
         Ctrl+Enter never reaches the screen's ``on_key``; if it somehow does,
-        the screen must treat it as a no-op (no insert, no submit).
+        the screen must treat it as a no-op (no submit).
         """
-        screens, _ = import_screens()
-        screen = screens.TaskLaunchScreen(container_name="c", project_name="p", task_id="1")
+        screen = self._screen_focused_on("launch-prompt", ready=True)
 
-        mock_textarea = mock.Mock()
-        mock_textarea.text = "line1"
-        mock_textarea.has_focus = True
-        mock_textarea.insert = mock.Mock()
-
-        mock_select = mock.Mock()
-
-        def query_one(selector, cls=None):
-            if "login-agent" in selector:
-                return mock_select
-            return mock_textarea
-
-        screen.query_one = query_one
-
-        # Simulate Ctrl+Enter
         event = mock.Mock()
         event.key = "ctrl+enter"
         screen.on_key(event)
 
-        # The screen does nothing — the widget already handled the newline.
-        mock_textarea.insert.assert_not_called()
+        screen._do_login.assert_not_called()
         event.stop.assert_not_called()
 
     def test_on_key_enter_submits_when_ready_and_focused(self) -> None:
         """Enter (without Ctrl) submits when container ready and prompt has focus."""
-        screens, _ = import_screens()
-        screen = screens.TaskLaunchScreen(container_name="c", project_name="p", task_id="1")
-        screen._container_ready = True
-        screen._do_login = mock.Mock()
+        screen = self._screen_focused_on("launch-prompt", ready=True)
 
-        mock_textarea = mock.Mock()
-        mock_textarea.has_focus = True
-
-        mock_select = mock.Mock()
-
-        def query_one(selector, cls=None):
-            if "login-agent" in selector:
-                return mock_select
-            return mock_textarea
-
-        screen.query_one = query_one
-
-        # Simulate Enter (without Ctrl)
         event = mock.Mock()
         event.key = "enter"
-        event.ctrl = False
         screen.on_key(event)
 
         screen._do_login.assert_called_once()
         event.stop.assert_called_once()
 
+    def test_action_login_submits_when_ready(self) -> None:
+        """Enter on the agent select fires ``screen.login`` — submits once ready."""
+        screen = self._screen_focused_on("login-agent", ready=True)
+        screen.action_login()
+        screen._do_login.assert_called_once()
+
+    def test_action_login_noop_when_not_ready(self) -> None:
+        """The ``screen.login`` binding is gated on container readiness."""
+        screen = self._screen_focused_on("login-agent", ready=False)
+        screen.action_login()
+        screen._do_login.assert_not_called()
+
     def test_on_key_enter_noop_when_not_ready(self) -> None:
         """Enter does nothing when container is not ready, even with focus."""
-        screens, _ = import_screens()
-        screen = screens.TaskLaunchScreen(container_name="c", project_name="p", task_id="1")
-        screen._container_ready = False
-        screen._do_login = mock.Mock()
+        screen = self._screen_focused_on("launch-prompt", ready=False)
 
-        mock_textarea = mock.Mock()
-        mock_textarea.has_focus = True
-
-        mock_select = mock.Mock()
-
-        def query_one(selector, cls=None):
-            if "login-agent" in selector:
-                return mock_select
-            return mock_textarea
-
-        screen.query_one = query_one
-
-        # Simulate Enter (without Ctrl)
         event = mock.Mock()
         event.key = "enter"
-        event.ctrl = False
         screen.on_key(event)
 
         screen._do_login.assert_not_called()
         event.stop.assert_not_called()
 
-    def test_on_key_enter_noop_when_not_focused(self) -> None:
-        """Enter does nothing when prompt doesn't have focus, even if ready."""
-        screens, _ = import_screens()
-        screen = screens.TaskLaunchScreen(container_name="c", project_name="p", task_id="1")
-        screen._container_ready = True
-        screen._do_login = mock.Mock()
+    @pytest.mark.parametrize("focused_id", [None, "btn-dismiss"])
+    def test_on_key_enter_noop_when_not_focused(self, focused_id: str | None) -> None:
+        """Enter elsewhere (a button, or nothing focused) is left alone, even if ready."""
+        screen = self._screen_focused_on(focused_id, ready=True)
 
-        mock_textarea = mock.Mock()
-        mock_textarea.has_focus = False  # No focus
-
-        mock_select = mock.Mock()
-
-        def query_one(selector, cls=None):
-            if "login-agent" in selector:
-                return mock_select
-            return mock_textarea
-
-        screen.query_one = query_one
-
-        # Simulate Enter (without Ctrl)
         event = mock.Mock()
         event.key = "enter"
-        event.ctrl = False
         screen.on_key(event)
 
         screen._do_login.assert_not_called()
         event.stop.assert_not_called()
+
+    def test_agent_select_rebinds_enter_to_screen_login(self) -> None:
+        """The agent select's own Enter binding routes to ``screen.login``.
+
+        Subclass bindings replace same-key base bindings, so Enter no longer
+        expands the list — while Space/Up/Down (untouched base keys) still do.
+        """
+        screens, _ = import_screens()
+        # The stub Binding captures its constructor args as _stub_args.
+        own = {b._stub_args[0]: b._stub_args[1] for b in screens._LoginAgentSelect.BINDINGS}
+        assert own == {"enter": "screen.login"}
 
 
 class TestUnattendedPromptOnKey:
@@ -484,8 +450,8 @@ class TestTaskLaunchScreenHint:
         hint = self._screen("launch-prompt", ready=False)._enter_hint()
         assert "[dim]" in hint and "Enter login" in hint and "⌛" in hint
 
-    def test_enter_hint_agent_select_describes_the_dropdown(self) -> None:
-        assert self._screen("login-agent", ready=True)._enter_hint() == "Enter shows agent list"
+    def test_enter_hint_agent_select_logs_in(self) -> None:
+        assert self._screen("login-agent", ready=True)._enter_hint() == "Enter login"
 
     def test_enter_hint_button_is_omitted(self) -> None:
         assert self._screen("btn-dismiss", ready=True)._enter_hint() is None
@@ -496,6 +462,13 @@ class TestTaskLaunchScreenHint:
         screen.query_one = lambda *a, **k: dialog
         screen._refresh_hint()
         assert dialog.border_subtitle == "Ctrl+J newline · Esc dismiss · Enter login"
+
+    def test_refresh_hint_agent_select_promises_space_and_enter(self) -> None:
+        screen = self._screen("login-agent", ready=True)
+        dialog = mock.Mock()
+        screen.query_one = lambda *a, **k: dialog
+        screen._refresh_hint()
+        assert dialog.border_subtitle == "Space agent list · Esc dismiss · Enter login"
 
     def test_refresh_hint_on_button_drops_newline_and_enter(self) -> None:
         screen = self._screen("btn-login", ready=True)


### PR DESCRIPTION
## Problem

On the task launch dialog (initial prompt + agent dropdown), **Enter** in the prompt input performs **Login** — but Tab-focusing the agent selection dropdown changed Enter's meaning to "expand the option list" (the stock Textual `Select` binds `enter,down,space,up` all to `show_overlay`). Space already opens the list, so Enter-as-expand was redundant and inconsistent.

## Fix

A small `_LoginAgentSelect(Select)` subclass rebinds **Enter → `screen.login`** (subclass bindings replace same-key base bindings per Textual's `_merge_bindings`), backed by a new readiness-gated `TaskLaunchScreen.action_login`. Result:

- **Enter** means **Login** everywhere in the dialog (prompt *and* collapsed agent select), gated on container readiness as before
- **Space/Up/Down** still expand the agent list (untouched base bindings)
- **Enter inside the open list** still confirms the highlighted option (the overlay's own binding sits closer to focus in the binding chain)
- the border-subtitle hint on the select now reads `Space agent list · Esc dismiss · Enter login`

Note: the `_SubmittablePromptArea`-style `prevent_default()` trick does **not** work for `Select` — `Message._bubble_to` resets `_no_default_action` on every hop, and Select's binding fires later at the App's binding-chain check. Rebinding is the mechanism that holds.

## Verification

- Pilot app against real Textual 8.2: collapsed Enter fires login without expanding; Space/Down expand; in-list Enter selects without triggering login
- `tests/unit/tui`: 800 passed; unit tests updated + new coverage for `action_login` gating and the Enter rebind
- ruff check/format, docstr-coverage green

🤖 Generated with [Claude Code](https://claude.com/claude-code)