### PR TITLE
fix(wizard): stop the project template from degrading gatekeeping security posture

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -272,10 +272,6 @@ git:
   upstream_url: git@github.com:yourorg/yourrepo.git  # optional; omit for local-only
   default_branch: main
   # authorship: human-agent  # optional: author = human, committer = agent
-
-# gate:
-#   enabled: false          # optional; skip the host-side gate mirror
-                            #           (container fetches upstream directly)
 ```
 
 See [Gate and upstream combinations](#gate-and-upstream-combinations)

--- a/src/terok/lib/domain/wizards/new_project.py
+++ b/src/terok/lib/domain/wizards/new_project.py
@@ -59,9 +59,9 @@ class Choice:
     disabled_reason: str = ""
 
 
-# The wizard picks a project template by asking two independent
+# The wizard picks the template variant by asking two independent
 # questions (security mode + base image) instead of one combinatorial
-# menu.  Template files on disk follow ``{security}-{base}.yml``.
+# menu.  A single Jinja template renders all combinations.
 SECURITY_CLASSES: tuple[Choice, ...] = (
     Choice("online", "Online (agent pushes directly to upstream)"),
     Choice("gatekeeping", "Gatekeeping (changes staged for human review)"),

--- a/src/terok/resources/templates/projects/project.yml.template
+++ b/src/terok/resources/templates/projects/project.yml.template
@@ -14,6 +14,7 @@ project:
 git:
   upstream_url: "{{UPSTREAM_URL}}"
   default_branch: "{{DEFAULT_BRANCH}}"
+{%- if SECURITY_CLASS == "online" %}
 
 # gate:
 #   enabled: false   # uncomment if the host cannot reach upstream
@@ -21,6 +22,7 @@ git:
 #                    # the container's own network path can — terok will
 #                    # then skip the host-side mirror and let the
 #                    # container fetch directly from upstream.
+{%- endif %}
 
 image:
   base_image: "{{BASE_IMAGE}}"
@@ -44,11 +46,12 @@ run:
 {%- endif %}
 {%- if SECURITY_CLASS == "gatekeeping" %}
 
-gatekeeping:
-  expose_external_remote: true
-  upstream_polling:
-    enabled: true
-    interval_minutes: 5
+# The gate polls upstream every 5 minutes; uncomment to change the
+# interval or turn auto-polling off.
+# gatekeeping:
+#   upstream_polling:
+#     enabled: true
+#     interval_minutes: 5
 {%- endif %}
 {%- if CREDENTIALS_SCOPE == "project" %}
 

--- a/tests/unit/lib/test_wizard_templates.py
+++ b/tests/unit/lib/test_wizard_templates.py
@@ -86,9 +86,30 @@ class TestProjectTemplate:
         assert parsed["project"]["security_class"] == security_class
         assert parsed["image"]["base_image"] == BASE_IMAGES[base]
 
-    def test_gatekeeping_section_only_for_gatekeeping(self) -> None:
-        assert "gatekeeping:" in _render("gatekeeping", "ubuntu")
-        assert "gatekeeping:" not in _render("online", "ubuntu")
+    def test_gatekeeping_hint_only_for_gatekeeping(self) -> None:
+        """The gatekeeping knobs appear as a commented example, never active.
+
+        The runtime defaults are the secure configuration; a freshly
+        generated project.yml must not override any of them.
+        """
+        rendered = _render("gatekeeping", "ubuntu")
+        assert "# gatekeeping:" in rendered
+        assert "gatekeeping" not in yaml.safe_load(rendered)
+        assert "gatekeeping" not in _render("online", "ubuntu")
+
+    def test_gatekeeping_template_never_mentions_posture_degrading_knobs(self) -> None:
+        """``expose_external_remote`` (default off) stays out of the template.
+
+        Advertising it — even commented — would nudge users toward
+        weakening the gatekeeping isolation; it belongs in the docs.
+        """
+        assert "expose_external_remote" not in _render("gatekeeping", "ubuntu")
+
+    def test_gate_disable_hint_only_for_online(self) -> None:
+        """``gate.enabled: false`` is rejected for gatekeeping projects at
+        load time, so only the online template may advertise it."""
+        assert "# gate:" in _render("online", "ubuntu")
+        assert "# gate:" not in _render("gatekeeping", "ubuntu")
 
     def test_run_gpus_section_only_for_nvidia(self) -> None:
         assert "gpus: all" in _render("online", "nvidia")


### PR DESCRIPTION
## Problem

The wizard's generated `project.yml` for **gatekeeping** projects contradicted its own security story in three ways:

1. **`gatekeeping.expose_external_remote: true` was rendered active** — flipping a schema default that is deliberately `false` (`yaml_schema.py`), so every fresh gatekeeping project started with the upstream exposed inside the container.
2. **The commented `gate.enabled: false` hint was shown for both security classes** — but `gatekeeping` + `gate.enabled: false` is rejected at config load time (`projects.py`). The template was advertising a knob that bricks the project if uncommented.
3. **`upstream_polling` was rendered as an active section restating runtime defaults** — pure noise that also invites casual editing of a section that didn't need to exist.

## Fix

The generated file now follows one rule: *a fresh project.yml never overrides a secure default, and only shows knobs that are valid for its security class.*

- Gatekeeping render: the `gatekeeping:` section becomes a commented-out example showing the upstream-polling knobs at their default values under a one-line note that the gate polls upstream every 5 minutes and the knobs below tune or disable it. `expose_external_remote` is not mentioned at all — it belongs in the docs, not in a template nudging users toward weakening isolation.
- The `gate.enabled: false` hint renders only for **online** projects, where it is valid (firewalled-host use case).
- `docs/usage.md` quick-start: removed the same invalid gatekeeping + `gate.enabled: false` combo from the Step-2 snippet (the existing pointer to the gate/upstream matrix section stays).
- Corrected a stale comment in `new_project.py` claiming per-combination `{security}-{base}.yml` template files exist on disk — there is one unified Jinja template.

## Tests

- `test_gatekeeping_hint_only_for_gatekeeping` — the gatekeeping knobs appear commented, and the parsed YAML of a fresh gatekeeping project contains no `gatekeeping` key.
- `test_gatekeeping_template_never_mentions_posture_degrading_knobs` — `expose_external_remote` stays out of the template entirely.
- `test_gate_disable_hint_only_for_online` — the `# gate:` hint renders only for online.

`make check` green locally (2918 passed, lint/tach/reuse/security clean).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the “From Zero to First Run” → “Step 2: Create project.yml” example to remove the commented-out gate snippet.
* **New Features**
  * Project template guidance and commented configuration hints are now tailored to the selected security mode (online vs gatekeeping).
* **Bug Fixes**
  * Gatekeeping projects no longer emit an active `gatekeeping` YAML block; upstream polling guidance is provided only as commented documentation.
* **Tests**
  * Expanded unit tests to verify which hint comments appear per security mode and that restricted options are never mentioned for gatekeeping.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

