### PR TITLE
ci: opt in to fork-PR checkout in the Sonar workflow_run scan

### DIFF
--- a/.github/workflows/sonar_pr.yml
+++ b/.github/workflows/sonar_pr.yml
@@ -61,6 +61,10 @@ jobs:
           ref: ${{ env.PR_SHA }}
           fetch-depth: 0
           persist-credentials: false
+          # Reviewed opt-in to checkout@v7's workflow_run pwn-request guard: this
+          # trusted-context checkout is the workflow's entire purpose; the header
+          # comment documents the mitigations.
+          allow-unsafe-pr-checkout: true
 
       - uses: actions/download-artifact@v8
         with:


### PR DESCRIPTION
## What

One-line opt-in on the `sonar_pr.yml` checkout step: `allow-unsafe-pr-checkout: true`.

## Why

`actions/checkout@v7` added a pwn-request guard that refuses fork-PR checkouts inside `workflow_run` workflows without an explicit opt-in. Since the v6→v7 dependabot bump, every fork PR's "Sonar PR" run has failed on the checkout step, so **no fork PR has had SonarCloud analysis for ~3 weeks** — invisible because Sonar is not a required check and the PR-visible `sonar.yml` job legitimately reports "skipping" for forks.

This workflow is deliberately the pattern the guard protects against, with the mitigations already in place (see its header comment): artifact-only inputs from the untrusted run, PR sha/repo verified against the `workflow_run` payload, `persist-credentials: false`, and only the Sonar scanner touching the checked-out tree (reads sources, executes nothing from the repo).

Part of terok-ai/terok#1142 — same one-line fix across all six repos carrying this workflow.

Note: analysis for currently-open fork PRs resumes on their next push (the `workflow_run` trigger needs a fresh "Tests & Analysis" run).

🤖 Generated with [Claude Code](https://claude.com/claude-code)