### PR TITLE
ci: sonar pair rides the fleet reusables; util refs on the newest tag

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ permissions:
 
 jobs:
   checks:
-    uses: terok-ai/terok-util/.github/workflows/fleet-checks.yml@v0.3.0a3
+    uses: terok-ai/terok-util/.github/workflows/fleet-checks.yml@v0.3.0a4
     with:
       run-lint-imports: true
 

--- a/.github/workflows/no-git-deps.yml
+++ b/.github/workflows/no-git-deps.yml
@@ -13,4 +13,4 @@ jobs:
   # the package family); this caller keeps the local triggers and the
   # release.yml gate wiring.
   scan:
-    uses: terok-ai/terok-util/.github/workflows/no-git-deps.yml@v0.3.0a3
+    uses: terok-ai/terok-util/.github/workflows/no-git-deps.yml@v0.3.0a4

--- a/.github/workflows/sonar.yml
+++ b/.github/workflows/sonar.yml
@@ -1,22 +1,9 @@
+# Same-repo SonarQube Cloud scan.  The job body lives in terok-util's
+# fleet-sonar.yml (reusable across the package family), pinned here by
+# release tag.  Fork PRs are handled by sonar_pr.yml via workflow_run in
+# the trusted base-repo context, because GitHub does not expose
+# SONAR_TOKEN to runs originating from forks.
 name: SonarQube Cloud
-
-# Pin third-party actions to full commit SHAs for supply-chain security.
-# GitHub-owned actions (actions/*) may use version tags.
-#
-# Same-repo SonarQube scan. Split out of analysis.yml so its third-party
-# wait time doesn't block the Tests & Analysis workflow's conclusion (which
-# docs.yml waits on, and which gates the master Pages deploy).
-#
-# Triggering contexts (must match the inline sonar job this replaces):
-#   - push to master in terok-ai/terok
-#   - same-repo pull request against master (excluding dependabot)
-# Fork PRs continue to be handled by sonar_pr.yml via workflow_run in the
-# trusted base-repo context, because GitHub does not expose SONAR_TOKEN to
-# runs originating from forks.
-#
-# Wait/handoff: poll analysis.yml's run for this commit to complete, then
-# download its coverage/ruff/bandit artifacts via dawidd6 — same shape as
-# docs.yml's master gate.
 
 on:
   push:
@@ -31,77 +18,6 @@ permissions:
 
 jobs:
   sonar:
-    name: SonarQube Cloud
-    if: >-
-      github.repository == 'terok-ai/terok' &&
-      (github.event_name == 'push'
-       || (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/master')
-       || (github.actor != 'dependabot[bot]'
-           && github.event.pull_request.head.repo.full_name == github.repository))
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v7
-        with:
-          fetch-depth: 0
-
-      - name: Wait for Tests & Analysis on this commit
-        uses: actions/github-script@v9
-        with:
-          script: |
-            const deadline = Date.now() + 20 * 60 * 1000;
-            const sleep = ms => new Promise(r => setTimeout(r, ms));
-            const sha = context.payload.pull_request?.head.sha || context.sha;
-            while (Date.now() < deadline) {
-              const { data } = await github.rest.actions.listWorkflowRuns({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                workflow_id: 'analysis.yml',
-                head_sha: sha,
-                per_page: 5,
-              });
-              const run = data.workflow_runs[0];
-              if (run?.status === 'completed') {
-                if (run.conclusion === 'success') {
-                  core.info(`Tests & Analysis succeeded for ${sha}`);
-                  return;
-                }
-                core.setFailed(`Tests & Analysis ${run.conclusion} for ${sha}`);
-                return;
-              }
-              core.info(`Tests & Analysis for ${sha}: ${run?.status ?? 'not yet started'} — waiting`);
-              await sleep(20_000);
-            }
-            core.setFailed('Timed out after 20m waiting for Tests & Analysis')
-
-      - name: Coverage artifact
-        uses: dawidd6/action-download-artifact@b6e2e70617bc3265edd6dab6c906732b2f1ae151 # v21
-        with:
-          workflow: analysis.yml
-          workflow_conclusion: success
-          commit: ${{ github.event.pull_request.head.sha || github.sha }}
-          name: coverage
-          path: reports
-
-      - name: Ruff artifact
-        uses: dawidd6/action-download-artifact@b6e2e70617bc3265edd6dab6c906732b2f1ae151 # v21
-        with:
-          workflow: analysis.yml
-          workflow_conclusion: success
-          commit: ${{ github.event.pull_request.head.sha || github.sha }}
-          name: ruff
-          path: reports
-
-      - name: Bandit artifact
-        uses: dawidd6/action-download-artifact@b6e2e70617bc3265edd6dab6c906732b2f1ae151 # v21
-        with:
-          workflow: analysis.yml
-          workflow_conclusion: success
-          commit: ${{ github.event.pull_request.head.sha || github.sha }}
-          name: bandit
-          path: reports
-
-      - name: SonarQube Cloud scan
-        uses: SonarSource/sonarqube-scan-action@713881670b6b3676cda39549040e2d88c70d582e # v8.2.0
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
-          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+    uses: terok-ai/terok-util/.github/workflows/fleet-sonar.yml@v0.3.0a4
+    secrets:
+      SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/sonar_pr.yml
+++ b/.github/workflows/sonar_pr.yml
@@ -1,11 +1,10 @@
+# Fork-PR SonarQube Cloud scan.  A workflow_run trigger cannot live in a
+# reusable workflow, so this thin file carries only the trigger; the job
+# body — including every pwn-request mitigation and the reviewed
+# ``allow-unsafe-pr-checkout`` opt-in — lives in terok-util's
+# fleet-sonar-pr.yml (reusable across the package family), pinned here by
+# release tag.
 name: Sonar PR
-
-# Pin third-party actions to full commit SHAs for supply-chain security.
-# GitHub-owned actions (actions/*) may use version tags.
-# Fork pull requests cannot access SONAR_TOKEN in the original PR-triggered run.
-# This follow-up workflow runs in the base repository context, downloads only the
-# previously generated artifacts, checks out the exact PR commit, and runs Sonar
-# without re-running untrusted test commands under repository secrets.
 
 on:
   workflow_run:
@@ -17,84 +16,7 @@ permissions:
   contents: read
 
 jobs:
-  # Restrict this workflow to fork PRs only. Same-repo PRs already scan directly in
-  # analysis.yml, and pushes scan there as well.
   sonar:
-    name: SonarQube Cloud
-    if: github.repository == 'terok-ai/terok' && github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.head_repository.full_name != github.repository
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/download-artifact@v8
-        with:
-          github-token: ${{ github.token }}
-          run-id: ${{ github.event.workflow_run.id }}
-          name: pr
-          path: reports/pr
-
-      - name: Load PR metadata
-        env:
-          EXPECTED_REPO: ${{ github.event.workflow_run.head_repository.full_name }}
-          EXPECTED_SHA: ${{ github.event.workflow_run.head_sha }}
-        run: |
-          read -r PR_NUMBER < reports/pr/number
-          read -r PR_BASE < reports/pr/base
-          read -r PR_REF < reports/pr/ref
-          read -r PR_REPO < reports/pr/repo
-          read -r PR_SHA < reports/pr/sha
-
-          test "$PR_REPO" = "$EXPECTED_REPO"
-          test "$PR_SHA" = "$EXPECTED_SHA"
-
-          {
-            printf 'PR_NUMBER=%s\n' "$PR_NUMBER"
-            printf 'PR_BASE=%s\n' "$PR_BASE"
-            printf 'PR_REF=%s\n' "$PR_REF"
-            printf 'PR_REPO=%s\n' "$PR_REPO"
-            printf 'PR_SHA=%s\n' "$PR_SHA"
-          } >> "$GITHUB_ENV"
-
-      # Checkout happens after metadata is loaded so the workflow can analyze the PR's
-      # exact head commit while still running under the trusted base-repo workflow context.
-      - uses: actions/checkout@v7
-        with:
-          repository: ${{ env.PR_REPO }}
-          ref: ${{ env.PR_SHA }}
-          fetch-depth: 0
-          persist-credentials: false
-          # Reviewed opt-in to checkout@v7's workflow_run pwn-request guard: this
-          # trusted-context checkout is the workflow's entire purpose; the header
-          # comment documents the mitigations.
-          allow-unsafe-pr-checkout: true
-
-      - uses: actions/download-artifact@v8
-        with:
-          github-token: ${{ github.token }}
-          run-id: ${{ github.event.workflow_run.id }}
-          name: coverage
-          path: reports
-
-      - uses: actions/download-artifact@v8
-        with:
-          github-token: ${{ github.token }}
-          run-id: ${{ github.event.workflow_run.id }}
-          name: ruff
-          path: reports
-
-      - uses: actions/download-artifact@v8
-        with:
-          github-token: ${{ github.token }}
-          run-id: ${{ github.event.workflow_run.id }}
-          name: bandit
-          path: reports
-
-      - name: SonarQube Cloud scan
-        uses: SonarSource/sonarqube-scan-action@713881670b6b3676cda39549040e2d88c70d582e # v8.2.0
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
-          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-        with:
-          args: >
-            -Dsonar.pullrequest.key=${{ env.PR_NUMBER }}
-            -Dsonar.pullrequest.branch=${{ env.PR_REF }}
-            -Dsonar.pullrequest.base=${{ env.PR_BASE }}
-            -Dsonar.scm.revision=${{ env.PR_SHA }}
+    uses: terok-ai/terok-util/.github/workflows/fleet-sonar-pr.yml@v0.3.0a4
+    secrets:
+      SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}


### PR DESCRIPTION
Fleet sweep for terok-ai/terok-util#50: `sonar.yml` and `sonar_pr.yml` become thin callers of the `fleet-sonar[-pr].yml` reusables pinned at `v0.3.0a4`, with only the triggers (including the local `workflow_run` on "Tests & Analysis") staying in this repo. The `fleet-checks.yml` / `no-git-deps.yml` refs ride the same tag. Note the required-check names change to the reusable-caller style, e.g. "sonar / SonarQube Cloud".

🤖 Generated with [Claude Code](https://claude.com/claude-code)