### PR TITLE
fix(tests): probe the real store, and keep real-podman runs out of the tmp XDG

### DIFF
--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -478,7 +478,11 @@ def terok_env(
     # the ambient podman where it lives -- deriving (not hardcoding) the
     # driver keeps vfs-backed slots correct too.
     storage_conf = xdg_config_home / "containers" / "storage.conf"
-    if not storage_conf.exists():
+    # The nix slot ships no podman at all: probing for a binary that isn't
+    # there raises FileNotFoundError (check=False does not cover it), which
+    # would error this fixture for every test that only *might* need podman
+    # -- they must keep reaching their own skip guards.
+    if _has("podman") and not storage_conf.exists():
         # Probe with the real environment: HOME/XDG are already scrubbed at
         # this point, and asking a scrubbed podman where its store is would
         # answer with the empty tmp store it would create -- pinning every

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -43,6 +43,7 @@ from .helpers import (
     PODMAN_TEST_IMAGE,
     TerokIntegrationEnv,
     TerokShieldIntegrationEnv,
+    podman_subprocess_env,
     start_shielded_container,
 )
 
@@ -478,6 +479,10 @@ def terok_env(
     # driver keeps vfs-backed slots correct too.
     storage_conf = xdg_config_home / "containers" / "storage.conf"
     if not storage_conf.exists():
+        # Probe with the real environment: HOME/XDG are already scrubbed at
+        # this point, and asking a scrubbed podman where its store is would
+        # answer with the empty tmp store it would create -- pinning every
+        # later podman call to a store that has no images in it.
         probe = subprocess.run(
             [
                 "podman",
@@ -489,6 +494,7 @@ def terok_env(
             text=True,
             timeout=30,
             check=False,
+            env=podman_subprocess_env(),
         )
         if probe.returncode == 0 and probe.stdout.count("|") == 2:
             driver, graphroot, runroot = probe.stdout.strip().split("|")

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -49,7 +49,13 @@ def podman_subprocess_env() -> dict[str, str]:
     broadly, re-evaluate whether they belong in an integration test at all.
     """
     real_home = pwd.getpwuid(os.getuid()).pw_dir
-    return {**os.environ, "HOME": real_home}
+    env = {**os.environ, "HOME": real_home}
+    # XDG_CONFIG_HOME must go with it: the fixture's tmp XDG carries a
+    # generated containers/storage.conf for terok's *children*; leaving it
+    # in place here would point this real-HOME podman at that store
+    # definition too, and the image _pull_image built would be invisible.
+    env.pop("XDG_CONFIG_HOME", None)
+    return env
 
 
 @dataclass(frozen=True)

--- a/tests/integration/tasks/test_lifecycle.py
+++ b/tests/integration/tasks/test_lifecycle.py
@@ -12,6 +12,7 @@ import pytest
 from tests.test_utils import assert_task_id
 from tests.testnet import EXAMPLE_UPSTREAM_URL
 
+from ..conftest import podman_missing
 from ..helpers import NEW_TASK_MARKER, TerokIntegrationEnv
 
 pytestmark = pytest.mark.needs_host_features
@@ -35,6 +36,10 @@ def _extract_task_id(stdout: str) -> str:
 class TestTaskLifecycle:
     """Verify task creation, status, rename, and archive flows."""
 
+    # ``task list`` computes live state from the container runtime, so this
+    # one needs podman despite the module's needs_host_features marker --
+    # the nix slot (no podman by design) is where that claim first failed.
+    @podman_missing
     def test_task_new_creates_workspace_and_lists_tasks(
         self, terok_env: TerokIntegrationEnv
     ) -> None:


### PR DESCRIPTION
Fixes the all-slot regression from #1157 (`localhost/terok-itest:latest: image not known`, 10/10 FAIL).

Two linked mistakes, both mine:
1. The `podman info` probe ran **after** HOME/XDG were scrubbed, so podman reported the store it *would create* under the tmp HOME — an empty one — and that graphroot got baked into the generated `storage.conf`.
2. `podman_subprocess_env()` splices the real HOME back for direct podman calls but left `XDG_CONFIG_HOME` pointing at the tmp config — so those calls picked up the generated conf too and looked for `_pull_image`'s image in the empty store.

Now the probe uses the real environment, and `podman_subprocess_env()` drops `XDG_CONFIG_HOME` along with HOME. Terok's children still get the generated conf (that's the podman-slot fix); real-store callers stay on the real store.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved integration test reliability by ensuring Podman probes and subprocesses run against the real operator home/config context, avoiding misdirected storage/config resolution.
  * Prevented Podman-dependent lifecycle tests from failing when Podman isn’t available by conditionally skipping/handling that specific live-state check.
* **Tests**
  * Updated Podman environment setup logic used by integration tests to be more consistent and resilient across environments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->