### PR TITLE
fix(tui): thread the suspended subprocess; distinct operands in tests

### DIFF
--- a/src/terok/tui/project_actions.py
+++ b/src/terok/tui/project_actions.py
@@ -148,7 +148,11 @@ class ProjectActionsMixin(_MixinBase):
         else:
             with self.suspend():
                 try:
-                    subprocess.run(cmd)
+                    # Threaded like the prompt below it: the app is suspended,
+                    # not stopped, and an interactive session can last minutes
+                    # -- blocking the loop for its whole duration would freeze
+                    # every background worker and timer with it.
+                    await asyncio.to_thread(subprocess.run, cmd)
                 except Exception as e:
                     print(f"Error: {e}")
                 await asyncio.to_thread(input, _RESUME_PROMPT)

--- a/tests/unit/lib/domain/test_project_aggregate.py
+++ b/tests/unit/lib/domain/test_project_aggregate.py
@@ -38,11 +38,13 @@ class TestProjectIdentity:
         assert p.config is p._config
 
     def test_equality_and_hash_by_name(self) -> None:
-        assert _project() == _project()
-        assert _project() != _project(name="other")
-        assert _project() != object()
-        assert hash(_project()) == hash(_project())
-        assert {_project(), _project()} == {_project()}
+        # Two separate instances throughout: equality is by name, not identity.
+        first, second = _project(), _project()
+        assert first == second
+        assert first != _project(name="other")
+        assert first != object()
+        assert hash(first) == hash(second)
+        assert {first, second} == {first}
 
     def test_repr(self) -> None:
         assert repr(_project()) == f"Project(name={_PROJ!r}, security='online')"

--- a/tests/unit/lib/domain/test_task_aggregate.py
+++ b/tests/unit/lib/domain/test_task_aggregate.py
@@ -49,7 +49,8 @@ class TestTaskIdentity:
         assert t.meta is t._meta
 
     def test_equality_by_project_and_id(self) -> None:
-        assert _task() == _task()
+        first, second = _task(), _task()
+        assert first == second
 
     def test_inequality_across_projects(self) -> None:
         other = Task(SimpleNamespace(name="otherproj"), _task()._meta)  # type: ignore[arg-type]
@@ -59,8 +60,9 @@ class TestTaskIdentity:
         assert _task() != _task(task_id="different")
 
     def test_hashes_by_project_and_id(self) -> None:
-        assert hash(_task()) == hash(_task())
-        assert {_task(), _task()} == {_task()}  # dedups in a set
+        first, second = _task(), _task()
+        assert hash(first) == hash(second)
+        assert {first, second} == {first}  # dedups in a set
 
     def test_repr_carries_id_name_mode(self) -> None:
         assert repr(_task()) == f"Task(id={_TID!r}, name='my-task', mode='cli')"

--- a/tests/unit/lib/test_image.py
+++ b/tests/unit/lib/test_image.py
@@ -272,11 +272,14 @@ class TestPerLayerHashes:
             "L1.cli.Dockerfile": "FROM terok-l0:ubuntu-24-04",
             "L2.Dockerfile": "FROM terok-l1-cli:ubuntu-24-04",
         }
-        assert l0_content_hash("ubuntu:24.04", rendered) == l0_content_hash(
-            "ubuntu:24.04", rendered
-        )
-        assert l1_content_hash(rendered) == l1_content_hash(rendered)
-        assert l2_content_hash(rendered) == l2_content_hash(rendered)
+        # Two calls each: the property under test is determinism.
+        first_l0 = l0_content_hash("ubuntu:24.04", rendered)
+        second_l0 = l0_content_hash("ubuntu:24.04", rendered)
+        assert first_l0 == second_l0
+        first_l1, second_l1 = l1_content_hash(rendered), l1_content_hash(rendered)
+        assert first_l1 == second_l1
+        first_l2, second_l2 = l2_content_hash(rendered), l2_content_hash(rendered)
+        assert first_l2 == second_l2
 
     def test_l0_changes_dont_affect_l1_hash(self) -> None:
         """Changing L0 Dockerfile does not change L1 hash."""

--- a/tests/unit/lib/test_images.py
+++ b/tests/unit/lib/test_images.py
@@ -74,7 +74,8 @@ def test_base_tag_length_and_hash(name: str, prefix_len: int, suffix_len: int) -
 
 def test_base_tag_long_name_hash_is_stable() -> None:
     name = "b" * 150
-    assert images._base_tag(name) == images._base_tag(name)
+    first, second = images._base_tag(name), images._base_tag(name)
+    assert first == second
 
 
 def test_base_tag_long_name_hash_changes_for_different_inputs() -> None:

--- a/tests/unit/tui/test_serve.py
+++ b/tests/unit/tui/test_serve.py
@@ -138,7 +138,8 @@ class TestPasswordHashing:
 
     def test_hash_is_salted(self) -> None:
         """Hashing the same password twice produces different records."""
-        assert _hash_password("same") != _hash_password("same")
+        first, second = _hash_password("same"), _hash_password("same")
+        assert first != second
 
     def test_verify_rejects_garbage(self) -> None:
         """Malformed records never verify."""


### PR DESCRIPTION
Sonar's ten open bugs on master. One is real.

**Real: `project_actions.py:151` (S7487).** The interactive fallback ran `subprocess.run(cmd)` directly inside an `async` handler. `self.suspend()` hands the terminal to the child, but the event loop keeps owning the app — so a session that lasts minutes blocks every background worker and timer for its entire duration. The tell that this was an oversight rather than a decision: the `input()` prompt on the *very next line* was already wrapped in `asyncio.to_thread`. The subprocess above it now is too.

**Not real (but worth tidying): the nine `S5863` "same actual and expected expression" bugs.** None is a tautology — each side is a *separate call*, and that is precisely what's being tested: `_project() == _project()` asserts equality by name rather than identity; `l0_content_hash(x) == l0_content_hash(x)` asserts the content hash is **deterministic**; `_hash_password("same") != _hash_password("same")` asserts it is **salted**. Sonar matches textually and cannot see the side effects. Binding each operand to a name states the intent and dissolves the finding without weakening a single assertion.

2812 unit tests green, lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)