### PR TITLE
fix(acp): type the select() watch set as file-descriptor-like

### DIFF
--- a/src/terok/cli/commands/acp.py
+++ b/src/terok/cli/commands/acp.py
@@ -309,7 +309,7 @@ def _inprocess_pump(sock_path: Path, *, log_path: Path) -> None:
             # ``select`` keeps marking it ready and we'd attempt a
             # second ``shutdown(SHUT_WR)``, dropping the daemon's
             # final reply on the floor.
-            read_fds: list[object] = [sock]
+            read_fds: list[socket.socket | int] = [sock]
             if stdin_open:
                 read_fds.append(stdin_fd)
             ready, _, _ = select.select(read_fds, [], [])


### PR DESCRIPTION
## Problem

The `typecheck` job on #1144 (dev-deps bump) fails with:

```
src/terok/cli/commands/acp.py:315: error: Value of type variable "_R" of "select" cannot be "object"  [type-var]
```

The bump takes mypy 2.1.0 → 2.2.0, and 2.2.0 enforces `select.select`'s `_R` type-variable bound (`FileDescriptorLike`). The ACP bridge builds its watch set as `read_fds: list[object]` — it actually holds a `socket.socket` and stdin's `int` fd, both valid selectables — so the over-wide annotation, not the code, trips the new check.

## Fix

Annotate the watch set with its actual element types: `list[socket.socket | int]`. Verified clean under both mypy 2.1.0 (current lock) and 2.2.0 (#1144's lock); full `make typecheck` green, acp tests pass (36).

Merge this first, then rebase #1144 (`@dependabot rebase`) and its typecheck goes green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)