### PR TITLE
fix(tui): login shows a blocking "Logging in" spinner instead of freezing the TUI

### DIFF
--- a/src/terok/tui/project_actions.py
+++ b/src/terok/tui/project_actions.py
@@ -191,7 +191,10 @@ class ProjectActionsMixin(_MixinBase):
             )
             return
 
-        method, _port = launch_login(cmd, title=title, reuse_key=cname)
+        # Threaded: launch_login shells out to tmux / ps / terminal
+        # spawners — each call is timeout-capped, but even a few capped
+        # probes back-to-back would stall the loop for whole seconds.
+        method, _port = await asyncio.to_thread(launch_login, cmd, title=title, reuse_key=cname)
 
         if method == "tmux-existing":
             self.notify(f"Switched to existing tmux window: {cname}")

--- a/src/terok/tui/screens.py
+++ b/src/terok/tui/screens.py
@@ -57,6 +57,14 @@ else:
     except Exception:  # pragma: no cover - textual may be a stub module
         Select = None
 
+if TYPE_CHECKING:
+    from textual.widgets import LoadingIndicator
+else:
+    try:  # pragma: no cover - optional import for test stubs
+        from textual.widgets import LoadingIndicator
+    except Exception:  # pragma: no cover - textual may be a stub module
+        LoadingIndicator = None
+
 from rich.style import Style
 from rich.text import Text
 
@@ -1899,6 +1907,51 @@ class UpdateRestartScreen(screen.ModalScreen[bool]):
         """Restart on ``r``; any other key dismisses the offer."""
         event.stop()
         self.dismiss(event.key == "r")
+
+
+class LoginProgressScreen(screen.ModalScreen[None]):
+    """Blocking "Logging in" overlay while a container login is prepared.
+
+    Login ends with the view jumping into the container's window, so any
+    action the operator starts in the meantime would be yanked away
+    mid-gesture.  This modal deliberately blocks: it swallows every key
+    and covers the screen while the preflight (podman state probe) and
+    the terminal/tmux launch run on a worker thread — the thread keeps
+    the loop free, which is what lets the spinner spin.  The login flow
+    dismisses it once the view has switched (or the attempt failed).
+    """
+
+    CSS = """
+    LoginProgressScreen {
+        align: center middle;
+    }
+    #login-progress {
+        width: auto;
+        height: auto;
+        border: round $primary;
+        background: $surface;
+        padding: 1 2;
+    }
+    #login-progress LoadingIndicator {
+        width: 8;
+        height: 1;
+    }
+    """
+
+    def __init__(self, label: str) -> None:
+        """Remember the session *label* (project:task:name) being logged into."""
+        super().__init__()
+        self._label = label
+
+    def compose(self) -> ComposeResult:
+        """A centred spinner naming the session being prepared."""
+        with Horizontal(id="login-progress"):
+            yield LoadingIndicator()
+            yield Static(f" Logging in: {self._label} …")
+
+    def on_key(self, event: events.Key) -> None:
+        """Swallow all input — the login flow is the only thing that dismisses this."""
+        event.stop()
 
 
 class TaskDetailsScreen(screen.Screen[str | None]):

--- a/src/terok/tui/task_actions.py
+++ b/src/terok/tui/task_actions.py
@@ -36,6 +36,7 @@ from ..lib.api import (
 from .clipboard import copy_to_clipboard_detailed
 from .screens import (
     AgentSelectionScreen,
+    LoginProgressScreen,
     TaskCreateScreen,
     TaskLaunchScreen,
     TaskNameScreen,
@@ -323,28 +324,30 @@ class TaskActionsMixin(_MixinBase):
         # All agents (including bash) launch interactively inside tmux so the
         # user can re-attach later with 'login'.  The base command is always
         # podman exec -it <cname> tmux new-session -A -s main [bash -lc <cmd>].
+        # Blocking spinner + threaded preflight, same rationale as
+        # ``_action_login``.
+        title = _login_title(pid, tid, task_name)
+        progress = LoginProgressScreen(title)
+        await self.push_screen(progress)
         try:
-            # Threaded for the same reason as ``_action_login``: the
-            # preflight's podman state probe must not stall the loop.
             base_cmd = await asyncio.to_thread(get_login_command, pid, tid)
+
+            if agent == "bash":
+                cmd = base_cmd
+            else:
+                from terok.lib.api.agents import AGENTS
+
+                agent_obj = AGENTS.get(agent)
+                if not agent_obj:
+                    self.notify(f"Unknown agent: {agent}")
+                    return
+                cmd = [*base_cmd, "bash", "-lc", agent_obj.binary]
+
+            await self._launch_terminal_session(cmd, title=title, cname=cname)
         except SystemExit as e:
             self.notify(str(e))
-            return
-
-        if agent == "bash":
-            cmd = base_cmd
-        else:
-            from terok.lib.api.agents import AGENTS
-
-            agent_obj = AGENTS.get(agent)
-            if not agent_obj:
-                self.notify(f"Unknown agent: {agent}")
-                return
-            cmd = [*base_cmd, "bash", "-lc", agent_obj.binary]
-
-        await self._launch_terminal_session(
-            cmd, title=_login_title(pid, tid, task_name), cname=cname
-        )
+        finally:
+            progress.dismiss()
 
     async def _action_task_start_toad(self) -> None:
         """Create a new task and immediately run Toad serve."""
@@ -677,6 +680,10 @@ class TaskActionsMixin(_MixinBase):
     async def _action_login(self) -> None:
         """Log into the selected task's running container.
 
+        The whole flow runs under a blocking
+        [`LoginProgressScreen`][terok.tui.screens.LoginProgressScreen]
+        spinner — see its docstring for why blocking is the point here.
+
         CLI login attaches a host terminal to the container — impossible
         when the TUI is served over the web (textual-serve), where there
         is no host terminal.  Gated on ``App.is_web``: web users get an
@@ -697,23 +704,26 @@ class TaskActionsMixin(_MixinBase):
             return
         pid = self.current_project_name
         tid = self.current_task.task_id
-        try:
-            # Threaded: the preflight asks podman for the container's live
-            # state, and podman can sit on its lock for many seconds (a
-            # concurrent build, an event stream hiccup).  Off the loop the
-            # TUI stays responsive; on it, every keystroke and timer would
-            # freeze until podman answered.
-            cmd = await asyncio.to_thread(get_login_command, pid, tid)
-        except SystemExit as e:
-            self.notify(str(e))
-            return
-
         mode = self.current_task.mode or "cli"
         cname = container_name(pid, mode, tid)
         task_name = self.current_task.name or tid
-        await self._launch_terminal_session(
-            cmd, title=_login_title(pid, tid, task_name), cname=cname
-        )
+        title = _login_title(pid, tid, task_name)
+
+        # A blocking spinner covers the whole login: it ends with the view
+        # jumping into the container, so anything the operator started in
+        # the meantime would be yanked away mid-gesture.  The blocking
+        # work runs threaded — the preflight asks podman for the
+        # container's live state, and podman can sit on its lock for many
+        # seconds — which is what keeps the spinner animating.
+        progress = LoginProgressScreen(title)
+        await self.push_screen(progress)
+        try:
+            cmd = await asyncio.to_thread(get_login_command, pid, tid)
+            await self._launch_terminal_session(cmd, title=title, cname=cname)
+        except SystemExit as e:
+            self.notify(str(e))
+        finally:
+            progress.dismiss()
 
     # ---------- Task management actions ----------
 

--- a/src/terok/tui/task_actions.py
+++ b/src/terok/tui/task_actions.py
@@ -7,6 +7,7 @@ Handles task creation, deletion, renaming, running (CLI/toad/unattended),
 login, restart, follow-up, log viewing, and diff copying.
 """
 
+import asyncio
 from collections.abc import Callable
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
@@ -323,7 +324,9 @@ class TaskActionsMixin(_MixinBase):
         # user can re-attach later with 'login'.  The base command is always
         # podman exec -it <cname> tmux new-session -A -s main [bash -lc <cmd>].
         try:
-            base_cmd = get_login_command(pid, tid)
+            # Threaded for the same reason as ``_action_login``: the
+            # preflight's podman state probe must not stall the loop.
+            base_cmd = await asyncio.to_thread(get_login_command, pid, tid)
         except SystemExit as e:
             self.notify(str(e))
             return
@@ -695,7 +698,12 @@ class TaskActionsMixin(_MixinBase):
         pid = self.current_project_name
         tid = self.current_task.task_id
         try:
-            cmd = get_login_command(pid, tid)
+            # Threaded: the preflight asks podman for the container's live
+            # state, and podman can sit on its lock for many seconds (a
+            # concurrent build, an event stream hiccup).  Off the loop the
+            # TUI stays responsive; on it, every keystroke and timer would
+            # freeze until podman answered.
+            cmd = await asyncio.to_thread(get_login_command, pid, tid)
         except SystemExit as e:
             self.notify(str(e))
             return

--- a/tests/unit/tui/test_login_action.py
+++ b/tests/unit/tui/test_login_action.py
@@ -1,0 +1,107 @@
+# SPDX-FileCopyrightText: 2026 Jiri Vyskocil
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the TUI login action's off-loop preflight.
+
+The login preflight (``get_login_command``) asks podman for the
+container's live state, and podman can sit on its lock for many seconds.
+These tests pin that the blocking work runs on a worker thread — on the
+event loop it would freeze every keystroke and timer until podman
+answered (the "TUI froze on ``i``" bug).
+"""
+
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from terok.tui import project_actions as project_actions_mod, task_actions as task_actions_mod
+from terok.tui.project_actions import ProjectActionsMixin
+from terok.tui.task_actions import TaskActionsMixin
+
+
+def _record_loop_presence(seen: dict[str, bool]) -> None:
+    """Record whether the calling frame runs on the asyncio event loop."""
+    try:
+        asyncio.get_running_loop()
+        seen["on_loop"] = True
+    except RuntimeError:
+        seen["on_loop"] = False
+
+
+def _login_app_stub() -> SimpleNamespace:
+    """App double with a selected cli task, ready for ``_action_login``."""
+    return SimpleNamespace(
+        current_project_name="proj",
+        current_task=SimpleNamespace(task_id="t1", mode="cli", name="mytask"),
+        is_web=False,
+        notify=MagicMock(),
+        _launch_terminal_session=AsyncMock(),
+    )
+
+
+class TestActionLoginOffLoop:
+    """``_action_login`` keeps the podman preflight off the event loop."""
+
+    @pytest.mark.asyncio
+    async def test_preflight_runs_off_the_event_loop(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """The blocking ``get_login_command`` call runs on a worker thread."""
+        seen: dict[str, bool] = {}
+
+        def fake_get_login_command(pid: str, tid: str) -> list[str]:
+            _record_loop_presence(seen)
+            return ["podman", "exec", "-it", "cname", "bash"]
+
+        monkeypatch.setattr(task_actions_mod, "get_login_command", fake_get_login_command)
+        stub = _login_app_stub()
+
+        await TaskActionsMixin._action_login(stub)
+
+        assert seen["on_loop"] is False
+        stub._launch_terminal_session.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_preflight_refusal_still_notifies(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """A ``SystemExit`` from the threaded preflight surfaces as a notification."""
+
+        def refuse(pid: str, tid: str) -> list[str]:
+            raise SystemExit("Container cname is not running (state: exited).")
+
+        monkeypatch.setattr(task_actions_mod, "get_login_command", refuse)
+        stub = _login_app_stub()
+
+        await TaskActionsMixin._action_login(stub)
+
+        stub.notify.assert_called_once()
+        assert "not running" in stub.notify.call_args[0][0]
+        stub._launch_terminal_session.assert_not_awaited()
+
+
+class TestLaunchTerminalSessionOffLoop:
+    """``_launch_terminal_session`` keeps the tmux/terminal probes off the loop."""
+
+    @pytest.mark.asyncio
+    async def test_launch_login_runs_off_the_event_loop(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The launch orchestrator (tmux/ps subprocess probes) runs on a worker thread."""
+        seen: dict[str, bool] = {}
+
+        def fake_launch_login(
+            cmd: list[str], title: str | None = None, reuse_key: str | None = None
+        ) -> tuple[str, None]:
+            _record_loop_presence(seen)
+            return ("tmux", None)
+
+        monkeypatch.setattr(project_actions_mod, "launch_login", fake_launch_login)
+        stub = SimpleNamespace(is_web=False, notify=MagicMock())
+
+        await ProjectActionsMixin._launch_terminal_session(
+            stub, ["podman", "exec", "-it", "cname", "bash"], title="login", cname="cname"
+        )
+
+        assert seen["on_loop"] is False
+        stub.notify.assert_called_once()

--- a/tests/unit/tui/test_login_action.py
+++ b/tests/unit/tui/test_login_action.py
@@ -1,13 +1,14 @@
 # SPDX-FileCopyrightText: 2026 Jiri Vyskocil
 # SPDX-License-Identifier: Apache-2.0
 
-"""Tests for the TUI login action's off-loop preflight.
+"""Tests for the TUI login action's off-loop preflight and blocking spinner.
 
 The login preflight (``get_login_command``) asks podman for the
 container's live state, and podman can sit on its lock for many seconds.
-These tests pin that the blocking work runs on a worker thread — on the
-event loop it would freeze every keystroke and timer until podman
-answered (the "TUI froze on ``i``" bug).
+These tests pin two halves of the fix for the "TUI froze on ``i``" bug:
+the blocking work runs on a worker thread (so the loop keeps rendering),
+and a ``LoginProgressScreen`` modal covers the wait (so the operator
+can't start an action that the jump into the container would yank away).
 """
 
 from __future__ import annotations
@@ -39,8 +40,16 @@ def _login_app_stub() -> SimpleNamespace:
         current_task=SimpleNamespace(task_id="t1", mode="cli", name="mytask"),
         is_web=False,
         notify=MagicMock(),
+        push_screen=AsyncMock(),
         _launch_terminal_session=AsyncMock(),
     )
+
+
+def _stub_progress_screen(monkeypatch: pytest.MonkeyPatch) -> MagicMock:
+    """Replace ``LoginProgressScreen`` with a factory returning one recordable stub."""
+    progress = MagicMock()
+    monkeypatch.setattr(task_actions_mod, "LoginProgressScreen", lambda _label: progress)
+    return progress
 
 
 class TestActionLoginOffLoop:
@@ -56,6 +65,7 @@ class TestActionLoginOffLoop:
             return ["podman", "exec", "-it", "cname", "bash"]
 
         monkeypatch.setattr(task_actions_mod, "get_login_command", fake_get_login_command)
+        _stub_progress_screen(monkeypatch)
         stub = _login_app_stub()
 
         await TaskActionsMixin._action_login(stub)
@@ -71,6 +81,7 @@ class TestActionLoginOffLoop:
             raise SystemExit("Container cname is not running (state: exited).")
 
         monkeypatch.setattr(task_actions_mod, "get_login_command", refuse)
+        _stub_progress_screen(monkeypatch)
         stub = _login_app_stub()
 
         await TaskActionsMixin._action_login(stub)
@@ -78,6 +89,59 @@ class TestActionLoginOffLoop:
         stub.notify.assert_called_once()
         assert "not running" in stub.notify.call_args[0][0]
         stub._launch_terminal_session.assert_not_awaited()
+
+
+class TestActionLoginProgressModal:
+    """The whole login runs under a pushed-then-dismissed blocking spinner."""
+
+    @pytest.mark.asyncio
+    async def test_modal_covers_the_flow(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """The spinner is pushed before the preflight and dismissed after the launch."""
+        events: list[str] = []
+        monkeypatch.setattr(
+            task_actions_mod,
+            "get_login_command",
+            lambda pid, tid: events.append("preflight") or ["podman", "exec", "-it", "c", "bash"],
+        )
+        progress = _stub_progress_screen(monkeypatch)
+        progress.dismiss.side_effect = lambda: events.append("dismiss")
+        stub = _login_app_stub()
+        stub.push_screen = AsyncMock(side_effect=lambda _s: events.append("push"))
+        stub._launch_terminal_session = AsyncMock(
+            side_effect=lambda *a, **kw: events.append("launch")
+        )
+
+        await TaskActionsMixin._action_login(stub)
+
+        assert events == ["push", "preflight", "launch", "dismiss"]
+
+    @pytest.mark.asyncio
+    async def test_modal_dismissed_on_refusal(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """A preflight refusal must not leave the blocking spinner up."""
+
+        def refuse(pid: str, tid: str) -> list[str]:
+            raise SystemExit("nope")
+
+        monkeypatch.setattr(task_actions_mod, "get_login_command", refuse)
+        progress = _stub_progress_screen(monkeypatch)
+        stub = _login_app_stub()
+
+        await TaskActionsMixin._action_login(stub)
+
+        progress.dismiss.assert_called_once()
+
+
+class TestLoginProgressScreen:
+    """The spinner modal itself blocks input."""
+
+    def test_swallows_every_key(self) -> None:
+        """No keystroke escapes the modal — the login flow alone dismisses it."""
+        from terok.tui.screens import LoginProgressScreen
+
+        screen = LoginProgressScreen.__new__(LoginProgressScreen)
+        event = SimpleNamespace(key="q", stop=MagicMock())
+        LoginProgressScreen.on_key(screen, event)
+        event.stop.assert_called_once()
 
 
 class TestLaunchTerminalSessionOffLoop:

--- a/tests/unit/tui/test_new_task_flow.py
+++ b/tests/unit/tui/test_new_task_flow.py
@@ -605,6 +605,7 @@ def _run_launch_with_prompt(agent: str | None, prompt: str | None) -> tuple[mock
     instance.current_project_name = "proj1"
     instance.refresh_tasks = mock.AsyncMock()
     instance._launch_terminal_session = mock.AsyncMock()
+    instance.push_screen = mock.AsyncMock()
 
     fake_provider = mock.Mock()
     fake_provider.binary = "claude"
@@ -617,6 +618,7 @@ def _run_launch_with_prompt(agent: str | None, prompt: str | None) -> tuple[mock
             {
                 "get_login_command": mock.Mock(return_value=["podman", "exec", "-it", "c"]),
                 "_save_initial_prompt": save,
+                "LoginProgressScreen": mock.Mock(return_value=mock.Mock()),
             },
         ),
         mock.patch.dict(
@@ -1123,6 +1125,7 @@ class TestActionLoginTitle:
         instance.current_task.mode = "cli"
         instance.notify = mock.Mock()
         instance._launch_terminal_session = mock.AsyncMock()
+        instance.push_screen = mock.AsyncMock()
 
         action_globals = app_class._action_login.__globals__
 
@@ -1131,6 +1134,7 @@ class TestActionLoginTitle:
             {
                 "get_login_command": mock.Mock(return_value=["podman", "exec", "-it", "c"]),
                 "container_name": lambda *a: "proj1-cli-5",
+                "LoginProgressScreen": mock.Mock(return_value=mock.Mock()),
             },
         ):
             run(app_class._action_login(instance))
@@ -1150,6 +1154,7 @@ class TestActionLoginTitle:
         instance.current_task.mode = "run"
         instance.notify = mock.Mock()
         instance._launch_terminal_session = mock.AsyncMock()
+        instance.push_screen = mock.AsyncMock()
 
         action_globals = app_class._action_login.__globals__
 
@@ -1158,6 +1163,7 @@ class TestActionLoginTitle:
             {
                 "get_login_command": mock.Mock(return_value=["podman", "exec", "-it", "c"]),
                 "container_name": lambda *a: "proj1-run-8",
+                "LoginProgressScreen": mock.Mock(return_value=mock.Mock()),
             },
         ):
             run(app_class._action_login(instance))
@@ -1463,12 +1469,16 @@ class TestOnLaunchScreenResultTitle:
         instance.current_project_name = "proj1"
         instance.refresh_tasks = mock.AsyncMock()
         instance._launch_terminal_session = mock.AsyncMock()
+        instance.push_screen = mock.AsyncMock()
 
         action_globals = app_class._on_launch_screen_result.__globals__
 
         with mock.patch.dict(
             action_globals,
-            {"get_login_command": mock.Mock(return_value=["podman", "exec", "-it", "c", "bash"])},
+            {
+                "get_login_command": mock.Mock(return_value=["podman", "exec", "-it", "c", "bash"]),
+                "LoginProgressScreen": mock.Mock(return_value=mock.Mock()),
+            },
         ):
             result = ("proj1", "3", "fix-auth", "proj1-cli-3", "bash", None)
             run(app_class._on_launch_screen_result(instance, result))
@@ -1484,6 +1494,7 @@ class TestOnLaunchScreenResultTitle:
         instance.current_project_name = "proj1"
         instance.refresh_tasks = mock.AsyncMock()
         instance._launch_terminal_session = mock.AsyncMock()
+        instance.push_screen = mock.AsyncMock()
 
         fake_provider = mock.Mock()
         fake_provider.binary = "claude"
@@ -1496,6 +1507,7 @@ class TestOnLaunchScreenResultTitle:
                 {
                     "get_login_command": mock.Mock(return_value=["podman", "exec", "-it", "c"]),
                     "_save_initial_prompt": mock.Mock(),
+                    "LoginProgressScreen": mock.Mock(return_value=mock.Mock()),
                 },
             ),
             mock.patch.dict(
@@ -1528,6 +1540,7 @@ class TestOnLaunchScreenResultTitle:
         instance.refresh_tasks = mock.AsyncMock()
         instance.notify = mock.Mock()
         instance._launch_terminal_session = mock.AsyncMock()
+        instance.push_screen = mock.AsyncMock()
 
         action_globals = app_class._on_launch_screen_result.__globals__
 
@@ -1537,6 +1550,7 @@ class TestOnLaunchScreenResultTitle:
                 {
                     "get_login_command": mock.Mock(return_value=["podman", "exec", "-it", "c"]),
                     "_save_initial_prompt": mock.Mock(),
+                    "LoginProgressScreen": mock.Mock(return_value=mock.Mock()),
                 },
             ),
             mock.patch.dict(

--- a/tests/unit/tui/tui_test_helpers.py
+++ b/tests/unit/tui/tui_test_helpers.py
@@ -251,6 +251,10 @@ def build_textual_stubs() -> dict[str, types.ModuleType]:
     class Label(_StubObject):
         """Stub label widget that only captures construction args."""
 
+    class LoadingIndicator(_StubObject):
+        """Stub spinner widget that only captures construction args."""
+
+    widgets_mod.LoadingIndicator = LoadingIndicator
     widgets_mod.Button = Button
     widgets_mod.Input = Input
     widgets_mod.Footer = Footer


### PR DESCRIPTION
## What

Pressing the login key (`i`) froze the whole TUI: the handler ran `get_login_command` synchronously on the event loop, and its preflight asks podman for the container's live state — `podman inspect` can sit on the libpod lock for many seconds (a concurrent build, an event-stream hiccup), during which no keystroke, timer, or repaint got through. Reported when logging into a stopped task; the TUI unfroze only once podman's lock cleared.

The fix makes the wait *deliberate and visible* instead of accidental and dead:

- **A blocking `LoginProgressScreen` modal covers the whole login flow.** Login ends with the view jumping into the container's tmux window, so any action the operator starts in the meantime would be yanked away mid-gesture — blocking is the correct UX here, not a compromise. The modal names the session (`proj:task:name`), shows a spinner, and swallows every key until the flow dismisses it (view switched, or the attempt failed and the error is notified).
- **The blocking work runs on a worker thread** (`asyncio.to_thread`) at both entry points — the login key and the task-launch screen — plus `_launch_terminal_session`'s `launch_login` (tmux/ps probes; individually timeout-capped, but several back-to-back still stall the loop for whole seconds). The thread is what keeps the event loop rendering, i.e. what lets the spinner actually spin; a loop-block couldn't even paint it.

## Notes

The state probe itself (`PodmanContainer.state` in terok-sandbox) also deserves a subprocess timeout so a wedged podman can't hang even a worker thread forever — that's terok-ai/terok-sandbox#455. With both merged, the worst case is a bounded spinner ending in an error message instead of an indefinite freeze.

## Tests

`tests/unit/tui/test_login_action.py` pins: both blocking calls execute off the event loop; the modal is pushed before the preflight and dismissed after the launch (and on refusal); the modal swallows keys; a `SystemExit` refusal still surfaces as a notification. Also verified against a live Textual app (`run_test` pilot): the modal composes, survives `q`/`escape`/`enter`, and dismisses cleanly. `make check` green (2906 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)