### PR TITLE
fix(gate): persist the gate token per task so recreates keep working

### DIFF
--- a/docs/container-lifecycle.md
+++ b/docs/container-lifecycle.md
@@ -96,10 +96,10 @@ rebuilt underneath it, so a long-running task keeps its in-container
 state.  A stale image is only *warned* about (pointing at recreate +
 restart), not upgraded.  When the resume rung is gone — the container no
 longer exists, or podman refuses to start it — it recreates through the
-normal launch path (workspace kept, fresh tokens).  `--recreate` skips
-straight to that rung, the explicit upgrade that picks up a rebuilt
-image.  Headless tasks are the exception — recreating would replay their
-original prompt, so a missing container is an error there.
+normal launch path (workspace kept, gate token reused).  `--recreate`
+skips straight to that rung, the explicit upgrade that picks up a
+rebuilt image.  Headless tasks are the exception — recreating would
+replay their original prompt, so a missing container is an error there.
 
 ### Container Naming
 

--- a/docs/developer.md
+++ b/docs/developer.md
@@ -163,7 +163,8 @@ Containers follow podman's own lifecycle, split across the three layers:
   everything that brings a container back goes through one ladder in
   `task_runners/restart.py`: resume the existing container, else
   recreate it in place through the normal launch path (same names,
-  fresh tokens, config re-read, per-task settings from metadata).
+  same task-persistent gate token, config re-read, per-task settings
+  from metadata).
   `task_restart` is the ladder's bounce flavor (stop-if-running first);
   a plain restart resumes the container as-is and an image-ID drift
   probe only *warns* that the image is stale (long-running tasks keep

--- a/docs/developer.md
+++ b/docs/developer.md
@@ -180,6 +180,17 @@ run state (no running/stopped status is persisted in task metadata —
 only markers such as `exit_code` and `ready_at`), and `task delete`
 is the only teardown of task state.
 
+**Gate-token SSOT.**  The task meta's `gate_token` is the single source
+of truth for a task's gate token; the only mint point is the task-scoped
+accessor in `orchestration/environment.py` (raw `mint_gate_token` is
+deliberately absent from `terok.lib.api`).  Every other occurrence is a
+derived copy with a defined refresh boundary: the container env and the
+sidecar JSON are snapshots frozen at container (re)creation, and the
+workspace's token-bearing remote is re-asserted from the container env
+by the init script on every start.  The container doctor audits the
+chain (`Gate token sync`) and can re-assert a live container's remote
+without a restart.
+
 ---
 
 ## Volume Mounts and Environment Variables

--- a/src/terok/cli/commands/project.py
+++ b/src/terok/cli/commands/project.py
@@ -395,6 +395,9 @@ def _cmd_gate_sync(args: argparse.Namespace) -> None:
         f"Gate ready at {res['path']} "
         f"(upstream: {upstream_label}; created: {res['created']}){cache_note}"
     )
+    if res.get("cache_error"):
+        print(f"Warning: clone cache refresh failed: {res['cache_error']}")
+        print("New tasks fall back to a full clone until the next successful sync.")
 
 
 def _cmd_agents_set(project_name: str, selection: str | None) -> None:

--- a/src/terok/lib/api/__init__.py
+++ b/src/terok/lib/api/__init__.py
@@ -94,7 +94,6 @@ from terok.lib.api.gate import (  # noqa: F401 — re-exported public API
     GateAuthNotConfigured,
     GateStalenessInfo,
     make_git_gate,
-    mint_gate_token,
 )
 from terok.lib.api.project import (  # noqa: F401 — re-exported public API
     AGENTS_QUESTION,
@@ -366,7 +365,6 @@ __all__ = [
     "GateAuthNotConfigured",
     "GateStalenessInfo",
     "make_git_gate",
-    "mint_gate_token",
     # Project
     "AGENTS_QUESTION",
     "BrokenProject",

--- a/src/terok/lib/api/gate.py
+++ b/src/terok/lib/api/gate.py
@@ -5,23 +5,26 @@
 
 Re-export catalog for the per-container git gate.  Sources:
 [`terok.lib.integrations.sandbox`][terok.lib.integrations.sandbox] for
-the mirror staleness / auth types and ``mint_gate_token`` (terok-sandbox
-owns the gate infrastructure — the gate runs inside each container's
-supervisor), and
+the mirror staleness / auth types (terok-sandbox owns the gate
+infrastructure — the gate runs inside each container's supervisor), and
 [`terok.lib.domain.project`][terok.lib.domain.project] for
 ``make_git_gate`` (terok's per-project gate factory).
+
+Deliberately absent: raw token minting.  The task meta's ``gate_token``
+is the single source of truth for a task's gate token; the only mint
+point is the task-scoped accessor inside
+[`terok.lib.orchestration.environment`][terok.lib.orchestration.environment],
+so no caller can create a token value that bypasses the store.
 """
 
 from terok.lib.domain.project import make_git_gate  # noqa: F401 — re-exported public API
 from terok.lib.integrations.sandbox import (  # noqa: F401 — re-exported public API
     GateAuthNotConfigured,
     GateStalenessInfo,
-    mint_gate_token,
 )
 
 __all__ = [
     "GateAuthNotConfigured",
     "GateStalenessInfo",
     "make_git_gate",
-    "mint_gate_token",
 ]

--- a/src/terok/lib/orchestration/container_doctor.py
+++ b/src/terok/lib/orchestration/container_doctor.py
@@ -39,7 +39,7 @@ from ..core.config import make_sandbox_config
 from ..core.projects import load_project
 from ..util.check_reporter import CheckReporter
 from ..util.logging_utils import _log_debug
-from .tasks import container_name, load_task_meta, task_exists
+from .tasks import container_name, load_task_meta, read_task_meta, task_exists, tasks_meta_dir
 
 # Type alias matching sickbay.py convention
 _CheckResult = tuple[str, str, str]
@@ -205,6 +205,71 @@ def _git_remote_check(security_class: str) -> DoctorCheck:
     )
 
 
+def _gate_token_check(security_class: str, meta_token: str | None) -> DoctorCheck:
+    """Audit the gate-token chain: task meta → container env → workspace remote.
+
+    The task meta's ``gate_token`` is the single source of truth; the
+    container env is a snapshot frozen at (re)creation, and the
+    workspace's token-bearing remote (``origin`` in gatekeeping mode,
+    ``gate`` in online mode) is derived from that env.  The one broken
+    link that 403s git *right now* — workspace remote ≠ this container's
+    env — is an error and fixable in place; drift between the running
+    generation and the task meta merely reconciles at the next recreate,
+    so it only warns.  Token values never appear in messages.
+    """
+    remote, url_var = (
+        ("origin", "CODE_REPO") if security_class == "gatekeeping" else ("gate", "GATE_REMOTE_URL")
+    )
+
+    def _eval(rc: int, stdout: str, stderr: str) -> CheckVerdict:
+        """Compare the env token against the workspace remote and the task meta."""
+        lines = stdout.splitlines()
+        env_token = lines[0].strip() if lines else ""
+        remote_url = lines[1].strip() if len(lines) > 1 else ""
+        if not env_token:
+            return CheckVerdict("ok", "gate token: not wired for this container")
+        if not remote_url:
+            return CheckVerdict("warn", f"gate token: no {remote!r} remote to carry it")
+        if (urlparse(remote_url).username or "") != env_token:
+            return CheckVerdict(
+                "error",
+                f"gate token: {remote!r} remote embeds a stale token — git 403s at the gate",
+                fixable=True,
+            )
+        if meta_token is None:
+            return CheckVerdict(
+                "warn",
+                "gate token: consistent in-container, but not recorded in task meta "
+                "(task predates token persistence) — a recreate mints a new one",
+            )
+        if meta_token != env_token:
+            return CheckVerdict(
+                "warn",
+                "gate token: container runs a previous generation's token; "
+                "the task meta value takes over at the next recreate",
+            )
+        return CheckVerdict("ok", "gate token: task meta, container env, and workspace agree")
+
+    return DoctorCheck(
+        category="git",
+        label="Gate token sync",
+        probe_cmd=[
+            "bash",
+            "-lc",
+            f'echo "${{TEROK_GATE_TOKEN:-}}"; '
+            f"git -C {_CONTAINER_WORKSPACE} remote get-url {remote} 2>/dev/null || true",
+        ],
+        evaluate=_eval,
+        fix_cmd=[
+            "bash",
+            "-lc",
+            f'git -C {_CONTAINER_WORKSPACE} remote set-url {remote} "${{{url_var}}}" && '
+            f'git -C {_CONTAINER_WORKSPACE} remote set-url --push {remote} "${{{url_var}}}"',
+        ],
+        fix_description=f"Re-assert the {remote!r} remote URL from the container's ${url_var}.",
+    )
+
+
 def _port_drift_check(env_var: str, label: str, expected: int) -> DoctorCheck:
     """Check that a baked-in port env var still matches the resolved port."""
 
@@ -236,13 +301,16 @@ def _terok_doctor_checks(
     project_name: str,
     token_broker_port: int | None,
     ssh_signer_port: int | None,
+    meta_token: str | None = None,
 ) -> list[DoctorCheck]:
     """Build terok-level health checks from project config.
 
     ``None`` for either port argument selects socket mode for that
     subsystem: the matching drift check is omitted because sandbox
     doesn't bake a ``TEROK_*_PORT`` env into the container in that mode,
-    so there is no value to drift from.
+    so there is no value to drift from.  *meta_token* is the task meta's
+    ``gate_token`` (the durable source of truth) for the token-chain
+    audit; ``None`` when the task meta records none.
     """
     project = load_project(project_name)
 
@@ -257,6 +325,7 @@ def _terok_doctor_checks(
     checks.append(_git_identity_check(human_name, human_email, "email"))
 
     checks.append(_git_remote_check(project.security_class))
+    checks.append(_gate_token_check(project.security_class, meta_token))
     if token_broker_port is not None:
         checks.append(
             _port_drift_check(
@@ -403,6 +472,7 @@ def _check_per_container_services(cname: str) -> list[_CheckResult]:
 def _collect_all_checks(
     project_name: str,
     task_dir: Path,
+    task_id: str | None = None,
 ) -> list[DoctorCheck]:
     """Gather health checks from sandbox, agent, and terok layers.
 
@@ -441,7 +511,15 @@ def _collect_all_checks(
         )
     )
     checks.extend(AgentRoster.shared().doctor_checks(token_broker_port=token_broker_port))
-    checks.extend(_terok_doctor_checks(project_name, token_broker_port, ssh_signer_port))
+    # Tolerant meta read: the doctor must diagnose, not die, when the task
+    # meta is absent (the token-chain check then reports the gap itself).
+    meta = read_task_meta(tasks_meta_dir(project_name), task_id) if task_id else None
+    meta_token = (meta or {}).get("gate_token")
+    checks.extend(
+        _terok_doctor_checks(
+            project_name, token_broker_port, ssh_signer_port, meta_token=meta_token
+        )
+    )
     return checks
 
 
@@ -586,7 +664,7 @@ class ContainerDoctor:
         # (under krun: SSH over a passt-forwarded TCP port; under crun:
         # podman exec).
         runtime = _rt.resolve_runtime(load_project(self.project_name))
-        checks = list(_collect_all_checks(self.project_name, task_dir))
+        checks = list(_collect_all_checks(self.project_name, task_dir, self.task_id))
 
         # Per-container vault + gate reachability — host-side, best-effort.
         # Emitted after the layered probes so they read as a closing

--- a/src/terok/lib/orchestration/environment.py
+++ b/src/terok/lib/orchestration/environment.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 
 import logging
 import os
+from collections.abc import Callable
 from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -142,17 +143,42 @@ def _resolve_gate_port() -> int:
     return _CONTAINER_GATE_PORT
 
 
+def _task_gate_token(project_name: str, task_id: str) -> str:
+    """Return the task's gate token, minting and persisting it on first use.
+
+    Task-scoped, not container-scoped: the restart ladder's recreate rung
+    builds a fresh container while the workspace keeps the origin URL a
+    previous generation wrote into ``.git/config`` — a per-container
+    token would strand every recreated task on a dead credential (403
+    from the gate).  Persisting the token in the task meta (next to the
+    toad ``web_token``) keeps one token valid for the task's whole life;
+    it dies with the task's metadata.  The sidecar JSON already carries
+    the token in plaintext on the host, so this adds no new exposure.
+    """
+    from .tasks import load_task_meta, write_task_meta
+
+    meta, handle = load_task_meta(project_name, task_id)
+    token = meta.get("gate_token")
+    if not token:
+        token = mint_gate_token()
+        meta["gate_token"] = token
+        write_task_meta(handle, meta)
+    return str(token)
+
+
 def _gatekeeping_repo_env(
     project: ProjectConfig,
     gate_base: Path,
     gate_port: int,
+    token_source: Callable[[], str],
 ) -> dict[str, str]:
     """Repo-access env for a gatekeeping-class task — the gate *is* origin.
 
     The container clones and pushes through the gate, so a missing gate
-    mirror is fatal.  Mints a fresh per-task gate token, embeds it in the
-    gate URL, and exposes it via ``TEROK_GATE_TOKEN`` so the per-container
-    supervisor can validate the requests it receives.
+    mirror is fatal.  Resolves the task's persistent gate token via
+    *token_source*, embeds it in the gate URL, and exposes it via
+    ``TEROK_GATE_TOKEN`` so the per-container supervisor can validate
+    the requests it receives.
     """
     gate_repo = project.gate_path
     if not gate_repo.exists():
@@ -161,7 +187,7 @@ def _gatekeeping_repo_env(
             f"Expected at: {gate_repo}\n"
             f"Run 'terok project gate-sync {project.name}' to create/update the local mirror."
         )
-    token = mint_gate_token()
+    token = token_source()
     gate_url = _gate_url(gate_repo, gate_base, gate_port, token)
     env: dict[str, str] = {"CODE_REPO": gate_url, "TEROK_GATE_TOKEN": token}
     if project.default_branch:
@@ -175,20 +201,21 @@ def _online_repo_env(
     project: ProjectConfig,
     gate_base: Path,
     gate_port: int,
+    token_source: Callable[[], str],
 ) -> dict[str, str]:
     """Repo-access env for an online-class task — clones from upstream directly.
 
     The gate is used only as an opt-in clone accelerator
     (``gate.enabled``) when its mirror exists; ``gate.enabled: false``
     is the escape hatch for hosts that cannot use the gate.  When the
-    gate is in play it mints a fresh per-task token, embeds it in the
-    gate URL, and exposes it via ``TEROK_GATE_TOKEN`` for the
-    per-container supervisor to validate.
+    gate is in play it resolves the task's persistent token via
+    *token_source*, embeds it in the gate URL, and exposes it via
+    ``TEROK_GATE_TOKEN`` for the per-container supervisor to validate.
     """
     env: dict[str, str] = {}
     gate_repo = project.gate_path
     if project.gate_enabled and gate_repo.exists():
-        token = mint_gate_token()
+        token = token_source()
         gate_url = _gate_url(gate_repo, gate_base, gate_port, token)
         env["CLONE_FROM"] = gate_url
         env["TEROK_GATE_TOKEN"] = token
@@ -209,19 +236,25 @@ def _online_repo_env(
 def _security_mode_env_and_volumes(
     project: ProjectConfig,
     cfg: SandboxConfig,
+    token_source: Callable[[], str],
     *,
     use_socket: bool = False,
 ) -> tuple[dict[str, str], list[VolumeSpec]]:
-    """Return env vars and volumes for the project's security mode."""
+    """Return env vars and volumes for the project's security mode.
+
+    *token_source* supplies the gate token lazily — it is only called
+    (and thus only persisted into the task meta) when the mode actually
+    wires a gate URL.
+    """
     volumes: list[VolumeSpec] = []
     gate_repo = project.gate_path
     gate_base = cfg.gate_base_path
     gate_port = _resolve_gate_port()
 
     if project.security_class == "gatekeeping":
-        env = _gatekeeping_repo_env(project, gate_base, gate_port)
+        env = _gatekeeping_repo_env(project, gate_base, gate_port, token_source)
     else:
-        env = _online_repo_env(project, gate_base, gate_port)
+        env = _online_repo_env(project, gate_base, gate_port, token_source)
 
     # Gate socket path for the container-side socat bridge.  The gate now
     # runs inside the per-container supervisor, which binds
@@ -525,7 +558,12 @@ class TaskEnvironment:
 
         # Pre-resolve gate server URLs → CODE_REPO / CLONE_FROM / GIT_BRANCH,
         # plus any security-mode volumes (the gate socket sub-mount).
-        sec_env, sec_volumes = _security_mode_env_and_volumes(project, cfg, use_socket=use_socket)
+        sec_env, sec_volumes = _security_mode_env_and_volumes(
+            project,
+            cfg,
+            lambda: _task_gate_token(project.name, task_id),
+            use_socket=use_socket,
+        )
 
         # Seed workspace from clone cache (fast-start optimisation).
         # Only for new tasks (marker present, no .git yet).  The in-container

--- a/src/terok/lib/orchestration/task_runners/restart.py
+++ b/src/terok/lib/orchestration/task_runners/restart.py
@@ -50,8 +50,10 @@ def task_restart(project_name: str, task_id: str, *, fresh: bool = False) -> Non
     When the resume rung is gone — the container no longer exists or
     podman refuses to start it — recreate the container through the
     normal launch path: same task and container name, workspace reused
-    as-is (never re-seeded), project config re-read, tokens minted fresh,
-    per-task settings carried over from the saved metadata.
+    as-is (never re-seeded), project config re-read, the task's
+    persistent gate token reused (the workspace's origin URL embeds it,
+    so it must survive the recreate), per-task settings carried over
+    from the saved metadata.
 
     *fresh* skips straight to the recreate rung — the explicit
     "recreate + restart" that picks up a rebuilt image, upgrading a task
@@ -309,9 +311,9 @@ def _recreate_in_place(
 ) -> None:
     """Tear the old container down and relaunch the task into the same name.
 
-    The mode runner's launch path re-reads project config and mints
-    fresh tokens; the workspace is reused as-is — with no new-task
-    marker the init script fetches without resetting — and the task's
+    The mode runner's launch path re-reads project config and reuses the
+    task's persistent gate token; the workspace is reused as-is — with no
+    new-task marker the init script fetches without resetting — and the task's
     ``unrestricted`` choice (caller override, else saved metadata)
     overrides the runner's config resolution.
 

--- a/src/terok/lib/orchestration/tasks/lifecycle.py
+++ b/src/terok/lib/orchestration/tasks/lifecycle.py
@@ -393,11 +393,13 @@ def _task_delete(project: ProjectConfig, task_id: str) -> TaskDeleteResult:
         _log_debug("task_delete: archiving task")
         _archive_task(project, task_id, meta)
 
-    # The gate token is a stateless pair-match between the container's
-    # env and the supervisor sidecar.  *Successful* removal below kills
-    # both live ends (env + supervisor); the sidecar's on-disk copy is
-    # swept right after — it must outlive mere stops so restarts come
-    # back supervised, so delete is where it actually goes.
+    # At request time the gate token is a stateless pair-match between
+    # the container's env and the supervisor sidecar.  *Successful*
+    # removal below kills both live ends (env + supervisor); the
+    # sidecar's on-disk copy is swept right after — it must outlive mere
+    # stops so restarts come back supervised, so delete is where it
+    # actually goes.  The task meta's ``gate_token`` (the durable mint
+    # record) leaves with the task metadata at the end of this delete.
     _log_debug("task_delete: removing task containers")
     containers_removed = _remove_task_containers(project.name, task_id, warnings)
     if containers_removed:
@@ -405,9 +407,10 @@ def _task_delete(project: ProjectConfig, task_id: str) -> TaskDeleteResult:
     else:
         # Removal failed, so the supervisor — and the in-memory gate token it
         # holds — may still be live even as the rest of the delete proceeds.
-        # There is no host-side store to revoke from, so surface it loudly:
-        # the operator must stop the container manually or run `terok panic`
-        # to invalidate the token.
+        # No host-side store can revoke it (the task meta only records the
+        # value for minting reuse; the gate consults the supervisor's copy),
+        # so surface it loudly: the operator must stop the container manually
+        # or run `terok panic` to invalidate the token.
         warnings.append(
             "Container removal failed — its supervisor may still be live and "
             "holding a valid gate token; stop the container manually or run "

--- a/src/terok/tui/worker_actions.py
+++ b/src/terok/tui/worker_actions.py
@@ -126,6 +126,9 @@ def sync_gate(project_name: str) -> None:
             if result["created"]
             else "Gate synced from upstream."
         )
+        if result.get("cache_error"):
+            print(f"Warning: clone cache refresh failed: {result['cache_error']}")
+            print("New tasks fall back to a full clone until the next successful sync.")
         return
     _print_sync_gate_ssh_help(project_name)
     raise SystemExit(f"Gate sync failed: {', '.join(result['errors'])}")

--- a/tach.toml
+++ b/tach.toml
@@ -429,6 +429,7 @@ layer = "orchestration"
 depends_on = [
     "terok.lib.core.config",
     "terok.lib.core.projects",
+    "terok.lib.orchestration.tasks",
     "terok.lib.util.fs",
     "terok.lib.util.host_cmd",
 ]

--- a/tests/unit/lib/test_container_doctor.py
+++ b/tests/unit/lib/test_container_doctor.py
@@ -14,6 +14,7 @@ from terok_sandbox.doctor import CheckVerdict, DoctorCheck
 
 from terok.lib.orchestration.container_doctor import (
     _exec_in_container,
+    _gate_token_check,
     _git_identity_check,
     _git_remote_check,
     _port_drift_check,
@@ -124,6 +125,66 @@ class TestGitRemoteCheck:
         assert verdict.severity == "error"
         assert "5555" in verdict.detail
         assert "re-allocated" in verdict.detail
+
+
+class TestGateTokenCheck:
+    """Gate-token chain audit: task meta → container env → workspace remote.
+
+    Probe output shape: first line is ``$TEROK_GATE_TOKEN`` (empty when
+    unset), second line the token-bearing remote's URL.  Token values
+    must never leak into verdict messages.
+    """
+
+    def test_ok_when_full_chain_agrees(self) -> None:
+        check = _gate_token_check("gatekeeping", "terok-g-aa")
+        verdict = check.evaluate(0, "terok-g-aa\nhttp://terok-g-aa@localhost:9418/proj.git\n", "")
+        assert verdict.severity == "ok"
+
+    def test_ok_when_gate_not_wired(self) -> None:
+        check = _gate_token_check("gatekeeping", None)
+        verdict = check.evaluate(0, "\n\n", "")
+        assert verdict.severity == "ok"
+        assert "not wired" in verdict.detail
+
+    def test_error_and_fixable_when_workspace_token_stale(self) -> None:
+        """The incident shape: recreate minted a new token, workspace kept the old."""
+        check = _gate_token_check("gatekeeping", "terok-g-new")
+        verdict = check.evaluate(0, "terok-g-new\nhttp://terok-g-old@localhost:9418/proj.git\n", "")
+        assert verdict.severity == "error"
+        assert verdict.fixable is True
+        assert "terok-g-old" not in verdict.detail
+        assert "terok-g-new" not in verdict.detail
+
+    def test_warn_when_meta_has_no_token(self) -> None:
+        """Pre-persistence task: in-container consistent, but no durable record."""
+        check = _gate_token_check("gatekeeping", None)
+        verdict = check.evaluate(0, "terok-g-aa\nhttp://terok-g-aa@localhost:9418/proj.git\n", "")
+        assert verdict.severity == "warn"
+        assert "task meta" in verdict.detail
+
+    def test_warn_when_container_behind_meta(self) -> None:
+        """A resumed old generation is fine now and reconciles at recreate."""
+        check = _gate_token_check("gatekeeping", "terok-g-meta")
+        verdict = check.evaluate(0, "terok-g-aa\nhttp://terok-g-aa@localhost:9418/proj.git\n", "")
+        assert verdict.severity == "warn"
+        assert "recreate" in verdict.detail
+
+    def test_warn_when_remote_missing(self) -> None:
+        check = _gate_token_check("gatekeeping", "terok-g-aa")
+        verdict = check.evaluate(0, "terok-g-aa\n", "")
+        assert verdict.severity == "warn"
+
+    def test_online_mode_audits_gate_remote(self) -> None:
+        check = _gate_token_check("online", "terok-g-aa")
+        assert "gate" in check.probe_cmd[-1]
+        assert "GATE_REMOTE_URL" in check.fix_cmd[-1]
+        verdict = check.evaluate(0, "terok-g-aa\nhttp://terok-g-aa@localhost:9418/proj.git\n", "")
+        assert verdict.severity == "ok"
+
+    def test_gatekeeping_fix_reasserts_origin_from_env(self) -> None:
+        check = _gate_token_check("gatekeeping", "terok-g-aa")
+        assert "origin" in check.fix_cmd[-1]
+        assert "CODE_REPO" in check.fix_cmd[-1]
 
 
 class TestPortDriftCheck:

--- a/tests/unit/lib/test_environment_gate_server.py
+++ b/tests/unit/lib/test_environment_gate_server.py
@@ -52,17 +52,15 @@ def resolve_security_env(
 ) -> tuple[ProjectConfig, dict[str, str], list]:
     """Load a project and evaluate gate-related env/volume settings.
 
-    Patches ``mint_gate_token`` so the embedded token is deterministic;
-    the gate base path is read straight off ``cfg.gate_base_path`` (a
-    ``SandboxConfig`` property), so no manager patching is needed.
+    Supplies a deterministic token source (the callers of the real thing
+    resolve the task-persistent token); the gate base path is read
+    straight off ``cfg.gate_base_path`` (a ``SandboxConfig`` property),
+    so no manager patching is needed.
     """
+    token_value = token or "tok" * 10 + "ab"
     with (
         mock_git_config(),
         project_env(yaml_text, project_name=project_name, with_gate=with_gate) as ctx,
-        patch(
-            "terok.lib.orchestration.environment.mint_gate_token",
-            return_value=token or "tok" * 10 + "ab",
-        ),
         patch(
             "terok.lib.orchestration.environment.SandboxConfig.gate_base_path",
             new_callable=lambda: property(lambda self: ctx.base / "sandbox-state" / "gate"),
@@ -72,7 +70,7 @@ def resolve_security_env(
 
         project = load_project(project_name)
         env, volumes = _security_mode_env_and_volumes(
-            project, SandboxConfig(), use_socket=use_socket
+            project, SandboxConfig(), lambda: token_value, use_socket=use_socket
         )
     return project, env, volumes
 
@@ -110,12 +108,49 @@ def test_gate_projects_use_http_urls_with_tokens(
         assert env["CODE_REPO"] == "https://example.com/repo.git"
 
 
+def test_task_gate_token_is_minted_once_and_persisted() -> None:
+    """The gate token is task-scoped: minted on first use, then reused.
+
+    Regression: the recreate rung of the restart ladder builds a fresh
+    container env — a per-container token stranded the reused workspace
+    on the dead credential embedded in its origin URL (403 from the
+    gate).  The token must come back identical across env rebuilds.
+    """
+    from terok.lib.orchestration.environment import _task_gate_token
+    from terok.lib.orchestration.tasks import dossier_path, tasks_meta_dir, write_task_meta
+
+    with mock_git_config(), project_env(_ONLINE_YAML, project_name="online-proj"):
+        meta_dir = tasks_meta_dir("online-proj")
+        write_task_meta(
+            dossier_path(meta_dir, "t1"), {"project_name": "online-proj", "task_id": "t1"}
+        )
+
+        first = _task_gate_token("online-proj", "t1")
+        second = _task_gate_token("online-proj", "t1")
+
+        assert first == second
+        assert first.startswith("terok-g-")
+        # Persisted in the task meta, like the toad web_token.
+        from terok.lib.orchestration.tasks import read_task_meta
+
+        assert read_task_meta(meta_dir, "t1")["gate_token"] == first
+
+
+def test_task_gate_token_unknown_task_raises() -> None:
+    """Resolving a token for a task without metadata fails loudly."""
+    from terok.lib.orchestration.environment import _task_gate_token
+
+    with mock_git_config(), project_env(_ONLINE_YAML, project_name="online-proj"):
+        with pytest.raises(SystemExit, match="Unknown task"):
+            _task_gate_token("online-proj", "no-such-task")
+
+
 def test_gatekeeping_missing_gate_raises() -> None:
     """Gatekeeping mode requires a synced gate mirror before task startup."""
     with mock_git_config(), project_env(_GATEKEEPING_YAML, project_name="gk-proj", with_gate=False):
         project = load_project("gk-proj")
         with pytest.raises(SystemExit, match="gate-sync"):
-            _security_mode_env_and_volumes(project, MagicMock())
+            _security_mode_env_and_volumes(project, MagicMock(), lambda: "t" * 32)
 
 
 def test_online_gate_uses_clone_from_and_gate_remote() -> None:

--- a/tests/unit/lib/test_tasks.py
+++ b/tests/unit/lib/test_tasks.py
@@ -56,6 +56,19 @@ from tests.testfs import CONTAINER_SSH_DIR
 from tests.testnet import GATE_PORT
 
 
+def _seed_task_meta(project_name: str, task_id: str) -> None:
+    """Create the minimal on-disk task meta ``build_task_env_and_volumes`` expects.
+
+    The real runners load the task meta before materializing the env, and
+    the task-persistent gate token is stored in that same file — a
+    gate-wired env build without task meta fails loudly ("Unknown task").
+    """
+    write_task_meta(
+        dossier_path(tasks_meta_dir(project_name), task_id),
+        {"project_name": project_name, "task_id": task_id},
+    )
+
+
 def _set_state_sequence(mock_runtime, states: list[str | None]):
     """Patch ``runtime.container(...).state`` to yield ``states`` across calls.
 
@@ -363,6 +376,7 @@ class TestTask:
             with_config_file=True,
             with_gate=True,
         ):
+            _seed_task_meta(project_name, "7")
             env, volumes = build_task_env_and_volumes(
                 project=load_project(project_name),
                 task_id="7",
@@ -398,6 +412,7 @@ class TestTask:
                 f"project:\n  id: {project_name}\n  security_class: gatekeeping\ngit:\n  default_branch: main\n",
             )
 
+            _seed_task_meta(project_name, "9")
             env, volumes = build_task_env_and_volumes(
                 project=load_project(project_name),
                 task_id="9",
@@ -427,6 +442,7 @@ class TestTask:
                 f"project:\n  id: {project_name}\n  security_class: online\ngit:\n  upstream_url: https://example.com/repo.git\n  default_branch: main\n",
             )
 
+            _seed_task_meta(project_name, "8")
             env, volumes = build_task_env_and_volumes(load_project(project_name), task_id="8")
             assert env["CODE_REPO"] == "https://example.com/repo.git"
             assert env["GIT_BRANCH"] == "main"
@@ -882,6 +898,7 @@ class TestTask:
             with_config_file=True,
             with_gate=True,
         ):
+            _seed_task_meta(project_name, "10")
             env, _ = build_task_env_and_volumes(
                 project=load_project(project_name),
                 task_id="10",
@@ -906,6 +923,7 @@ class TestTask:
             with_config_file=True,
             with_gate=True,
         ):
+            _seed_task_meta(project_name, "11")
             env, _ = build_task_env_and_volumes(
                 project=load_project(project_name),
                 task_id="11",
@@ -929,6 +947,7 @@ class TestTask:
             with_config_file=True,
             with_gate=True,
         ):
+            _seed_task_meta(project_name, "12")
             env, _ = build_task_env_and_volumes(
                 project=load_project(project_name),
                 task_id="12",
@@ -959,6 +978,7 @@ class TestTask:
             with_config_file=True,
             with_gate=True,
         ):
+            _seed_task_meta(project_name, "13")
             env, _ = build_task_env_and_volumes(
                 project=load_project(project_name),
                 task_id="13",

--- a/tests/unit/test_error_surfacing.py
+++ b/tests/unit/test_error_surfacing.py
@@ -443,20 +443,16 @@ class TestEnvironmentWarnings:
         gate_path.resolve.return_value.parent = Path("/fake/gate")
         mock_project.gate_path = gate_path
 
-        with (
-            patch(
-                "terok.lib.orchestration.environment.SandboxConfig.gate_base_path",
-                new_callable=PropertyMock,
-                return_value=Path("/fake/gate"),
-            ),
-            patch(
-                "terok.lib.orchestration.environment.mint_gate_token",
-                return_value="t" * 32,
-            ),
+        with patch(
+            "terok.lib.orchestration.environment.SandboxConfig.gate_base_path",
+            new_callable=PropertyMock,
+            return_value=Path("/fake/gate"),
         ):
             from terok.lib.integrations.sandbox import SandboxConfig
 
-            env, _vols = _security_mode_env_and_volumes(mock_project, SandboxConfig())
+            env, _vols = _security_mode_env_and_volumes(
+                mock_project, SandboxConfig(), lambda: "t" * 32
+            )
 
         err = capsys.readouterr().err
         assert "unreachable" not in err.lower()

--- a/tests/unit/tui/test_worker_actions.py
+++ b/tests/unit/tui/test_worker_actions.py
@@ -76,6 +76,30 @@ def test_sync_gate_success_does_not_raise() -> None:
     fake_gate.sync.assert_called_once()
 
 
+def test_sync_gate_reports_cache_refresh_failure(capsys: pytest.CaptureFixture[str]) -> None:
+    """A successful sync with a failed clone-cache refresh names the failure.
+
+    The sync itself stays green (the cache is an optimization), but the
+    summary must not read as an all-clear while the refresh silently
+    failed.
+    """
+    fake_gate = mock.Mock()
+    fake_gate.sync.return_value = {
+        "success": True,
+        "created": False,
+        "errors": [],
+        "cache_error": "exit status 128: fatal: bad ref",
+    }
+    with (
+        mock.patch("terok.lib.api.load_project"),
+        mock.patch("terok.lib.api.make_git_gate", return_value=fake_gate),
+    ):
+        worker_actions.sync_gate("proj")
+    out = capsys.readouterr().out
+    assert "Gate synced from upstream." in out
+    assert "clone cache refresh failed: exit status 128: fatal: bad ref" in out
+
+
 def test_sync_gate_failure_raises_systemexit() -> None:
     """A failed sync raises ``SystemExit`` so the child exits non-zero."""
     fake_gate = mock.Mock()


### PR DESCRIPTION
## Problem (field report, 0.8.3 → 0.8.4 upgrade)

After upgrading a host to 0.8.4 and rebooting, a pre-existing task's git operations started failing with a gate 403 while new tasks worked. Chain of events:

1. The gate token was minted fresh on every container **creation** and embedded in the workspace's origin URL (persisted in `.git/config`).
2. The upgrade rebuilt the project image, so the 0.8.4 restart ladder (#1115) took the **recreate** rung: new container, new token in env + sidecar — but the workspace was reused as-is, still carrying the old token in its origin URL.
3. The init script's origin fixup only recognised `file://` gate URLs (pre-HTTP-gate relic), so the dead URL was never repaired → permanent 403.

## Fix

**The token is now task-scoped, not container-scoped**: resolved through the task meta (minted on first use, reused by every later env build, gone when the task's metadata goes) — the same pattern as the toad `web_token`. The sidecar JSON already stores the token in plaintext on the host, so persistence adds no new exposure. The token source is threaded into the security-mode env builders as a callable, so gate-less tasks never write the meta key. New tach edge: `orchestration.environment → orchestration.tasks` (no cycle; both symbols were already in the exposed interface).

Also makes gate-sync reporting honest: TUI worker and CLI now print the new `GateSyncResult.cache_error` ("Clone cache refresh failed … exit status 128" was previously logged as *non-fatal* and then contradicted by an unqualified "Gate synced from upstream." + exit 0).

## Companion PRs

- terok-ai/terok-executor#440 — init script re-asserts `origin == CODE_REPO` before the first fetch (heals already-stranded workspaces; defense in depth).
- terok-ai/terok-sandbox#430 — clone-cache `origin/HEAD` refresh fix + the `cache_error` field consumed here.

**⚠ Repin before merge:** `pyproject.toml` points `terok-executor` / `terok-sandbox` at the two PR branch tips. Once those merge and release, repin to the release wheels/ranges and re-lock (remember the version-sync rule: bump executor's sandbox pin first).

## Tests

- `_task_gate_token`: minted once, persisted in meta, identical across env rebuilds; unknown task fails loudly.
- `sync_gate` reports a failed cache refresh while staying green.
- `make check` fully green (2746 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## SSOT contract (second commit)

The task meta's `gate_token` is the **single source of truth** for a task's gate token, enforced three ways:

- **One writer**: raw `mint_gate_token` is removed from the `terok.lib.api` surface (it was re-exported but unused); the task-scoped accessor in `orchestration/environment.py` is the only mint point, so no code path can produce a token value that bypasses the store.
- **Derived copies with defined refresh boundaries**: container env + sidecar JSON are snapshots frozen at container (re)creation; the workspace's token-bearing remote is re-asserted from the container env on every start (executor PR).
- **Divergence is observable and repairable**: a new `Gate token sync` doctor check audits the chain task meta → container env → workspace remote. The one link that 403s git *right now* (workspace ≠ this generation's env) is an error and fixable in place — `doctor --fix` re-asserts the remote from the container's own `$CODE_REPO`/`$GATE_REMOTE_URL` without a restart. Cross-generation drift (container ≠ meta) only warns: it reconciles at the next recreate by construction. Token values never appear in check output.

Contract documented in `docs/developer.md` next to the restart-ladder invariants.

## Pin status (rebased on master, 2026-07-11)

Rebased on master after #1138 and #1135 landed. This branch no longer touches `pyproject.toml` / `poetry.lock` at all — the sandbox 0.4.1a1 / executor 0.3.1a1 wheel pins are inherited from master, and both wheels contain the companion fixes (sandbox#430, executor#440). Docstrings/docs were re-merged onto #1135'''s new restart semantics (image drift warn-only, `--recreate` as the explicit upgrade). Full `make check` green: 2786 passed.

On final (non-alpha) sibling releases, swap the wheel URLs for range pins as usual — that repin now belongs to master, not this PR.

