### PR TITLE
chore(dev): add make test-fast and steer agents to it during development

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,10 +33,22 @@
 
 ## Build, Lint, and Test Commands
 
+**During development — ALWAYS use the fast loop:**
+```bash
+make test-fast # Only the tests affected by your branch diff (tach impact analysis)
+```
+Rerunning the full suite after every edit is the single biggest time sink in
+agent dev loops — don't do it. Iterate with `make test-fast`; run the full
+`make test` exactly once, right before committing. One exception: impact
+analysis follows the Python import graph only, so after changing non-Python
+inputs (`resources/` templates, YAML, shell scripts) `make test-fast` skips
+tests that are actually affected — run the full `make test` for those changes.
+
 **Before committing:**
 ```bash
 make lint      # Run linter (required before every commit)
 make format    # Auto-fix lint issues if lint fails
+make test      # Full unit suite — once, after iterating with test-fast
 ```
 
 **Before pushing:**
@@ -99,9 +111,9 @@ make spdx NAME="Real Human Name" FILES="src/terok/new_file.py"  # Add SPDX heade
 ## Development Workflow
 
 1. Make changes in appropriate module (`src/terok/`)
-2. Run `make lint` frequently during development
+2. Run `make lint` and `make test-fast` frequently during development
 3. Add/update tests in `tests/` directory
-4. Run `make test` to verify changes
+4. Run the full `make test` once, before committing
 5. If you added or changed cross-module imports, run `make tach` to verify module boundary rules
 6. Update documentation in `docs/` if needed
 7. Run `make check` before pushing

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all lint format test test-unit ruff-report bandit-report sonar-inputs test-integration test-integration-host test-integration-network test-integration-podman test-integration-map test-matrix ci-map tach lint-imports security docstrings complexity deadcode reuse check install install-dev docs docs-build clean spdx typecheck
+.PHONY: all lint format test test-unit test-fast ruff-report bandit-report sonar-inputs test-integration test-integration-host test-integration-network test-integration-podman test-integration-map test-matrix ci-map tach lint-imports security docstrings complexity deadcode reuse check install install-dev docs docs-build clean spdx typecheck
 
 REPORTS_DIR ?= reports
 COVERAGE_XML ?= $(REPORTS_DIR)/coverage.xml
@@ -28,6 +28,13 @@ format:
 
 # Run tests with coverage (excludes integration tests)
 test: test-unit
+
+# Fast dev loop: run only the tests affected by the branch diff (tach
+# impact analysis), no coverage.  Impact analysis follows the Python
+# import graph only — after touching non-Python inputs (resources/,
+# YAML, templates, scripts) run the full `make test` instead.
+test-fast:
+	poetry run pytest tests/unit/ --tach
 
 test-unit:
 	mkdir -p $(REPORTS_DIR)


### PR DESCRIPTION
Adds a `make test-fast` target that runs only the tests affected by the branch diff (tach impact analysis, `pytest --tach`, no coverage/junit reports), and updates AGENTS.md to explicitly instruct agents to iterate with it — reserving the full `make test` for the single pre-commit run.

Rationale: agents rerunning the full coverage suite after every edit is the biggest recurring inefficiency in our dev loops. On a branch with no Python changes, `test-fast` deselects all 2743 tests in ~3.6s vs a full coverage run.

Caveat documented in both the Makefile comment and AGENTS.md: tach impact analysis follows the Python import graph only, so changes to non-Python inputs (`resources/` templates, YAML, shell scripts) must still run the full suite. CI keeps running everything unmasked.

Companion PR in terok-executor: terok-ai/terok-executor#439.

🤖 Generated with [Claude Code](https://claude.com/claude-code)