### PR TITLE
feat(auth): badge authed entries in the auth menu; uncap the TUI auth modal

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -510,6 +510,11 @@ terok auth claude --project myproj
 terok auth
 ```
 
+The interactive menu marks entries that already hold a stored credential
+with `✓ authenticated` (scoped to the project's vault bucket when
+`--project` is given). When the vault can't be read — not yet provisioned
+or currently sealed — the menu says so instead of guessing.
+
 Each provider offers the methods its vendor supports — OAuth / interactive
 login (launches an auth container), the OAuth **device-code** variant (for
 vendors that support it, e.g. Codex), and API key (paste, no container

--- a/src/terok/cli/commands/auth.py
+++ b/src/terok/cli/commands/auth.py
@@ -148,19 +148,26 @@ def _run_interactive(project_name: str | None, *, device_auth: bool = False) -> 
     *device_auth* forces the device-code login for every selected provider —
     the headless escape hatch when driving the menu on a remote host.
     """
-    from terok.lib.api.agents import AUTH_PROVIDERS, available_auth_modes
+    from terok.lib.api.agents import AUTH_PROVIDERS, authenticated_entries, available_auth_modes
 
     if project_name is not None:
         require_project_exists(project_name)
 
     provider_names = list(AUTH_PROVIDERS)
     provider_of = _provider_of()
+    authed = authenticated_entries(project_name)
     print("Authenticate agents — pick one or more by number or name (agent or provider):")
     for i, name in enumerate(provider_names, 1):
         info = AUTH_PROVIDERS[name]
-        modes = [_MODE_LABELS[m] for m in available_auth_modes(name)]
+        modes = f"[{', '.join(_MODE_LABELS[m] for m in available_auth_modes(name))}]"
         label = f"{info.label} → {provider_of[name]}" if name in provider_of else info.label
-        print(f"  {i:>2}. {name:<12} {label:<22} [{', '.join(modes)}]")
+        mark = "  ✓ authenticated" if name in (authed or ()) else ""
+        print(f"  {i:>2}. {name:<12} {label:<22} {modes:<30}{mark}".rstrip())
+    if authed is None:
+        print(
+            "  (vault locked — cannot tell which entries are already authenticated)",
+            file=sys.stderr,
+        )
 
     try:
         answer = input("\nChoice (numbers or names, comma-separated; empty = cancel): ").strip()

--- a/src/terok/lib/api/agents.py
+++ b/src/terok/lib/api/agents.py
@@ -30,6 +30,7 @@ if TYPE_CHECKING:
     from terok.lib.domain.auth import (
         auth_provider_aliases as auth_provider_aliases,
         authenticate as authenticate,
+        authenticated_entries as authenticated_entries,
         available_auth_modes as available_auth_modes,
         find_host_auth_image as find_host_auth_image,
         resolve_auth_provider as resolve_auth_provider,
@@ -89,6 +90,7 @@ _LAZY: dict[str, str] = {
     "acp_socket_is_live": "terok.lib.integrations.executor",
     "auth_provider_aliases": "terok.lib.domain.auth",
     "authenticate": "terok.lib.domain.auth",
+    "authenticated_entries": "terok.lib.domain.auth",
     "available_auth_modes": "terok.lib.domain.auth",
     "build_images": "terok.lib.orchestration.image",
     "bundled_default_instructions": "terok.lib.integrations.executor",

--- a/src/terok/lib/domain/auth.py
+++ b/src/terok/lib/domain/auth.py
@@ -18,7 +18,13 @@ from __future__ import annotations
 from collections.abc import Callable
 from pathlib import Path
 
-from terok.lib.integrations.executor import AGENTS, AUTH_PROVIDERS, Authenticator
+from terok.lib.integrations.executor import (
+    AGENTS,
+    AUTH_PROVIDERS,
+    Authenticator,
+    credential_provider,
+    list_authenticated_agents,
+)
 
 from ..core.images import project_cli_image
 from ..orchestration.image import image_exists
@@ -116,6 +122,33 @@ def resolve_credential_routing(project_name: str | None) -> tuple[Path, str]:
         mounts_dir.mkdir(parents=True, exist_ok=True, mode=0o700)
         mounts_dir.chmod(0o700)
     return mounts_dir, project.credential_set
+
+
+def authenticated_entries(project_name: str | None = None) -> frozenset[str] | None:
+    """Auth entries that already hold a stored credential, or ``None`` when unknowable.
+
+    The vault stores credentials under provider keys (``anthropic``, ``github``);
+    this maps them back onto the auth entries that write them (``claude``,
+    ``gh``) so listings can badge already-authenticated entries.  The queried
+    credential set follows the same routing as
+    [`authenticate`][terok.lib.domain.auth.authenticate]: the host-wide bucket
+    for ``project_name=None`` and shared-scope projects, the project's private
+    set for ``credentials.scope: project``.
+
+    Returns ``None`` when the vault cannot be read — not yet provisioned,
+    sealed, or unlocking with a stale passphrase.  ``terok auth`` is often the
+    first command run on a fresh install, so an unreadable vault is a normal
+    state here, not an error; callers should present the auth state as unknown
+    rather than as "nothing authenticated".
+    """
+    from terok.lib.integrations.sandbox import NoPassphraseError, WrongPassphraseError
+
+    _, credential_set = resolve_credential_routing(project_name)
+    try:
+        stored = set(list_authenticated_agents(scope=credential_set))
+    except (NoPassphraseError, WrongPassphraseError):
+        return None
+    return frozenset(entry for entry in AUTH_PROVIDERS if credential_provider(entry) in stored)
 
 
 def authenticate(
@@ -310,6 +343,7 @@ def _resolve_host_auth_image(provider: str) -> str:
 __all__ = [
     "auth_provider_aliases",
     "authenticate",
+    "authenticated_entries",
     "available_auth_modes",
     "find_host_auth_image",
     "resolve_auth_provider",

--- a/src/terok/tui/screens.py
+++ b/src/terok/tui/screens.py
@@ -344,8 +344,8 @@ class ProjectDetailsScreen(screen.Screen[str | None]):
 class AuthActionsScreen(screen.ModalScreen[str | None]):
     """Small modal for authenticating agents and tools.
 
-    Options are built dynamically from ``AUTH_PROVIDERS``.
-    Number keys (1-9) act as shortcuts for the corresponding list entry.
+    Options are built dynamically from ``AUTH_PROVIDERS`` — every entry is
+    listed; navigate with the arrow keys and select with Enter.
     """
 
     BINDINGS = [
@@ -375,21 +375,14 @@ class AuthActionsScreen(screen.ModalScreen[str | None]):
     """
 
     def compose(self) -> ComposeResult:
-        """Build the numbered list of authentication providers."""
+        """Build the list of authentication providers."""
         from terok.lib.api.agents import AUTH_PROVIDERS
 
-        providers = list(AUTH_PROVIDERS.values())
         options: list[Option | None] = [
-            Option(f"\\[{i}] {p.label}", id=f"auth_{p.name}")
-            for i, p in enumerate(providers, 1)
-            if i <= 9
+            Option(p.label, id=f"auth_{p.name}") for p in AUTH_PROVIDERS.values()
         ]
-        next_num = len(providers) + 1
         options.append(None)
-        import_label = (
-            f"\\[{next_num}] Import OpenCode config" if next_num <= 9 else "Import OpenCode config"
-        )
-        options.append(Option(import_label, id="import_opencode_config"))
+        options.append(Option("Import OpenCode config", id="import_opencode_config"))
         with Vertical(id="auth-dialog") as dialog:
             yield OptionList(*options, id="auth-actions-list")
         dialog.border_title = "Authenticate agents and tools"
@@ -404,20 +397,6 @@ class AuthActionsScreen(screen.ModalScreen[str | None]):
         """Dismiss with the selected provider's action ID."""
         if event.option_id:
             self.dismiss(event.option_id)
-
-    def on_key(self, event: events.Key) -> None:
-        """Handle number-key shortcuts (1-9) to select a provider or import."""
-        from terok.lib.api.agents import AUTH_PROVIDERS
-
-        if event.character and event.character.isdigit():
-            idx = int(event.character) - 1
-            providers = list(AUTH_PROVIDERS.values())
-            if 0 <= idx < min(len(providers), 9):
-                self.dismiss(f"auth_{providers[idx].name}")
-                event.stop()
-            elif idx == len(providers) and idx < 9:
-                self.dismiss("import_opencode_config")
-                event.stop()
 
     async def action_dismiss(self, result: str | None = None) -> None:
         """Close the auth modal without selecting a provider."""

--- a/tests/unit/cli/test_cli_auth.py
+++ b/tests/unit/cli/test_cli_auth.py
@@ -182,6 +182,7 @@ def test_run_interactive_cancels_on_empty_answer(capsys: pytest.CaptureFixture[s
     """Empty input aborts without launching any auth."""
     with (
         patch("sys.stdin", new=StringIO("\n")),
+        patch("terok.lib.api.agents.authenticated_entries", return_value=frozenset()),
         patch("terok.cli.commands.auth._run_one") as mock_run,
     ):
         _run_interactive(project_name=None)
@@ -193,6 +194,7 @@ def test_run_interactive_runs_each_selected_provider() -> None:
     with (
         patch("sys.stdin", new=StringIO("claude, codex\n")),
         patch("terok.cli.commands.auth.require_project_exists"),
+        patch("terok.lib.api.agents.authenticated_entries", return_value=frozenset()),
         patch("terok.cli.commands.auth._run_one") as mock_run,
     ):
         _run_interactive(project_name="myproj")
@@ -207,6 +209,7 @@ def test_run_interactive_hides_oauth_when_disabled(capsys: pytest.CaptureFixture
     with (
         patch("sys.stdin", new=StringIO("\n")),
         patch("terok.lib.core.config.is_oauth_enabled_for", return_value=False),
+        patch("terok.lib.api.agents.authenticated_entries", return_value=frozenset()),
         patch("terok.cli.commands.auth._run_one"),
     ):
         _run_interactive(project_name=None)
@@ -220,11 +223,54 @@ def test_run_interactive_shows_oauth_when_enabled(capsys: pytest.CaptureFixture[
     with (
         patch("sys.stdin", new=StringIO("\n")),
         patch("terok.lib.core.config.is_oauth_enabled_for", return_value=True),
+        patch("terok.lib.api.agents.authenticated_entries", return_value=frozenset()),
         patch("terok.cli.commands.auth._run_one"),
     ):
         _run_interactive(project_name=None)
     out = capsys.readouterr().out
     assert "oauth" in out
+
+
+def test_run_interactive_marks_authenticated_entries(capsys: pytest.CaptureFixture[str]) -> None:
+    """Entries with a stored credential get the ✓ badge; the rest stay bare."""
+    with (
+        patch("sys.stdin", new=StringIO("\n")),
+        patch("terok.lib.api.agents.authenticated_entries", return_value=frozenset({"claude"})),
+        patch("terok.cli.commands.auth._run_one"),
+    ):
+        _run_interactive(project_name=None)
+    lines = capsys.readouterr().out.splitlines()
+    claude_line = next(line for line in lines if " claude " in line)
+    codex_line = next(line for line in lines if " codex " in line)
+    assert "✓ authenticated" in claude_line
+    assert "✓" not in codex_line
+
+
+def test_run_interactive_notes_unreadable_vault(capsys: pytest.CaptureFixture[str]) -> None:
+    """When the vault can't be read, no badge is shown and stderr says why."""
+    with (
+        patch("sys.stdin", new=StringIO("\n")),
+        patch("terok.lib.api.agents.authenticated_entries", return_value=None),
+        patch("terok.cli.commands.auth._run_one"),
+    ):
+        _run_interactive(project_name=None)
+    captured = capsys.readouterr()
+    assert "✓" not in captured.out
+    assert "vault locked" in captured.err
+
+
+def test_run_interactive_scopes_auth_state_to_project() -> None:
+    """The badge query follows the menu's project scope."""
+    with (
+        patch("sys.stdin", new=StringIO("\n")),
+        patch("terok.cli.commands.auth.require_project_exists"),
+        patch(
+            "terok.lib.api.agents.authenticated_entries", return_value=frozenset()
+        ) as mock_authed,
+        patch("terok.cli.commands.auth._run_one"),
+    ):
+        _run_interactive(project_name="myproj")
+    mock_authed.assert_called_once_with("myproj")
 
 
 # ── single-provider runner ─────────────────────────────────────────────
@@ -276,6 +322,48 @@ def test_run_one_warns_on_stale_image(capsys: pytest.CaptureFixture[str]) -> Non
     ):
         _run_one("codex", project_name="p1")
     assert "Warning: stale image" in capsys.readouterr().err
+
+
+# ── authenticated_entries (vault-backed auth-state query) ───────────────
+
+
+def test_authenticated_entries_maps_stored_providers_to_entries() -> None:
+    """Stored credential-provider keys map back to the auth entries that write them."""
+    from terok.lib.domain import auth as domain_auth
+
+    with patch.object(
+        domain_auth, "list_authenticated_agents", return_value=["anthropic", "github"]
+    ) as mock_list:
+        entries = domain_auth.authenticated_entries(None)
+    assert entries == frozenset({"claude", "gh"})
+    mock_list.assert_called_once_with(scope="default")
+
+
+def test_authenticated_entries_uses_project_credential_set() -> None:
+    """A project-scoped project queries its private vault set, not the host bucket."""
+    from terok.lib.domain import auth as domain_auth
+
+    with (
+        patch.object(
+            domain_auth, "resolve_credential_routing", return_value=(None, "myproj")
+        ) as mock_route,
+        patch.object(domain_auth, "list_authenticated_agents", return_value=[]) as mock_list,
+    ):
+        entries = domain_auth.authenticated_entries("myproj")
+    assert entries == frozenset()
+    mock_route.assert_called_once_with("myproj")
+    mock_list.assert_called_once_with(scope="myproj")
+
+
+def test_authenticated_entries_unreadable_vault_returns_none() -> None:
+    """A sealed or unprovisioned vault yields ``None`` (unknown), not an error."""
+    from terok.lib.domain import auth as domain_auth
+    from terok.lib.integrations.sandbox import NoPassphraseError
+
+    with patch.object(
+        domain_auth, "list_authenticated_agents", side_effect=NoPassphraseError("sealed")
+    ):
+        assert domain_auth.authenticated_entries(None) is None
 
 
 # ── available_auth_modes (shared CLI/TUI source of truth) ───────────────

--- a/tests/unit/tui/test_detail_screens.py
+++ b/tests/unit/tui/test_detail_screens.py
@@ -673,28 +673,15 @@ class TestAuthScreenOptions:
         screen.on_option_list_option_selected(event)
         screen.dismiss.assert_called_once_with("import_opencode_config")
 
-    def test_auth_screen_number_key_triggers_import(self) -> None:
-        """Verify the number key after last provider selects import option.
-
-        The shortcut only exists when the provider count is below 9
-        (single-digit keys 1-9).  When all 9 slots are occupied, the
-        import option has no number shortcut and pressing the next
-        number is a no-op.
-        """
+    def test_auth_screen_lists_every_provider(self) -> None:
+        """Every ``AUTH_PROVIDERS`` entry is listed — no 9-entry shortcut cap."""
         from terok_executor import AUTH_PROVIDERS
 
         screens, _ = import_screens()
         screen = screens.AuthActionsScreen()
-        screen.dismiss = mock.Mock()
-
-        import_num = len(AUTH_PROVIDERS) + 1
-        event = make_key_event(str(import_num))
-        event.character = str(import_num)
-        screen.on_key(event)
-        if import_num <= 9:
-            screen.dismiss.assert_called_once_with("import_opencode_config")
-        else:
-            screen.dismiss.assert_not_called()
+        (option_list,) = list(screen.compose())
+        ids = [opt._stub_kwargs.get("id") for opt in option_list._stub_args if opt is not None]
+        assert ids == [f"auth_{name}" for name in AUTH_PROVIDERS] + ["import_opencode_config"]
 
     def test_opencode_config_screen_construction(self) -> None:
         """Verify OpenCodeConfigScreen can be instantiated."""


### PR DESCRIPTION
## What

Two auth-listing UX fixes:

**1. `terok auth` now indicates which entries are already authenticated.** The interactive menu badges entries whose credential is already stored:

```
   1. claude       Claude → anthropic     [api-key]                       ✓ authenticated
   2. coderabbit   CodeRabbit             [api-key]
   ...
```

- New domain helper `authenticated_entries(project_name)` maps the vault's stored credential-provider keys (`anthropic`, `github`) back onto the auth entries that write them (`claude`, `gh`), via `credential_provider()` — the same mapping `store_api_key`/capture use, so the badge can't drift from what auth actually stores.
- Scope follows the existing `resolve_credential_routing()`: host-wide bucket by default, the project's private vault set for `credentials.scope: project` under `--project`.
- An unreadable vault (fresh install, sealed, stale passphrase) returns `None` → the menu prints an explicit "vault locked — cannot tell which entries are already authenticated" note on stderr instead of failing or presenting everything as unauthenticated. `terok auth` is often the first command on a fresh install, so this state is normal there, not an error.

**2. The TUI auth modal lists every provider.** It built number-key shortcuts (1–9) into the option list and silently dropped every entry past the ninth — with 10 registry entries, `openrouter` was unreachable. The shortcuts were never load-bearing (OptionList navigates with arrows + Enter), so they're removed entirely rather than paginated; the modal now lists all entries plus the OpenCode import.

## Verification

- `make check` green (2925 unit tests, lint, tach, import-linter, docstrings, reuse, bandit).
- Exercised end-to-end in a container: menu with an empty vault shows no badges; after `store_api_key('claude', …)` the `claude` row shows `✓ authenticated` (stored under `anthropic`, correctly mapped back).
- New tests: badge rendering, unreadable-vault note, project scoping, provider-key→entry mapping, and a TUI regression test asserting the modal lists the full `AUTH_PROVIDERS` registry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The interactive `terok auth` menu now marks entries with stored credentials as “✓ authenticated.”
  * Authentication status respects the selected project scope.
  * When the credential vault cannot be read, the menu clearly indicates that status is unavailable.
  * The authentication provider selector now supports arrow-key navigation and Enter selection, including all available providers and configuration import options.

* **Documentation**
  * Updated usage documentation to describe authentication indicators and unavailable vault status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->