### PR TITLE
fix(vault): report leaked shared-mount credentials as red errors at task start

### DIFF
--- a/src/terok/lib/orchestration/environment.py
+++ b/src/terok/lib/orchestration/environment.py
@@ -416,13 +416,15 @@ def _vault_patch_provider_sets(
     return enabled, disabled
 
 
-def _warn_leaked_credentials(mounts_dir: Path) -> None:
-    """Warn about real credential files in shared mounts.
+def _report_leaked_credentials(mounts_dir: Path) -> None:
+    """Report real credential files found in shared mounts.
 
-    When an OAuth token is intentionally exposed (for Claude subscription
-    features or direct Codex control), the
-    provider-specific leak warning is suppressed and replaced by a loud,
-    explicit banner so the user can't miss that a real token is mounted.
+    A real credential in a shared mount is a containment failure — every
+    task container can read it — so each finding is printed as a red
+    error.  The deliberate exceptions are the explicitly enabled
+    exposed-OAuth modes (Claude subscription features, direct Codex
+    control): those suppress the error and print a loud yellow banner
+    instead, so the user still can't miss that a real token is mounted.
 
     *mounts_dir* is the project's effective agent-config mount tree —
     shared or project-scoped per
@@ -433,38 +435,42 @@ def _warn_leaked_credentials(mounts_dir: Path) -> None:
     from terok.lib.integrations.executor import scan_leaked_credentials
 
     from ..core.config import is_claude_oauth_exposed, is_codex_oauth_exposed
-    from ..util.ansi import bold, supports_color, yellow
+    from ..util.ansi import bold, red, supports_color, yellow
 
     leaked = scan_leaked_credentials(mounts_dir)
     color = supports_color()
 
-    def _banner(provider_label: str, file_desc: str) -> None:
-        print(
-            "\n"
-            + bold(
-                yellow(
-                    f"  WARNING: {provider_label} OAuth token is EXPOSED to all task containers.\n"
-                    f"  The vault does NOT protect this token — it is mounted\n"
-                    f"  directly via {file_desc} in the shared config directory.\n"
-                    f"  Every task container managed by terok can read the real token.\n",
-                    color,
-                ),
-                color,
-            ),
-            file=sys.stderr,
+    def _block(paint: Callable[[str, bool], str], text: str) -> None:
+        print("\n" + bold(paint(text, color), color), file=sys.stderr)
+
+    def _exposed_banner(provider_label: str, file_desc: str) -> None:
+        _block(
+            yellow,
+            f"  WARNING: {provider_label} OAuth token is EXPOSED to all task containers.\n"
+            f"  The vault does NOT protect this token — it is mounted\n"
+            f"  directly via {file_desc} in the shared config directory.\n"
+            f"  Every task container managed by terok can read the real token.\n",
         )
 
     if is_claude_oauth_exposed():
-        _banner("Claude", ".credentials.json")
+        _exposed_banner("Claude", ".credentials.json")
         leaked = [(p, path) for p, path in leaked if p != "claude"]
 
     if is_codex_oauth_exposed():
-        _banner("Codex", "auth.json")
+        _exposed_banner("Codex", "auth.json")
         leaked = [(p, path) for p, path in leaked if p != "codex"]
 
-    for provider, path in leaked:
-        _logger.warning("Real credential in shared mount for provider %s", provider)
-        _logger.debug("  path: %s", path)
+    if leaked:
+        providers = ", ".join(sorted({p for p, _ in leaked}))
+        _block(
+            red,
+            f"  ERROR: Real credential in shared mount for provider(s): {providers}.\n"
+            "  Every task container managed by terok can read these files —\n"
+            "  the vault does NOT protect them.\n"
+            "  Run `terok vault clean` to remove leaked credential files.\n",
+        )
+        for provider, path in leaked:
+            _logger.debug("Leaked credential for %s: %s", provider, path)
 
 
 # ---------- Clone-cache workspace seeding ----------
@@ -652,7 +658,7 @@ class TaskEnvironment:
         # Claude OAuth env override + leaked-cred scan with exposed-token filtering
         if not vault_bypass:
             _apply_claude_oauth_overrides(env)
-            _warn_leaked_credentials(mounts_dir)
+            _report_leaked_credentials(mounts_dir)
 
         return env, volumes
 

--- a/tests/unit/lib/test_vault_env.py
+++ b/tests/unit/lib/test_vault_env.py
@@ -129,39 +129,43 @@ class TestVaultPatchProviderSets:
 
 
 class TestLeakedCredentialsScan:
-    """Verify _warn_leaked_credentials with exposed-token filtering."""
+    """Verify _report_leaked_credentials with exposed-token filtering."""
 
-    def test_warns_for_leaked_files(self, caplog: pytest.LogCaptureFixture) -> None:
-        """Leaked credential files produce log warnings."""
-        from terok.lib.orchestration.environment import _warn_leaked_credentials
+    def test_reports_leaked_files_as_red_errors(
+        self, capsys: pytest.CaptureFixture[str], caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Leaked credential files print a red ERROR block to stderr."""
+        from terok.lib.orchestration.environment import _report_leaked_credentials
 
         mounts = Path("/tmp/terok-testing/mounts")
         with (
-            caplog.at_level(logging.WARNING, logger="terok.lib.orchestration.environment"),
+            caplog.at_level(logging.DEBUG, logger="terok.lib.orchestration.environment"),
             patch(
                 "terok.lib.integrations.executor.scan_leaked_credentials",
                 return_value=[("claude", Path("/tmp/terok-testing/m/.credentials.json"))],
             ) as mock_scan,
             patch("terok.lib.core.config.is_claude_oauth_exposed", return_value=False),
+            patch("terok.lib.core.config.is_codex_oauth_exposed", return_value=False),
         ):
-            _warn_leaked_credentials(mounts)
+            _report_leaked_credentials(mounts)
 
-        warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
-        assert any("claude" in r.message for r in warnings)
-        # Full path must not leak at WARNING — only at DEBUG
-        assert not any(".credentials.json" in r.message for r in warnings)
+        err = capsys.readouterr().err
+        assert "ERROR" in err and "claude" in err
+        assert "terok vault clean" in err
+        # Full path must not appear on the console — only at DEBUG
+        assert ".credentials.json" not in err
+        assert any(".credentials.json" in r.message for r in caplog.records)
         # The mounts dir is forwarded verbatim — no implicit fallback to the
         # global path.  Pins the route from materialize() through to the scan.
         mock_scan.assert_called_once_with(mounts)
 
-    def test_exposed_token_suppresses_claude_warning(
-        self, capsys: pytest.CaptureFixture[str], caplog: pytest.LogCaptureFixture
+    def test_exposed_token_suppresses_claude_error(
+        self, capsys: pytest.CaptureFixture[str]
     ) -> None:
-        """Exposed Claude OAuth token: Claude warning suppressed, other providers still warned."""
-        from terok.lib.orchestration.environment import _warn_leaked_credentials
+        """Exposed Claude OAuth token: Claude error suppressed, other providers still red."""
+        from terok.lib.orchestration.environment import _report_leaked_credentials
 
         with (
-            caplog.at_level(logging.WARNING, logger="terok.lib.orchestration.environment"),
             patch(
                 "terok.lib.integrations.executor.scan_leaked_credentials",
                 return_value=[
@@ -172,24 +176,23 @@ class TestLeakedCredentialsScan:
             patch("terok.lib.core.config.is_claude_oauth_exposed", return_value=True),
             patch("terok.lib.core.config.is_codex_oauth_exposed", return_value=False),
         ):
-            _warn_leaked_credentials(Path("/tmp/terok-testing/mounts"))
+            _report_leaked_credentials(Path("/tmp/terok-testing/mounts"))
 
         # Exposed-token warning printed to stderr
         err = capsys.readouterr().err
         assert "EXPOSED" in err
-        # Claude filtered out, vibe still warned via logger
-        log_messages = [r.message for r in caplog.records]
-        assert not any("claude" in m for m in log_messages)
-        assert any("vibe" in m for m in log_messages)
+        # Claude filtered out of the error block, vibe still reported
+        error_block = err[err.index("ERROR") :]
+        assert "claude" not in error_block
+        assert "vibe" in error_block
 
-    def test_exposed_codex_token_suppresses_codex_warning(
-        self, capsys: pytest.CaptureFixture[str], caplog: pytest.LogCaptureFixture
+    def test_exposed_codex_token_suppresses_codex_error(
+        self, capsys: pytest.CaptureFixture[str]
     ) -> None:
-        """Exposed Codex OAuth token: Codex warning suppressed, banner printed."""
-        from terok.lib.orchestration.environment import _warn_leaked_credentials
+        """Exposed Codex OAuth token: Codex error suppressed, banner printed."""
+        from terok.lib.orchestration.environment import _report_leaked_credentials
 
         with (
-            caplog.at_level(logging.WARNING, logger="terok.lib.orchestration.environment"),
             patch(
                 "terok.lib.integrations.executor.scan_leaked_credentials",
                 return_value=[
@@ -200,10 +203,26 @@ class TestLeakedCredentialsScan:
             patch("terok.lib.core.config.is_claude_oauth_exposed", return_value=False),
             patch("terok.lib.core.config.is_codex_oauth_exposed", return_value=True),
         ):
-            _warn_leaked_credentials(Path("/tmp/terok-testing/mounts"))
+            _report_leaked_credentials(Path("/tmp/terok-testing/mounts"))
 
         err = capsys.readouterr().err
         assert "Codex" in err and "EXPOSED" in err
-        log_messages = [r.message for r in caplog.records]
-        assert not any("codex" in m for m in log_messages)
-        assert any("vibe" in m for m in log_messages)
+        error_block = err[err.index("ERROR") :]
+        assert "codex" not in error_block
+        assert "vibe" in error_block
+
+    def test_no_output_when_nothing_leaked(self, capsys: pytest.CaptureFixture[str]) -> None:
+        """A clean scan prints nothing — no empty ERROR block."""
+        from terok.lib.orchestration.environment import _report_leaked_credentials
+
+        with (
+            patch(
+                "terok.lib.integrations.executor.scan_leaked_credentials",
+                return_value=[],
+            ),
+            patch("terok.lib.core.config.is_claude_oauth_exposed", return_value=False),
+            patch("terok.lib.core.config.is_codex_oauth_exposed", return_value=False),
+        ):
+            _report_leaked_credentials(Path("/tmp/terok-testing/mounts"))
+
+        assert capsys.readouterr().err == ""


### PR DESCRIPTION
## Problem

An *actual* real credential in a shared mount is a containment failure — every task container can read it — yet the task-start scan surfaced it as a plain logger warning, easy to scroll past.

## Fix

- `_warn_leaked_credentials` → `_report_leaked_credentials`: findings now print a bold red stderr error block naming the affected providers and pointing at `terok vault clean`; file paths stay at DEBUG (unchanged policy).
- The explicitly enabled exposed-OAuth modes (Claude subscription features, direct Codex control) keep their loud yellow banner and stay filtered out of the error block — unchanged behavior, now sharing one block-printing helper with the error path.
- Clean scan prints nothing.

## Related

terok-ai/terok-executor#464 fixes the glab false positive (settings-only `config.yml` flagged since executor#412 made the mount writable). The two PRs are independent — no pin coupling; until #464 is released, the glab false positive simply shows red instead of as a warning.

## Tests

Updated `TestLeakedCredentialsScan`: red ERROR block on stderr (with `terok vault clean` hint, no paths), exposed-Claude/Codex filtering out of the error block, and a no-output-on-clean-scan case. Full suite: no new failures (the 32 failing tests fail identically on upstream/master — podman-dependent).

🤖 Generated with [Claude Code](https://claude.com/claude-code)