### PR TITLE
feat(tui): revive TUI as window 1 on tmux resume; add `terok --tmux` shortcut

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -440,7 +440,7 @@ method automatically:
 #### Running the TUI under tmux (recommended)
 
 ```bash
-terok tui --tmux
+terok tui --tmux    # or the shortcut: terok --tmux
 ```
 
 This wraps the TUI in a managed tmux session with a blue status bar showing

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -463,9 +463,10 @@ When tmux mode is active, terok **attaches to the shared `terok` session** if
 one is already running, so a second `terok tui --tmux` reconnects to your
 existing TUI instead of failing on the duplicate session name. Resuming lands
 you directly on the window running the TUI (even if you had killed and
-relaunched it in a different window), and revives the TUI in a new window if
-none is running anymore. Pass `--new-session` to opt out and start a separate,
-tmux-named session alongside it.
+relaunched it in a different window), and if none is running anymore — you quit
+the TUI while task windows kept the session alive — it revives the TUI back in
+its original spot as window 1. Pass `--new-session` to opt out and start a
+separate, tmux-named session alongside it.
 
 Inside a terok-managed tmux, a few extra conveniences apply:
 

--- a/src/terok/cli/main.py
+++ b/src/terok/cli/main.py
@@ -202,6 +202,19 @@ def main(prog: str = "terok") -> None:
         except FileNotFoundError:
             pass
 
+    # Fast-path: ``terok --tmux [args...]`` is a shortcut for ``terok tui
+    # --tmux [args...]`` — exec before any parser or subcommand registration
+    # work.  A missing ``terok-tui`` falls through to argparse like the bare
+    # invocation above.
+    if prog == "terok" and sys.argv[1:2] == ["--tmux"]:
+        import os
+
+        try:
+            os.execlp("terok-tui", "terok-tui", *sys.argv[1:])
+            return  # type: ignore[unreachable]  # in tests os.execlp is mocked
+        except FileNotFoundError:
+            pass
+
     # Get version info for --version flag
     version, branch = get_version_info()
     version_string = format_version_string(version, branch)

--- a/src/terok/cli/main.py
+++ b/src/terok/cli/main.py
@@ -210,7 +210,7 @@ def main(prog: str = "terok") -> None:
         import os
 
         try:
-            os.execlp("terok-tui", "terok-tui", *sys.argv[1:])
+            os.execlp("terok-tui", "terok-tui", *sys.argv[1:])  # nosec B606 B607 — PATH lookup of our own entry point is the install contract; argv is fixed + user's own flags
             return  # type: ignore[unreachable]  # in tests os.execlp is mocked
         except FileNotFoundError:
             pass

--- a/src/terok/tui/app.py
+++ b/src/terok/tui/app.py
@@ -2179,8 +2179,9 @@ if _HAS_TEXTUAL:
         By default a second ``terok --tmux`` resumes the shared ``terok``
         session: the client lands on the window stamped ``@terok-main``,
         and when no stamped window is left (the TUI was quit while task
-        windows kept the session alive) a fresh TUI window is spawned
-        first.  Pass ``force_new=True`` (``--new-session``) to spin up a
+        windows kept the session alive) a fresh TUI window is spawned in
+        the original spot — first in the window list — before attaching.
+        Pass ``force_new=True`` (``--new-session``) to spin up a
         fresh, tmux-named session alongside the existing one instead.
 
         Sessions are created with the ``TEROK_TMUX=1`` session environment
@@ -2206,15 +2207,17 @@ if _HAS_TEXTUAL:
 
         if not force_new and tmux_session.session_exists():
             # Resume: land the client on the TUI's stamped window rather
-            # than wherever the session last was; revive the TUI in a new
-            # window when none is stamped (window ids are stable handles,
-            # indexes are not — the host config renumbers windows).
+            # than wherever the session last was; revive the TUI as the
+            # session's first window when none is stamped (window ids are
+            # stable handles, indexes are not — the host config renumbers
+            # windows).
             session = f"={tmux_session.SESSION_NAME}"
             main_window = tmux_session.find_main_window()
             if main_window:
                 land_args = ["select-window", "-t", main_window]
             else:
-                land_args = ["new-window", "-t", session, "-n", "terok", "terok-tui"]
+                revive = tmux_session.revive_window_args()
+                land_args = ["new-window", *revive, "-n", "terok", "terok-tui"]
             os.execvp(  # nosec B606 B607 — tmux from PATH, argv of fixed verbs
                 "tmux", ["tmux", *land_args, ";", "attach-session", "-t", session]
             )

--- a/src/terok/tui/tmux_session.py
+++ b/src/terok/tui/tmux_session.py
@@ -152,7 +152,7 @@ def stamp_main_window() -> None:
     _tmux("set-option", "-w", "-t", own, MAIN_WINDOW_OPTION, "1")
 
 
-def revive_window_args(session: str = SESSION_NAME) -> tuple[str, ...]:
+def revive_window_args(session: str = SESSION_NAME) -> list[str]:
     """``new-window`` arguments reviving the TUI as *session*'s first window.
 
     When a resume finds no stamped main window the TUI is respawned, and
@@ -166,8 +166,8 @@ def revive_window_args(session: str = SESSION_NAME) -> tuple[str, ...]:
     use".
     """
     if _version_at_least(3, 2):
-        return ("-b", "-t", f"={session}:^")
-    return ("-t", f"={session}:")
+        return ["-b", "-t", f"={session}:^"]
+    return ["-t", f"={session}:"]
 
 
 def find_login_window(cname: str) -> str | None:

--- a/src/terok/tui/tmux_session.py
+++ b/src/terok/tui/tmux_session.py
@@ -78,19 +78,28 @@ def session_exists() -> bool:
     return _tmux("has-session", "-t", f"={SESSION_NAME}") is not None
 
 
+def _version_at_least(major: int, minor: int) -> bool:
+    """Return True when the installed tmux reports at least *major*.*minor*.
+
+    Probes ``tmux -V`` (versions like ``3.2a`` or ``next-3.4``); an
+    unprobeable tmux reads as too old — degrade, don't break.
+    """
+    version = re.search(r"(\d+)\.(\d+)", _tmux("-V") or "")
+    if version is None:
+        return False
+    return (int(version.group(1)), int(version.group(2))) >= (major, minor)
+
+
 def session_marker_args() -> tuple[str, ...]:
     """``new-session`` arguments carrying the terok marker, when tmux supports them.
 
     Setting a session-environment variable at creation (``new-session
     -e``) needs tmux >= 3.2; an older tmux rejects the flag outright,
     which would kill session creation entirely rather than merely losing
-    the marker.  Probing ``tmux -V`` (versions like ``3.2a`` or
-    ``next-3.4``) keeps old tmuxes working: without the marker the
-    terok-specific niceties quietly stay off and the base behaviour is
-    unchanged.
+    the marker.  Without the marker the terok-specific niceties quietly
+    stay off and the base behaviour is unchanged.
     """
-    version = re.search(r"(\d+)\.(\d+)", _tmux("-V") or "")
-    if version and (int(version.group(1)), int(version.group(2))) >= (3, 2):
+    if _version_at_least(3, 2):
         return ("-e", f"{TEROK_TMUX_ENV}=1")
     return ()
 
@@ -141,6 +150,24 @@ def stamp_main_window() -> None:
         if stamp and window_id != own:
             _tmux("set-option", "-w", "-t", window_id, "-u", MAIN_WINDOW_OPTION)
     _tmux("set-option", "-w", "-t", own, MAIN_WINDOW_OPTION, "1")
+
+
+def revive_window_args(session: str = SESSION_NAME) -> tuple[str, ...]:
+    """``new-window`` arguments reviving the TUI as *session*'s first window.
+
+    When a resume finds no stamped main window the TUI is respawned, and
+    it should land where the original lived: window 1, ahead of the task
+    windows that kept the session alive.  Inserting before the
+    lowest-numbered window (``-b -t session:^``) needs tmux >= 3.2 — the
+    same floor as the session marker; an older tmux appends at the
+    session's next free index instead.  Both forms spell the window part
+    of the target out explicitly: a bare session target resolves to the
+    session's *current* window on newer tmuxes and fails with "index in
+    use".
+    """
+    if _version_at_least(3, 2):
+        return ("-b", "-t", f"={session}:^")
+    return ("-t", f"={session}:")
 
 
 def find_login_window(cname: str) -> str | None:

--- a/tests/unit/cli/test_cli_main.py
+++ b/tests/unit/cli/test_cli_main.py
@@ -84,6 +84,28 @@ class TestTuiSubcommand:
         result = _run_cli("--help")
         assert "tui" in result.stdout
 
+    def test_root_tmux_flag_is_tui_shortcut(self) -> None:
+        """``terok --tmux`` is a shortcut for ``terok tui --tmux``."""
+        with patch("os.execlp") as mock_exec:
+            from terok.cli.main import main
+
+            with patch("sys.argv", ["terok", "--tmux"]):
+                main()
+
+            args = mock_exec.call_args[0]
+            assert args == ("terok-tui", "terok-tui", "--tmux")
+
+    def test_root_tmux_shortcut_forwards_args(self) -> None:
+        """``terok --tmux --new-session`` forwards the extra flags to terok-tui."""
+        with patch("os.execlp") as mock_exec:
+            from terok.cli.main import main
+
+            with patch("sys.argv", ["terok", "--tmux", "--new-session"]):
+                main()
+
+            args = mock_exec.call_args[0]
+            assert args == ("terok-tui", "terok-tui", "--tmux", "--new-session")
+
 
 class TestEmojiFlag:
     """Verify --no-emoji flag propagation."""

--- a/tests/unit/tui/test_tmux_session.py
+++ b/tests/unit/tui/test_tmux_session.py
@@ -158,14 +158,14 @@ class TestReviveWindowArgs:
     @pytest.mark.parametrize(
         ("version_line", "expected"),
         [
-            ("tmux 3.7b\n", ("-b", "-t", "=terok:^")),
-            ("tmux 3.2a\n", ("-b", "-t", "=terok:^")),
-            ("tmux 3.1c\n", ("-t", "=terok:")),
+            ("tmux 3.7b\n", ["-b", "-t", "=terok:^"]),
+            ("tmux 3.2a\n", ["-b", "-t", "=terok:^"]),
+            ("tmux 3.1c\n", ["-t", "=terok:"]),
         ],
         ids=["modern", "exactly-3.2", "too-old"],
     )
     def test_placement_follows_tmux_version(
-        self, monkeypatch: pytest.MonkeyPatch, version_line: str, expected: tuple[str, ...]
+        self, monkeypatch: pytest.MonkeyPatch, version_line: str, expected: list[str]
     ) -> None:
         """tmux >= 3.2 inserts before the first window; older appends at the next free index."""
         FakeTmux(outputs={"-V": version_line}).install(monkeypatch)
@@ -174,7 +174,7 @@ class TestReviveWindowArgs:
     def test_appends_when_probe_fails(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """An unprobeable tmux is treated as too old and gets the append form."""
         FakeTmux(fail=True).install(monkeypatch)
-        assert tmux_session.revive_window_args() == ("-t", "=terok:")
+        assert tmux_session.revive_window_args() == ["-t", "=terok:"]
 
 
 class TestLoginWindows:

--- a/tests/unit/tui/test_tmux_session.py
+++ b/tests/unit/tui/test_tmux_session.py
@@ -152,6 +152,31 @@ class TestSessionMarkerArgs:
         assert tmux_session.session_marker_args() == ()
 
 
+class TestReviveWindowArgs:
+    """A revived TUI window is inserted first on tmux >= 3.2, appended on older."""
+
+    @pytest.mark.parametrize(
+        ("version_line", "expected"),
+        [
+            ("tmux 3.7b\n", ("-b", "-t", "=terok:^")),
+            ("tmux 3.2a\n", ("-b", "-t", "=terok:^")),
+            ("tmux 3.1c\n", ("-t", "=terok:")),
+        ],
+        ids=["modern", "exactly-3.2", "too-old"],
+    )
+    def test_placement_follows_tmux_version(
+        self, monkeypatch: pytest.MonkeyPatch, version_line: str, expected: tuple[str, ...]
+    ) -> None:
+        """tmux >= 3.2 inserts before the first window; older appends at the next free index."""
+        FakeTmux(outputs={"-V": version_line}).install(monkeypatch)
+        assert tmux_session.revive_window_args() == expected
+
+    def test_appends_when_probe_fails(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """An unprobeable tmux is treated as too old and gets the append form."""
+        FakeTmux(fail=True).install(monkeypatch)
+        assert tmux_session.revive_window_args() == ("-t", "=terok:")
+
+
 class TestLoginWindows:
     """Login windows are stamped per container and found for reuse."""
 

--- a/tests/unit/tui/test_tui_module.py
+++ b/tests/unit/tui/test_tui_module.py
@@ -101,8 +101,9 @@ def test_launch_in_tmux_creates_or_forks(
             [
                 "tmux",
                 "new-window",
+                "-b",
                 "-t",
-                "=terok",
+                "=terok:^",
                 "-n",
                 "terok",
                 "terok-tui",
@@ -129,6 +130,9 @@ def test_launch_in_tmux_resumes_existing_session(
     monkeypatch.setattr(shutil, "which", lambda _cmd: "/usr/bin/tmux")
     monkeypatch.setattr(tmux_session, "session_exists", lambda: True)
     monkeypatch.setattr(tmux_session, "find_main_window", lambda: main_window)
+    # Modern-tmux placement args; the version split itself is pinned in
+    # tests/unit/tui/test_tmux_session.py.
+    monkeypatch.setattr(tmux_session, "revive_window_args", lambda: ("-b", "-t", "=terok:^"))
 
     captured: list[str] = []
 

--- a/tests/unit/tui/test_tui_module.py
+++ b/tests/unit/tui/test_tui_module.py
@@ -132,7 +132,7 @@ def test_launch_in_tmux_resumes_existing_session(
     monkeypatch.setattr(tmux_session, "find_main_window", lambda: main_window)
     # Modern-tmux placement args; the version split itself is pinned in
     # tests/unit/tui/test_tmux_session.py.
-    monkeypatch.setattr(tmux_session, "revive_window_args", lambda: ("-b", "-t", "=terok:^"))
+    monkeypatch.setattr(tmux_session, "revive_window_args", lambda: ["-b", "-t", "=terok:^"])
 
     captured: list[str] = []
 


### PR DESCRIPTION
## What

Two small tmux-UX follow-ups to #1164/#1173:

1. **Revive placement**: when `terok tui --tmux` resumes the shared session and finds no stamped main window (the TUI was quit while task windows kept the session alive), the revived TUI window now lands as **window 1** — where the original lived — instead of appearing after all task windows. Uses `new-window -b -t '=terok:^'` on tmux >= 3.2 (the same version floor already probed for the session marker, now shared via `_version_at_least`); older tmuxes keep the append behaviour, spelled explicitly as `-t '=terok:'`.

2. **CLI shortcut**: `terok --tmux [args...]` now works as a shortcut for `terok tui --tmux [args...]`, fast-pathed before parser construction like the bare-`terok` TTY launch, and forwarding any extra flags.

## Bug fixed along the way

The pre-existing revive command used a bare session target (`new-window -t =terok`). On newer tmuxes that resolves to the session's *current window index* and fails with `create window failed: index 1 in use`, so revive was broken there regardless of placement. Both new argument forms always spell out the window part of the target.

## Verification

- Empirically validated on an isolated tmux 3.7b server: seeded a `terok` session (host conf: `base-index 1`, `renumber-windows on`) with two task windows and no `@terok-main` stamp, drove the real `_launch_in_tmux` resume path — the revived window lands at index 1 with the task windows shifted to 2 and 3.
- Unit tests cover the version split (3.7 / 3.2 / 3.1c / unprobeable) and both CLI shortcut forms.
- `make check` green (2888 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `terok --tmux` as a direct shortcut to launch the TUI.
  * Improved TUI revive/landing behavior so it reopens in the correct window position within an existing tmux session (modern-tmux aware).

* **Bug Fixes**
  * Enhanced tmux version handling for session/window revive so behavior is consistent across tmux versions, including graceful fallback when tmux version probing fails.

* **Documentation**
  * Updated tmux/TUI guidance to document `terok --tmux`, clarify revive behavior in shared managed tmux sessions, and note `--new-session` as the opt-out for starting a separate session.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->