### PR TITLE
feat(tui): probe for upgrades the moment focus returns to the TUI

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -476,7 +476,9 @@ Inside a terok-managed tmux, a few extra conveniences apply:
   hint in the window you land on explains how to get back.
 - **Upgrades:** if a newer terok is installed on disk while the TUI is
   running (e.g. `pipx upgrade terok`), the TUI offers to restart itself in
-  place to pick up the new version.
+  place to pick up the new version. The offer appears as soon as you come
+  back to the TUI — re-attaching the session or switching back to its
+  window — or within ten minutes if you stay put.
 
 #### tmux Quick Reference
 

--- a/src/terok/resources/tmux/host-tmux.conf
+++ b/src/terok/resources/tmux/host-tmux.conf
@@ -15,5 +15,9 @@ set -g default-terminal "screen-256color"
 set -g base-index 1
 set -g renumber-windows on
 
+# Forward terminal focus to apps that request it — the TUI probes for
+# terok upgrades when focus returns to its window.
+set -s focus-events on
+
 # First window is always the TUI
 set -g automatic-rename off

--- a/src/terok/tui/app.py
+++ b/src/terok/tui/app.py
@@ -106,9 +106,12 @@ if _HAS_TEXTUAL:
     _RESTART_EXIT_RESULT = "terok-restart"
 
     # How often to compare the on-disk terok version against the running
-    # one.  A subprocess probe every five minutes is cheap, and upgrades
-    # under a live TUI are rare events.
-    _UPDATE_CHECK_INTERVAL_S = 300.0
+    # one when nothing else triggers a probe.  Focus-in (re-attaching the
+    # tmux session, switching back to the TUI's window) probes immediately
+    # — that's the "operator just came back" moment the offer should meet
+    # — so the interval only covers terminals that don't report focus, and
+    # can afford to be lazy.
+    _UPDATE_CHECK_INTERVAL_S = 600.0
 
     @dataclass(frozen=True)
     class ProjectStateResult:
@@ -1621,6 +1624,19 @@ if _HAS_TEXTUAL:
                 exit_on_error=False,
             )
 
+        def on_app_focus(self) -> None:
+            """Probe for a landed upgrade the moment attention returns to the TUI.
+
+            Fires on terminal focus-in: re-attaching the tmux session,
+            switching back to the TUI's window or pane, refocusing the
+            terminal.  Whoever just upgraded terok in another window and
+            came back should meet the restart offer right away, not
+            after the idle interval.  The probe worker is exclusive, so
+            a burst of focus flips collapses into one probe.
+            """
+            if not self.is_web:
+                self._check_for_update()
+
         def _probe_installed_version(self) -> None:
             """Compare the on-disk version with the running one (worker thread).
 
@@ -2154,6 +2170,9 @@ if _HAS_TEXTUAL:
         """
         import shutil
 
+        # Must precede the app: tmux honours a pane's focus-reporting
+        # request only if the option is on when Textual makes it.
+        tmux_session.enable_focus_events()
         result = TerokTUI().run()
         if result != _RESTART_EXIT_RESULT:
             return

--- a/src/terok/tui/tmux_session.py
+++ b/src/terok/tui/tmux_session.py
@@ -104,6 +104,22 @@ def session_marker_args() -> tuple[str, ...]:
     return ()
 
 
+def enable_focus_events() -> None:
+    """Ask the tmux server to forward terminal focus to interested panes.
+
+    ``focus-events`` is a server-wide option the host conf turns on for
+    servers terok itself starts — but when terok joins a pre-existing
+    server that conf was never read.  tmux only honours a pane's
+    focus-reporting request (``\\e[?1004h``) made while the option is
+    already on, so this must run *before* Textual starts its driver;
+    flipping the option under a running app does nothing for it.  The
+    TUI probes for landed upgrades on focus-in; without the events it
+    falls back to its slow interval.
+    """
+    if is_terok_tmux():
+        _tmux("set-option", "-s", "focus-events", "on")
+
+
 def _window_stamps(option: str, *target: str) -> list[tuple[str, str]]:
     """List ``(window_id, stamp)`` pairs for *option* across the targeted session.
 

--- a/tests/unit/tui/test_app_update_check.py
+++ b/tests/unit/tui/test_app_update_check.py
@@ -99,6 +99,22 @@ class TestProbeInstalledVersion:
         stub.call_from_thread.assert_not_called()
 
 
+class TestFocusProbe:
+    """Focus-in probes immediately; the interval is only the idle fallback."""
+
+    def test_focus_kicks_the_probe(self) -> None:
+        """Attention returning to the TUI triggers an immediate version check."""
+        stub = SimpleNamespace(is_web=False, _check_for_update=MagicMock())
+        TerokTUI.on_app_focus(stub)
+        stub._check_for_update.assert_called_once_with()
+
+    def test_web_tui_never_probes_on_focus(self) -> None:
+        """A web-served TUI can't re-exec, so focus must not probe."""
+        stub = SimpleNamespace(is_web=True, _check_for_update=MagicMock())
+        TerokTUI.on_app_focus(stub)
+        stub._check_for_update.assert_not_called()
+
+
 class TestOfferUpdateRestart:
     """The offer pushes the modal once per on-disk version."""
 

--- a/tests/unit/tui/test_tmux_session.py
+++ b/tests/unit/tui/test_tmux_session.py
@@ -177,6 +177,27 @@ class TestReviveWindowArgs:
         assert tmux_session.revive_window_args() == ["-t", "=terok:"]
 
 
+class TestEnableFocusEvents:
+    """Focus forwarding is switched on for terok's server, and only there."""
+
+    def test_sets_server_option_inside_terok_tmux(
+        self, inside_terok_tmux: None, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Inside a terok-managed tmux the server option is turned on."""
+        fake = FakeTmux().install(monkeypatch)
+        tmux_session.enable_focus_events()
+        assert fake.calls == [["tmux", "set-option", "-s", "focus-events", "on"]]
+
+    def test_noop_in_users_own_tmux(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """A user's own tmux server is never reconfigured."""
+        # Any truthy TMUX means "inside some tmux"; without the TEROK_TMUX
+        # marker it is the user's own server.
+        monkeypatch.setenv("TMUX", "users-own-tmux")
+        fake = FakeTmux().install(monkeypatch)
+        tmux_session.enable_focus_events()
+        assert fake.calls == []
+
+
 class TestLoginWindows:
     """Login windows are stamped per container and found for reuse."""
 


### PR DESCRIPTION
## What

The live-upgrade restart offer rode a five-minute poll only, so `terok tui --tmux` re-attaching right after an upgrade showed nothing until the next tick. The TUI now kicks the version probe on **terminal focus-in** — re-attaching the session, switching back to the TUI's window or pane, refocusing the terminal — which is the "operator just came back" moment the offer should meet. The interval stays as the idle fallback (for terminals that don't report focus, or an upgrade landing while the TUI keeps focus), relaxed from 5 to 10 minutes since the interactive case no longer depends on it.

## Why focus events, not an activity poller or inotify

- A "poll faster while the user is active" scheme approximates the same signal focus events deliver exactly, at zero polling cost: upgrades happen *outside* the TUI, so the interesting moment is always attention returning to it.
- An inotify watch on the installed dist would break on the common upgrade paths — pipx/uv replace the whole venv directory, killing the watch.

## The tmux plumbing (verified against a live tmux server)

tmux forwards focus only when the server-wide `focus-events` option is on — and only to panes whose focus-reporting request (`\e[?1004h`) it saw **while the option was already on**. Empirically confirmed:

- option on before app start → attach/detach and window switches deliver focus events ✓
- option flipped after the app started → nothing, ever, for that app ✗

Hence two hooks: `host-tmux.conf` turns it on for servers terok starts, and `_run_tui` flips it (best-effort, terok-managed sessions only) just before Textual starts — covering pre-existing servers where the conf was never read. A TUI already running from an older build benefits after its next restart; until then the interval covers it.

## Tests

- `on_app_focus` kicks the (exclusive) probe worker; web-served TUI never probes on focus.
- `enable_focus_events` issues the server-option flip inside a terok-managed tmux and never touches a user's own server.
- `make check` green (2904 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Update checks now trigger immediately when the terminal interface regains focus (non-web mode), helping upgrades surface sooner.
  * Update checks run less frequently while running in the background.
  * tmux now forwards terminal focus events to supported applications.
* **Documentation**
  * Clarified the timing of the “restart to use the new version” prompt when using tmux.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->