### PR TITLE
fix: say L1, not L0, in refresh-agents user-facing strings

### DIFF
--- a/docs/container-layers.md
+++ b/docs/container-layers.md
@@ -52,7 +52,7 @@ Built `FROM` the L1 image.
 | `terok project build <project>` | L2 only | Project config changes |
 | `terok project build <project> --refresh-agents` | L1 + L2 | Bust the agent-install cache |
 | `terok project build <project> --full-rebuild` | L0 + L1 + L2 (no cache) | Refresh base image + system packages |
-| `terok project build <project> --agents <list>\|all` | L0 + L1 + L2 | One-shot override of which agents bake into L1 |
+| `terok project build <project> --agents <list>\|all` | L1 (if missing) + L2 | One-shot override of which agents bake into L1 |
 | `terok project build <project> --dev` | + L2-dev image | Manual debugging container |
 
 `--refresh-agents` rebuilds L1 with a fresh `AGENT_CACHE_BUST` build-arg (L0 is re-run fully cached); the per-agent install layers below the cache-bust point are re-executed, the system-package layer above it is reused.

--- a/docs/container-layers.md
+++ b/docs/container-layers.md
@@ -50,12 +50,12 @@ Built `FROM` the L1 image.
 | Command | Layers Built | When to Use |
 |---------|-------------|-------------|
 | `terok project build <project>` | L2 only | Project config changes |
-| `terok project build <project> --refresh-agents` | L0 + L1 + L2 | Bust the agent-install cache |
+| `terok project build <project> --refresh-agents` | L1 + L2 | Bust the agent-install cache |
 | `terok project build <project> --full-rebuild` | L0 + L1 + L2 (no cache) | Refresh base image + system packages |
 | `terok project build <project> --agents <list>\|all` | L0 + L1 + L2 | One-shot override of which agents bake into L1 |
 | `terok project build <project> --dev` | + L2-dev image | Manual debugging container |
 
-`--refresh-agents` rebuilds from L0 with a fresh `AGENT_CACHE_BUST` build-arg; the per-agent install layers below the cache-bust point are re-executed, the system-package layer above it is reused.
+`--refresh-agents` rebuilds L1 with a fresh `AGENT_CACHE_BUST` build-arg (L0 is re-run fully cached); the per-agent install layers below the cache-bust point are re-executed, the system-package layer above it is reused.
 
 `--full-rebuild` passes `--no-cache --pull=always`, forcing a fresh base-image pull and re-running system-package installs.
 

--- a/docs/container-lifecycle.md
+++ b/docs/container-lifecycle.md
@@ -172,7 +172,7 @@ Auth containers are ephemeral because:
 | Command | What it builds | When to use |
 |---------|---------------|-------------|
 | `terok project build <project>` | L2 only | Normal use (reuses L0/L1) |
-| `terok project build <project> --refresh-agents` | L0 + L1 + L2 | Bust the agent-install cache |
+| `terok project build <project> --refresh-agents` | L1 + L2 | Bust the agent-install cache |
 | `terok project build <project> --full-rebuild` | L0 + L1 + L2 (no cache) | Refresh base image + system packages |
 | `terok project build <project> --agents <list>\|all` | L0 + L1 + L2 | One-shot override of which agents bake into L1 |
 | `terok project build <project> --dev` | + L2-dev image | Manual debugging container |

--- a/docs/container-lifecycle.md
+++ b/docs/container-lifecycle.md
@@ -174,7 +174,7 @@ Auth containers are ephemeral because:
 | `terok project build <project>` | L2 only | Normal use (reuses L0/L1) |
 | `terok project build <project> --refresh-agents` | L1 + L2 | Bust the agent-install cache |
 | `terok project build <project> --full-rebuild` | L0 + L1 + L2 (no cache) | Refresh base image + system packages |
-| `terok project build <project> --agents <list>\|all` | L0 + L1 + L2 | One-shot override of which agents bake into L1 |
+| `terok project build <project> --agents <list>\|all` | L1 (if missing) + L2 | One-shot override of which agents bake into L1 |
 | `terok project build <project> --dev` | + L2-dev image | Manual debugging container |
 
 ### Image Staleness Detection

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -315,7 +315,7 @@ terok project build myproj --dev
 
 Build modes:
 - **Default** (`build`): Only rebuilds L2 project images, reuses existing L0/L1. Use for project config changes.
-- **`--refresh-agents`**: Rebuilds L0+L1+L2 and cache-busts the per-agent install layers, leaving the system-package layer intact. Use when an agent CLI has a new release.
+- **`--refresh-agents`**: Rebuilds L1+L2 and cache-busts the per-agent install layers, leaving the system-package layer intact. Use when an agent CLI has a new release.
 - **`--full-rebuild`**: Rebuilds L0+L1+L2 with `--no-cache --pull=always`. Use when the base image or system packages need updating.
 - **`--agents <list>|all`**: One-shot override of the agent selection for this build. Does not modify `project.yml`.
 

--- a/src/terok/cli/commands/project.py
+++ b/src/terok/cli/commands/project.py
@@ -94,7 +94,7 @@ def register(subparsers: argparse._SubParsersAction[argparse.ArgumentParser]) ->
         "--refresh-agents",
         dest="refresh_agents",
         action="store_true",
-        help="Rebuild from L0 with fresh agent installs (cache bust)",
+        help="Rebuild from L1 with fresh agent installs (cache bust)",
     )
     p_build.add_argument(
         "--agents",

--- a/src/terok/lib/orchestration/image.py
+++ b/src/terok/lib/orchestration/image.py
@@ -186,7 +186,8 @@ class ProjectImage:
 
         Args:
             include_dev: Also build the L2 dev image (tagged ``<project>:l2-dev``).
-            refresh_agents: Rebuild L0+L1 with fresh agents (cache bust).
+            refresh_agents: Rebuild L1 with fresh agents (cache bust); L0
+                is re-run fully cached.
             full_rebuild: Rebuild every layer with ``--no-cache --pull=always``.
             agents: One-shot override for the agent selection.  ``None``
                 uses ``project.agents`` (which inherits from the global

--- a/src/terok/tui/project_actions.py
+++ b/src/terok/tui/project_actions.py
@@ -291,7 +291,7 @@ class ProjectActionsMixin(_MixinBase):
         )
 
     async def _action_build_agents(self) -> None:
-        """Rebuild from L0 with fresh agents."""
+        """Rebuild from L1 with fresh agents."""
         if not self.current_project_name:
             self.notify("No project selected.")
             return
@@ -299,7 +299,7 @@ class ProjectActionsMixin(_MixinBase):
         self._run_console_action(
             "terok.tui.worker_actions:build_agents",
             pid,
-            title=f"Rebuilding {pid} from L0 with fresh agents",
+            title=f"Rebuilding {pid} from L1 with fresh agents",
             on_complete=self._invalidate_image_caches,
         )
 

--- a/src/terok/tui/worker_actions.py
+++ b/src/terok/tui/worker_actions.py
@@ -40,7 +40,7 @@ def build(project_name: str) -> None:
 
 
 def build_agents(project_name: str) -> None:
-    """Rebuild *project_name* from L0 with a fresh agent set."""
+    """Rebuild *project_name* from L1 with a fresh agent set."""
     from terok.lib.api import build_images
 
     build_images(project_name, refresh_agents=True)


### PR DESCRIPTION
## Problem

Several user-facing strings claim `--refresh-agents` rebuilds "from L0", but it is an L1 rebuild: terok-executor's `build_base_images()` passes `no_cache=full_rebuild` to the L0 build, so with `rebuild=True` (refresh) the L0 step re-runs fully cached (a no-op) and only the L1 build gets the fresh `AGENT_CACHE_BUST` build-arg. Only `--full-rebuild` (`--no-cache --pull=always`) genuinely rebuilds from L0.

## Changes

String/docstring-only — no behavior change:

- `cli/commands/project.py`: `--refresh-agents` help → "Rebuild from L1 …"
- `tui/project_actions.py`: rebuild-console title "Rebuilding <proj> from L1 with fresh agents" + docstring
- `tui/worker_actions.py`: `build_agents` docstring
- `lib/orchestration/image.py`: `build()` docstring — refresh rebuilds L1; L0 is re-run fully cached
- `docs/container-layers.md`, `docs/container-lifecycle.md`, `docs/usage.md`: build-mode tables/bullets → L1 + L2

The TUI `screens.py` binding/option labels already said "Rebuild L1 with fresh agents" and are untouched.

## Testing

- `make lint` clean
- full `make test`: 2919 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified that `--refresh-agents` refreshes **L1 + L2** (with per-agent cache busting) rather than **L0 + L1 + L2**.
  * Updated CLI help and TUI text to consistently describe rebuilding “from **L1** with fresh agents.”
  * Reaffirmed that the system-package layer remains fully cached while agent install layers are selectively re-executed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Follow-up commit sweeps the `--agents` rows in the same tables: a one-shot selection builds its L1 tag only when missing (L0 re-runs fully cached), so the row now reads "L1 (if missing) + L2" instead of "L0 + L1 + L2".
