### PR TITLE
feat(tui): clearer, structured tmux quit prompt

### DIFF
--- a/src/terok/tui/screens.py
+++ b/src/terok/tui/screens.py
@@ -1799,9 +1799,13 @@ class TmuxQuitScreen(screen.ModalScreen[str | None]):
     and other windows (logins, tasks) remain.  ``q`` keeps the plain-quit
     muscle memory but detaches tmux too, returning the user to their
     normal terminal; ``n`` quits into the next tmux window for users who
-    want to look at the remaining windows; any other key cancels.
+    want to look at the remaining windows; any other key cancels.  The
+    prompt also points at plain tmux detach (``^b d``) as the way to keep
+    the TUI itself alive in the background — that key is handled by tmux,
+    not by this screen.
 
     Dismisses with ``"detach"``, ``"next"``, or ``None`` (cancel).
+    Sized to stay comfortable on an 80x24 terminal.
     """
 
     CSS = """
@@ -1823,14 +1827,26 @@ class TmuxQuitScreen(screen.ModalScreen[str | None]):
         self._other_windows = other_windows
 
     def compose(self) -> ComposeResult:
-        """A centred prompt mapping each quit flavour to a single key."""
-        windows = f"{self._other_windows} window" + ("s" if self._other_windows != 1 else "")
+        """A centred, 80x24-safe prompt mapping each quit flavour to its key.
+
+        Accents are deliberately sparse: a bold title, the footer key
+        colour on the three key hints, dim for the parenthetical asides —
+        everything else stays plain so the choices carry the emphasis.
+        """
+        key = "$footer-key-foreground"
+        windows = f"{self._other_windows} other window" + ("s" if self._other_windows != 1 else "")
         yield Static(
-            f"Quitting closes this tmux window — {windows} (tasks, logins) stay open.\n\n"
-            "\\[[$footer-key-foreground]q[/]] quit and return to your terminal"
-            " (tasks keep running)\n"
-            "\\[[$footer-key-foreground]n[/]] quit into the next tmux window\n"
-            "any other key: go back to terok.",
+            f"[bold]Quit terok?[/]\n"
+            f"\n"
+            f"terok is running inside a tmux window.  Closing it leaves\n"
+            f"{windows} (tasks, logins) open, and tasks keep running.\n"
+            f"\n"
+            f"  \\[[{key}]q[/]]     close terok and return to your terminal\n"
+            f"  \\[[{key}]n[/]]     close terok and switch to the next tmux window\n"
+            f"  \\[[{key}]^b d[/]]  keep terok open in the background instead\n"
+            f"          [dim]come back any time with 'terok tui --tmux'[/]\n"
+            f"\n"
+            f"[dim]any other key: back to terok[/]",
             id="tmux-quit-confirm",
         )
 


### PR DESCRIPTION
Rewords the tmux-aware quit guard (from #1164) so each choice states its full effect, per live-testing feedback:

```
Quit terok?

terok is running inside a tmux window.  Closing it leaves
2 other windows (tasks, logins) open, and tasks keep running.

  [q]     close terok and return to your terminal
  [n]     close terok and switch to the next tmux window
  [^b d]  keep terok open in the background instead
          come back any time with 'terok tui --tmux'

any other key: back to terok
```

- `q`/`n` now both say they **close** terok — the old wording ("quit and return…") left it ambiguous what actually happens to the TUI.
- New `^b d` hint: plain tmux detach keeps the TUI itself alive in the background, reopened with `terok tui --tmux`. The key is handled by tmux, not the modal, so no code path changes — it works exactly as advertised even while the prompt is open.
- Accents kept sparse: bold title, footer-key colour on the three key hints, dim for the asides.
- Verified against Textual's markup parser: worst-case box is 67×15 including border and padding — comfortable on an 80×24 terminal.

Key handling (`q`/`n`/anything else) is unchanged; this is a compose-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)