### PR TITLE
fix(restart): recreate rung kills outright and survives a wedged stop

### DIFF
--- a/src/terok/lib/orchestration/task_runners/restart.py
+++ b/src/terok/lib/orchestration/task_runners/restart.py
@@ -238,15 +238,34 @@ def _validate_restart_preconditions(
 
 
 def _stop_running_container(
-    project: ProjectConfig, task_id: str, mode: str, cname: str, meta_path: Path
+    project: ProjectConfig,
+    task_id: str,
+    mode: str,
+    cname: str,
+    meta_path: Path,
+    *,
+    timeout: int | None = None,
+    fatal: bool = True,
 ) -> None:
-    """Stop the running task container, then fire its ``post_stop`` hook."""
+    """Stop the running task container, then fire its ``post_stop`` hook.
+
+    *timeout* overrides the project's graceful-shutdown grace period.
+    With *fatal* (the default) a failed stop aborts via ``SystemExit``
+    — right for the resume rung, which wants this same container back.
+    The recreate rung passes ``fatal=False``: the container is
+    force-removed right after, so a wedged stop is worth a warning,
+    not an abort.
+    """
     try:
-        _rt.resolve_runtime(project).container(cname).stop(timeout=project.shutdown_timeout)
+        _rt.resolve_runtime(project).container(cname).stop(
+            timeout=project.shutdown_timeout if timeout is None else timeout
+        )
     except FileNotFoundError:
         raise SystemExit("podman not found; please install podman")
     except RuntimeError as exc:
-        raise SystemExit(f"Failed to stop container: {exc}")
+        if fatal:
+            raise SystemExit(f"Failed to stop container: {exc}")
+        print(_yellow(f"Stop did not finish cleanly ({exc}); removing anyway", _supports_color()))
     run_hook(
         "post_stop",
         project.hook_post_stop,
@@ -334,7 +353,10 @@ def _recreate_in_place(
     print(_yellow(f"Recreating container {cname}: {reason}", _supports_color()))
     runtime = _rt.resolve_runtime(project)
     if runtime.container(cname).state == "running":
-        _stop_running_container(project, task_id, mode, cname, meta_path)
+        # The container is destroyed on the next line — the grace
+        # period would be pure latency, so kill outright, and let the
+        # force-remove clean up after a stop that failed anyway.
+        _stop_running_container(project, task_id, mode, cname, meta_path, timeout=0, fatal=False)
     if runtime.container(cname).state is not None:
         _sandbox(project).rm([cname])
     if unrestricted is None:

--- a/tests/unit/lib/test_container_lifecycle.py
+++ b/tests/unit/lib/test_container_lifecycle.py
@@ -406,8 +406,38 @@ def test_task_restart_fresh_skips_resume_and_recreates() -> None:
             output = capture_stdout(task_restart, project_name, task_id, fresh=True)
 
         assert "Recreating" in output
-        container.stop.assert_called_once_with(timeout=10)
+        # Recreate never grants a grace period — the container is
+        # destroyed right after, so the stop is an outright kill.
+        container.stop.assert_called_once_with(timeout=0)
         container.start.assert_not_called()
+        sandbox.return_value.rm.assert_called_once_with([container_name])
+        run_cli.assert_called_once()
+
+
+def test_task_restart_fresh_survives_wedged_stop() -> None:
+    """A stop failure on the recreate rung is a warning, not an abort.
+
+    The container is force-removed on the next step anyway; refusing
+    the whole recreate because the stop client timed out would strand
+    the operator with a half-stopped container and no relaunch.
+    """
+    project_name = "proj_restart_fresh_stopfail"
+    with project_env(project_config(project_name), project_name=project_name) as ctx:
+        task_id = create_task_with_mode(ctx, project_name)
+        container_name = f"{project_name}-cli-{task_id}"
+
+        container = _mock_container(state="running")
+        container.stop.side_effect = RuntimeError("podman stop aborted: cleanup wedged")
+        runtime_mock = _mock_runtime(container)
+        with (
+            mock_git_config(),
+            patch("terok.lib.core.runtime.resolve_runtime", return_value=runtime_mock),
+            patch("terok.lib.orchestration.task_runners.restart._sandbox") as sandbox,
+            patch("terok.lib.orchestration.task_runners.restart.task_run_cli") as run_cli,
+        ):
+            output = capture_stdout(task_restart, project_name, task_id, fresh=True)
+
+        assert "Stop did not finish cleanly" in output
         sandbox.return_value.rm.assert_called_once_with([container_name])
         run_cli.assert_called_once()
 


### PR DESCRIPTION
## Problem

Recreating a running cli task from the TUI failed:

```
Recreating container terok-cli-w9xk3: recreate requested
Failed to stop container: podman stop 'terok-cli-w9xk3' timed out after 15s
— exited with code 1 —
```

Task containers run `bash -lc ...` as namespace-init, which the kernel exempts from default-disposition signals — SIGTERM is a no-op, so **every** stop burns the full 10s grace period before podman SIGKILLs. The sandbox stop wrapper then allows only 5s more for the kill plus all podman-side teardown (unmounts, network, the poststop supervisor hook); when teardown ran long, the stop surfaced as failed and aborted the recreate — killing the `podman stop` client mid-cleanup on the way out.

## Fix (terok's share)

On the recreate rung, the container is force-removed on the next line, so:

- stop with `timeout=0` — the grace period there is pure latency for a container about to be destroyed;
- a stop failure is downgraded to a warning and the recreate proceeds — `Sandbox.rm()` is a force-remove and handles a half-stopped container, whereas aborting stranded the operator with no relaunch.

The resume rung is unchanged: graceful stop, fatal on failure — it wants that same container back and healthy.

## Companion PR

terok-ai/terok-sandbox#454 fixes the underlying two defects (managed containers now launch behind `--init` so SIGTERM works at all, and `PodmanContainer.stop()` watches container state with per-phase deadlines instead of the grace+5s wall-clock guess). This PR is independent of it — no API change on either side, no cross-pins; the fixes compose.

🤖 Generated with [Claude Code](https://claude.com/claude-code)