### PR TITLE
feat(tui): tmux session UX — main-window stamp, live-upgrade restart, quit guidance

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -445,7 +445,9 @@ terok tui --tmux
 
 This wraps the TUI in a managed tmux session with a blue status bar showing
 keyboard shortcuts. Login sessions open as additional tmux windows — press
-`^b n`/`^b p` to switch between TUI and container shells.
+`^b n`/`^b p` to switch between TUI and container shells. Logging into a
+container that already has a window open switches to that window instead of
+opening a duplicate.
 
 To launch the TUI in tmux by default without passing `--tmux` every time, set
 it in your config:

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -459,9 +459,21 @@ tui:
 
 When tmux mode is active, terok **attaches to the shared `terok` session** if
 one is already running, so a second `terok tui --tmux` reconnects to your
-existing TUI instead of failing on the duplicate session name. Pass
-`--new-session` to opt out and start a separate, tmux-named session alongside
-it.
+existing TUI instead of failing on the duplicate session name. Resuming lands
+you directly on the window running the TUI (even if you had killed and
+relaunched it in a different window), and revives the TUI in a new window if
+none is running anymore. Pass `--new-session` to opt out and start a separate,
+tmux-named session alongside it.
+
+Inside a terok-managed tmux, a few extra conveniences apply:
+
+- **Quitting the TUI** asks whether to return to your terminal (`q` again —
+  the session and its tasks keep running in the background) or hop to the
+  next tmux window (`n`). If the TUI window closes anyway, a brief status-bar
+  hint in the window you land on explains how to get back.
+- **Upgrades:** if a newer terok is installed on disk while the TUI is
+  running (e.g. `pipx upgrade terok`), the TUI offers to restart itself in
+  place to pick up the new version.
 
 #### tmux Quick Reference
 

--- a/src/terok/lib/core/version.py
+++ b/src/terok/lib/core/version.py
@@ -28,7 +28,7 @@ def installed_dist_version(timeout: float = 5.0) -> str | None:
     (package not installed, interpreter gone mid-upgrade, timeout).
     """
     try:
-        result = subprocess.run(
+        result = subprocess.run(  # nosec B603 — our own interpreter running a fixed probe
             [sys.executable, "-c", _INSTALLED_VERSION_PROBE],
             capture_output=True,
             text=True,

--- a/src/terok/lib/core/version.py
+++ b/src/terok/lib/core/version.py
@@ -9,9 +9,36 @@ used by both the CLI (--version) and TUI (title bar).
 
 import json
 import subprocess
+import sys
 from importlib import metadata
 from pathlib import Path
 from typing import Any
+
+_INSTALLED_VERSION_PROBE = "from importlib.metadata import version; print(version('terok'))"
+
+
+def installed_dist_version(timeout: float = 5.0) -> str | None:
+    """Return the terok version currently installed on disk, or None.
+
+    The running process froze its version (``terok.__version__``) at
+    import time; a ``pip``/``pipx`` upgrade performed while the TUI is
+    open only changes what is on disk.  Asking a *fresh* interpreter
+    reads the current dist-info, so comparing the two detects a stale
+    running instance.  Returns None when the probe fails for any reason
+    (package not installed, interpreter gone mid-upgrade, timeout).
+    """
+    try:
+        result = subprocess.run(
+            [sys.executable, "-c", _INSTALLED_VERSION_PROBE],
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+    if result.returncode != 0:
+        return None
+    return result.stdout.strip() or None
 
 
 def get_version_info() -> tuple[str, str | None]:

--- a/src/terok/tui/app.py
+++ b/src/terok/tui/app.py
@@ -87,9 +87,11 @@ if _HAS_TEXTUAL:
     # Import version info function (shared with CLI --version)
     from ..lib.core.version import (
         get_version_info as _get_version_info,
+        installed_dist_version as _installed_dist_version,
         short_version as _short_version,
     )
     from ..lib.util.yaml import YAMLError
+    from . import tmux_session
 
     # Exit code 5 is the ``terok setup`` partial-success signal — every
     # install phase succeeded but a manual step (currently: SELinux
@@ -97,6 +99,16 @@ if _HAS_TEXTUAL:
     # value is owned by the sandbox setup CLI; the TUI mirrors it here
     # so the post-run dispatch can branch into ``_offer_selinux_fix``.
     _EXIT_MANUAL_STEP_NEEDED = 5
+
+    # ``App.run()`` result asking ``_run_tui`` to re-exec the process in
+    # place — used when the operator accepts the restart offer after a
+    # terok upgrade landed on disk.
+    _RESTART_EXIT_RESULT = "terok-restart"
+
+    # How often to compare the on-disk terok version against the running
+    # one.  A subprocess probe every five minutes is cheap, and upgrades
+    # under a live TUI are rare events.
+    _UPDATE_CHECK_INTERVAL_S = 300.0
 
     @dataclass(frozen=True)
     class ProjectStateResult:
@@ -120,6 +132,8 @@ if _HAS_TEXTUAL:
         QuitConfirmScreen,
         ShieldScreen,
         TaskDetailsScreen,
+        TmuxQuitScreen,
+        UpdateRestartScreen,
         VaultScreen,
         VaultUnlockModal,
     )
@@ -353,6 +367,9 @@ if _HAS_TEXTUAL:
             # delete guard can tell an active teardown apart from a stale flag
             # left by an interrupted session.
             self._deleting_tasks: set[tuple[str, str]] = set()
+            # On-disk version already offered as a restart; a dismissed
+            # offer is not repeated until yet another version lands.
+            self._update_offered_version: str | None = None
 
         def _update_title(self) -> None:
             """Update the TUI title with version and branch information.
@@ -452,6 +469,17 @@ if _HAS_TEXTUAL:
             # Apply the persisted theme choice before the first paint,
             # and keep ``tui.theme`` in sync with later palette picks.
             self._apply_saved_theme()
+
+            # In a terok-managed tmux, mark this window as the one running
+            # the TUI — self-healing across kill-and-relaunch (best-effort,
+            # a few local socket calls; quiet no-op everywhere else).
+            tmux_session.stamp_main_window()
+
+            # Watch for a terok upgrade landing on disk under the running
+            # TUI.  Restarting re-execs this process, which makes no sense
+            # for a web-served TUI — there the server owns the lifecycle.
+            if not self.is_web:
+                self.set_interval(_UPDATE_CHECK_INTERVAL_S, self._check_for_update)
 
             try:
                 clipboard_status = get_clipboard_helper_status()
@@ -1503,7 +1531,15 @@ if _HAS_TEXTUAL:
             only intercepts the top-level quit; the command-palette "Quit"
             still calls [`action_quit`][terok.tui.app.TerokTUI.action_quit]
             directly.
+
+            When quitting would close a terok-managed tmux window and drop
+            the user into one of the remaining task windows, the guard is
+            the tmux-aware [`TmuxQuitScreen`][terok.tui.screens.TmuxQuitScreen]
+            instead — ``qq`` then detaches back to the user's terminal.
             """
+            if other_windows := tmux_session.quit_lands_in_other_window():
+                self.push_screen(TmuxQuitScreen(other_windows), self._on_tmux_quit_choice)
+                return
             self.push_screen(QuitConfirmScreen(), self._on_quit_confirmed)
 
         async def _on_quit_confirmed(self, should_quit: bool | None) -> None:
@@ -1511,7 +1547,15 @@ if _HAS_TEXTUAL:
             if should_quit:
                 await self.action_quit()
 
-        async def action_quit(self) -> None:
+        async def _on_tmux_quit_choice(self, choice: str | None) -> None:
+            """Apply the tmux-aware quit choice: detach to the terminal or hop windows."""
+            if choice == "detach":
+                tmux_session.detach_client()
+                await self.action_quit()
+            elif choice == "next":
+                await self.action_quit()
+
+        async def action_quit(self, *, restart: bool = False) -> None:
             """Exit the TUI cleanly.
 
             If real-work workers (task delete, image build, etc.) are
@@ -1519,6 +1563,11 @@ if _HAS_TEXTUAL:
             them in Textual's exit message so the user knows the terminal
             isn't hung — the process is just waiting for the threads to
             drain before returning the prompt.
+
+            With ``restart=True`` the app exits with
+            ``_RESTART_EXIT_RESULT`` so ``_run_tui`` re-execs the process
+            in place (same terminal, same tmux window) to pick up a terok
+            version that was installed while the TUI was running.
             """
             self._stop_upstream_polling()
             self._stop_container_status_polling()
@@ -1526,6 +1575,13 @@ if _HAS_TEXTUAL:
             if self._askpass_service is not None:
                 await self._askpass_service.stop()
 
+            # When the window dies with us and the client lands in another
+            # tmux window, leave a status-line breadcrumb there.  A restart
+            # keeps the window alive, so no hint.
+            if not restart:
+                tmux_session.flash_exit_hint()
+
+            exit_kwargs: dict[str, Any] = {"result": _RESTART_EXIT_RESULT} if restart else {}
             pending = [
                 w for w in self.workers if w.state in (WorkerState.PENDING, WorkerState.RUNNING)
             ]
@@ -1533,12 +1589,51 @@ if _HAS_TEXTUAL:
                 groups = sorted({w.group for w in pending if w.group})
                 suffix = f" ({', '.join(groups)})" if groups else ""
                 self.exit(
+                    **exit_kwargs,
                     message=(
                         f"Exiting. Waiting for {len(pending)} background task(s) to finish{suffix}."
-                    )
+                    ),
                 )
             else:
-                self.exit()
+                self.exit(**exit_kwargs)
+
+        def _check_for_update(self) -> None:
+            """Kick off the on-disk version probe on a worker thread."""
+            self.run_worker(
+                self._probe_installed_version,
+                name="update-check",
+                group="update-check",
+                thread=True,
+                exclusive=True,
+                exit_on_error=False,
+            )
+
+        def _probe_installed_version(self) -> None:
+            """Compare the on-disk version with the running one (worker thread).
+
+            Any difference means the running code is stale — upgrades and
+            downgrades alike — so direction is deliberately not compared.
+            """
+            installed = _installed_dist_version()
+            running, _ = _get_version_info()
+            if not installed or installed in (running, self._update_offered_version):
+                return
+            self.call_from_thread(self._offer_update_restart, running, installed)
+
+        def _offer_update_restart(self, running: str, installed: str) -> None:
+            """Push the restart offer for a freshly installed terok version."""
+            self._update_offered_version = installed
+            self.push_screen(
+                UpdateRestartScreen(
+                    running=_short_version(running), installed=_short_version(installed)
+                ),
+                self._on_update_restart_choice,
+            )
+
+        async def _on_update_restart_choice(self, restart: bool | None) -> None:
+            """Restart the TUI in place when the operator accepted the offer."""
+            if restart:
+                await self.action_quit(restart=True)
 
         async def ensure_askpass_service(self) -> AskpassService:
             """Return the running [`AskpassService`][terok.tui.app.AskpassService], starting it on first use.
@@ -2035,6 +2130,20 @@ if _HAS_TEXTUAL:
             """Open the clearance screen from the main screen."""
             await self.action_show_clearance()
 
+    def _run_tui() -> None:
+        """Run the TUI; when it exits requesting a restart, re-exec in place.
+
+        The re-exec replaces this process with a freshly resolved
+        ``terok-tui`` entry point (new code, same terminal, same tmux
+        window when running under one), preserving any CLI flags.
+        """
+        import shutil
+
+        result = TerokTUI().run()
+        if result == _RESTART_EXIT_RESULT:
+            exe = shutil.which("terok-tui") or sys.argv[0]
+            os.execvp(exe, [exe, *sys.argv[1:]])
+
     def _launch_in_tmux(force_new: bool = False) -> None:
         """Launch the TUI inside a managed tmux session.
 
@@ -2043,15 +2152,20 @@ if _HAS_TEXTUAL:
         (blue status bar, usage hints).  Exits with an actionable error
         message if tmux is not found on ``$PATH``.
 
-        By default this attaches to the shared ``terok`` session if one is
-        already running (``new-session -A``), so a second ``terok --tmux``
-        reconnects rather than failing on the duplicate name.  Pass
-        ``force_new=True`` (``--new-session``) to spin up a fresh, tmux-named
-        session alongside the existing one instead.
+        By default a second ``terok --tmux`` resumes the shared ``terok``
+        session: the client lands on the window stamped ``@terok-main``,
+        and when no stamped window is left (the TUI was quit while task
+        windows kept the session alive) a fresh TUI window is spawned
+        first.  Pass ``force_new=True`` (``--new-session``) to spin up a
+        fresh, tmux-named session alongside the existing one instead.
+
+        Sessions are created with the ``TEROK_TMUX=1`` session environment
+        marker (``new-session -e``, tmux >= 3.2) so everything inside can
+        tell a terok-managed tmux apart from the user's own.
         """
         if os.environ.get("TMUX"):
             # Already inside tmux — no double-wrap
-            TerokTUI().run()
+            _run_tui()
             return
 
         import shutil
@@ -2065,6 +2179,22 @@ if _HAS_TEXTUAL:
             )
             sys.exit(1)
 
+        marker = f"{tmux_session.TEROK_TMUX_ENV}=1"
+
+        if not force_new and tmux_session.session_exists():
+            # Resume: land the client on the TUI's stamped window rather
+            # than wherever the session last was; revive the TUI in a new
+            # window when none is stamped (window ids are stable handles,
+            # indexes are not — the host config renumbers windows).
+            session = f"={tmux_session.SESSION_NAME}"
+            main_window = tmux_session.find_main_window()
+            if main_window:
+                land_args = ["select-window", "-t", main_window]
+            else:
+                land_args = ["new-window", "-t", session, "-n", "terok", "terok-tui"]
+            os.execvp("tmux", ["tmux", *land_args, ";", "attach-session", "-t", session])
+            return
+
         from importlib import resources as _res
 
         tmux_conf = _res.files("terok") / "resources" / "tmux" / "host-tmux.conf"
@@ -2072,15 +2202,19 @@ if _HAS_TEXTUAL:
         # Note: os.execvp replaces this process so the context manager's
         # __exit__ never runs.  This is fine — tmux reads the config file
         # at startup, and OS process cleanup handles any temp resources.
-        # ``-A -s terok`` attaches to the shared session if it exists and
-        # creates it otherwise; ``--new-session`` drops the name so tmux
-        # auto-assigns one for a parallel session.  ``terok-tui`` is only run
-        # when tmux actually creates the session — on attach it is ignored.
-        session_args = ["new-session"] if force_new else ["new-session", "-A", "-s", "terok"]
+        # ``-A -s terok`` still guards the race where another ``terok
+        # --tmux`` creates the session between the check above and this
+        # exec; ``--new-session`` drops the name so tmux auto-assigns one
+        # for a parallel session.
+        session_args = (
+            ["new-session"]
+            if force_new
+            else ["new-session", "-A", "-s", tmux_session.SESSION_NAME, "-n", "terok"]
+        )
         with _res.as_file(tmux_conf) as conf_path:
             os.execvp(
                 "tmux",
-                ["tmux", "-f", str(conf_path), *session_args, "terok-tui"],
+                ["tmux", "-f", str(conf_path), *session_args, "-e", marker, "terok-tui"],
             )
 
     import argparse
@@ -2173,7 +2307,7 @@ if _HAS_TEXTUAL:
         if use_tmux and not is_web_mode():
             _launch_in_tmux(force_new=args.new_session)
             return
-        TerokTUI().run()
+        _run_tui()
 
 else:
 

--- a/src/terok/tui/app.py
+++ b/src/terok/tui/app.py
@@ -2148,7 +2148,7 @@ if _HAS_TEXTUAL:
         if not exe:
             print("terok-tui not found on PATH — restart it manually to pick up the update.")
             return
-        os.execv(exe, [exe, *restart_flags])
+        os.execv(exe, [exe, *restart_flags])  # nosec B606 — resolved entry point, literal flags
 
     def _launch_in_tmux(force_new: bool = False, restart_flags: tuple[str, ...] = ()) -> None:
         """Launch the TUI inside a managed tmux session.
@@ -2198,7 +2198,9 @@ if _HAS_TEXTUAL:
                 land_args = ["select-window", "-t", main_window]
             else:
                 land_args = ["new-window", "-t", session, "-n", "terok", "terok-tui"]
-            os.execvp("tmux", ["tmux", *land_args, ";", "attach-session", "-t", session])
+            os.execvp(  # nosec B606 B607 — tmux from PATH, argv of fixed verbs
+                "tmux", ["tmux", *land_args, ";", "attach-session", "-t", session]
+            )
 
         from importlib import resources as _res
 

--- a/src/terok/tui/app.py
+++ b/src/terok/tui/app.py
@@ -2130,21 +2130,27 @@ if _HAS_TEXTUAL:
             """Open the clearance screen from the main screen."""
             await self.action_show_clearance()
 
-    def _run_tui() -> None:
+    def _run_tui(restart_flags: tuple[str, ...] = ()) -> None:
         """Run the TUI; when it exits requesting a restart, re-exec in place.
 
         The re-exec replaces this process with a freshly resolved
         ``terok-tui`` entry point (new code, same terminal, same tmux
-        window when running under one), preserving any CLI flags.
+        window when running under one).  *restart_flags* carries the CLI
+        flags to preserve — rebuilt by ``_restart_flags`` from parsed
+        values, never echoed from raw ``sys.argv``.
         """
         import shutil
 
         result = TerokTUI().run()
-        if result == _RESTART_EXIT_RESULT:
-            exe = shutil.which("terok-tui") or sys.argv[0]
-            os.execvp(exe, [exe, *sys.argv[1:]])
+        if result != _RESTART_EXIT_RESULT:
+            return
+        exe = shutil.which("terok-tui")
+        if not exe:
+            print("terok-tui not found on PATH — restart it manually to pick up the update.")
+            return
+        os.execv(exe, [exe, *restart_flags])
 
-    def _launch_in_tmux(force_new: bool = False) -> None:
+    def _launch_in_tmux(force_new: bool = False, restart_flags: tuple[str, ...] = ()) -> None:
         """Launch the TUI inside a managed tmux session.
 
         If already inside tmux, just run the TUI directly.  Otherwise verify
@@ -2165,7 +2171,7 @@ if _HAS_TEXTUAL:
         """
         if os.environ.get("TMUX"):
             # Already inside tmux — no double-wrap
-            _run_tui()
+            _run_tui(restart_flags)
             return
 
         import shutil
@@ -2193,7 +2199,6 @@ if _HAS_TEXTUAL:
             else:
                 land_args = ["new-window", "-t", session, "-n", "terok", "terok-tui"]
             os.execvp("tmux", ["tmux", *land_args, ";", "attach-session", "-t", session])
-            return
 
         from importlib import resources as _res
 
@@ -2267,6 +2272,25 @@ if _HAS_TEXTUAL:
         )
         return parser
 
+    def _restart_flags(args: argparse.Namespace) -> tuple[str, ...]:
+        """Rebuild the CLI flags a restart re-exec should carry.
+
+        Reconstructed from the *parsed* values rather than echoed from raw
+        ``sys.argv``, so a restarted process can only ever receive flags
+        this parser understands.
+        """
+        return tuple(
+            flag
+            for flag, wanted in (
+                ("--tmux", args.tmux is True),
+                ("--no-tmux", args.tmux is False),
+                ("--new-session", args.new_session),
+                ("--experimental", args.experimental),
+                ("--no-emoji", args.no_emoji),
+            )
+            if wanted
+        )
+
     def main() -> None:
         """CLI entry-point for launching the terok TUI.
 
@@ -2304,10 +2328,11 @@ if _HAS_TEXTUAL:
 
         from .shell_launch import is_web_mode
 
+        restart_flags = _restart_flags(args)
         if use_tmux and not is_web_mode():
-            _launch_in_tmux(force_new=args.new_session)
+            _launch_in_tmux(force_new=args.new_session, restart_flags=restart_flags)
             return
-        _run_tui()
+        _run_tui(restart_flags)
 
 else:
 

--- a/src/terok/tui/project_actions.py
+++ b/src/terok/tui/project_actions.py
@@ -122,6 +122,11 @@ class ProjectActionsMixin(_MixinBase):
     ) -> None:
         """Launch *cmd* via tmux/terminal, falling back to a suspended TUI.
 
+        Inside tmux, a window already logged into *cname* is switched to
+        instead of opening a duplicate — every login command attaches to
+        the same tmux session *inside* the container, so one host window
+        per container is always enough.
+
         Hard-gated on ``App.is_web``: a container login attaches a host
         terminal, and under textual-serve there is none — the in-process
         ``suspend()`` fallback would literally kill
@@ -139,9 +144,11 @@ class ProjectActionsMixin(_MixinBase):
             )
             return
 
-        method, _port = launch_login(cmd, title=title)
+        method, _port = launch_login(cmd, title=title, reuse_key=cname)
 
-        if method == "tmux":
+        if method == "tmux-existing":
+            self.notify(f"Switched to existing tmux window: {cname}")
+        elif method == "tmux":
             self.notify(f"{label} in tmux window: {cname}")
         elif method == "terminal":
             self.notify(f"{label} in new terminal: {cname}")

--- a/src/terok/tui/screens.py
+++ b/src/terok/tui/screens.py
@@ -1791,6 +1791,98 @@ class QuitConfirmScreen(screen.ModalScreen[bool]):
         self.dismiss(event.key == "q")
 
 
+class TmuxQuitScreen(screen.ModalScreen[str | None]):
+    """tmux-aware second-``q`` guard: quitting would drop the user into another window.
+
+    Shown instead of [`QuitConfirmScreen`][terok.tui.screens.QuitConfirmScreen]
+    when the TUI is the root command of a window in a terok-managed tmux
+    and other windows (logins, tasks) remain.  ``q`` keeps the plain-quit
+    muscle memory but detaches tmux too, returning the user to their
+    normal terminal; ``n`` quits into the next tmux window for users who
+    want to look at the remaining windows; any other key cancels.
+
+    Dismisses with ``"detach"``, ``"next"``, or ``None`` (cancel).
+    """
+
+    CSS = """
+    TmuxQuitScreen {
+        align: center middle;
+    }
+    #tmux-quit-confirm {
+        width: auto;
+        height: auto;
+        border: round $primary;
+        background: $surface;
+        padding: 1 2;
+    }
+    """
+
+    def __init__(self, other_windows: int) -> None:
+        """Remember how many sibling tmux windows stay open after the quit."""
+        super().__init__()
+        self._other_windows = other_windows
+
+    def compose(self) -> ComposeResult:
+        """A centred prompt mapping each quit flavour to a single key."""
+        windows = f"{self._other_windows} window" + ("s" if self._other_windows != 1 else "")
+        yield Static(
+            f"Quitting closes this tmux window — {windows} (tasks, logins) stay open.\n\n"
+            "\\[[$footer-key-foreground]q[/]] quit and return to your terminal"
+            " (tasks keep running)\n"
+            "\\[[$footer-key-foreground]n[/]] quit into the next tmux window\n"
+            "any other key: go back to terok.",
+            id="tmux-quit-confirm",
+        )
+
+    def on_key(self, event: events.Key) -> None:
+        """Map ``q`` to detach-quit, ``n`` to next-window-quit, anything else to cancel."""
+        event.stop()
+        self.dismiss({"q": "detach", "n": "next"}.get(event.key))
+
+
+class UpdateRestartScreen(screen.ModalScreen[bool]):
+    """Offer a restart when a newer terok was installed under the running TUI.
+
+    Dismisses with ``True`` when the operator presses ``r`` (restart the
+    TUI in place, picking up the new version) and ``False`` on any other
+    key.  A dismissed offer is not repeated for the same on-disk version.
+    """
+
+    CSS = """
+    UpdateRestartScreen {
+        align: center middle;
+    }
+    #update-restart {
+        width: auto;
+        height: auto;
+        border: round $primary;
+        background: $surface;
+        padding: 1 2;
+    }
+    """
+
+    def __init__(self, running: str, installed: str) -> None:
+        """Remember the running and freshly installed version strings."""
+        super().__init__()
+        self._running = running
+        self._installed = installed
+
+    def compose(self) -> ComposeResult:
+        """A centred prompt naming both versions and the restart key."""
+        yield Static(
+            f"terok has been updated: {self._installed} is now installed\n"
+            f"(this TUI is still running {self._running}).\n\n"
+            "\\[[$footer-key-foreground]r[/]] restart terok now\n"
+            "any other key: keep running, restart later.",
+            id="update-restart",
+        )
+
+    def on_key(self, event: events.Key) -> None:
+        """Restart on ``r``; any other key dismisses the offer."""
+        event.stop()
+        self.dismiss(event.key == "r")
+
+
 class TaskDetailsScreen(screen.Screen[str | None]):
     """Full-page detail screen for a task with categorized actions."""
 

--- a/src/terok/tui/screens.py
+++ b/src/terok/tui/screens.py
@@ -1864,14 +1864,16 @@ class UpdateRestartScreen(screen.ModalScreen[bool]):
     def __init__(self, running: str, installed: str) -> None:
         """Remember the running and freshly installed version strings."""
         super().__init__()
-        self._running = running
-        self._installed = installed
+        # Not ``_running`` — that would shadow (and clobber) the bool
+        # driving Textual's MessagePump.
+        self._running_version = running
+        self._installed_version = installed
 
     def compose(self) -> ComposeResult:
         """A centred prompt naming both versions and the restart key."""
         yield Static(
-            f"terok has been updated: {self._installed} is now installed\n"
-            f"(this TUI is still running {self._running}).\n\n"
+            f"terok has been updated: {self._installed_version} is now installed\n"
+            f"(this TUI is still running {self._running_version}).\n\n"
             "\\[[$footer-key-foreground]r[/]] restart terok now\n"
             "any other key: keep running, restart later.",
             id="update-restart",

--- a/src/terok/tui/shell_launch.py
+++ b/src/terok/tui/shell_launch.py
@@ -137,7 +137,9 @@ def tmux_new_window(command: list[str], title: str | None = None, stamp: str | N
         tmux_cmd += ["-n", title]
     tmux_cmd.append(shell_cmd)
     try:
-        result = subprocess.run(tmux_cmd, check=True, capture_output=True, text=True)
+        result = subprocess.run(  # nosec B603 — fixed tmux verbs; command is shell-quoted above
+            tmux_cmd, check=True, capture_output=True, text=True
+        )
     except (subprocess.CalledProcessError, FileNotFoundError):
         return False
     if stamp and (window_id := result.stdout.strip()):

--- a/src/terok/tui/shell_launch.py
+++ b/src/terok/tui/shell_launch.py
@@ -16,6 +16,8 @@ import os
 import shlex
 import subprocess
 
+from .tmux_session import find_login_window, select_window, stamp_login_window
+
 
 def is_inside_tmux() -> bool:
     """Return True if the current process is running inside a tmux session."""
@@ -117,22 +119,30 @@ def _parent_process_has_name(*names: str) -> bool:
     return False
 
 
-def tmux_new_window(command: list[str], title: str | None = None) -> bool:
+def tmux_new_window(command: list[str], title: str | None = None, stamp: str | None = None) -> bool:
     """Open a new tmux window running the given command.
+
+    With *stamp*, the created window is marked as the login window for
+    that container (``@terok-login``) so a later login can switch back to
+    it instead of opening a duplicate.  ``-P -F`` makes tmux print the new
+    window's id, which the stamp needs — window indexes are not stable
+    under ``renumber-windows``.
 
     Returns True if the tmux command succeeded, False otherwise.
     The caller must verify that we are inside tmux before calling this.
     """
     shell_cmd = " ".join(shlex.quote(c) for c in command)
-    tmux_cmd: list[str] = ["tmux", "new-window"]
+    tmux_cmd: list[str] = ["tmux", "new-window", "-P", "-F", "#{window_id}"]
     if title:
         tmux_cmd += ["-n", title]
     tmux_cmd.append(shell_cmd)
     try:
-        subprocess.run(tmux_cmd, check=True)
-        return True
+        result = subprocess.run(tmux_cmd, check=True, capture_output=True, text=True)
     except (subprocess.CalledProcessError, FileNotFoundError):
         return False
+    if stamp and (window_id := result.stdout.strip()):
+        stamp_login_window(window_id, stamp)
+    return True
 
 
 def spawn_terminal_with_command(command: list[str], title: str | None = None) -> bool:
@@ -197,19 +207,27 @@ def is_web_mode() -> bool:
 def launch_login(
     command: list[str],
     title: str | None = None,
+    reuse_key: str | None = None,
 ) -> tuple[str, int | None]:
     """Launch a login session using the best available method.
 
     Only reached from a local-terminal TUI (the web case is refused
-    upstream), so a host terminal is assumed available.  Returns a
-    tuple of (method, port):
+    upstream), so a host terminal is assumed available.  With a
+    *reuse_key* (the container name), an existing tmux login window for
+    that container is switched to instead of opening a duplicate, and a
+    newly created window is stamped for future reuse.  Returns a tuple
+    of (method, port):
 
+    - ("tmux-existing", None): switched to the container's open tmux window
     - ("tmux", None): opened in a new tmux window
     - ("terminal", None): opened in a new desktop terminal window
     - ("none", None): no external method available; caller should suspend
     """
-    if is_inside_tmux() and tmux_new_window(command, title=title):
-        return ("tmux", None)
+    if is_inside_tmux():
+        if reuse_key and (window := find_login_window(reuse_key)) and select_window(window):
+            return ("tmux-existing", None)
+        if tmux_new_window(command, title=title, stamp=reuse_key):
+            return ("tmux", None)
     if spawn_terminal_with_command(command, title=title):
         return ("terminal", None)
     return ("none", None)

--- a/src/terok/tui/tmux_session.py
+++ b/src/terok/tui/tmux_session.py
@@ -13,6 +13,10 @@ that makes that session recognisably *terok's*:
 - the ``@terok-main`` window option stamp the TUI puts on its own window
   at startup, so a resume can land the client back on terok even after
   the user killed and relaunched the TUI in a different window;
+- the ``@terok-login`` window option stamp on every container-login
+  window terok opens, so a repeated login switches to the container's
+  existing window instead of piling up duplicates (this one works in
+  *any* tmux — it only ever touches windows terok itself created);
 - quit-time guidance for users unfamiliar with tmux: detecting that
   quitting the TUI will drop them into another tmux window, and flashing
   a status-line hint that survives the window switch.
@@ -33,6 +37,9 @@ TEROK_TMUX_ENV = "TEROK_TMUX"
 
 MAIN_WINDOW_OPTION = "@terok-main"
 """tmux window option stamped on the window the TUI is running in."""
+
+LOGIN_WINDOW_OPTION = "@terok-login"
+"""tmux window option stamped with the container name a login window is attached to."""
 
 _TMUX_TIMEOUT_S = 5
 _EXIT_HINT_MS = 10000
@@ -68,6 +75,19 @@ def session_exists() -> bool:
     return _tmux("has-session", "-t", f"={SESSION_NAME}") is not None
 
 
+def _window_stamps(option: str, *target: str) -> list[tuple[str, str]]:
+    """List ``(window_id, stamp)`` pairs for *option* across the targeted session.
+
+    With no *target* the current session (from ``$TMUX``) is listed;
+    pass ``"-t", "=name"`` to query a named session from outside tmux.
+    """
+    out = _tmux("list-windows", *target, "-F", f"#{{window_id}} #{{{option}}}")
+    return [
+        (window_id, stamp)
+        for window_id, _, stamp in (line.partition(" ") for line in (out or "").splitlines())
+    ]
+
+
 def find_main_window(session: str = SESSION_NAME) -> str | None:
     """Return the window id (``@N``) stamped as terok's main window, or None.
 
@@ -75,11 +95,7 @@ def find_main_window(session: str = SESSION_NAME) -> str | None:
     config sets ``renumber-windows on``, so index 1 can become a task
     window the moment an earlier window closes.
     """
-    out = _tmux(
-        "list-windows", "-t", f"={session}", "-F", f"#{{window_id}} #{{{MAIN_WINDOW_OPTION}}}"
-    )
-    for line in (out or "").splitlines():
-        window_id, _, stamp = line.partition(" ")
+    for window_id, stamp in _window_stamps(MAIN_WINDOW_OPTION, "-t", f"={session}"):
         if stamp == "1":
             return window_id
     return None
@@ -101,12 +117,33 @@ def stamp_main_window() -> None:
     own = (_tmux("display-message", "-p", "-t", pane, "#{window_id}") or "").strip()
     if not own:
         return
-    listed = _tmux("list-windows", "-F", f"#{{window_id}} #{{{MAIN_WINDOW_OPTION}}}") or ""
-    for line in listed.splitlines():
-        window_id, _, stamp = line.partition(" ")
+    for window_id, stamp in _window_stamps(MAIN_WINDOW_OPTION):
         if stamp and window_id != own:
             _tmux("set-option", "-w", "-t", window_id, "-u", MAIN_WINDOW_OPTION)
     _tmux("set-option", "-w", "-t", own, MAIN_WINDOW_OPTION, "1")
+
+
+def find_login_window(cname: str) -> str | None:
+    """Return the current session's window logged into container *cname*, or None.
+
+    Login windows close with their ``podman exec`` (no ``remain-on-exit``
+    in the host config), so a stamp never outlives its session — whatever
+    this finds is live.
+    """
+    for window_id, stamp in _window_stamps(LOGIN_WINDOW_OPTION):
+        if stamp == cname:
+            return window_id
+    return None
+
+
+def stamp_login_window(window_id: str, cname: str) -> None:
+    """Stamp *window_id* as the login window for container *cname*."""
+    _tmux("set-option", "-w", "-t", window_id, LOGIN_WINDOW_OPTION, cname)
+
+
+def select_window(window_id: str) -> bool:
+    """Make *window_id* the current window; True when tmux accepted it."""
+    return _tmux("select-window", "-t", window_id) is not None
 
 
 def _pane_is_root_command() -> bool:

--- a/src/terok/tui/tmux_session.py
+++ b/src/terok/tui/tmux_session.py
@@ -1,0 +1,155 @@
+# SPDX-FileCopyrightText: 2026 Jiri Vyskocil
+# SPDX-License-Identifier: Apache-2.0
+
+"""Helpers for the terok-managed host tmux session.
+
+``terok tui --tmux`` wraps the TUI in a tmux session so login windows and
+long-running tasks survive terminal closes.  This module owns everything
+that makes that session recognisably *terok's*:
+
+- the ``TEROK_TMUX`` session environment marker (set at session creation
+  via ``new-session -e``, tmux >= 3.2) that lets any process inside the
+  session tell a terok-managed tmux apart from the user's own;
+- the ``@terok-main`` window option stamp the TUI puts on its own window
+  at startup, so a resume can land the client back on terok even after
+  the user killed and relaunched the TUI in a different window;
+- quit-time guidance for users unfamiliar with tmux: detecting that
+  quitting the TUI will drop them into another tmux window, and flashing
+  a status-line hint that survives the window switch.
+
+Every tmux invocation here is best-effort: a missing binary, a dead
+server, or an unsupported flag degrades to a quiet no-op, never an error
+in the TUI.
+"""
+
+import os
+import subprocess
+
+SESSION_NAME = "terok"
+"""Name of the shared tmux session ``terok tui --tmux`` creates/resumes."""
+
+TEROK_TMUX_ENV = "TEROK_TMUX"
+"""Session-environment marker present in every pane of a terok-managed tmux."""
+
+MAIN_WINDOW_OPTION = "@terok-main"
+"""tmux window option stamped on the window the TUI is running in."""
+
+_TMUX_TIMEOUT_S = 5
+_EXIT_HINT_MS = 10000
+_EXIT_HINT = "terok closed — Ctrl-b d returns to your terminal; 'terok tui --tmux' reopens terok"
+
+
+def _tmux(*args: str) -> str | None:
+    """Run a tmux command quietly; return its stdout, or None on any failure."""
+    try:
+        result = subprocess.run(
+            ["tmux", *args],
+            capture_output=True,
+            text=True,
+            timeout=_TMUX_TIMEOUT_S,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+    return result.stdout if result.returncode == 0 else None
+
+
+def is_terok_tmux() -> bool:
+    """Return True when running inside a tmux session that terok launched.
+
+    Both conditions must hold: we are inside *some* tmux (``TMUX`` set by
+    tmux itself) and that session carries the terok marker — a user's
+    custom tmux never gets terok-specific behaviour.
+    """
+    return bool(os.environ.get("TMUX")) and bool(os.environ.get(TEROK_TMUX_ENV))
+
+
+def session_exists() -> bool:
+    """Return True when the shared terok session exists on the default server."""
+    return _tmux("has-session", "-t", f"={SESSION_NAME}") is not None
+
+
+def find_main_window(session: str = SESSION_NAME) -> str | None:
+    """Return the window id (``@N``) stamped as terok's main window, or None.
+
+    Window ids are stable handles; window *indexes* are not — the host
+    config sets ``renumber-windows on``, so index 1 can become a task
+    window the moment an earlier window closes.
+    """
+    out = _tmux(
+        "list-windows", "-t", f"={session}", "-F", f"#{{window_id}} #{{{MAIN_WINDOW_OPTION}}}"
+    )
+    for line in (out or "").splitlines():
+        window_id, _, stamp = line.partition(" ")
+        if stamp == "1":
+            return window_id
+    return None
+
+
+def stamp_main_window() -> None:
+    """Stamp the calling process's window as terok's main window.
+
+    Called by the TUI at startup so the stamp self-heals: when the user
+    kills terok and relaunches it in a different window, the new instance
+    marks its own window and clears any stale stamp left behind.  No-op
+    outside a terok-managed tmux.
+    """
+    if not is_terok_tmux():
+        return
+    pane = os.environ.get("TMUX_PANE")
+    if not pane:
+        return
+    own = (_tmux("display-message", "-p", "-t", pane, "#{window_id}") or "").strip()
+    if not own:
+        return
+    listed = _tmux("list-windows", "-F", f"#{{window_id}} #{{{MAIN_WINDOW_OPTION}}}") or ""
+    for line in listed.splitlines():
+        window_id, _, stamp = line.partition(" ")
+        if stamp and window_id != own:
+            _tmux("set-option", "-w", "-t", window_id, "-u", MAIN_WINDOW_OPTION)
+    _tmux("set-option", "-w", "-t", own, MAIN_WINDOW_OPTION, "1")
+
+
+def _pane_is_root_command() -> bool:
+    """Return True when this process *is* the pane's command (window dies with us)."""
+    pane = os.environ.get("TMUX_PANE")
+    if not pane:
+        return False
+    pane_pid = (_tmux("display-message", "-p", "-t", pane, "#{pane_pid}") or "").strip()
+    return pane_pid == str(os.getpid())
+
+
+def quit_lands_in_other_window() -> int:
+    """Return how many sibling windows would catch the user when the TUI quits.
+
+    Non-zero means: we are inside a terok-managed tmux, this process is
+    the pane's root command (so quitting closes the window), and other
+    windows remain — the user will be dropped into one of them instead of
+    their terminal.  Zero means quitting behaves unsurprisingly (last
+    window ends the session, or a shell below us survives) and no tmux
+    guidance is needed.
+    """
+    if not (is_terok_tmux() and _pane_is_root_command()):
+        return 0
+    windows = (_tmux("display-message", "-p", "#{session_windows}") or "").strip()
+    try:
+        return max(int(windows) - 1, 0)
+    except ValueError:
+        return 0
+
+
+def detach_client() -> None:
+    """Detach the attached tmux client, returning the user to their terminal."""
+    _tmux("detach-client")
+
+
+def flash_exit_hint() -> None:
+    """Flash a status-line hint telling the user how to leave tmux.
+
+    ``display-message`` is per-*client*, so a message fired just before
+    the TUI's window dies stays visible in whatever window the client
+    lands in.  No-op unless quitting actually drops the user into another
+    window.
+    """
+    if not quit_lands_in_other_window():
+        return
+    _tmux("display-message", "-d", str(_EXIT_HINT_MS), _EXIT_HINT)

--- a/src/terok/tui/tmux_session.py
+++ b/src/terok/tui/tmux_session.py
@@ -27,7 +27,7 @@ in the TUI.
 """
 
 import os
-import subprocess
+import subprocess  # nosec B404 — every call is a fixed "tmux" argv, no shell
 
 SESSION_NAME = "terok"
 """Name of the shared tmux session ``terok tui --tmux`` creates/resumes."""
@@ -49,7 +49,7 @@ _EXIT_HINT = "terok closed — Ctrl-b d returns to your terminal; 'terok tui --t
 def _tmux(*args: str) -> str | None:
     """Run a tmux command quietly; return its stdout, or None on any failure."""
     try:
-        result = subprocess.run(
+        result = subprocess.run(  # nosec B603 B607 — tmux from PATH, argv verbs built here
             ["tmux", *args],
             capture_output=True,
             text=True,

--- a/tach.toml
+++ b/tach.toml
@@ -1022,5 +1022,11 @@ expose = [
 from = ["terok.lib.core.paths"]
 
 [[interfaces]]
-expose = ["get_version_info", "format_version_string", "base_version", "short_version"]
+expose = [
+    "get_version_info",
+    "format_version_string",
+    "base_version",
+    "short_version",
+    "installed_dist_version",
+]
 from = ["terok.lib.core.version"]

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -76,6 +76,11 @@ def _isolate_user_paths(
     # CLI ``--config`` / ``--raw`` mutate ``os.environ`` directly,
     # bypassing monkeypatch — clear per-test to avoid leakage.
     monkeypatch.delenv("TEROK_CONFIG_FILE", raising=False)
+    # Never let tests act on the operator's real tmux: with these set
+    # (e.g. pytest run inside ``terok tui --tmux``), tmux_session helpers
+    # would stamp windows and flash messages on the live session.
+    for var in ("TMUX", "TMUX_PANE", "TEROK_TMUX"):
+        monkeypatch.delenv(var, raising=False)
 
 
 @pytest.fixture(autouse=True)

--- a/tests/unit/lib/test_shell_launch.py
+++ b/tests/unit/lib/test_shell_launch.py
@@ -113,14 +113,23 @@ class TestTmuxNewWindow:
     @pytest.mark.parametrize(
         ("side_effect", "expected"),
         [
-            (subprocess.CompletedProcess(args=[], returncode=0), True),
+            (subprocess.CompletedProcess(args=[], returncode=0, stdout="@7\n"), True),
             (subprocess.CalledProcessError(1, "tmux"), False),
             (FileNotFoundError("tmux"), False),
         ],
         ids=["success", "failure", "tmux-not-found"],
     )
     def test_tmux_new_window(self, side_effect: object, expected: bool) -> None:
-        expected_argv = ["tmux", "new-window", "-n", "login:c1", _shell_payload(SHELL_COMMAND)]
+        expected_argv = [
+            "tmux",
+            "new-window",
+            "-P",
+            "-F",
+            "#{window_id}",
+            "-n",
+            "login:c1",
+            _shell_payload(SHELL_COMMAND),
+        ]
         with unittest.mock.patch("terok.tui.shell_launch.subprocess.run") as mock_run:
             if isinstance(side_effect, Exception):
                 mock_run.side_effect = side_effect
@@ -128,7 +137,33 @@ class TestTmuxNewWindow:
                 mock_run.return_value = side_effect
             result = tmux_new_window(SHELL_COMMAND, title="login:c1")
         assert result is expected
-        mock_run.assert_called_once_with(expected_argv, check=True)
+        mock_run.assert_called_once_with(expected_argv, check=True, capture_output=True, text=True)
+
+    @pytest.mark.parametrize(
+        ("stamp", "stdout", "expected_stamps"),
+        [
+            ("terok-p1-t1", "@7\n", [("@7", "terok-p1-t1")]),
+            ("terok-p1-t1", "", []),
+            (None, "@7\n", []),
+        ],
+        ids=["stamps-new-window", "no-window-id-no-stamp", "no-stamp-requested"],
+    )
+    def test_tmux_new_window_stamping(
+        self, stamp: str | None, stdout: str, expected_stamps: list[tuple[str, str]]
+    ) -> None:
+        stamped: list[tuple[str, str]] = []
+        with (
+            unittest.mock.patch(
+                "terok.tui.shell_launch.subprocess.run",
+                return_value=subprocess.CompletedProcess(args=[], returncode=0, stdout=stdout),
+            ),
+            unittest.mock.patch(
+                "terok.tui.shell_launch.stamp_login_window",
+                side_effect=lambda wid, cname: stamped.append((wid, cname)),
+            ),
+        ):
+            assert tmux_new_window(SHELL_COMMAND, title="login:c1", stamp=stamp)
+        assert stamped == expected_stamps
 
 
 class TestSpawnTerminal:
@@ -343,12 +378,53 @@ class TestLaunchLogin:
         mock_inside_tmux.assert_called_once_with()
 
         if expected == ("tmux", None):
-            mock_tmux.assert_called_once_with(SHELL_COMMAND, title="login:c1")
+            mock_tmux.assert_called_once_with(SHELL_COMMAND, title="login:c1", stamp=None)
             mock_spawn_terminal.assert_not_called()
             return
 
         if patches["is_inside_tmux"]:
-            mock_tmux.assert_called_once_with(SHELL_COMMAND, title="login:c1")
+            mock_tmux.assert_called_once_with(SHELL_COMMAND, title="login:c1", stamp=None)
         else:
             mock_tmux.assert_not_called()
         mock_spawn_terminal.assert_called_once_with(SHELL_COMMAND, title="login:c1")
+
+    @pytest.mark.parametrize(
+        ("existing_window", "select_ok", "expected"),
+        [
+            ("@7", True, ("tmux-existing", None)),
+            ("@7", False, ("tmux", None)),
+            (None, True, ("tmux", None)),
+        ],
+        ids=["switches-to-existing", "creates-when-select-fails", "creates-when-none-open"],
+    )
+    def test_launch_login_reuses_container_window(
+        self,
+        existing_window: str | None,
+        select_ok: bool,
+        expected: tuple[str, int | None],
+    ) -> None:
+        """A reuse key switches to the container's open window; otherwise a stamped one opens."""
+        with (
+            unittest.mock.patch("terok.tui.shell_launch.is_inside_tmux", return_value=True),
+            unittest.mock.patch(
+                "terok.tui.shell_launch.find_login_window",
+                return_value=existing_window,
+            ) as mock_find,
+            unittest.mock.patch(
+                "terok.tui.shell_launch.select_window",
+                return_value=select_ok,
+            ) as mock_select,
+            unittest.mock.patch(
+                "terok.tui.shell_launch.tmux_new_window",
+                return_value=True,
+            ) as mock_new,
+        ):
+            assert launch_login(SHELL_COMMAND, title="login:c1", reuse_key="c1") == expected
+
+        mock_find.assert_called_once_with("c1")
+        if existing_window is None:
+            mock_select.assert_not_called()
+        if expected[0] == "tmux-existing":
+            mock_new.assert_not_called()
+        else:
+            mock_new.assert_called_once_with(SHELL_COMMAND, title="login:c1", stamp="c1")

--- a/tests/unit/tui/test_app_quit.py
+++ b/tests/unit/tui/test_app_quit.py
@@ -18,8 +18,9 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 from textual.worker import WorkerState
 
-from terok.tui.app import TerokTUI
-from terok.tui.screens import QuitConfirmScreen
+from terok.tui import tmux_session
+from terok.tui.app import _RESTART_EXIT_RESULT, TerokTUI
+from terok.tui.screens import QuitConfirmScreen, TmuxQuitScreen
 
 
 def _worker(state: WorkerState, group: str = "") -> SimpleNamespace:
@@ -91,17 +92,54 @@ class TestActionQuit:
         quit_stub._askpass_service.stop.assert_awaited_once()
         quit_stub.exit.assert_called_once()
 
+    @pytest.mark.asyncio
+    async def test_plain_quit_flashes_the_tmux_exit_hint(
+        self, quit_stub: SimpleNamespace, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A normal quit leaves the status-line breadcrumb (no-op outside terok tmux)."""
+        flash = MagicMock()
+        monkeypatch.setattr(tmux_session, "flash_exit_hint", flash)
+        await TerokTUI.action_quit(quit_stub)
+        flash.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_restart_exits_with_sentinel_and_no_hint(
+        self, quit_stub: SimpleNamespace, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """``restart=True`` skips the hint and exits with the re-exec sentinel."""
+        flash = MagicMock()
+        monkeypatch.setattr(tmux_session, "flash_exit_hint", flash)
+        await TerokTUI.action_quit(quit_stub, restart=True)
+        flash.assert_not_called()
+        quit_stub.exit.assert_called_once_with(result=_RESTART_EXIT_RESULT)
+
 
 class TestConfirmQuit:
     """The main-screen ``q`` asks for a second ``q`` before tearing down the TUI."""
 
-    def test_confirm_quit_opens_the_guard_modal(self) -> None:
+    def test_confirm_quit_opens_the_guard_modal(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """``q`` pushes a QuitConfirmScreen rather than quitting outright."""
+        monkeypatch.setattr(tmux_session, "quit_lands_in_other_window", lambda: 0)
         stub = SimpleNamespace(push_screen=MagicMock(), _on_quit_confirmed=object())
         TerokTUI.action_confirm_quit(stub)
         screen, callback = stub.push_screen.call_args[0]
         assert isinstance(screen, QuitConfirmScreen)
         assert callback is stub._on_quit_confirmed
+
+    def test_confirm_quit_uses_tmux_guard_when_landing_in_other_window(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Quitting into a sibling tmux window swaps in the tmux-aware guard."""
+        monkeypatch.setattr(tmux_session, "quit_lands_in_other_window", lambda: 2)
+        stub = SimpleNamespace(
+            push_screen=MagicMock(),
+            _on_quit_confirmed=object(),
+            _on_tmux_quit_choice=object(),
+        )
+        TerokTUI.action_confirm_quit(stub)
+        screen, callback = stub.push_screen.call_args[0]
+        assert isinstance(screen, TmuxQuitScreen)
+        assert callback is stub._on_tmux_quit_choice
 
     @pytest.mark.asyncio
     async def test_second_q_quits(self) -> None:
@@ -137,3 +175,59 @@ class TestQuitConfirmScreen:
         screen.dismiss = MagicMock()
         QuitConfirmScreen.on_key(screen, SimpleNamespace(key="x", stop=MagicMock()))
         screen.dismiss.assert_called_once_with(False)
+
+
+class TestTmuxQuitScreen:
+    """The tmux-aware guard maps q→detach, n→next window, anything else→cancel."""
+
+    @pytest.mark.parametrize(
+        ("key", "expected"),
+        [
+            pytest.param("q", "detach", id="qq-detaches"),
+            pytest.param("n", "next", id="qn-hops-windows"),
+            pytest.param("escape", None, id="escape-cancels"),
+            pytest.param("x", None, id="other-key-cancels"),
+        ],
+    )
+    def test_key_mapping(self, key: str, expected: str | None) -> None:
+        """Each quit flavour dismisses with its choice; the event never propagates."""
+        screen = TmuxQuitScreen.__new__(TmuxQuitScreen)
+        screen.dismiss = MagicMock()
+        event = SimpleNamespace(key=key, stop=MagicMock())
+        TmuxQuitScreen.on_key(screen, event)
+        event.stop.assert_called_once()
+        screen.dismiss.assert_called_once_with(expected)
+
+
+class TestTmuxQuitChoice:
+    """``_on_tmux_quit_choice`` wires each modal answer to the right teardown."""
+
+    @pytest.mark.asyncio
+    async def test_detach_detaches_then_quits(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """``detach`` returns the user to their terminal before the TUI exits."""
+        detach = MagicMock()
+        monkeypatch.setattr(tmux_session, "detach_client", detach)
+        stub = SimpleNamespace(action_quit=AsyncMock())
+        await TerokTUI._on_tmux_quit_choice(stub, "detach")
+        detach.assert_called_once()
+        stub.action_quit.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_next_quits_without_detaching(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """``next`` quits in place; the client falls through to the next window."""
+        detach = MagicMock()
+        monkeypatch.setattr(tmux_session, "detach_client", detach)
+        stub = SimpleNamespace(action_quit=AsyncMock())
+        await TerokTUI._on_tmux_quit_choice(stub, "next")
+        detach.assert_not_called()
+        stub.action_quit.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_cancel_keeps_the_tui_running(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """``None`` (any other key) neither detaches nor quits."""
+        detach = MagicMock()
+        monkeypatch.setattr(tmux_session, "detach_client", detach)
+        stub = SimpleNamespace(action_quit=AsyncMock())
+        await TerokTUI._on_tmux_quit_choice(stub, None)
+        detach.assert_not_called()
+        stub.action_quit.assert_not_awaited()

--- a/tests/unit/tui/test_app_update_check.py
+++ b/tests/unit/tui/test_app_update_check.py
@@ -162,22 +162,66 @@ class TestRunTui:
             app_mod, "TerokTUI", lambda: SimpleNamespace(run=lambda: _RESTART_EXIT_RESULT)
         )
         monkeypatch.setattr(shutil, "which", lambda _cmd: "/usr/local/bin/terok-tui")
-        monkeypatch.setattr(app_mod.sys, "argv", ["terok-tui", "--experimental"])
         execs: list[tuple[str, list[str]]] = []
-        monkeypatch.setattr(app_mod.os, "execvp", lambda f, argv: execs.append((f, argv)))
+        monkeypatch.setattr(app_mod.os, "execv", lambda f, argv: execs.append((f, argv)))
 
-        app_mod._run_tui()
+        app_mod._run_tui(("--experimental",))
 
         assert execs == [
             ("/usr/local/bin/terok-tui", ["/usr/local/bin/terok-tui", "--experimental"])
         ]
 
     def test_normal_exit_does_not_re_exec(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        """A plain quit returns without touching execvp."""
+        """A plain quit returns without touching execv."""
         monkeypatch.setattr(app_mod, "TerokTUI", lambda: SimpleNamespace(run=lambda: None))
         execs: list[object] = []
-        monkeypatch.setattr(app_mod.os, "execvp", lambda f, argv: execs.append((f, argv)))
+        monkeypatch.setattr(app_mod.os, "execv", lambda f, argv: execs.append((f, argv)))
 
         app_mod._run_tui()
 
         assert execs == []
+
+    def test_declines_restart_when_entry_point_missing(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """No ``terok-tui`` on PATH ⇒ exit normally instead of exec'ing a guess."""
+        import shutil
+
+        monkeypatch.setattr(
+            app_mod, "TerokTUI", lambda: SimpleNamespace(run=lambda: _RESTART_EXIT_RESULT)
+        )
+        monkeypatch.setattr(shutil, "which", lambda _cmd: None)
+        execs: list[object] = []
+        monkeypatch.setattr(app_mod.os, "execv", lambda f, argv: execs.append((f, argv)))
+
+        app_mod._run_tui()
+
+        assert execs == []
+
+
+class TestRestartFlags:
+    """Restart flags are rebuilt from parsed values, never echoed from argv."""
+
+    @pytest.mark.parametrize(
+        ("namespace", "expected"),
+        [
+            (
+                {"tmux": None, "new_session": False, "experimental": False, "no_emoji": False},
+                (),
+            ),
+            (
+                {"tmux": True, "new_session": True, "experimental": False, "no_emoji": False},
+                ("--tmux", "--new-session"),
+            ),
+            (
+                {"tmux": False, "new_session": False, "experimental": True, "no_emoji": True},
+                ("--no-tmux", "--experimental", "--no-emoji"),
+            ),
+        ],
+        ids=["defaults-carry-nothing", "tmux-fork", "no-tmux-extras"],
+    )
+    def test_flags_mirror_parsed_values(
+        self, namespace: dict[str, object], expected: tuple[str, ...]
+    ) -> None:
+        """Each flag reappears exactly when its parsed value asks for it."""
+        assert app_mod._restart_flags(SimpleNamespace(**namespace)) == expected

--- a/tests/unit/tui/test_app_update_check.py
+++ b/tests/unit/tui/test_app_update_check.py
@@ -1,0 +1,183 @@
+# SPDX-FileCopyrightText: 2026 Jiri Vyskocil
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the live-upgrade detection and in-place restart flow.
+
+A ``pip``/``pipx`` upgrade while the TUI is open only changes what is on
+disk; the running process keeps its imported code.  The TUI probes the
+on-disk version periodically, offers a restart when it differs, and
+``_run_tui`` re-execs the process in place when the offer is accepted.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from terok.lib.core import version as version_mod
+from terok.tui import app as app_mod
+from terok.tui.app import _RESTART_EXIT_RESULT, TerokTUI
+from terok.tui.screens import UpdateRestartScreen
+
+
+class TestInstalledDistVersion:
+    """The probe asks a fresh interpreter and degrades every failure to None."""
+
+    def _patch_run(self, monkeypatch: pytest.MonkeyPatch, **result_attrs: object) -> None:
+        monkeypatch.setattr(
+            version_mod.subprocess,
+            "run",
+            lambda *_a, **_kw: SimpleNamespace(**result_attrs),
+        )
+
+    def test_returns_stripped_version(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """A successful probe yields the dist version without the trailing newline."""
+        self._patch_run(monkeypatch, returncode=0, stdout="0.9.0\n")
+        assert version_mod.installed_dist_version() == "0.9.0"
+
+    def test_none_on_probe_failure(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """A non-zero exit (package missing, interpreter gone mid-upgrade) ⇒ None."""
+        self._patch_run(monkeypatch, returncode=1, stdout="")
+        assert version_mod.installed_dist_version() is None
+
+    def test_none_on_empty_output(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Zero exit but empty stdout still reads as unknown."""
+        self._patch_run(monkeypatch, returncode=0, stdout="\n")
+        assert version_mod.installed_dist_version() is None
+
+    def test_none_on_oserror(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """A missing interpreter raises OSError; the probe answers None."""
+
+        def boom(*_a: object, **_kw: object) -> None:
+            raise OSError("gone")
+
+        monkeypatch.setattr(version_mod.subprocess, "run", boom)
+        assert version_mod.installed_dist_version() is None
+
+
+class TestProbeInstalledVersion:
+    """The worker-thread comparison only escalates a genuinely new on-disk version."""
+
+    def _probe(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        *,
+        running: str = "0.8.0",
+        installed: str | None,
+        already_offered: str | None = None,
+    ) -> SimpleNamespace:
+        monkeypatch.setattr(app_mod, "_installed_dist_version", lambda: installed)
+        monkeypatch.setattr(app_mod, "_get_version_info", lambda: (running, None))
+        stub = SimpleNamespace(
+            _update_offered_version=already_offered,
+            call_from_thread=MagicMock(),
+            _offer_update_restart=object(),
+        )
+        TerokTUI._probe_installed_version(stub)
+        return stub
+
+    def test_new_version_offers_restart(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """A different on-disk version hops to the UI thread with both versions."""
+        stub = self._probe(monkeypatch, installed="0.9.0")
+        stub.call_from_thread.assert_called_once_with(stub._offer_update_restart, "0.8.0", "0.9.0")
+
+    def test_same_version_is_silent(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Disk matches the running version ⇒ nothing to offer."""
+        stub = self._probe(monkeypatch, installed="0.8.0")
+        stub.call_from_thread.assert_not_called()
+
+    def test_failed_probe_is_silent(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """An unreadable disk version never produces an offer."""
+        stub = self._probe(monkeypatch, installed=None)
+        stub.call_from_thread.assert_not_called()
+
+    def test_dismissed_version_not_reoffered(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """A version the operator already dismissed stays dismissed."""
+        stub = self._probe(monkeypatch, installed="0.9.0", already_offered="0.9.0")
+        stub.call_from_thread.assert_not_called()
+
+
+class TestOfferUpdateRestart:
+    """The offer pushes the modal once per on-disk version."""
+
+    def test_pushes_modal_and_records_version(self) -> None:
+        """The modal carries both versions; the offer is recorded for dedup."""
+        stub = SimpleNamespace(
+            _update_offered_version=None,
+            push_screen=MagicMock(),
+            _on_update_restart_choice=object(),
+        )
+        TerokTUI._offer_update_restart(stub, "0.8.0", "0.9.0")
+        assert stub._update_offered_version == "0.9.0"
+        screen, callback = stub.push_screen.call_args[0]
+        assert isinstance(screen, UpdateRestartScreen)
+        assert callback is stub._on_update_restart_choice
+
+    @pytest.mark.asyncio
+    async def test_accepting_restarts_via_action_quit(self) -> None:
+        """``r`` routes into the restart-flavoured quit."""
+        stub = SimpleNamespace(action_quit=AsyncMock())
+        await TerokTUI._on_update_restart_choice(stub, True)
+        stub.action_quit.assert_awaited_once_with(restart=True)
+
+    @pytest.mark.asyncio
+    async def test_dismissing_keeps_running(self) -> None:
+        """Any other key keeps the current instance alive."""
+        stub = SimpleNamespace(action_quit=AsyncMock())
+        await TerokTUI._on_update_restart_choice(stub, False)
+        await TerokTUI._on_update_restart_choice(stub, None)
+        stub.action_quit.assert_not_awaited()
+
+
+class TestUpdateRestartScreen:
+    """The modal restarts only on ``r``."""
+
+    @pytest.mark.parametrize(
+        ("key", "expected"),
+        [
+            pytest.param("r", True, id="r-restarts"),
+            pytest.param("x", False, id="other-key-dismisses"),
+        ],
+    )
+    def test_key_mapping(self, key: str, expected: bool) -> None:
+        """``r`` confirms the restart; anything else dismisses the offer."""
+        screen = UpdateRestartScreen.__new__(UpdateRestartScreen)
+        screen.dismiss = MagicMock()
+        event = SimpleNamespace(key=key, stop=MagicMock())
+        UpdateRestartScreen.on_key(screen, event)
+        event.stop.assert_called_once()
+        screen.dismiss.assert_called_once_with(expected)
+
+
+class TestRunTui:
+    """``_run_tui`` re-execs in place only on the restart sentinel."""
+
+    def test_restart_sentinel_re_execs_entry_point(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """The freshly resolved ``terok-tui`` replaces the process, flags preserved."""
+        import shutil
+
+        monkeypatch.setattr(
+            app_mod, "TerokTUI", lambda: SimpleNamespace(run=lambda: _RESTART_EXIT_RESULT)
+        )
+        monkeypatch.setattr(shutil, "which", lambda _cmd: "/usr/local/bin/terok-tui")
+        monkeypatch.setattr(app_mod.sys, "argv", ["terok-tui", "--experimental"])
+        execs: list[tuple[str, list[str]]] = []
+        monkeypatch.setattr(app_mod.os, "execvp", lambda f, argv: execs.append((f, argv)))
+
+        app_mod._run_tui()
+
+        assert execs == [
+            ("/usr/local/bin/terok-tui", ["/usr/local/bin/terok-tui", "--experimental"])
+        ]
+
+    def test_normal_exit_does_not_re_exec(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """A plain quit returns without touching execvp."""
+        monkeypatch.setattr(app_mod, "TerokTUI", lambda: SimpleNamespace(run=lambda: None))
+        execs: list[object] = []
+        monkeypatch.setattr(app_mod.os, "execvp", lambda f, argv: execs.append((f, argv)))
+
+        app_mod._run_tui()
+
+        assert execs == []

--- a/tests/unit/tui/test_tmux_session.py
+++ b/tests/unit/tui/test_tmux_session.py
@@ -1,0 +1,200 @@
+# SPDX-FileCopyrightText: 2026 Jiri Vyskocil
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for [`terok.tui.tmux_session`][] — the terok-managed tmux helpers.
+
+All tmux invocations are faked at the ``subprocess.run`` seam: the tests
+pin the exact command lines issued and the parsing of their output, never
+touching a real tmux server (the autouse conftest fixture also strips
+``TMUX``/``TEROK_TMUX`` from the environment).
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from types import SimpleNamespace
+
+import pytest
+
+from terok.tui import tmux_session
+
+
+class FakeTmux:
+    """Record tmux command lines; reply with canned stdout keyed by argv substring.
+
+    ``outputs`` maps a distinctive fragment (a subcommand like
+    ``list-windows`` or a format string like ``#{pane_pid}``) to the
+    stdout to return; the first key found anywhere in the argv wins.
+    """
+
+    def __init__(self, outputs: dict[str, str] | None = None, fail: bool = False) -> None:
+        self.outputs = outputs or {}
+        self.fail = fail
+        self.calls: list[list[str]] = []
+
+    def __call__(self, argv: list[str], **_kwargs: object) -> SimpleNamespace:
+        self.calls.append(list(argv))
+        if self.fail:
+            return SimpleNamespace(returncode=1, stdout="")
+        for key, out in self.outputs.items():
+            if any(key in arg for arg in argv[1:]):
+                return SimpleNamespace(returncode=0, stdout=out)
+        return SimpleNamespace(returncode=0, stdout="")
+
+    def install(self, monkeypatch: pytest.MonkeyPatch) -> FakeTmux:
+        """Patch ``subprocess.run`` inside tmux_session with this fake."""
+        monkeypatch.setattr(tmux_session.subprocess, "run", self)
+        return self
+
+
+@pytest.fixture
+def inside_terok_tmux(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Simulate running inside a terok-managed tmux pane."""
+    monkeypatch.setenv("TMUX", "/tmp/terok-testing/tmux-1000/default,42,0")
+    monkeypatch.setenv(tmux_session.TEROK_TMUX_ENV, "1")
+    monkeypatch.setenv("TMUX_PANE", "%7")
+
+
+def _root_command_outputs(windows: str) -> dict[str, str]:
+    """Canned probes for "this process is the pane's root command"."""
+    return {"#{pane_pid}": f"{os.getpid()}\n", "#{session_windows}": windows}
+
+
+class TestIsTerokTmux:
+    """The marker only fires inside tmux *and* with the terok session env var."""
+
+    def test_true_inside_marked_session(self, inside_terok_tmux: None) -> None:
+        """Both TMUX and TEROK_TMUX set ⇒ terok-managed."""
+        assert tmux_session.is_terok_tmux() is True
+
+    def test_false_in_users_own_tmux(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """A custom user tmux (no marker) never gets terok behaviour."""
+        monkeypatch.setenv("TMUX", "/tmp/terok-testing/tmux-1000/default,42,0")
+        assert tmux_session.is_terok_tmux() is False
+
+    def test_false_outside_tmux(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """A stale TEROK_TMUX without TMUX (e.g. inherited env) is not enough."""
+        monkeypatch.setenv(tmux_session.TEROK_TMUX_ENV, "1")
+        assert tmux_session.is_terok_tmux() is False
+
+
+class TestSessionQueries:
+    """``session_exists`` / ``find_main_window`` target the session by exact name."""
+
+    def test_session_exists_uses_exact_match(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """``=terok`` prevents prefix-matching a user session like ``terok2``."""
+        fake = FakeTmux().install(monkeypatch)
+        assert tmux_session.session_exists() is True
+        assert fake.calls == [["tmux", "has-session", "-t", "=terok"]]
+
+    def test_session_exists_false_on_failure(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """A failing has-session (no server, no session) reads as absent."""
+        FakeTmux(fail=True).install(monkeypatch)
+        assert tmux_session.session_exists() is False
+
+    def test_find_main_window_returns_stamped_id(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """The window whose @terok-main expands to 1 wins; unstamped lines don't."""
+        FakeTmux(outputs={"list-windows": "@1 \n@3 1\n@4 \n"}).install(monkeypatch)
+        assert tmux_session.find_main_window() == "@3"
+
+    def test_find_main_window_none_when_unstamped(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """No stamped window ⇒ None (the TUI window was closed)."""
+        FakeTmux(outputs={"list-windows": "@1 \n@2 \n"}).install(monkeypatch)
+        assert tmux_session.find_main_window() is None
+
+
+class TestStampMainWindow:
+    """The TUI stamps its own window and clears stale stamps elsewhere."""
+
+    def test_noop_outside_terok_tmux(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """No tmux calls at all outside a terok-managed session."""
+        fake = FakeTmux().install(monkeypatch)
+        tmux_session.stamp_main_window()
+        assert fake.calls == []
+
+    def test_stamps_own_window_and_clears_stale(
+        self, inside_terok_tmux: None, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Own window gets the stamp; a stale stamp on another window is unset."""
+        fake = FakeTmux(outputs={"list-windows": "@1 1\n@2 \n", "#{window_id}": "@2\n"}).install(
+            monkeypatch
+        )
+        tmux_session.stamp_main_window()
+        assert ["tmux", "set-option", "-w", "-t", "@1", "-u", "@terok-main"] in fake.calls
+        assert fake.calls[-1] == ["tmux", "set-option", "-w", "-t", "@2", "@terok-main", "1"]
+
+
+class TestQuitLandsInOtherWindow:
+    """Quit guidance fires only for the root command with sibling windows."""
+
+    def test_counts_sibling_windows_for_root_command(
+        self, inside_terok_tmux: None, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Root command (pane_pid == our pid) with 3 windows ⇒ 2 siblings."""
+        FakeTmux(outputs=_root_command_outputs("3\n")).install(monkeypatch)
+        assert tmux_session.quit_lands_in_other_window() == 2
+
+    def test_zero_when_not_root_command(
+        self, inside_terok_tmux: None, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Launched from a shell inside the pane ⇒ the shell survives, no guidance."""
+        FakeTmux(outputs={"#{pane_pid}": "12345\n", "#{session_windows}": "3\n"}).install(
+            monkeypatch
+        )
+        assert tmux_session.quit_lands_in_other_window() == 0
+
+    def test_zero_for_last_window(
+        self, inside_terok_tmux: None, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Only window left ⇒ quitting ends the session, back to the terminal."""
+        FakeTmux(outputs=_root_command_outputs("1\n")).install(monkeypatch)
+        assert tmux_session.quit_lands_in_other_window() == 0
+
+    def test_zero_outside_terok_tmux(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Outside a terok tmux nothing is probed and the answer is 0."""
+        fake = FakeTmux().install(monkeypatch)
+        assert tmux_session.quit_lands_in_other_window() == 0
+        assert fake.calls == []
+
+
+class TestFlashExitHint:
+    """The status-line breadcrumb fires only when the user lands in another window."""
+
+    def test_fires_display_message_with_delay(
+        self, inside_terok_tmux: None, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """When quitting drops into a sibling window, the hint is flashed."""
+        fake = FakeTmux(outputs=_root_command_outputs("2\n")).install(monkeypatch)
+        tmux_session.flash_exit_hint()
+        hint = fake.calls[-1]
+        assert hint[:3] == ["tmux", "display-message", "-d"]
+        assert "Ctrl-b d" in hint[-1]
+
+    def test_noop_when_quit_is_unsurprising(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """No hint outside a terok tmux."""
+        fake = FakeTmux().install(monkeypatch)
+        tmux_session.flash_exit_hint()
+        assert fake.calls == []
+
+
+class TestTmuxRunner:
+    """The quiet runner degrades every failure mode to None."""
+
+    def test_missing_binary(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """FileNotFoundError (no tmux installed) ⇒ None."""
+
+        def run(*_args: object, **_kwargs: object) -> SimpleNamespace:
+            raise FileNotFoundError("tmux")
+
+        monkeypatch.setattr(tmux_session.subprocess, "run", run)
+        assert tmux_session._tmux("has-session") is None
+
+    def test_timeout(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """A hung server ⇒ None instead of a TUI stall."""
+
+        def run(*_args: object, **_kwargs: object) -> SimpleNamespace:
+            raise subprocess.TimeoutExpired(cmd="tmux", timeout=5)
+
+        monkeypatch.setattr(tmux_session.subprocess, "run", run)
+        assert tmux_session._tmux("has-session") is None

--- a/tests/unit/tui/test_tmux_session.py
+++ b/tests/unit/tui/test_tmux_session.py
@@ -125,6 +125,44 @@ class TestStampMainWindow:
         assert fake.calls[-1] == ["tmux", "set-option", "-w", "-t", "@2", "@terok-main", "1"]
 
 
+class TestLoginWindows:
+    """Login windows are stamped per container and found for reuse."""
+
+    def test_find_login_window_matches_container(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """The window stamped with the container name wins; others don't."""
+        fake = FakeTmux(outputs={"list-windows": "@1 \n@3 terok-p1-t1\n@4 terok-p1-t2\n"}).install(
+            monkeypatch
+        )
+        assert tmux_session.find_login_window("terok-p1-t2") == "@4"
+        assert fake.calls == [
+            ["tmux", "list-windows", "-F", "#{window_id} #{@terok-login}"],
+        ]
+
+    def test_find_login_window_none_when_absent(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """No window logged into the container ⇒ None (open a fresh one)."""
+        FakeTmux(outputs={"list-windows": "@1 \n@3 terok-p1-t1\n"}).install(monkeypatch)
+        assert tmux_session.find_login_window("terok-p2-t9") is None
+
+    def test_stamp_login_window(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """The stamp is a window option carrying the container name."""
+        fake = FakeTmux().install(monkeypatch)
+        tmux_session.stamp_login_window("@7", "terok-p1-t1")
+        assert fake.calls == [
+            ["tmux", "set-option", "-w", "-t", "@7", "@terok-login", "terok-p1-t1"],
+        ]
+
+    @pytest.mark.parametrize(
+        ("fail", "expected"), [(False, True), (True, False)], ids=["accepted", "window-gone"]
+    )
+    def test_select_window(
+        self, monkeypatch: pytest.MonkeyPatch, fail: bool, expected: bool
+    ) -> None:
+        """Selecting reports whether tmux accepted the window id."""
+        fake = FakeTmux(fail=fail).install(monkeypatch)
+        assert tmux_session.select_window("@7") is expected
+        assert fake.calls == [["tmux", "select-window", "-t", "@7"]]
+
+
 class TestQuitLandsInOtherWindow:
     """Quit guidance fires only for the root command with sibling windows."""
 

--- a/tests/unit/tui/test_tui_module.py
+++ b/tests/unit/tui/test_tui_module.py
@@ -122,8 +122,15 @@ def test_launch_in_tmux_resumes_existing_session(
     monkeypatch.setattr(tmux_session, "find_main_window", lambda: main_window)
 
     captured: list[str] = []
-    monkeypatch.setattr(app.os, "execvp", lambda _file, argv: captured.extend(argv))
 
-    app._launch_in_tmux(force_new=False)
+    def fake_execvp(_file: str, argv: list[str]) -> None:
+        # Like the real execvp, never return to the caller.
+        captured.extend(argv)
+        raise SystemExit(0)
+
+    monkeypatch.setattr(app.os, "execvp", fake_execvp)
+
+    with pytest.raises(SystemExit):
+        app._launch_in_tmux(force_new=False)
 
     assert captured == expected_argv

--- a/tests/unit/tui/test_tui_module.py
+++ b/tests/unit/tui/test_tui_module.py
@@ -47,30 +47,83 @@ def test_tmux_configuration_integration(
 @pytest.mark.parametrize(
     ("force_new", "expected_session_args"),
     [
-        pytest.param(False, ["new-session", "-A", "-s", "terok"], id="attach-shared"),
+        pytest.param(
+            False, ["new-session", "-A", "-s", "terok", "-n", "terok"], id="create-shared"
+        ),
         pytest.param(True, ["new-session"], id="force-new"),
     ],
 )
-def test_launch_in_tmux_attaches_or_forks(
+def test_launch_in_tmux_creates_or_forks(
     monkeypatch: pytest.MonkeyPatch,
     force_new: bool,
     expected_session_args: list[str],
 ) -> None:
-    """Default launch attaches to the shared ``terok`` session; ``--new-session`` forks."""
+    """With no session running, launch creates the shared (or a forked) marked session."""
     import shutil
 
-    from terok.tui import app
+    from terok.tui import app, tmux_session
 
     monkeypatch.delenv("TMUX", raising=False)
     # ``_launch_in_tmux`` does a local ``import shutil``; patch the real module.
     monkeypatch.setattr(shutil, "which", lambda _cmd: "/usr/bin/tmux")
+    monkeypatch.setattr(tmux_session, "session_exists", lambda: False)
 
     captured: list[str] = []
     monkeypatch.setattr(app.os, "execvp", lambda _file, argv: captured.extend(argv))
 
     app._launch_in_tmux(force_new=force_new)
 
-    # argv is ["tmux", "-f", <conf>, *session_args, "terok-tui"]; the conf path
-    # is materialised at runtime so we assert around it rather than on it.
+    # argv is ["tmux", "-f", <conf>, *session_args, "-e", <marker>, "terok-tui"];
+    # the conf path is materialised at runtime so we assert around it.
     assert captured[:2] == ["tmux", "-f"]
-    assert captured[3:] == [*expected_session_args, "terok-tui"]
+    assert captured[3:] == [*expected_session_args, "-e", "TEROK_TMUX=1", "terok-tui"]
+
+
+@pytest.mark.parametrize(
+    ("main_window", "expected_argv"),
+    [
+        pytest.param(
+            "@3",
+            ["tmux", "select-window", "-t", "@3", ";", "attach-session", "-t", "=terok"],
+            id="land-on-stamped-window",
+        ),
+        pytest.param(
+            None,
+            [
+                "tmux",
+                "new-window",
+                "-t",
+                "=terok",
+                "-n",
+                "terok",
+                "terok-tui",
+                ";",
+                "attach-session",
+                "-t",
+                "=terok",
+            ],
+            id="revive-tui-window",
+        ),
+    ],
+)
+def test_launch_in_tmux_resumes_existing_session(
+    monkeypatch: pytest.MonkeyPatch,
+    main_window: str | None,
+    expected_argv: list[str],
+) -> None:
+    """Resume lands on the stamped TUI window, reviving the TUI when none is stamped."""
+    import shutil
+
+    from terok.tui import app, tmux_session
+
+    monkeypatch.delenv("TMUX", raising=False)
+    monkeypatch.setattr(shutil, "which", lambda _cmd: "/usr/bin/tmux")
+    monkeypatch.setattr(tmux_session, "session_exists", lambda: True)
+    monkeypatch.setattr(tmux_session, "find_main_window", lambda: main_window)
+
+    captured: list[str] = []
+    monkeypatch.setattr(app.os, "execvp", lambda _file, argv: captured.extend(argv))
+
+    app._launch_in_tmux(force_new=False)
+
+    assert captured == expected_argv


### PR DESCRIPTION
Smooths out `terok tui --tmux` for users unfamiliar with tmux. Four features; the first three are scoped strictly to terok-managed tmux sessions (detected via a `TEROK_TMUX=1` session-environment marker set at `new-session`; a user's own tmux never gets terok-specific session behaviour).

## 1. Main-window stamping

The TUI stamps its own window with a `@terok-main` window option at startup, so `terok tui --tmux` resume lands directly on the window running the TUI — accurate even after killing and relaunching terok in a different window (self-stamping heals it). If the session exists but no TUI is running, resume revives it in a new window instead of dropping the user into an arbitrary shell.

## 2. Live-upgrade restart offer

Every 5 minutes the TUI probes the on-disk terok version with a fresh interpreter (`importlib.metadata` in a subprocess) and compares it to the frozen in-memory version. On mismatch it offers a one-key restart that re-execs the process in place — same terminal, same tmux window, argv preserved. Comparison is by inequality (a downgrade also means the running instance is stale). Offered once per detected version; disabled under textual-serve where the server owns the lifecycle.

## 3. Quit guidance

Quitting from inside a terok-managed tmux (where closing the window would strand the user in another window — likely a running task) replaces the plain quit confirm with a tmux-aware one:

- `q` → quit **and detach** back to the original terminal (keeps the `qq` muscle memory; detach is the presumed intent — tasks keep running)
- `n` → quit into the next tmux window
- anything else → cancel

If the window closes anyway, a 10-second `display-message` hint appears on the status line of the landing window explaining what happened and how to get back (`Ctrl-b d`, `terok tui --tmux`).

## 4. Login-window reuse

Every login window terok opens inside tmux is stamped with its container name (`@terok-login`, window id captured via `new-window -P -F`). A repeated login to the same container — pressing `i` again, most commonly — switches to that window instead of piling up duplicates: every login command attaches to the same tmux session *inside* the container, so one host window per container is always enough. This one works in **any** tmux, not just terok-managed sessions, since it only ever touches windows terok itself created. Stale stamps cannot mislead: a login window closes with its `podman exec` (no `remain-on-exit`), taking the stamp with it.

## Implementation notes

- New `src/terok/tui/tmux_session.py` holds all managed-tmux helpers (no textual imports); everything is best-effort — any tmux failure degrades to a quiet no-op.
- The root-command check (`#{pane_pid}` == our pid, thanks to shell exec-optimization of a single-command window) is what distinguishes "quit kills the window" from "quit returns to a shell", so the guidance only fires when it's actually needed.
- `tests/unit/conftest.py` now scrubs `TMUX`/`TMUX_PANE`/`TEROK_TMUX` so a pytest run inside a live terok tmux can never stamp windows or flash messages on it.
- All tmux mechanisms (session-env marker visibility, `pane_pid` equality, window options, `display-message -d` surviving window death) were verified empirically against tmux 3.6b before building.
- `docs/usage.md` tmux section updated.

Requires tmux ≥ 3.2 for the `-e` marker (older tmux: features quietly stay off, base behavior unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved tmux integration, including shared session reuse and switching to existing container windows.
  * Added tmux-aware quit options for detaching, moving to the next window, or cancelling.
  * Added automatic detection of installed updates with an option to restart the TUI and apply them immediately.

* **Documentation**
  * Expanded tmux usage guidance, including window switching, session reuse, quitting, and upgrading.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->