### PR TITLE
fix(tui): tmux UX review follow-ups — old-tmux marker guard, timeouts, off-loop calls

### DIFF
--- a/src/terok/tui/app.py
+++ b/src/terok/tui/app.py
@@ -473,7 +473,15 @@ if _HAS_TEXTUAL:
             # In a terok-managed tmux, mark this window as the one running
             # the TUI — self-healing across kill-and-relaunch (best-effort,
             # a few local socket calls; quiet no-op everywhere else).
-            tmux_session.stamp_main_window()
+            # Threaded so a hung tmux server can't stall startup for the
+            # helper's subprocess timeouts.
+            self.run_worker(
+                tmux_session.stamp_main_window,
+                name="stamp-tmux-window",
+                group="tmux-stamp",
+                thread=True,
+                exit_on_error=False,
+            )
 
             # Watch for a terok upgrade landing on disk under the running
             # TUI.  Restarting re-execs this process, which makes no sense
@@ -1577,9 +1585,14 @@ if _HAS_TEXTUAL:
 
             # When the window dies with us and the client lands in another
             # tmux window, leave a status-line breadcrumb there.  A restart
-            # keeps the window alive, so no hint.
+            # keeps the window alive, so no hint.  Threaded but awaited:
+            # the hint must be issued before the process (and with it the
+            # window) dies, yet a hung tmux server should freeze at most
+            # this coroutine, not the whole UI.
             if not restart:
-                tmux_session.flash_exit_hint()
+                import asyncio
+
+                await asyncio.to_thread(tmux_session.flash_exit_hint)
 
             exit_kwargs: dict[str, Any] = {"result": _RESTART_EXIT_RESULT} if restart else {}
             pending = [
@@ -2148,7 +2161,12 @@ if _HAS_TEXTUAL:
         if not exe:
             print("terok-tui not found on PATH — restart it manually to pick up the update.")
             return
-        os.execv(exe, [exe, *restart_flags])  # nosec B606 — resolved entry point, literal flags
+        try:
+            os.execv(exe, [exe, *restart_flags])  # nosec B606 — resolved entry point, literal flags
+        except OSError:
+            # The entry point vanished or lost its exec bit between the
+            # which() above and here — an upgrade in flight can do that.
+            print(f"Could not restart {exe} — start terok-tui again manually.")
 
     def _launch_in_tmux(force_new: bool = False, restart_flags: tuple[str, ...] = ()) -> None:
         """Launch the TUI inside a managed tmux session.
@@ -2166,8 +2184,9 @@ if _HAS_TEXTUAL:
         fresh, tmux-named session alongside the existing one instead.
 
         Sessions are created with the ``TEROK_TMUX=1`` session environment
-        marker (``new-session -e``, tmux >= 3.2) so everything inside can
-        tell a terok-managed tmux apart from the user's own.
+        marker so everything inside can tell a terok-managed tmux apart
+        from the user's own — on a tmux too old for ``new-session -e``
+        (< 3.2) the marker is skipped and the tmux niceties stay off.
         """
         if os.environ.get("TMUX"):
             # Already inside tmux — no double-wrap
@@ -2184,8 +2203,6 @@ if _HAS_TEXTUAL:
                 file=sys.stderr,
             )
             sys.exit(1)
-
-        marker = f"{tmux_session.TEROK_TMUX_ENV}=1"
 
         if not force_new and tmux_session.session_exists():
             # Resume: land the client on the TUI's stamped window rather
@@ -2218,10 +2235,11 @@ if _HAS_TEXTUAL:
             if force_new
             else ["new-session", "-A", "-s", tmux_session.SESSION_NAME, "-n", "terok"]
         )
+        marker_args = tmux_session.session_marker_args()
         with _res.as_file(tmux_conf) as conf_path:
             os.execvp(
                 "tmux",
-                ["tmux", "-f", str(conf_path), *session_args, "-e", marker, "terok-tui"],
+                ["tmux", "-f", str(conf_path), *session_args, *marker_args, "terok-tui"],
             )
 
     import argparse

--- a/src/terok/tui/shell_launch.py
+++ b/src/terok/tui/shell_launch.py
@@ -16,7 +16,7 @@ import os
 import shlex
 import subprocess
 
-from .tmux_session import find_login_window, select_window, stamp_login_window
+from .tmux_session import TMUX_TIMEOUT_S, find_login_window, select_window, stamp_login_window
 
 
 def is_inside_tmux() -> bool:
@@ -138,9 +138,9 @@ def tmux_new_window(command: list[str], title: str | None = None, stamp: str | N
     tmux_cmd.append(shell_cmd)
     try:
         result = subprocess.run(  # nosec B603 — fixed tmux verbs; command is shell-quoted above
-            tmux_cmd, check=True, capture_output=True, text=True
+            tmux_cmd, check=True, capture_output=True, text=True, timeout=TMUX_TIMEOUT_S
         )
-    except (subprocess.CalledProcessError, FileNotFoundError):
+    except (subprocess.SubprocessError, FileNotFoundError):
         return False
     if stamp and (window_id := result.stdout.strip()):
         stamp_login_window(window_id, stamp)

--- a/src/terok/tui/tmux_session.py
+++ b/src/terok/tui/tmux_session.py
@@ -27,6 +27,7 @@ in the TUI.
 """
 
 import os
+import re
 import subprocess  # nosec B404 — every call is a fixed "tmux" argv, no shell
 
 SESSION_NAME = "terok"
@@ -41,7 +42,9 @@ MAIN_WINDOW_OPTION = "@terok-main"
 LOGIN_WINDOW_OPTION = "@terok-login"
 """tmux window option stamped with the container name a login window is attached to."""
 
-_TMUX_TIMEOUT_S = 5
+TMUX_TIMEOUT_S = 5
+"""Best-effort ceiling for any single host tmux command (a hung server must not stall the TUI)."""
+
 _EXIT_HINT_MS = 10000
 _EXIT_HINT = "terok closed — Ctrl-b d returns to your terminal; 'terok tui --tmux' reopens terok"
 
@@ -53,7 +56,7 @@ def _tmux(*args: str) -> str | None:
             ["tmux", *args],
             capture_output=True,
             text=True,
-            timeout=_TMUX_TIMEOUT_S,
+            timeout=TMUX_TIMEOUT_S,
         )
     except (OSError, subprocess.SubprocessError):
         return None
@@ -73,6 +76,23 @@ def is_terok_tmux() -> bool:
 def session_exists() -> bool:
     """Return True when the shared terok session exists on the default server."""
     return _tmux("has-session", "-t", f"={SESSION_NAME}") is not None
+
+
+def session_marker_args() -> tuple[str, ...]:
+    """``new-session`` arguments carrying the terok marker, when tmux supports them.
+
+    Setting a session-environment variable at creation (``new-session
+    -e``) needs tmux >= 3.2; an older tmux rejects the flag outright,
+    which would kill session creation entirely rather than merely losing
+    the marker.  Probing ``tmux -V`` (versions like ``3.2a`` or
+    ``next-3.4``) keeps old tmuxes working: without the marker the
+    terok-specific niceties quietly stay off and the base behaviour is
+    unchanged.
+    """
+    version = re.search(r"(\d+)\.(\d+)", _tmux("-V") or "")
+    if version and (int(version.group(1)), int(version.group(2))) >= (3, 2):
+        return ("-e", f"{TEROK_TMUX_ENV}=1")
+    return ()
 
 
 def _window_stamps(option: str, *target: str) -> list[tuple[str, str]]:

--- a/tests/unit/lib/test_shell_launch.py
+++ b/tests/unit/lib/test_shell_launch.py
@@ -21,6 +21,7 @@ from terok.tui.shell_launch import (
     spawn_terminal_with_command,
     tmux_new_window,
 )
+from terok.tui.tmux_session import TMUX_TIMEOUT_S
 from tests.testfs import FAKE_TMUX_SOCKET
 
 SHELL_COMMAND = ["podman", "exec", "-it", "c1", "bash"]
@@ -116,8 +117,9 @@ class TestTmuxNewWindow:
             (subprocess.CompletedProcess(args=[], returncode=0, stdout="@7\n"), True),
             (subprocess.CalledProcessError(1, "tmux"), False),
             (FileNotFoundError("tmux"), False),
+            (subprocess.TimeoutExpired("tmux", TMUX_TIMEOUT_S), False),
         ],
-        ids=["success", "failure", "tmux-not-found"],
+        ids=["success", "failure", "tmux-not-found", "hung-server"],
     )
     def test_tmux_new_window(self, side_effect: object, expected: bool) -> None:
         expected_argv = [
@@ -137,7 +139,9 @@ class TestTmuxNewWindow:
                 mock_run.return_value = side_effect
             result = tmux_new_window(SHELL_COMMAND, title="login:c1")
         assert result is expected
-        mock_run.assert_called_once_with(expected_argv, check=True, capture_output=True, text=True)
+        mock_run.assert_called_once_with(
+            expected_argv, check=True, capture_output=True, text=True, timeout=TMUX_TIMEOUT_S
+        )
 
     @pytest.mark.parametrize(
         ("stamp", "stdout", "expected_stamps"),

--- a/tests/unit/tui/test_app_update_check.py
+++ b/tests/unit/tui/test_app_update_check.py
@@ -181,6 +181,26 @@ class TestRunTui:
 
         assert execs == []
 
+    def test_exec_failure_becomes_a_message_not_a_traceback(
+        self, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+    ) -> None:
+        """The entry point vanishing between which() and exec (upgrade in flight) exits cleanly."""
+        import shutil
+
+        monkeypatch.setattr(
+            app_mod, "TerokTUI", lambda: SimpleNamespace(run=lambda: _RESTART_EXIT_RESULT)
+        )
+        monkeypatch.setattr(shutil, "which", lambda _cmd: "/usr/local/bin/terok-tui")
+
+        def broken_execv(_file: str, _argv: list[str]) -> None:
+            raise OSError("gone")
+
+        monkeypatch.setattr(app_mod.os, "execv", broken_execv)
+
+        app_mod._run_tui()
+
+        assert "Could not restart" in capsys.readouterr().out
+
     def test_declines_restart_when_entry_point_missing(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:

--- a/tests/unit/tui/test_tmux_session.py
+++ b/tests/unit/tui/test_tmux_session.py
@@ -125,6 +125,33 @@ class TestStampMainWindow:
         assert fake.calls[-1] == ["tmux", "set-option", "-w", "-t", "@2", "@terok-main", "1"]
 
 
+class TestSessionMarkerArgs:
+    """The ``-e`` marker is only offered on a tmux new enough to accept it."""
+
+    @pytest.mark.parametrize(
+        ("version_line", "expected"),
+        [
+            ("tmux 3.6b\n", ("-e", "TEROK_TMUX=1")),
+            ("tmux 3.2a\n", ("-e", "TEROK_TMUX=1")),
+            ("tmux next-3.4\n", ("-e", "TEROK_TMUX=1")),
+            ("tmux 3.1c\n", ()),
+            ("tmux 2.9\n", ()),
+        ],
+        ids=["modern", "exactly-3.2", "next-prefix", "too-old-minor", "too-old-major"],
+    )
+    def test_marker_follows_tmux_version(
+        self, monkeypatch: pytest.MonkeyPatch, version_line: str, expected: tuple[str, ...]
+    ) -> None:
+        """tmux >= 3.2 gets the marker; anything older (which rejects -e) gets none."""
+        FakeTmux(outputs={"-V": version_line}).install(monkeypatch)
+        assert tmux_session.session_marker_args() == expected
+
+    def test_no_marker_when_probe_fails(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """An unprobeable tmux is treated as too old — degrade, don't break."""
+        FakeTmux(fail=True).install(monkeypatch)
+        assert tmux_session.session_marker_args() == ()
+
+
 class TestLoginWindows:
     """Login windows are stamped per container and found for reuse."""
 

--- a/tests/unit/tui/test_tui_module.py
+++ b/tests/unit/tui/test_tui_module.py
@@ -45,6 +45,13 @@ def test_tmux_configuration_integration(
 
 
 @pytest.mark.parametrize(
+    "marker_args",
+    [
+        pytest.param(("-e", "TEROK_TMUX=1"), id="modern-tmux"),
+        pytest.param((), id="old-tmux"),
+    ],
+)
+@pytest.mark.parametrize(
     ("force_new", "expected_session_args"),
     [
         pytest.param(
@@ -57,6 +64,7 @@ def test_launch_in_tmux_creates_or_forks(
     monkeypatch: pytest.MonkeyPatch,
     force_new: bool,
     expected_session_args: list[str],
+    marker_args: tuple[str, ...],
 ) -> None:
     """With no session running, launch creates the shared (or a forked) marked session."""
     import shutil
@@ -67,16 +75,17 @@ def test_launch_in_tmux_creates_or_forks(
     # ``_launch_in_tmux`` does a local ``import shutil``; patch the real module.
     monkeypatch.setattr(shutil, "which", lambda _cmd: "/usr/bin/tmux")
     monkeypatch.setattr(tmux_session, "session_exists", lambda: False)
+    monkeypatch.setattr(tmux_session, "session_marker_args", lambda: marker_args)
 
     captured: list[str] = []
     monkeypatch.setattr(app.os, "execvp", lambda _file, argv: captured.extend(argv))
 
     app._launch_in_tmux(force_new=force_new)
 
-    # argv is ["tmux", "-f", <conf>, *session_args, "-e", <marker>, "terok-tui"];
+    # argv is ["tmux", "-f", <conf>, *session_args, *marker_args, "terok-tui"];
     # the conf path is materialised at runtime so we assert around it.
     assert captured[:2] == ["tmux", "-f"]
-    assert captured[3:] == [*expected_session_args, "-e", "TEROK_TMUX=1", "terok-tui"]
+    assert captured[3:] == [*expected_session_args, *marker_args, "terok-tui"]
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Follow-ups to the review comments on #1164, verified against current master. All four findings were valid; one arrived with a stale description but a live core.

## Old-tmux guard for the session marker (the important one)

`new-session -e` needs tmux ≥ 3.2, and an older tmux **rejects the flag outright** — so on e.g. tmux 3.0/3.1 the marker didn't "quietly stay off" as #1164 claimed, it killed session creation entirely. `session_marker_args()` now probes `tmux -V` (handles `3.2a`, `next-3.4` forms) and only emits `-e TEROK_TMUX=1` on a tmux that accepts it; an unprobeable tmux is treated as too old. Old tmuxes launch normally with the terok niceties off.

## tmux calls off the Textual event loop

`stamp_main_window()` (a handful of subprocess calls, 5 s timeout each) now runs in a thread worker from `on_mount`, so a hung tmux server can't stall startup. `flash_exit_hint()` runs via `asyncio.to_thread` in `action_quit` — threaded but awaited, because the hint must be issued before the process (and with it the window) dies; the event loop stays responsive either way.

## Timeout on `tmux new-window`

`tmux_new_window` had no timeout while every other tmux call is bounded at 5 s. It now shares the constant (promoted to public `TMUX_TIMEOUT_S` in `tmux_session`), and the except clause widened to `subprocess.SubprocessError` so `TimeoutExpired` degrades to the same best-effort `False`.

## OSError on the restart re-exec

The reviewed code (`execvp` + `sys.argv[0]` fallback) is already gone — #1164's final form execs only the `shutil.which`-resolved entry point — but the core still applied: the binary can vanish or lose its exec bit between `which()` and `execv` (an upgrade in flight does exactly that). An `OSError` there now prints a one-line message instead of a raw traceback.

Tests cover each: the version-probe matrix (3.6b/3.2a/next-3.4/3.1c/2.9/unprobeable), launch argv with and without marker args, the hung-server `TimeoutExpired` branch, and the exec-failure message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented TUI startup and exit actions from blocking when tmux is slow or unresponsive.
  * Added graceful handling when automatic restart cannot be launched.
  * Improved compatibility with both modern and older tmux versions.
  * Added timeouts and broader error handling for tmux window creation.

* **Tests**
  * Expanded coverage for hung tmux servers, restart failures, and version-specific tmux behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->