### PR TITLE
refactor(cli): make the drift guard a real check; drop a redundant assert

### DIFF
--- a/src/terok/cli/main.py
+++ b/src/terok/cli/main.py
@@ -29,7 +29,7 @@ except ImportError:  # pragma: no cover - optional dep
 #: executor passthrough plus the ``sandbox`` / ``vault`` / ``gate`` / ``ssh``
 #: shortcuts and the clearance-backed ``dbus`` group.  Single source of truth
 #: for both [`_build_wired_tree`][terok.cli.main._build_wired_tree] (which
-#: asserts the tree it builds matches this set) and the gate predicate
+#: checks the tree it builds matches this set) and the gate predicate
 #: [`_invocation_needs_wired_tree`][terok.cli.main._invocation_needs_wired_tree].
 #: Building the tree imports the executor / sandbox / clearance wheels, so a
 #: terok-own verb (``info``, ``task``, …) skips it entirely.
@@ -435,9 +435,8 @@ def _build_wired_tree() -> CommandTree:
     # Drift guard: the gate predicate keys off ``_WIRED_TREE_ROOTS``; keep it
     # in lockstep with what we actually wire so a new sibling group can't
     # silently become ungated (and unreachable for terok-own verbs).
-    assert {root.name for root in tree.roots} == set(_WIRED_TREE_ROOTS), (
-        "wired-tree roots drifted from _WIRED_TREE_ROOTS — update the gate set"
-    )
+    if {root.name for root in tree.roots} != set(_WIRED_TREE_ROOTS):
+        raise RuntimeError("wired-tree roots drifted from _WIRED_TREE_ROOTS — update the gate set")
     return tree
 
 

--- a/src/terok/lib/orchestration/tasks/identity.py
+++ b/src/terok/lib/orchestration/tasks/identity.py
@@ -83,7 +83,6 @@ def _gen_task_id() -> str:
     """Return a fresh task ID: Crockford-letter head + digit + 3 Crockford chars."""
     alphabets = (_TASK_ID_HEAD_CHARS, string.digits) + (_TASK_ID_BODY_CHARS,) * (_TASK_ID_LEN - 2)
     tid = "".join(map(secrets.choice, alphabets))
-    assert _TASK_ID_CROCKFORD_4_5_RE.fullmatch(tid), tid  # generator-output invariant
     return tid
 
 


### PR DESCRIPTION
Part of a cross-repo assert sweep (independent per repo) toward running under `python -O` for faster task startup — `-O` strips every assert, so no production behaviour may depend on one, and Bandit/Sonar flag asserts regardless.

Two production asserts here, handled by kind:

- **`_build_wired_tree` drift guard** → real `if … raise RuntimeError`. This is a security-relevant startup invariant (a sibling group drifting from `_WIRED_TREE_ROOTS` would silently become ungated/unreachable), so it must survive `-O`. `test_import_laziness` independently covers the same invariant.
- **`_gen_task_id` generator check** → dropped. It can't trip — the id is built from the exact alphabets the regex accepts — and `test_produces_valid_task_id` already asserts the invariant.

The two `assert`s in `clipboard.py` are docstring examples (not executable), left as-is. ruff + mypy green; task-id / import-laziness / util tests pass.