### PR TITLE
fix(tui): scrub terminal state left behind by suspended foreground children

### DIFF
--- a/src/terok/tui/project_actions.py
+++ b/src/terok/tui/project_actions.py
@@ -11,10 +11,13 @@ project and task actions.
 from __future__ import annotations
 
 import asyncio
+import fcntl
 import os
 import shlex
-import subprocess
-from collections.abc import Callable
+import sys
+import termios
+from collections.abc import Callable, Iterator
+from contextlib import contextmanager, suppress
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -41,6 +44,50 @@ if TYPE_CHECKING:
     _MixinBase = App
 else:
     _MixinBase = object
+
+#: Indices into the ``termios.tcgetattr`` attribute list.
+_IFLAG = 0
+_LFLAG = 3
+
+
+@contextmanager
+def _terminal_pollution_guard() -> Iterator[None]:
+    """Shield the TUI from terminal state a foreground child leaves behind.
+
+    Interactive children run under a suspended TUI (agent CLIs, editors,
+    ``podman attach``) share stdin/stdout with the app, and some exit
+    without undoing their terminal tweaks.  Two of those poisons outlive
+    the child: a tty left in raw mode swallows the Enter that should
+    complete ``_RESUME_PROMPT`` (``\\r`` is never translated to ``\\n``),
+    and ``O_NONBLOCK`` left on
+    stdout kills Textual's writer thread with a ``BlockingIOError`` on
+    the first write after resume — its bounded queue then fills and
+    wedges the whole app.  Node-based agent CLIs are known to do both.
+
+    Snapshots the tty attributes on entry; on exit clears ``O_NONBLOCK``
+    from stdin and stdout and restores the snapshot with canonical line
+    input re-forced (in case the snapshot itself was already polluted).
+    A no-op wherever there is no real tty to guard.
+    """
+    try:
+        stdin_fd = sys.stdin.fileno()
+        saved = termios.tcgetattr(stdin_fd)
+    except (ValueError, OSError, termios.error):
+        stdin_fd, saved = -1, None
+    try:
+        yield
+    finally:
+        for stream in (sys.stdin, sys.stdout):
+            with suppress(ValueError, OSError):
+                fd = stream.fileno()
+                flags = fcntl.fcntl(fd, fcntl.F_GETFL)
+                if flags & os.O_NONBLOCK:
+                    fcntl.fcntl(fd, fcntl.F_SETFL, flags & ~os.O_NONBLOCK)
+        if saved is not None:
+            saved[_IFLAG] |= termios.ICRNL
+            saved[_LFLAG] |= termios.ICANON | termios.ECHO
+            with suppress(termios.error):
+                termios.tcsetattr(stdin_fd, termios.TCSADRAIN, saved)
 
 
 class ProjectActionsMixin(_MixinBase):
@@ -153,17 +200,41 @@ class ProjectActionsMixin(_MixinBase):
         elif method == "terminal":
             self.notify(f"{label} in new terminal: {cname}")
         else:
-            with self.suspend():
-                try:
-                    # Threaded like the prompt below it: the app is suspended,
-                    # not stopped, and an interactive session can last minutes
-                    # -- blocking the loop for its whole duration would freeze
-                    # every background worker and timer with it.
-                    await asyncio.to_thread(subprocess.run, cmd)
-                except Exception as e:
-                    print(f"Error: {e}")
-                await asyncio.to_thread(input, _RESUME_PROMPT)
+            await self._run_suspended(*cmd)
             await self.refresh_tasks()
+
+    async def _run_suspended(self, *argv: str, prompt_on_success: bool = True) -> int | None:
+        """Run *argv* in the foreground with the TUI suspended.
+
+        The single home of the suspend dance shared by container logins,
+        OAuth containers and the external editor.  The child runs as an
+        asyncio subprocess and the resume prompt reads in a thread: the
+        app is suspended, not stopped, and an interactive session can
+        last minutes — blocking the loop for its whole duration would
+        freeze every background worker and timer with it.  The terminal
+        is scrubbed after the child exits
+        ([`_terminal_pollution_guard`][terok.tui.project_actions._terminal_pollution_guard])
+        so the prompt and the TUI resume get a sane tty, and the prompt
+        keeps the child's last lines readable before the TUI redraws
+        over them.  Launch failures always prompt so the error stays
+        visible; clean exits prompt unless *prompt_on_success* is false.
+
+        Returns:
+            The child's exit code, or ``None`` if it could not be launched.
+        """
+        with self.suspend():
+            code: int | None
+            with _terminal_pollution_guard():
+                try:
+                    proc = await asyncio.create_subprocess_exec(*argv)
+                    code = await proc.wait()
+                except (OSError, ValueError) as exc:
+                    print(f"Error: {exc}")
+                    code = None
+            if code is None or prompt_on_success:
+                with suppress(EOFError):
+                    await asyncio.to_thread(input, _RESUME_PROMPT)
+        return code
 
     # ---------- Project infrastructure actions ----------
 
@@ -459,15 +530,8 @@ class ProjectActionsMixin(_MixinBase):
             self._watch_auth_session(session)
             return
 
-        with self.suspend():
-            try:
-                proc = await asyncio.create_subprocess_exec(*session.argv)
-                exit_code = await proc.wait()
-            except (OSError, ValueError) as exc:
-                print(f"Error: {exc}")
-                exit_code = 1
-            await asyncio.to_thread(input, _RESUME_PROMPT)
-        self._capture_auth_session(session, exit_code=exit_code)
+        code = await self._run_suspended(*session.argv)
+        self._capture_auth_session(session, exit_code=1 if code is None else code)
 
     @work(exclusive=False, group="auth-watch", exit_on_error=False)
     async def _watch_auth_session(self, session: AuthSession) -> None:
@@ -598,14 +662,11 @@ class ProjectActionsMixin(_MixinBase):
         login path keeps).
         """
         instr_path.parent.mkdir(parents=True, exist_ok=True)
-        with self.suspend():
-            try:
-                proc = await asyncio.create_subprocess_exec(*shlex.split(editor), str(instr_path))
-                await proc.wait()
-            except (OSError, ValueError) as exc:
-                print(f"Error launching {editor}: {exc}")
-                await asyncio.to_thread(input, _RESUME_PROMPT)
-                return
+        code = await self._run_suspended(
+            *shlex.split(editor), str(instr_path), prompt_on_success=False
+        )
+        if code is None:
+            return
         self.notify(done_msg)
         self._refresh_project_state()
 

--- a/src/terok/tui/project_actions.py
+++ b/src/terok/tui/project_actions.py
@@ -216,8 +216,9 @@ class ProjectActionsMixin(_MixinBase):
         ([`_terminal_pollution_guard`][terok.tui.project_actions._terminal_pollution_guard])
         so the prompt and the TUI resume get a sane tty, and the prompt
         keeps the child's last lines readable before the TUI redraws
-        over them.  Launch failures always prompt so the error stays
-        visible; clean exits prompt unless *prompt_on_success* is false.
+        over them.  Failures — launch errors and non-zero exits — always
+        prompt so the error stays visible; clean (zero) exits prompt
+        unless *prompt_on_success* is false.
 
         Returns:
             The child's exit code, or ``None`` if it could not be launched.
@@ -231,7 +232,7 @@ class ProjectActionsMixin(_MixinBase):
                 except (OSError, ValueError) as exc:
                     print(f"Error: {exc}")
                     code = None
-            if code is None or prompt_on_success:
+            if prompt_on_success or code != 0:
                 with suppress(EOFError):
                     await asyncio.to_thread(input, _RESUME_PROMPT)
         return code
@@ -665,7 +666,7 @@ class ProjectActionsMixin(_MixinBase):
         code = await self._run_suspended(
             *shlex.split(editor), str(instr_path), prompt_on_success=False
         )
-        if code is None:
+        if code != 0:
             return
         self.notify(done_msg)
         self._refresh_project_state()

--- a/tests/unit/tui/test_detail_screens.py
+++ b/tests/unit/tui/test_detail_screens.py
@@ -987,6 +987,16 @@ class TestEditInExternalEditor:
         instance.notify.assert_not_called()
         instance._refresh_project_state.assert_not_called()
 
+    def test_nonzero_editor_exit_suppresses_success(self, tmp_path: object) -> None:
+        """An editor exiting non-zero (e.g. vim ``:cq``) must not claim success."""
+        mixin = self._get_mixin()
+        instance = self._instance(mixin)
+        instance._run_suspended = mock.AsyncMock(return_value=1)
+        instr_path = tmp_path / "instructions.md"
+        run(mixin._edit_in_external_editor(instance, instr_path, "vim", done_msg="ok"))
+        instance.notify.assert_not_called()
+        instance._refresh_project_state.assert_not_called()
+
 
 class TestActionAuth:
     """Per-project ``_action_auth`` and host-wide ``_action_auth_host_wide`` dispatch."""

--- a/tests/unit/tui/test_detail_screens.py
+++ b/tests/unit/tui/test_detail_screens.py
@@ -967,34 +967,23 @@ class TestEditInExternalEditor:
         """A clean editor exit creates the parent dir, notifies, and refreshes state."""
         mixin = self._get_mixin()
         instance = self._instance(mixin)
+        instance._run_suspended = mock.AsyncMock(return_value=0)
         instr_path = tmp_path / "nested" / "instructions.md"
-        proc = mock.AsyncMock()
-        with mock.patch(
-            "terok.tui.project_actions.asyncio.create_subprocess_exec",
-            new=mock.AsyncMock(return_value=proc),
-        ) as exec_mock:
-            run(mixin._edit_in_external_editor(instance, instr_path, "vim -u NONE", done_msg="ok"))
-        exec_mock.assert_awaited_once_with("vim", "-u", "NONE", str(instr_path))
-        proc.wait.assert_awaited_once()
+        run(mixin._edit_in_external_editor(instance, instr_path, "vim -u NONE", done_msg="ok"))
+        instance._run_suspended.assert_awaited_once_with(
+            "vim", "-u", "NONE", str(instr_path), prompt_on_success=False
+        )
         assert instr_path.parent.is_dir()
-        instance.suspend.assert_called_once_with()
         instance.notify.assert_called_once_with("ok")
         instance._refresh_project_state.assert_called_once()
 
     def test_launch_failure_is_surfaced_not_raised(self, tmp_path: object) -> None:
-        """A failed spawn prints an error and waits — it never crashes the TUI."""
+        """A failed spawn (``None`` exit code) aborts quietly — no notify, no refresh."""
         mixin = self._get_mixin()
         instance = self._instance(mixin)
+        instance._run_suspended = mock.AsyncMock(return_value=None)
         instr_path = tmp_path / "instructions.md"
-        with (
-            mock.patch(
-                "terok.tui.project_actions.asyncio.create_subprocess_exec",
-                new=mock.AsyncMock(side_effect=FileNotFoundError("no such editor")),
-            ),
-            mock.patch("builtins.input") as input_mock,
-        ):
-            run(mixin._edit_in_external_editor(instance, instr_path, "bogus-editor", done_msg="ok"))
-        input_mock.assert_called_once()
+        run(mixin._edit_in_external_editor(instance, instr_path, "bogus-editor", done_msg="ok"))
         instance.notify.assert_not_called()
         instance._refresh_project_state.assert_not_called()
 

--- a/tests/unit/tui/test_suspend_terminal_guard.py
+++ b/tests/unit/tui/test_suspend_terminal_guard.py
@@ -59,11 +59,16 @@ def test_clears_nonblock_left_by_child(guarded_tty):
     assert not _nonblock(guarded_tty)
 
 
+def _crashing_polluting_child(fd: int) -> None:
+    """Simulate a child that trashes the tty and then dies."""
+    tty.setraw(fd)
+    _set_nonblock(fd)
+    raise RuntimeError("child launch failed")
+
+
 def test_scrubs_even_when_child_raises(guarded_tty):
     with pytest.raises(RuntimeError), _terminal_pollution_guard():
-        tty.setraw(guarded_tty)
-        _set_nonblock(guarded_tty)
-        raise RuntimeError("child launch failed")
+        _crashing_polluting_child(guarded_tty)
     assert termios.tcgetattr(guarded_tty)[3] & termios.ICANON
     assert not _nonblock(guarded_tty)
 

--- a/tests/unit/tui/test_suspend_terminal_guard.py
+++ b/tests/unit/tui/test_suspend_terminal_guard.py
@@ -1,0 +1,161 @@
+# SPDX-FileCopyrightText: 2026 Jiri Vyskocil
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the suspended-child terminal pollution guard and its runner.
+
+Children run under a suspended TUI can exit leaving the shared tty in
+raw mode and/or the stdio file descriptions ``O_NONBLOCK``; the guard
+must scrub both so the resume prompt and Textual's writer thread get a
+sane terminal back (see ``_terminal_pollution_guard``).  ``_run_suspended``
+is the shared suspend-run-scrub-prompt dance built on top of it.
+"""
+
+import asyncio
+import fcntl
+import os
+import pty
+import sys
+import termios
+import tty
+from types import SimpleNamespace
+from unittest import mock
+
+import pytest
+
+from terok.tui.project_actions import ProjectActionsMixin, _terminal_pollution_guard
+
+
+def _nonblock(fd: int) -> bool:
+    return bool(fcntl.fcntl(fd, fcntl.F_GETFL) & os.O_NONBLOCK)
+
+
+def _set_nonblock(fd: int) -> None:
+    fcntl.fcntl(fd, fcntl.F_SETFL, fcntl.fcntl(fd, fcntl.F_GETFL) | os.O_NONBLOCK)
+
+
+@pytest.fixture
+def guarded_tty(monkeypatch):
+    """A pty wired up as the process's stdin/stdout, as the guard sees them."""
+    primary, replica = pty.openpty()
+    monkeypatch.setattr(sys, "stdin", SimpleNamespace(fileno=lambda: replica))
+    monkeypatch.setattr(sys, "stdout", SimpleNamespace(fileno=lambda: replica))
+    yield replica
+    os.close(replica)
+    os.close(primary)
+
+
+def test_restores_cooked_mode_after_raw_child(guarded_tty):
+    with _terminal_pollution_guard():
+        tty.setraw(guarded_tty)
+    attrs = termios.tcgetattr(guarded_tty)
+    assert attrs[3] & termios.ICANON
+    assert attrs[3] & termios.ECHO
+    assert attrs[0] & termios.ICRNL
+
+
+def test_clears_nonblock_left_by_child(guarded_tty):
+    with _terminal_pollution_guard():
+        _set_nonblock(guarded_tty)
+    assert not _nonblock(guarded_tty)
+
+
+def test_scrubs_even_when_child_raises(guarded_tty):
+    with pytest.raises(RuntimeError), _terminal_pollution_guard():
+        tty.setraw(guarded_tty)
+        _set_nonblock(guarded_tty)
+        raise RuntimeError("child launch failed")
+    assert termios.tcgetattr(guarded_tty)[3] & termios.ICANON
+    assert not _nonblock(guarded_tty)
+
+
+def test_clears_nonblock_on_non_tty_stdio(monkeypatch):
+    read_end, write_end = os.pipe()
+    monkeypatch.setattr(sys, "stdin", SimpleNamespace(fileno=lambda: read_end))
+    monkeypatch.setattr(sys, "stdout", SimpleNamespace(fileno=lambda: write_end))
+    try:
+        with _terminal_pollution_guard():
+            _set_nonblock(write_end)
+        assert not _nonblock(write_end)
+    finally:
+        os.close(read_end)
+        os.close(write_end)
+
+
+def test_noop_without_usable_stdio(monkeypatch):
+    def _no_fileno() -> int:
+        raise ValueError("I/O operation on closed file")
+
+    monkeypatch.setattr(sys, "stdin", SimpleNamespace(fileno=_no_fileno))
+    monkeypatch.setattr(sys, "stdout", SimpleNamespace(fileno=_no_fileno))
+    with _terminal_pollution_guard():
+        pass  # must simply not raise
+
+
+class TestRunSuspended:
+    """``_run_suspended`` — the shared suspend-run-scrub-prompt dance."""
+
+    def _instance(self) -> mock.Mock:
+        instance = mock.Mock(spec=ProjectActionsMixin)
+        instance.suspend = mock.MagicMock()
+        return instance
+
+    def _run(self, instance: mock.Mock, *argv: str, **kwargs: bool) -> int | None:
+        return asyncio.run(ProjectActionsMixin._run_suspended(instance, *argv, **kwargs))
+
+    def test_clean_exit_prompts_and_returns_code(self):
+        instance = self._instance()
+        proc = mock.AsyncMock()
+        proc.wait.return_value = 3
+        with (
+            mock.patch(
+                "terok.tui.project_actions.asyncio.create_subprocess_exec",
+                new=mock.AsyncMock(return_value=proc),
+            ) as exec_mock,
+            mock.patch("builtins.input") as input_mock,
+        ):
+            code = self._run(instance, "agent", "--flag")
+        exec_mock.assert_awaited_once_with("agent", "--flag")
+        assert code == 3
+        instance.suspend.assert_called_once_with()
+        input_mock.assert_called_once()
+
+    def test_prompt_on_success_false_skips_prompt(self):
+        instance = self._instance()
+        proc = mock.AsyncMock()
+        proc.wait.return_value = 0
+        with (
+            mock.patch(
+                "terok.tui.project_actions.asyncio.create_subprocess_exec",
+                new=mock.AsyncMock(return_value=proc),
+            ),
+            mock.patch("builtins.input") as input_mock,
+        ):
+            code = self._run(instance, "vim", prompt_on_success=False)
+        assert code == 0
+        input_mock.assert_not_called()
+
+    def test_launch_failure_returns_none_and_always_prompts(self):
+        instance = self._instance()
+        with (
+            mock.patch(
+                "terok.tui.project_actions.asyncio.create_subprocess_exec",
+                new=mock.AsyncMock(side_effect=FileNotFoundError("no such agent")),
+            ),
+            mock.patch("builtins.input") as input_mock,
+        ):
+            code = self._run(instance, "bogus", prompt_on_success=False)
+        assert code is None
+        input_mock.assert_called_once()
+
+    def test_eof_at_the_prompt_is_survived(self):
+        instance = self._instance()
+        proc = mock.AsyncMock()
+        proc.wait.return_value = 0
+        with (
+            mock.patch(
+                "terok.tui.project_actions.asyncio.create_subprocess_exec",
+                new=mock.AsyncMock(return_value=proc),
+            ),
+            mock.patch("builtins.input", side_effect=EOFError),
+        ):
+            assert self._run(instance, "agent") == 0

--- a/tests/unit/tui/test_suspend_terminal_guard.py
+++ b/tests/unit/tui/test_suspend_terminal_guard.py
@@ -17,6 +17,7 @@ import pty
 import sys
 import termios
 import tty
+from collections.abc import Iterator
 from types import SimpleNamespace
 from unittest import mock
 
@@ -34,7 +35,7 @@ def _set_nonblock(fd: int) -> None:
 
 
 @pytest.fixture
-def guarded_tty(monkeypatch):
+def guarded_tty(monkeypatch: pytest.MonkeyPatch) -> Iterator[int]:
     """A pty wired up as the process's stdin/stdout, as the guard sees them."""
     primary, replica = pty.openpty()
     monkeypatch.setattr(sys, "stdin", SimpleNamespace(fileno=lambda: replica))
@@ -44,7 +45,8 @@ def guarded_tty(monkeypatch):
     os.close(primary)
 
 
-def test_restores_cooked_mode_after_raw_child(guarded_tty):
+def test_restores_cooked_mode_after_raw_child(guarded_tty: int) -> None:
+    """A tty left in raw mode comes back with canonical line input and echo."""
     with _terminal_pollution_guard():
         tty.setraw(guarded_tty)
     attrs = termios.tcgetattr(guarded_tty)
@@ -53,7 +55,8 @@ def test_restores_cooked_mode_after_raw_child(guarded_tty):
     assert attrs[0] & termios.ICRNL
 
 
-def test_clears_nonblock_left_by_child(guarded_tty):
+def test_clears_nonblock_left_by_child(guarded_tty: int) -> None:
+    """``O_NONBLOCK`` left on the stdio file description is cleared."""
     with _terminal_pollution_guard():
         _set_nonblock(guarded_tty)
     assert not _nonblock(guarded_tty)
@@ -66,14 +69,16 @@ def _crashing_polluting_child(fd: int) -> None:
     raise RuntimeError("child launch failed")
 
 
-def test_scrubs_even_when_child_raises(guarded_tty):
+def test_scrubs_even_when_child_raises(guarded_tty: int) -> None:
+    """The scrub happens on the exception path too, not just clean exits."""
     with pytest.raises(RuntimeError), _terminal_pollution_guard():
         _crashing_polluting_child(guarded_tty)
     assert termios.tcgetattr(guarded_tty)[3] & termios.ICANON
     assert not _nonblock(guarded_tty)
 
 
-def test_clears_nonblock_on_non_tty_stdio(monkeypatch):
+def test_clears_nonblock_on_non_tty_stdio(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Pipes have no termios to restore, but still get ``O_NONBLOCK`` scrubbed."""
     read_end, write_end = os.pipe()
     monkeypatch.setattr(sys, "stdin", SimpleNamespace(fileno=lambda: read_end))
     monkeypatch.setattr(sys, "stdout", SimpleNamespace(fileno=lambda: write_end))
@@ -86,7 +91,9 @@ def test_clears_nonblock_on_non_tty_stdio(monkeypatch):
         os.close(write_end)
 
 
-def test_noop_without_usable_stdio(monkeypatch):
+def test_noop_without_usable_stdio(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Closed or fd-less stdio (headless runs) degrades to a silent no-op."""
+
     def _no_fileno() -> int:
         raise ValueError("I/O operation on closed file")
 
@@ -100,21 +107,28 @@ class TestRunSuspended:
     """``_run_suspended`` — the shared suspend-run-scrub-prompt dance."""
 
     def _instance(self) -> mock.Mock:
+        """Build a mixin mock with ``suspend`` wired as a context manager."""
         instance = mock.Mock(spec=ProjectActionsMixin)
         instance.suspend = mock.MagicMock()
         return instance
 
     def _run(self, instance: mock.Mock, *argv: str, **kwargs: bool) -> int | None:
+        """Drive the unbound coroutine against *instance* to completion."""
         return asyncio.run(ProjectActionsMixin._run_suspended(instance, *argv, **kwargs))
 
-    def test_clean_exit_prompts_and_returns_code(self):
-        instance = self._instance()
+    def _proc(self, exit_code: int) -> mock.AsyncMock:
+        """A fake asyncio subprocess whose ``wait()`` returns *exit_code*."""
         proc = mock.AsyncMock()
-        proc.wait.return_value = 3
+        proc.wait.return_value = exit_code
+        return proc
+
+    def test_clean_exit_prompts_and_returns_code(self) -> None:
+        """Default mode: the child runs suspended and the prompt always shows."""
+        instance = self._instance()
         with (
             mock.patch(
                 "terok.tui.project_actions.asyncio.create_subprocess_exec",
-                new=mock.AsyncMock(return_value=proc),
+                new=mock.AsyncMock(return_value=self._proc(3)),
             ) as exec_mock,
             mock.patch("builtins.input") as input_mock,
         ):
@@ -124,14 +138,13 @@ class TestRunSuspended:
         instance.suspend.assert_called_once_with()
         input_mock.assert_called_once()
 
-    def test_prompt_on_success_false_skips_prompt(self):
+    def test_prompt_on_success_false_skips_prompt(self) -> None:
+        """A zero exit returns straight to the TUI when the prompt is opted out."""
         instance = self._instance()
-        proc = mock.AsyncMock()
-        proc.wait.return_value = 0
         with (
             mock.patch(
                 "terok.tui.project_actions.asyncio.create_subprocess_exec",
-                new=mock.AsyncMock(return_value=proc),
+                new=mock.AsyncMock(return_value=self._proc(0)),
             ),
             mock.patch("builtins.input") as input_mock,
         ):
@@ -139,7 +152,22 @@ class TestRunSuspended:
         assert code == 0
         input_mock.assert_not_called()
 
-    def test_launch_failure_returns_none_and_always_prompts(self):
+    def test_nonzero_exit_prompts_even_without_prompt_on_success(self) -> None:
+        """A failing child's last output stays readable — the prompt is forced."""
+        instance = self._instance()
+        with (
+            mock.patch(
+                "terok.tui.project_actions.asyncio.create_subprocess_exec",
+                new=mock.AsyncMock(return_value=self._proc(2)),
+            ),
+            mock.patch("builtins.input") as input_mock,
+        ):
+            code = self._run(instance, "vim", prompt_on_success=False)
+        assert code == 2
+        input_mock.assert_called_once()
+
+    def test_launch_failure_returns_none_and_always_prompts(self) -> None:
+        """A child that never launched reports ``None`` and keeps the error visible."""
         instance = self._instance()
         with (
             mock.patch(
@@ -152,14 +180,13 @@ class TestRunSuspended:
         assert code is None
         input_mock.assert_called_once()
 
-    def test_eof_at_the_prompt_is_survived(self):
+    def test_eof_at_the_prompt_is_survived(self) -> None:
+        """EOF instead of Enter (dead stdin) must not crash the resume path."""
         instance = self._instance()
-        proc = mock.AsyncMock()
-        proc.wait.return_value = 0
         with (
             mock.patch(
                 "terok.tui.project_actions.asyncio.create_subprocess_exec",
-                new=mock.AsyncMock(return_value=proc),
+                new=mock.AsyncMock(return_value=self._proc(0)),
             ),
             mock.patch("builtins.input", side_effect=EOFError),
         ):


### PR DESCRIPTION
## Problem

On hosts without tmux, container logins / OAuth containers / the external editor run under `App.suspend()` with a `[Press Enter to return to TerokTUI]` prompt before resuming. After exiting an agent CLI session, the TUI wedged permanently — Enter did nothing and even Ctrl-C shutdown hung.

Two distinct poisons, both left on the shared terminal by interactive children (Node-based agent CLIs are known for both):

1. **tty left in raw mode** — `\r` is never translated to `\n`, so the `input()` resume prompt can never complete.
2. **`O_NONBLOCK` left on the stdio file descriptions** — Textual's `WriterThread.run()` has no exception handling, so the first `BlockingIOError` after resume kills it; its queue is bounded (`Queue(30)`), so once it fills every subsequent `write()` blocks forever, including the shutdown path (`_shutdown → disable_input → queue.put → not_full.wait()`, confirmed by traceback).

The suspend fallback had gone unexercised because every previously tested host had tmux — this surfaced while verifying non-systemd support (#959, #1113) in an Alpine microVM.

## Fix

- New `_terminal_pollution_guard()` context manager: snapshots tty attributes before the child; after it exits, clears `O_NONBLOCK` from stdin/stdout and restores the snapshot with canonical line input (`ICANON|ECHO`, `ICRNL`) re-forced in case the snapshot itself was already polluted. No-op when there is no usable tty (tests, headless).
- The suspend dance existed in three slightly different copies (`_launch_terminal_session`, `_launch_oauth_container`, `_edit_in_external_editor`); it is now factored into one `_run_suspended()` helper wrapping the guard, with per-site behavior preserved (the editor still skips the prompt on clean exits and bails without notifying when `$EDITOR` cannot launch).

## Tests

- `test_suspend_terminal_guard.py`: guard exercised against a real pty (raw mode restored, `O_NONBLOCK` cleared, scrubbing survives child exceptions, no-op without stdio) plus the `_run_suspended` prompt/exit-code contract.
- The two existing external-editor tests updated to the new `_run_suspended` seam.
- `make lint`, `make tach`, `make reuse` clean; full suite 2897 passed; docstring coverage 97%.

## Follow-up (not this PR)

Textual's `WriterThread` arguably shouldn't die silently on `BlockingIOError` — worth a small upstream issue; this fix protects terok regardless.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved terminal recovery after running interactive commands, preventing input issues and stalled terminal interactions.
  * Ensured terminal settings are restored even when an external command fails.
  * Improved handling when launching external editors or authentication sessions fails.

* **User Experience**
  * Reduced unnecessary prompts after successful editor operations.
  * Prevented crashes when terminal input is closed or unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->