### PR TITLE
fix(tui): render console output on the ANSI palette's own background

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -842,6 +842,14 @@ Command palette (`Ctrl+P`) actions:
 - **Edit Global Instructions** — edit the global `instructions.md` in `$EDITOR`
 - **Show Default Instructions** — view the bundled default instructions (read-only)
 
+#### Theme
+
+Pick a theme from the command palette (`Ctrl+P` → "Change theme"); the choice
+is saved to `tui.theme` in your global `config.yml` and applied on the next
+launch. The built-in `ansi-dark` theme renders with your terminal's own
+palette and default background — console output (image builds, gate syncs)
+then looks exactly as it would running the command directly in your terminal.
+
 ### Debugging
 
 Resolved instructions are always written to `<tasks_root>/<task_id>/agent-config/instructions.md` on the host for inspection.

--- a/examples/terok-config.yml
+++ b/examples/terok-config.yml
@@ -65,6 +65,13 @@ tui:
   # editor, even when $EDITOR is set. Default: true.
   # external_editor: false
 
+  # Textual theme applied at TUI startup (e.g. textual-dark, textual-light,
+  # ansi-dark — the latter uses your terminal's own colors and default
+  # background). Maintained automatically: picking a theme in the TUI's
+  # command palette (Ctrl+P → "Change theme") writes the choice here.
+  # Unset, or an unknown name, keeps the default theme.
+  # theme: ansi-dark
+
 # Agent configuration
 # -----------------------------------------------------------------
 # Native Claude handles sub-agents, skills, and MCPs — terok does not own a

--- a/src/terok/lib/api/__init__.py
+++ b/src/terok/lib/api/__init__.py
@@ -217,6 +217,7 @@ from terok.lib.core import config as _config, paths as _paths
 # Side-effecting / factory helpers that don't fit on the frozen Config object.
 from terok.lib.core.config import (  # noqa: F401 — re-exported public API
     make_sandbox_config,
+    save_tui_theme,
     set_experimental,
 )
 from terok.lib.integrations.sandbox import (  # noqa: F401 — re-exported public API
@@ -261,6 +262,9 @@ class Config:
     tui_external_editor: bool
     # Presentation hints
     shield_security_hint: str
+    # Defaulted late additions — hand-built Config literals in tests
+    # predate them, so new fields land here with a default.
+    tui_theme: str | None = None
 
 
 def get_config() -> Config:
@@ -277,6 +281,7 @@ def get_config() -> Config:
         shield_bypass_firewall_no_protection=_config.get_shield_bypass_firewall_no_protection(),
         tui_default_tmux=_config.get_tui_default_tmux(),
         tui_external_editor=_config.get_tui_external_editor(),
+        tui_theme=_config.get_tui_theme(),
         shield_security_hint=_config.SHIELD_SECURITY_HINT,
     )
 
@@ -302,6 +307,7 @@ __all__ = [
     "get_config",
     # Side-effecting helpers
     "make_sandbox_config",
+    "save_tui_theme",
     "set_experimental",
     "get_container_state",
     # Shared sandbox types and ANSI helpers kept on __init__

--- a/src/terok/lib/core/config.py
+++ b/src/terok/lib/core/config.py
@@ -18,7 +18,7 @@ if TYPE_CHECKING:
 
     from terok.lib.integrations.sandbox import SandboxConfig
 
-from ..util.yaml import YAMLError, load as _yaml_load
+from ..util.yaml import YAMLError, dump as _yaml_dump, load as _yaml_load
 from .paths import config_root as _config_root_base
 from .yaml_schema import RawGlobalConfig
 
@@ -433,6 +433,46 @@ def get_tui_external_editor() -> bool:
     session — the web TUI always uses the integrated editor.
     """
     return _load_validated().tui.external_editor
+
+
+def get_tui_theme() -> str | None:
+    """Return the Textual theme name to apply at TUI startup, or ``None`` if not set."""
+    return _load_validated().tui.theme
+
+
+def save_tui_theme(theme: str) -> None:
+    """Persist *theme* as ``tui.theme`` in the user's global config file.
+
+    A surgical round-trip update of
+    [`global_config_path`][terok.lib.core.config.global_config_path]:
+    only the one key changes — everything else in the file, comments
+    included, survives via ruamel's round-trip mode.  Creates the file
+    (and its parent directory) when missing, and invalidates the
+    in-process config caches so subsequent reads observe the new value.
+
+    Raises:
+        OSError: The config file or its directory cannot be read or written.
+        YAMLError: The existing file is malformed, or its top level is
+            not a mapping — the file is left untouched rather than
+            clobbered with a theme-only stump.
+    """
+    global _validated_config_cache, _raw_config_cache  # noqa: PLW0603
+    path = global_config_path()
+    data: dict[str, Any] = {}
+    if path.is_file():
+        raw = _yaml_load(path.read_text(encoding="utf-8"))
+        if raw is not None and not isinstance(raw, dict):
+            raise YAMLError(f"{path}: expected a mapping at top level, got {type(raw).__name__}")
+        data = raw or {}
+    tui = data.get("tui")
+    if not isinstance(tui, dict):
+        tui = {}
+        data["tui"] = tui
+    tui["theme"] = theme
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(_yaml_dump(data), encoding="utf-8")
+    _validated_config_cache = None
+    _raw_config_cache = None
 
 
 def get_tui_desktop_entry() -> str:

--- a/src/terok/lib/core/yaml_schema.py
+++ b/src/terok/lib/core/yaml_schema.py
@@ -392,6 +392,16 @@ class RawTUISection(BaseModel):
     default_tmux: bool = Field(
         default=False, description="Default to tmux mode when launching the TUI"
     )
+    theme: str | None = Field(
+        default=None,
+        description=(
+            "Textual theme applied at TUI startup (e.g. ``textual-dark``, "
+            "``ansi-dark``).  Maintained automatically: picking a theme in "
+            "the TUI's command palette writes the choice here so it "
+            "persists across sessions.  Unset — or a name the installed "
+            "Textual doesn't know — keeps the default theme."
+        ),
+    )
     external_editor: bool = Field(
         default=True,
         description=(

--- a/src/terok/tui/app.py
+++ b/src/terok/tui/app.py
@@ -282,6 +282,10 @@ if _HAS_TEXTUAL:
         def __init__(self) -> None:
             """Initialize the TUI, setting up internal state and dynamic title."""
             super().__init__()
+            # Console panes show CLI/build output authored for dark
+            # terminals; keep the dark ANSI palette in light themes too
+            # so AnsiLog's palette/background pairing holds everywhere.
+            self.ansi_theme_light = self.ansi_theme_dark
             # Snapshot the global config once; reuse via ``self._config``.
             self._config: Config = get_config()
             # Set dynamic title with version and branch info

--- a/src/terok/tui/app.py
+++ b/src/terok/tui/app.py
@@ -48,6 +48,7 @@ if _HAS_TEXTUAL:
     from textual.binding import Binding
     from textual.containers import Horizontal, Vertical
     from textual.css.query import NoMatches
+    from textual.theme import Theme
     from textual.timer import Timer
     from textual.widgets import Footer, Header
     from textual.worker import Worker, WorkerState
@@ -79,6 +80,7 @@ if _HAS_TEXTUAL:
         load_project,
         make_git_gate,
         panic_stop_containers,
+        save_tui_theme,
         set_experimental,
     )
 
@@ -87,6 +89,7 @@ if _HAS_TEXTUAL:
         get_version_info as _get_version_info,
         short_version as _short_version,
     )
+    from ..lib.util.yaml import YAMLError
 
     # Exit code 5 is the ``terok setup`` partial-success signal — every
     # install phase succeeded but a manual step (currently: SELinux
@@ -440,6 +443,10 @@ if _HAS_TEXTUAL:
 
         async def on_mount(self) -> None:
             """Load projects, restore selection state, and start polling on first mount."""
+            # Apply the persisted theme choice before the first paint,
+            # and keep ``tui.theme`` in sync with later palette picks.
+            self._apply_saved_theme()
+
             try:
                 clipboard_status = get_clipboard_helper_status()
                 if not clipboard_status.available:
@@ -493,6 +500,38 @@ if _HAS_TEXTUAL:
             # actionable feedback the user shouldn't be allowed to mute
             # indefinitely.
             await self._maybe_show_first_run_flow()
+
+        def _apply_saved_theme(self) -> None:
+            """Apply ``tui.theme`` from config, then track palette picks.
+
+            An unknown name — a theme from a different Textual version,
+            or a typo from hand-editing — falls back to the default
+            silently: the config value is a preference, not a contract.
+            The comparison seed is the theme *in effect after* the
+            apply, so the signal echo of our own set (and of Textual's
+            startup default when nothing is saved) never writes the
+            default back into the user's config file.
+            """
+            saved = self._config.tui_theme
+            if saved and saved in self.available_themes:
+                self.theme = saved
+            self._persisted_theme = self.theme
+            self.theme_changed_signal.subscribe(self, self._on_theme_picked)
+
+        def _on_theme_picked(self, theme: Theme) -> None:
+            """Write a genuine palette theme pick through to the user config file."""
+            if theme.name == self._persisted_theme:
+                return
+            try:
+                save_tui_theme(theme.name)
+            except (OSError, YAMLError) as exc:
+                self.notify(
+                    f"Theme applied for this session, but saving it failed: {exc}",
+                    severity="warning",
+                    timeout=10,
+                )
+                return
+            self._persisted_theme = theme.name
 
         async def _maybe_show_first_run_flow(self) -> None:
             """Probe the setup verdict and decide whether to drive the first-run flow."""

--- a/src/terok/tui/log_viewer.py
+++ b/src/terok/tui/log_viewer.py
@@ -31,6 +31,7 @@ from textual.widgets import RichLog, Static
 from terok.lib.api.agents import AgentRunner
 
 from .screens import _modal_binding
+from .widgets.ansi_log import AnsiLog
 
 try:  # pragma: no cover - optional import for test stubs
     from textual.css.query import NoMatches
@@ -399,7 +400,7 @@ class LogViewerScreen(screen.Screen[None]):
             f" Task {self.task_id} ({self.mode}) | {self.container_name}",
             id="log-header",
         )
-        yield RichLog(auto_scroll=self.follow, id="log-view")
+        yield AnsiLog(auto_scroll=self.follow, id="log-view")
         yield Static(" \\[Esc/q/f] Back", id="log-footer")
 
     def on_mount(self) -> None:

--- a/src/terok/tui/widgets/__init__.py
+++ b/src/terok/tui/widgets/__init__.py
@@ -7,6 +7,7 @@ Re-exports widget classes and render helpers from focused submodules.
 """
 
 from ...lib.api import TaskMeta  # noqa: F401 — re-exported public API
+from .ansi_log import AnsiLog  # noqa: F401
 from .panic_button import PanicButton  # noqa: F401
 from .project_list import ProjectList, ProjectListItem  # noqa: F401
 from .project_state import (  # noqa: F401
@@ -20,6 +21,8 @@ from .task_detail import TaskDetails, render_task_details  # noqa: F401
 from .task_list import TaskList, TaskListItem, get_backend_name  # noqa: F401
 
 __all__ = [
+    # Console output
+    "AnsiLog",
     # Emergency
     "PanicButton",
     # Project widgets

--- a/src/terok/tui/widgets/ansi_log.py
+++ b/src/terok/tui/widgets/ansi_log.py
@@ -1,0 +1,56 @@
+# SPDX-FileCopyrightText: 2026 Jiri Vyskocil
+# SPDX-License-Identifier: Apache-2.0
+
+"""A ``RichLog`` for terminal-style output — ANSI colors on their own background.
+
+Console panes render subprocess output (``podman build``, ``git``,
+``terok setup``) whose ANSI color codes Textual translates to truecolor
+through the app's *ANSI theme*
+([`App.ansi_theme`][textual.app.App.ansi_theme]) — a palette designed
+against that theme's own background, not against the Textual theme's
+``$surface`` that [`RichLog`][textual.widgets.RichLog] paints by
+default.  Nothing guarantees contrast between the two: ANSI
+bright-black mapped through the default Monokai ANSI theme is a grey
+that vanishes on a grey ``$surface`` — the invisible ``STEP 3/15``
+build output.
+
+[`AnsiLog`][terok.tui.widgets.ansi_log.AnsiLog] restores the invariant
+*ANSI content is drawn on the background its palette was designed for*
+by pinning its background to the ANSI theme's own background color.
+
+When the app runs in native-ANSI mode (e.g. Textual's built-in
+``ansi-dark`` theme) there is nothing to pin: ANSI codes pass through
+to the terminal untranslated and the theme's ``ansi_default``
+background shows the terminal's own — the terminal palette's contrast
+contract applies, exactly as if the command ran outside the TUI.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from textual.color import Color
+from textual.widgets import RichLog
+
+if TYPE_CHECKING:
+    from textual.theme import Theme
+
+
+class AnsiLog(RichLog):
+    """A ``RichLog`` whose background always matches the active ANSI palette."""
+
+    def on_mount(self) -> None:
+        """Pin the background now and re-pin whenever the app theme changes."""
+        self._pin_background()
+        self.app.theme_changed_signal.subscribe(self, self._on_theme_changed)
+
+    def _on_theme_changed(self, _theme: Theme) -> None:
+        """Re-pin after a theme switch — the ANSI theme or ANSI mode may have changed."""
+        self._pin_background()
+
+    def _pin_background(self) -> None:
+        """Set the background to the ANSI theme's own; clear it in native-ANSI mode."""
+        if self.app.native_ansi_color:
+            self.styles.background = None
+        else:
+            self.styles.background = Color(*self.app.ansi_theme.background_color)

--- a/src/terok/tui/widgets/ansi_log.py
+++ b/src/terok/tui/widgets/ansi_log.py
@@ -5,11 +5,9 @@
 
 Console panes render subprocess output (``podman build``, ``git``,
 ``terok setup``) whose ANSI color codes Textual translates to truecolor
-through the app's *ANSI theme*
-([`App.ansi_theme`][textual.app.App.ansi_theme]) — a palette designed
-against that theme's own background, not against the Textual theme's
-``$surface`` that [`RichLog`][textual.widgets.RichLog] paints by
-default.  Nothing guarantees contrast between the two: ANSI
+through the app's *ANSI theme* (``App.ansi_theme``) — a palette
+designed against that theme's own background, not against the Textual
+theme's ``$surface`` that ``RichLog`` paints by default.  Nothing guarantees contrast between the two: ANSI
 bright-black mapped through the default Monokai ANSI theme is a grey
 that vanishes on a grey ``$surface`` — the invisible ``STEP 3/15``
 build output.

--- a/src/terok/tui/wizard_screens.py
+++ b/src/terok/tui/wizard_screens.py
@@ -58,6 +58,7 @@ from ..lib.api import (
 )
 from .agents_screen import AgentsSelectScreen
 from .askpass_service import build_askpass_env, gui_askpass_usable
+from .widgets.ansi_log import AnsiLog
 
 # ── Step 1: the form ──────────────────────────────────────────────────
 
@@ -625,7 +626,7 @@ class InitProgressScreen(ModalScreen[InitOutcome]):
                         id="wizard-init-ssh-continue",
                         variant="primary",
                     )
-            yield RichLog(id="wizard-init-log", markup=True, wrap=True)
+            yield AnsiLog(id="wizard-init-log", markup=True, wrap=True)
             with Horizontal(id="wizard-init-buttons"):
                 yield Button("Close", id="wizard-init-close", variant="default", disabled=True)
 
@@ -826,9 +827,10 @@ class InitProgressScreen(ModalScreen[InitOutcome]):
         )
 
         def _tail(line: str) -> None:
-            # Raw subprocess output — wrap in Text so the markup-enabled
-            # log pane renders stray brackets literally rather than as markup.
-            log.write(Text(line))
+            # Raw subprocess output — parse ANSI colour escapes (the pump
+            # forces colour out of the child) into a styled Text, which
+            # also keeps stray brackets literal in the markup-enabled pane.
+            log.write(Text.from_ansi(line))
 
         unsubscribe = entry.subscribe(_tail)
         try:

--- a/src/terok/tui/worker_log_screen.py
+++ b/src/terok/tui/worker_log_screen.py
@@ -37,6 +37,8 @@ from textual.containers import Horizontal, Vertical
 from textual.screen import ModalScreen
 from textual.widgets import Button, Label, RichLog
 
+from .widgets.ansi_log import AnsiLog
+
 if TYPE_CHECKING:
     from .console_log import ConsoleLogEntry
 
@@ -117,7 +119,7 @@ class WorkerLogScreen(ModalScreen[None]):
         dialog.border_title = self._entry.title
         with dialog:
             yield Label(f"$ {self._entry.command}", id="worker-log-command")
-            yield RichLog(id="worker-log-output", markup=False, wrap=True)
+            yield AnsiLog(id="worker-log-output", markup=False, wrap=True)
             with Horizontal(id="worker-log-buttons"):
                 yield Button("Hide", id="worker-log-close", variant="default")
 

--- a/tach.toml
+++ b/tach.toml
@@ -845,6 +845,8 @@ expose = [
     "get_tui_default_tmux",
     "get_tui_container_resync_seconds",
     "get_tui_desktop_entry",
+    "get_tui_theme",
+    "save_tui_theme",
     "get_global_human_name",
     "get_global_human_email",
     "get_global_default_agent",

--- a/tests/unit/lib/test_config.py
+++ b/tests/unit/lib/test_config.py
@@ -1147,3 +1147,71 @@ class TestLayeredConfig:
         labels = [label for label, _ in layers]
         assert labels[0] == "system"
         assert labels[-1] == "user"
+
+
+# ---------- TUI theme persistence (tui.theme) ----------
+
+
+class TestTuiThemePersistence:
+    """``save_tui_theme`` / ``get_tui_theme`` — the persisted TUI theme choice."""
+
+    def test_creates_missing_file_and_round_trips(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """Saving into a nonexistent config file creates it, and reads see the value."""
+        path = tmp_path / "confdir" / "config.yml"
+        monkeypatch.setenv("TEROK_CONFIG_FILE", str(path))
+        assert cfg.get_tui_theme() is None
+        cfg.save_tui_theme("ansi-dark")
+        assert path.is_file()
+        # The write invalidated the config caches — no manual reset needed.
+        assert cfg.get_tui_theme() == "ansi-dark"
+
+    def test_surgical_update_preserves_keys_and_comments(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """Only ``tui.theme`` changes; sibling keys and comments survive the rewrite."""
+        path = write_config(
+            tmp_path,
+            "# hand-written note\ngate_server:\n  port: 7000\ntui:\n  default_tmux: true\n",
+        )
+        monkeypatch.setenv("TEROK_CONFIG_FILE", str(path))
+        cfg.save_tui_theme("textual-light")
+        text = path.read_text(encoding="utf-8")
+        assert "# hand-written note" in text
+        assert cfg.get_tui_theme() == "textual-light"
+        assert cfg.get_tui_default_tmux() is True
+        assert cfg._load_validated().gate_server.port == 7000
+
+    def test_overwrites_previous_choice(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """A second save replaces the stored theme."""
+        path = tmp_path / "config.yml"
+        monkeypatch.setenv("TEROK_CONFIG_FILE", str(path))
+        cfg.save_tui_theme("textual-light")
+        cfg.save_tui_theme("ansi-dark")
+        assert cfg.get_tui_theme() == "ansi-dark"
+        assert path.read_text(encoding="utf-8").count("theme:") == 1
+
+    def test_non_mapping_file_left_untouched(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """A file whose top level isn't a mapping is refused, not clobbered."""
+        from terok.lib.util.yaml import YAMLError
+
+        path = write_config(tmp_path, "- not\n- a mapping\n")
+        monkeypatch.setenv("TEROK_CONFIG_FILE", str(path))
+        original = path.read_text(encoding="utf-8")
+        with pytest.raises(YAMLError):
+            cfg.save_tui_theme("ansi-dark")
+        assert path.read_text(encoding="utf-8") == original
+
+    def test_scalar_tui_section_is_replaced(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """An invalid scalar ``tui:`` value (schema-rejected anyway) becomes a mapping."""
+        path = write_config(tmp_path, "tui: nonsense\n")
+        monkeypatch.setenv("TEROK_CONFIG_FILE", str(path))
+        cfg.save_tui_theme("ansi-dark")
+        assert cfg.get_tui_theme() == "ansi-dark"

--- a/tests/unit/tui/test_ansi_log.py
+++ b/tests/unit/tui/test_ansi_log.py
@@ -1,0 +1,99 @@
+# SPDX-FileCopyrightText: 2026 Jiri Vyskocil
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for [`AnsiLog`][terok.tui.widgets.ansi_log.AnsiLog].
+
+The widget's contract is a single invariant: *ANSI content is drawn on
+the background its palette was designed for*.  Concretely —
+
+* in truecolor themes the pane's background is pinned to
+  ``app.ansi_theme.background_color`` (the palette Textual maps ANSI
+  codes through), never the Textual theme's ``$surface``;
+* a theme switch re-pins, so the pairing survives dark/light flips;
+* in native-ANSI mode (Textual's ``ansi-dark`` theme) nothing is
+  pinned — the terminal's own default background shows through and the
+  terminal palette's contrast contract applies.
+
+``TerokTUI`` additionally pairs light themes with the *dark* ANSI
+palette (console output is authored for dark terminals), which is
+asserted against the real app class.
+"""
+
+from __future__ import annotations
+
+import pytest
+from textual.app import App, ComposeResult
+from textual.color import Color
+
+from terok.tui.widgets.ansi_log import AnsiLog
+
+_PANE_ID = "ansi-log-pane"
+
+
+class _Host(App):
+    """Minimal app hosting a single [`AnsiLog`][terok.tui.widgets.ansi_log.AnsiLog]."""
+
+    def compose(self) -> ComposeResult:
+        """Mount the pane under test."""
+        yield AnsiLog(id=_PANE_ID)
+
+
+def _ansi_background(app: App) -> Color:
+    """The background color of *app*'s active ANSI palette."""
+    return Color(*app.ansi_theme.background_color)
+
+
+@pytest.mark.asyncio
+async def test_background_is_the_ansi_palette_background() -> None:
+    """On mount the pane's background is the ANSI theme's own, not ``$surface``."""
+    app = _Host()
+    async with app.run_test() as pilot:
+        pane = pilot.app.query_one(f"#{_PANE_ID}", AnsiLog)
+        assert pane.styles.background == _ansi_background(pilot.app)
+
+
+@pytest.mark.asyncio
+async def test_theme_switch_repins_to_the_new_ansi_palette() -> None:
+    """Switching themes re-pins the background to the now-active ANSI palette."""
+    app = _Host()
+    async with app.run_test() as pilot:
+        pane = pilot.app.query_one(f"#{_PANE_ID}", AnsiLog)
+        before = pane.styles.background
+
+        pilot.app.theme = "textual-light"
+        await pilot.pause()
+
+        after = pane.styles.background
+        assert after == _ansi_background(pilot.app)
+        assert after != before, "light theme selects a different ANSI palette"
+
+
+@pytest.mark.asyncio
+async def test_native_ansi_theme_leaves_the_terminal_background() -> None:
+    """Under the built-in ``ansi-dark`` theme the pane paints no background of its own."""
+    app = _Host()
+    async with app.run_test() as pilot:
+        pane = pilot.app.query_one(f"#{_PANE_ID}", AnsiLog)
+
+        pilot.app.theme = "ansi-dark"
+        await pilot.pause()
+
+        assert pilot.app.native_ansi_color, "ansi-dark is a native-ANSI theme"
+        # The inline pin is cleared, so the theme's transparent surface
+        # applies and the *effective* background is ``ansi_default`` —
+        # the terminal's own default background.
+        assert not pane._inline_styles.has_rule("background")
+        assert pane.background_colors[0].ansi == -1
+
+
+def test_terok_tui_pairs_light_themes_with_the_dark_ansi_palette() -> None:
+    """``TerokTUI`` keeps the dark ANSI palette in light themes too.
+
+    Console output is authored for dark terminals; pairing light app
+    themes with a near-white ANSI palette would re-break truecolor
+    greys that Rich-based children emit assuming a dark background.
+    """
+    from terok.tui.app import TerokTUI
+
+    app = TerokTUI()
+    assert app.ansi_theme_light is app.ansi_theme_dark

--- a/tests/unit/tui/test_theme_persistence.py
+++ b/tests/unit/tui/test_theme_persistence.py
@@ -1,0 +1,116 @@
+# SPDX-FileCopyrightText: 2026 Jiri Vyskocil
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for TerokTUI's theme persistence wiring.
+
+``_apply_saved_theme`` / ``_on_theme_picked`` are exercised on a minimal
+real-Textual host that borrows the methods from ``TerokTUI`` — running
+the full app (project loading, vault probing, pollers) buys nothing for
+this contract:
+
+* the saved ``tui.theme`` is applied on mount; unknown names fall back
+  to the default;
+* startup never writes the config file — only a genuine palette pick
+  does, and a failed write degrades to a session-only theme with a
+  warning instead of crashing.
+
+Persistence is asserted against the real config file (routed to a tmp
+path via ``TEROK_CONFIG_FILE``) rather than by monkeypatching the app
+module — fresh-import tests elsewhere in the suite swap out
+``terok.tui.app``, so a module-attribute patch is order-fragile while
+the file is not.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+from textual.app import App
+
+from terok.tui.app import TerokTUI
+
+
+class _ThemeHost(App):
+    """Real-Textual host borrowing TerokTUI's theme-persistence methods."""
+
+    _apply_saved_theme = TerokTUI._apply_saved_theme
+    _on_theme_picked = TerokTUI._on_theme_picked
+
+    def __init__(self, saved: str | None) -> None:
+        """Stand in a config snapshot carrying only the persisted theme."""
+        super().__init__()
+        self._config = SimpleNamespace(tui_theme=saved)
+
+    def on_mount(self) -> None:
+        """Mirror TerokTUI.on_mount's theme wiring."""
+        self._apply_saved_theme()
+
+
+@pytest.fixture
+def config_file(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> Path:
+    """Route the global config file to a fresh tmp path and return it."""
+    path = tmp_path / "config.yml"
+    monkeypatch.setenv("TEROK_CONFIG_FILE", str(path))
+    return path
+
+
+@pytest.mark.asyncio
+async def test_saved_theme_is_applied_on_mount(config_file: Path) -> None:
+    """A persisted theme name becomes the active theme at startup — without a re-save."""
+    app = _ThemeHost("textual-light")
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        assert app.theme == "textual-light"
+    assert not config_file.exists(), "applying the saved theme must not write the config"
+
+
+@pytest.mark.asyncio
+async def test_unknown_saved_theme_falls_back_to_default(config_file: Path) -> None:
+    """A name the installed Textual doesn't know keeps the default theme."""
+    app = _ThemeHost("no-such-theme")
+    default = App().theme
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        assert app.theme == default
+    assert not config_file.exists(), "the fallback must not overwrite the saved value"
+
+
+@pytest.mark.asyncio
+async def test_startup_without_saved_theme_writes_nothing(config_file: Path) -> None:
+    """With no persisted choice, startup leaves the config file alone."""
+    app = _ThemeHost(None)
+    async with app.run_test() as pilot:
+        await pilot.pause()
+    assert not config_file.exists()
+
+
+@pytest.mark.asyncio
+async def test_palette_pick_is_persisted(config_file: Path) -> None:
+    """A genuine theme switch writes exactly that name to the config file."""
+    app = _ThemeHost(None)
+    async with app.run_test() as pilot:
+        app.theme = "ansi-dark"
+        await pilot.pause()
+    assert "theme: ansi-dark" in config_file.read_text(encoding="utf-8")
+    assert app._persisted_theme == "ansi-dark"
+
+
+@pytest.mark.asyncio
+async def test_failed_save_degrades_to_session_theme(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """An unwritable config keeps the theme for the session and warns, not crashes."""
+    blocker = tmp_path / "blocker"
+    blocker.write_text("a file where a directory must go", encoding="utf-8")
+    monkeypatch.setenv("TEROK_CONFIG_FILE", str(blocker / "config.yml"))
+
+    app = _ThemeHost(None)
+    async with app.run_test() as pilot:
+        app.theme = "textual-light"
+        await pilot.pause()
+        assert app.theme == "textual-light"
+        # The failed name was not recorded as persisted, so a later
+        # pick retries the save.
+        assert app._persisted_theme != "textual-light"

--- a/tests/unit/tui/test_wizard_screens.py
+++ b/tests/unit/tui/test_wizard_screens.py
@@ -468,6 +468,52 @@ async def test_run_dispatched_step_tails_output_and_completes() -> None:
 
 
 @pytest.mark.asyncio
+async def test_run_dispatched_step_parses_ansi_colour() -> None:
+    """Tailed child output has its ANSI escapes parsed into styled Text, not printed raw.
+
+    The console-log pump forces colour out of the child
+    (``FORCE_COLOR=1``), so build/git output routinely carries escapes —
+    ``\\x1b[90m…`` must arrive as a coloured span, and the escape bytes
+    must never reach the pane.
+    """
+    from rich.text import Text
+
+    from terok.tui.console_log import ConsoleLogEntry
+    from terok.tui.wizard_screens import InitProgressScreen
+
+    screen = InitProgressScreen("demo")
+    entry = ConsoleLogEntry(id=1, title="Build", argv=["x"], command="x")
+    fake_app = MagicMock()
+    fake_app.dispatch_console_action = MagicMock(return_value=entry)
+    log = MagicMock()
+
+    async def _drive() -> None:
+        await asyncio.sleep(0)
+        entry.append("\x1b[90mSTEP 3/15: RUN pip install\x1b[0m done")
+        entry.finish(0)
+
+    with patch.object(InitProgressScreen, "app", new_callable=PropertyMock, return_value=fake_app):
+        await asyncio.gather(
+            screen._run_dispatched_step(
+                "terok.tui.worker_actions:build",
+                "demo",
+                log=log,
+                title="Building images for demo",
+                env=None,
+                fail_msg="Image build failed",
+            ),
+            _drive(),
+        )
+
+    tailed = [c.args[0] for c in log.write.call_args_list if isinstance(c.args[0], Text)]
+    assert len(tailed) == 1
+    text = tailed[0]
+    assert text.plain == "STEP 3/15: RUN pip install done"
+    assert "\x1b" not in text.plain, "escape bytes must not reach the pane"
+    assert text.spans, "the colour escape became a styled span"
+
+
+@pytest.mark.asyncio
 async def test_run_dispatched_step_raises_on_nonzero_exit() -> None:
     """A non-zero child exit raises ``RuntimeError(fail_msg)`` so the step is marked failed."""
     from terok.tui.console_log import ConsoleLogEntry

--- a/tests/unit/tui/tui_test_helpers.py
+++ b/tests/unit/tui/tui_test_helpers.py
@@ -86,6 +86,11 @@ def build_textual_stubs() -> dict[str, types.ModuleType]:
         # driver attached, which is the case for every stub-based unit test.
         is_web = False
 
+        # Mirror Textual's App.ansi_theme_dark / ansi_theme_light reactives;
+        # TerokTUI.__init__ re-pairs them so console panes keep the dark
+        # ANSI palette in light themes.  A shared placeholder is enough.
+        ansi_theme_dark = ansi_theme_light = object()
+
         def get_system_commands(self, _screen: Any) -> Any:
             return iter(())
 


### PR DESCRIPTION
## Problem

In the console-output viewer (`WorkerLogScreen`), grey text from image-build output (e.g. inside `STEP 3/15`) is near-invisible on the pane's grey background.

Root cause: three unrelated palettes collide in the log panes.

1. 16-color ANSI codes in subprocess output are converted to truecolor through the app's **ANSI theme** (`App.ansi_theme`, default Monokai) — a palette designed against Monokai's near-black background;
2. truecolor/256-color greys emitted directly by `FORCE_COLOR`'d Rich-based children assume a conventional dark terminal background;
3. the pane actually paints the Textual theme's `$surface` — a background neither palette was designed for.

## Fix

**`AnsiLog` widget** — restores the invariant *ANSI content is drawn on the background its palette was designed for*:

- pins its background to `app.ansi_theme.background_color`, re-pinning on theme switches;
- under a native-ANSI theme (the built-in `ansi-dark`) it pins nothing — codes pass through untranslated and the pane shows the terminal's own default background, so output looks exactly as it would running the command directly.

Used for the worker-log pane, the container-log viewer pane, and the wizard's init log pane (which additionally gains `Text.from_ansi` parsing — it previously rendered the forced-colour child output flat). `TerokTUI` pairs light themes with the *dark* ANSI palette, since console output is authored for dark terminals.

Measured contrast for the reported case (textual-dark): SGR 90 bright-black 2.56:1 on `$surface` → 3.00:1 on the Monokai background (its by-design comment-grey contrast); 8-bit grey 244: 4.22:1 → 4.95:1.

**Theme persistence** — picking a theme in the command palette (`Ctrl+P` → "Change theme") now writes `tui.theme` to the user's global `config.yml` and re-applies it at the next startup. `save_tui_theme` is a surgical ruamel round-trip update: comments and sibling keys survive, a non-mapping file is refused rather than clobbered, caches are invalidated. Unknown saved names fall back to the default silently; a failed save degrades to a session-only theme with a warning. This makes the terminal-native `ansi-dark` mode a durable choice, not a per-session one.

The stub `App` in `tui_test_helpers` grows the `ansi_theme_dark`/`ansi_theme_light` pair to mirror the real API.

## Verification

- 15 new unit tests: `AnsiLog` pin/re-pin/native-ANSI behavior, TerokTUI light/dark pairing, wizard ANSI parsing, `save_tui_theme` file semantics (creation, surgical update, comment preservation, refusal on non-mapping), and the TUI persistence wiring (apply-on-mount, unknown-name fallback, no startup write, pick persists, failed-save degradation).
- End-to-end pilot script drove a real `WorkerLogScreen` with ANSI-grey samples: verified the truecolor filter maps against the pinned background in truecolor themes, and that under `ansi-dark` the ANSI→truecolor filter is disabled, SGR codes stay system colors, and the pane's effective background is the terminal default (`ansi=-1`).
- Live round-trip through `lib.api`: `save_tui_theme('ansi-dark')` → minimal `tui:\n  theme: ansi-dark` file → `get_config().tui_theme` reads it back.
- Full unit suite: failure set byte-identical to clean `upstream/master` in the same env (32 known env-noise failures, all outside this change); ruff, tach, import-linter, docstr-coverage, bandit, reuse all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)