### PR TITLE
fix(tui): batch repaints while suspended so background renders cannot wedge the app

### DIFF
--- a/src/terok/tui/project_actions.py
+++ b/src/terok/tui/project_actions.py
@@ -221,12 +221,23 @@ class ProjectActionsMixin(_MixinBase):
         keeps the child's last lines readable before the TUI redraws
         over them.  Failures — launch errors and non-zero exits — always
         prompt so the error stays visible; clean (zero) exits prompt
-        unless *prompt_on_success* is false.
+        unless *prompt_on_success* is false.  Repaints are batched for the
+        entire suspension — a background render against the suspended
+        driver would wedge the whole app (see the in-body comment).
 
         Returns:
             The child's exit code, or ``None`` if it could not be launched.
         """
-        with self.suspend():
+        # ``batch_update`` keeps the app from rendering for the whole
+        # suspension.  ``suspend()`` stops the driver's writer thread but the
+        # loop deliberately keeps running, so anything that still repaints —
+        # a spinner, a podman-events refresh — feeds the writer's bounded
+        # queue that nothing drains any more; once it fills, ``queue.put``
+        # blocks the event loop itself and the app can never observe the
+        # child's exit.  Possibly a workaround for a Textual-level flaw
+        # (writes to a suspended driver deadlock instead of failing loud);
+        # the real cause deserves a later upstream investigation.
+        with self.suspend(), self.batch_update():
             code: int | None
             with _terminal_pollution_guard():
                 try:

--- a/tests/unit/tui/test_suspend_terminal_guard.py
+++ b/tests/unit/tui/test_suspend_terminal_guard.py
@@ -200,8 +200,10 @@ class TestRunSuspended:
         _record(instance.batch_update, "batch")
 
         async def _spawn(*_argv: str) -> mock.AsyncMock:
-            events.append("child")
-            return self._proc(0)
+            events.append("child:spawn")
+            proc = self._proc(0)
+            proc.wait.side_effect = lambda: events.append("child:exit") or 0
+            return proc
 
         with (
             mock.patch(
@@ -211,7 +213,14 @@ class TestRunSuspended:
             mock.patch("builtins.input"),
         ):
             assert self._run(instance, "agent") == 0
-        assert events == ["suspend:enter", "batch:enter", "child", "batch:exit", "suspend:exit"]
+        assert events == [
+            "suspend:enter",
+            "batch:enter",
+            "child:spawn",
+            "child:exit",
+            "batch:exit",
+            "suspend:exit",
+        ]
 
     def test_eof_at_the_prompt_is_survived(self) -> None:
         """EOF instead of Enter (dead stdin) must not crash the resume path."""

--- a/tests/unit/tui/test_suspend_terminal_guard.py
+++ b/tests/unit/tui/test_suspend_terminal_guard.py
@@ -107,9 +107,10 @@ class TestRunSuspended:
     """``_run_suspended`` — the shared suspend-run-scrub-prompt dance."""
 
     def _instance(self) -> mock.Mock:
-        """Build a mixin mock with ``suspend`` wired as a context manager."""
+        """Build a mixin mock with the app context managers wired up."""
         instance = mock.Mock(spec=ProjectActionsMixin)
         instance.suspend = mock.MagicMock()
+        instance.batch_update = mock.MagicMock()
         return instance
 
     def _run(self, instance: mock.Mock, *argv: str, **kwargs: bool) -> int | None:
@@ -179,6 +180,38 @@ class TestRunSuspended:
             code = self._run(instance, "bogus", prompt_on_success=False)
         assert code is None
         input_mock.assert_called_once()
+
+    def test_repaints_are_batched_for_the_whole_suspension(self) -> None:
+        """The batch opens after suspend and brackets the child's entire run.
+
+        ``suspend()`` stops the driver's writer thread while the loop keeps
+        running; an unbatched repaint (spinner, podman-events refresh) fills
+        the writer's bounded queue and deadlocks the event loop, so the app
+        never sees the child exit.
+        """
+        instance = self._instance()
+        events: list[str] = []
+
+        def _record(cm: mock.MagicMock, name: str) -> None:
+            cm.return_value.__enter__.side_effect = lambda *a: events.append(f"{name}:enter")
+            cm.return_value.__exit__.side_effect = lambda *a: events.append(f"{name}:exit")
+
+        _record(instance.suspend, "suspend")
+        _record(instance.batch_update, "batch")
+
+        async def _spawn(*_argv: str) -> mock.AsyncMock:
+            events.append("child")
+            return self._proc(0)
+
+        with (
+            mock.patch(
+                "terok.tui.project_actions.asyncio.create_subprocess_exec",
+                new=mock.AsyncMock(side_effect=_spawn),
+            ),
+            mock.patch("builtins.input"),
+        ):
+            assert self._run(instance, "agent") == 0
+        assert events == ["suspend:enter", "batch:enter", "child", "batch:exit", "suspend:exit"]
 
     def test_eof_at_the_prompt_is_survived(self) -> None:
         """EOF instead of Enter (dead stdin) must not crash the resume path."""


### PR DESCRIPTION
## The hang

Logging into a CLI container from a plain-terminal TUI (no host tmux → the `_run_suspended` fallback) and detaching from the in-container tmux left the TUI hung forever: `[detached (from session main)]` printed, then nothing — no resume prompt, no redraw, and Ctrl+C had to be pressed repeatedly to kill it.

## Root cause

`App.suspend()` stops the driver's writer thread (`suspend_application_mode()` → `stop_application_mode()` + `close()`), which is the **sole consumer of a bounded 30-slot write queue** — but leaves `_driver._writer_thread` assigned, so later writes enqueue instead of failing. Meanwhile the event loop deliberately keeps running (the login child is awaited on it), and nothing gates rendering on "suspended": `App._display` checks only `_running` / `_closed` / headless.

So anything that still repaints during the suspension — the `LoginProgressScreen` spinner (#1181, ~15 fps: wedges in ~2 s), or `podman events`-driven task refreshes on longer sessions (the chronic pre-#1181 hangs) — fills the dead queue, and the next `queue.put` **blocks the event-loop thread itself**. From then on the TUI is a zombie: `proc.wait()`'s completion is never processed, so when the operator detaches, the child exits cleanly and nobody notices. The repeated-Ctrl+C symptom falls out too: every shutdown step writes to the driver and re-blocks on the same full queue.

The #1180 terminal scrub addresses a real but different poison (a child leaving the tty raw / `O_NONBLOCK` **after exiting**); it runs after `proc.wait()` — code this deadlock never reaches.

Operator-side evidence: `pstree` showed the `podman exec` login child gone while the TUI hung, and the Ctrl+C tracebacks all ended in `_writer_thread.py:26 → queue.put → not_full.wait()`, entered from `Screen._on_timer_update → _compositor_refresh → _display → write(SYNC_START)`.

## The fix

Wrap the suspension in `batch_update()`: `_display` drops repaints while `_batch_count` is non-zero, and the batch's closing `check_idle()` coalesces everything into the normal full redraw after resume (exit order: batch first, then driver resume with a fresh writer thread). `_run_suspended` is the single home of the suspend dance (container logins, OAuth containers, external editor), so one site covers all flows.

This is possibly a workaround for a Textual-level flaw (writes to a suspended driver deadlock instead of failing loud) — marked as such in a comment at the `with`; upstream investigation to follow, reproducer below.

## Verification

- Minimal **stock-Textual 8.2.8** reproducer (no terok code) under a pty: an app with a `LoadingIndicator` that suspends around `sleep 5` deadlocks and never resumes; with `batch_update()` it resumes cleanly.
- Same harness driving the **real** `ProjectActionsMixin._run_suspended` with a spinner on screen: resumes and returns the child's exit code in 9/9 runs post-fix.
- New regression test asserts the batch brackets the child's entire run (`suspend:enter → batch:enter → child → batch:exit → suspend:exit`).
- `make check` green (full suite 2919 passed).

<details>
<summary>Minimal Textual reproducer (for the upstream report)</summary>

```python
import asyncio
import sys

from textual.app import App, ComposeResult
from textual.widgets import LoadingIndicator


class SuspendApp(App[None]):
    """Run under a real tty. Writes RESUMED to the marker file after resume.

    With the bug, the marker never appears and the process hangs forever:
    suspend() stops the writer thread, the LoadingIndicator keeps ticking,
    30 queued frames later queue.put blocks the event loop itself.
    """

    def compose(self) -> ComposeResult:
        yield LoadingIndicator()

    async def on_mount(self) -> None:
        self.run_worker(self._suspend_dance())

    async def _suspend_dance(self) -> None:
        with self.suspend():  # add self.batch_update() to see it pass
            proc = await asyncio.create_subprocess_exec("sleep", "5")
            await proc.wait()
        with open(sys.argv[1], "w") as fh:
            fh.write("RESUMED\n")
        self.exit()


if __name__ == "__main__":
    SuspendApp().run()
```

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved terminal suspension handling by batching screen updates throughout suspended operations.
  * Prevented queued rendering updates from accumulating and causing the interface to become unresponsive.

* **Tests**
  * Added coverage verifying that screen updates remain batched for the full duration of a suspended operation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->