### PR TITLE
fix(matrix): import has_global_hooks from its public podman_info home

### DIFF
--- a/tests/containers/matrix.yml
+++ b/tests/containers/matrix.yml
@@ -63,7 +63,12 @@ phases:
   - name: "phase 2: installing shield hooks"
     run:
       - terok shield install-hooks
-      - python3 -c "from terok_shield import has_global_hooks; assert has_global_hooks(), 'Shield hooks not detected after setup'; print('Shield hooks verified.')"
+      # has_global_hooks moved off shield's lazified root barrel; its public
+      # home is the terok_shield.podman_info subpackage (whose docstring
+      # invites submodule imports).  `check-environment` is no substitute:
+      # its hooks= field folds in podman-version policy, so it cannot assert
+      # "install-hooks put files on disk" on hooks_dir-persisting podman.
+      - python3 -c "from terok_shield.podman_info import has_global_hooks; assert has_global_hooks(), 'Shield hooks not detected after setup'; print('Shield hooks verified.')"
     expect-add: [hooks]
   - name: "phase 3: tests with hooks"
     scope: integ


### PR DESCRIPTION
## Problem

Tonight's parallel matrix run failed the **"phase 2: installing shield hooks"** phase on **all 10 slots** with the same error:

```
ImportError: cannot import name 'has_global_hooks' from 'terok_shield'
```

The phase verifies `terok shield install-hooks` with a python one-liner that imported `has_global_hooks` from the `terok_shield` root barrel. The import-lazification wave shrank shield's root `__all__` to the stable core surface, and `has_global_hooks` is no longer re-exported there — so the one-liner broke identically on every slot.

## Fix

Import the symbol from its actual public home, `terok_shield.podman_info` — a public subpackage that lists `has_global_hooks` in its `__all__` and whose docstring explicitly invites importing from the specific submodule when intent is clearer. This is not a private deep reach; it is the documented location.

## Why not `terok-shield check-environment`?

The CLI does print a `hooks=` line, but its value folds podman-version policy into the answer: on hooks_dir-persisting podman (>= 5.6) it reports `hooks=per-container` whether or not the global hook files exist on disk. The phase's assertion is specifically "install-hooks put files on disk", which only `has_global_hooks()` answers faithfully across the slot family.

## Validation

- `uv run --no-sync python -c "from terok_util.matrix import load_config; ..."` — config still loads, groups `('test', 'stories')`
- Against the installed shield wheel: the old root import reproduces the ImportError; the `podman_info` import succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated integration test coverage for shield hook installation.
  * Verification now checks the persisted global hook status through the supported Podman information interface.
  * Added clarifying test documentation describing the validation approach and why environment checks alone cannot confirm persisted hook files across Podman versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->