### PR TITLE
feat(auth): auth-state badge in the TUI modal; replace note in single-shot auth

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -512,8 +512,11 @@ terok auth
 
 The interactive menu marks entries that already hold a stored credential
 with `✓ authenticated` (scoped to the project's vault bucket when
-`--project` is given). When the vault can't be read — not yet provisioned
-or currently sealed — the menu says so instead of guessing.
+`--project` is given); the TUI's auth modal shows the same badge.
+Re-authenticating a badged entry replaces the stored credential — the
+single-provider form prints a heads-up first. When the vault can't be
+read — not yet provisioned or currently sealed — both surfaces say so
+instead of guessing.
 
 Each provider offers the methods its vendor supports — OAuth / interactive
 login (launches an auth container), the OAuth **device-code** variant (for

--- a/src/terok/cli/commands/auth.py
+++ b/src/terok/cli/commands/auth.py
@@ -126,14 +126,18 @@ def _run_one(provider: str, project_name: str | None, *, device_auth: bool = Fal
     With *device_auth* the method chooser is skipped and the provider's
     headless device-code login runs directly.
     """
-    from terok.lib.api.agents import resolve_auth_provider
+    from terok.lib.api.agents import authenticated_entries, resolve_auth_provider
 
+    resolved = resolve_auth_provider(provider)
     if project_name is not None:
         # Project-scoped: verify the L2 image actually has the agent baked
         # in before launching.  Host-wide auth resolves the image in the
         # facade and does its own checks there.
-        require_agent_installed(
-            load_project(project_name), resolve_auth_provider(provider), noun="Provider"
+        require_agent_installed(load_project(project_name), resolved, noun="Provider")
+    if resolved in (authenticated_entries(project_name) or ()):
+        print(
+            f"Note: {resolved} already has a stored credential — completing this flow replaces it.",
+            file=sys.stderr,
         )
     # Heads-up before launching: a stale project image bakes outdated login
     # scripts (host-wide auth returns None here — not yet detectable).

--- a/src/terok/cli/commands/auth.py
+++ b/src/terok/cli/commands/auth.py
@@ -130,9 +130,10 @@ def _run_one(provider: str, project_name: str | None, *, device_auth: bool = Fal
 
     resolved = resolve_auth_provider(provider)
     if project_name is not None:
-        # Project-scoped: verify the L2 image actually has the agent baked
-        # in before launching.  Host-wide auth resolves the image in the
-        # facade and does its own checks there.
+        # Project-scoped: verify the agent is baked into the project's L1
+        # image (which the L2 auth container builds on) before launching.
+        # Host-wide auth resolves the image in the facade and does its own
+        # checks there.
         require_agent_installed(load_project(project_name), resolved, noun="Provider")
     if resolved in (authenticated_entries(project_name) or ()):
         print(

--- a/src/terok/tui/screens.py
+++ b/src/terok/tui/screens.py
@@ -242,8 +242,8 @@ class ProjectDetailsScreen(screen.Screen[str | None]):
             self.dismiss(option_id)
 
     def _open_auth_modal(self) -> None:
-        """Push the authentication provider selection modal."""
-        self.app.push_screen(AuthActionsScreen(), self._on_auth_result)
+        """Push the authentication provider selection modal, project-scoped."""
+        self.app.push_screen(AuthActionsScreen(self._project.name), self._on_auth_result)
 
     def _on_auth_result(self, result: str | None) -> None:
         """Forward the selected auth action from the sub-modal as this screen's result."""
@@ -345,7 +345,15 @@ class AuthActionsScreen(screen.ModalScreen[str | None]):
     """Small modal for authenticating agents and tools.
 
     Options are built dynamically from ``AUTH_PROVIDERS`` — every entry is
-    listed; navigate with the arrow keys and select with Enter.
+    listed; navigate with the arrow keys and select with Enter.  Entries
+    that already hold a stored credential gain a ``✓ authenticated`` badge
+    once a background vault query lands — the lookup does keyring and
+    SQLCipher I/O, so it must never run on the UI thread.
+
+    *project_name* scopes the badge query the same way the auth flow it
+    fronts is scoped: ``None`` for the host-wide bucket, a project name for
+    that project's credential set (which only diverges from the host bucket
+    under ``credentials.scope: project``).
     """
 
     BINDINGS = [
@@ -374,6 +382,11 @@ class AuthActionsScreen(screen.ModalScreen[str | None]):
     }
     """
 
+    def __init__(self, project_name: str | None = None) -> None:
+        """Remember the credential scope the badge query should target."""
+        super().__init__()
+        self._project_name = project_name
+
     def compose(self) -> ComposeResult:
         """Build the list of authentication providers."""
         from terok.lib.api.agents import AUTH_PROVIDERS
@@ -389,9 +402,40 @@ class AuthActionsScreen(screen.ModalScreen[str | None]):
         dialog.border_subtitle = "Esc to close"
 
     def on_mount(self) -> None:
-        """Focus the auth provider list on mount."""
+        """Focus the auth provider list and start the auth-state lookup."""
         actions = self.query_one("#auth-actions-list", OptionList)
         actions.focus()
+        self.run_worker(self._fetch_auth_state, thread=True, exit_on_error=False)
+
+    def _fetch_auth_state(self) -> frozenset[str] | None:
+        """Query which entries already hold a stored credential (thread worker)."""
+        from terok.lib.api.agents import authenticated_entries
+
+        return authenticated_entries(self._project_name)
+
+    def on_worker_state_changed(self, event: Any) -> None:
+        """Apply the badges once the background vault query lands."""
+        if event.state.name == "SUCCESS":
+            self._show_auth_state(event.worker.result)
+
+    def _show_auth_state(self, authed: frozenset[str] | None) -> None:
+        """Badge already-authenticated entries, or flag an unreadable vault.
+
+        ``None`` means the vault couldn't be read (not yet provisioned or
+        sealed) — say so in the subtitle instead of presenting every entry
+        as unauthenticated.
+        """
+        from terok.lib.api.agents import AUTH_PROVIDERS
+
+        if authed is None:
+            dialog = self.query_one("#auth-dialog", Vertical)
+            dialog.border_subtitle = "vault locked — auth state unknown · Esc to close"
+            return
+        option_list = self.query_one("#auth-actions-list", OptionList)
+        for name in authed:
+            option_list.replace_option_prompt(
+                f"auth_{name}", f"{AUTH_PROVIDERS[name].label}  ✓ authenticated"
+            )
 
     def on_option_list_option_selected(self, event: OptionList.OptionSelected) -> None:
         """Dismiss with the selected provider's action ID."""

--- a/tests/unit/cli/test_cli_auth.py
+++ b/tests/unit/cli/test_cli_auth.py
@@ -15,7 +15,7 @@ from __future__ import annotations
 import argparse
 from io import StringIO
 from types import SimpleNamespace
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -32,6 +32,19 @@ def _make_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser()
     register(parser.add_subparsers(dest="cmd"))
     return parser
+
+
+@pytest.fixture(autouse=True)
+def mock_authed_entries():
+    """Keep the menu/runner auth-state lookups away from any real vault.
+
+    Yields the mock so individual tests can reshape ``return_value`` to
+    exercise the badge / already-authenticated paths.
+    """
+    with patch(
+        "terok.lib.api.agents.authenticated_entries", return_value=frozenset()
+    ) as mock_authed:
+        yield mock_authed
 
 
 # ── argparse registration ──────────────────────────────────────────────
@@ -182,7 +195,6 @@ def test_run_interactive_cancels_on_empty_answer(capsys: pytest.CaptureFixture[s
     """Empty input aborts without launching any auth."""
     with (
         patch("sys.stdin", new=StringIO("\n")),
-        patch("terok.lib.api.agents.authenticated_entries", return_value=frozenset()),
         patch("terok.cli.commands.auth._run_one") as mock_run,
     ):
         _run_interactive(project_name=None)
@@ -194,7 +206,6 @@ def test_run_interactive_runs_each_selected_provider() -> None:
     with (
         patch("sys.stdin", new=StringIO("claude, codex\n")),
         patch("terok.cli.commands.auth.require_project_exists"),
-        patch("terok.lib.api.agents.authenticated_entries", return_value=frozenset()),
         patch("terok.cli.commands.auth._run_one") as mock_run,
     ):
         _run_interactive(project_name="myproj")
@@ -209,7 +220,6 @@ def test_run_interactive_hides_oauth_when_disabled(capsys: pytest.CaptureFixture
     with (
         patch("sys.stdin", new=StringIO("\n")),
         patch("terok.lib.core.config.is_oauth_enabled_for", return_value=False),
-        patch("terok.lib.api.agents.authenticated_entries", return_value=frozenset()),
         patch("terok.cli.commands.auth._run_one"),
     ):
         _run_interactive(project_name=None)
@@ -223,7 +233,6 @@ def test_run_interactive_shows_oauth_when_enabled(capsys: pytest.CaptureFixture[
     with (
         patch("sys.stdin", new=StringIO("\n")),
         patch("terok.lib.core.config.is_oauth_enabled_for", return_value=True),
-        patch("terok.lib.api.agents.authenticated_entries", return_value=frozenset()),
         patch("terok.cli.commands.auth._run_one"),
     ):
         _run_interactive(project_name=None)
@@ -231,11 +240,13 @@ def test_run_interactive_shows_oauth_when_enabled(capsys: pytest.CaptureFixture[
     assert "oauth" in out
 
 
-def test_run_interactive_marks_authenticated_entries(capsys: pytest.CaptureFixture[str]) -> None:
+def test_run_interactive_marks_authenticated_entries(
+    mock_authed_entries: MagicMock, capsys: pytest.CaptureFixture[str]
+) -> None:
     """Entries with a stored credential get the ✓ badge; the rest stay bare."""
+    mock_authed_entries.return_value = frozenset({"claude"})
     with (
         patch("sys.stdin", new=StringIO("\n")),
-        patch("terok.lib.api.agents.authenticated_entries", return_value=frozenset({"claude"})),
         patch("terok.cli.commands.auth._run_one"),
     ):
         _run_interactive(project_name=None)
@@ -246,11 +257,13 @@ def test_run_interactive_marks_authenticated_entries(capsys: pytest.CaptureFixtu
     assert "✓" not in codex_line
 
 
-def test_run_interactive_notes_unreadable_vault(capsys: pytest.CaptureFixture[str]) -> None:
+def test_run_interactive_notes_unreadable_vault(
+    mock_authed_entries: MagicMock, capsys: pytest.CaptureFixture[str]
+) -> None:
     """When the vault can't be read, no badge is shown and stderr says why."""
+    mock_authed_entries.return_value = None
     with (
         patch("sys.stdin", new=StringIO("\n")),
-        patch("terok.lib.api.agents.authenticated_entries", return_value=None),
         patch("terok.cli.commands.auth._run_one"),
     ):
         _run_interactive(project_name=None)
@@ -259,18 +272,17 @@ def test_run_interactive_notes_unreadable_vault(capsys: pytest.CaptureFixture[st
     assert "vault locked" in captured.err
 
 
-def test_run_interactive_scopes_auth_state_to_project() -> None:
+def test_run_interactive_scopes_auth_state_to_project(
+    mock_authed_entries: MagicMock,
+) -> None:
     """The badge query follows the menu's project scope."""
     with (
         patch("sys.stdin", new=StringIO("\n")),
         patch("terok.cli.commands.auth.require_project_exists"),
-        patch(
-            "terok.lib.api.agents.authenticated_entries", return_value=frozenset()
-        ) as mock_authed,
         patch("terok.cli.commands.auth._run_one"),
     ):
         _run_interactive(project_name="myproj")
-    mock_authed.assert_called_once_with("myproj")
+    mock_authed_entries.assert_called_once_with("myproj")
 
 
 # ── single-provider runner ─────────────────────────────────────────────
@@ -307,6 +319,30 @@ def test_run_one_forwards_device_auth() -> None:
     with patch("terok.cli.commands.auth.authenticate") as mock_auth:
         _run_one("codex", project_name=None, device_auth=True)
     mock_auth.assert_called_once_with("codex", None, device_auth=True)
+
+
+def test_run_one_notes_existing_credential(
+    mock_authed_entries: MagicMock, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Re-authing an entry with a stored credential warns that it will be replaced."""
+    mock_authed_entries.return_value = frozenset({"codex"})
+    with patch("terok.cli.commands.auth.authenticate"):
+        # The alias resolves before the check, so ``openai`` matches the codex entry.
+        _run_one("openai", project_name=None)
+    err = capsys.readouterr().err
+    assert "codex already has a stored credential" in err
+    assert "replaces it" in err
+
+
+def test_run_one_stays_quiet_without_stored_credential(
+    mock_authed_entries: MagicMock, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """No stored credential — and an unreadable vault — produce no replace note."""
+    for auth_state in (frozenset(), None):
+        mock_authed_entries.return_value = auth_state
+        with patch("terok.cli.commands.auth.authenticate"):
+            _run_one("codex", project_name=None)
+        assert "stored credential" not in capsys.readouterr().err
 
 
 def test_run_one_warns_on_stale_image(capsys: pytest.CaptureFixture[str]) -> None:

--- a/tests/unit/tui/test_detail_screens.py
+++ b/tests/unit/tui/test_detail_screens.py
@@ -683,6 +683,38 @@ class TestAuthScreenOptions:
         ids = [opt._stub_kwargs.get("id") for opt in option_list._stub_args if opt is not None]
         assert ids == [f"auth_{name}" for name in AUTH_PROVIDERS] + ["import_opencode_config"]
 
+    def test_auth_screen_badges_authenticated_entries(self) -> None:
+        """Stored-credential entries get their option prompt badged."""
+        from terok_executor import AUTH_PROVIDERS
+
+        screens, _ = import_screens()
+        screen = screens.AuthActionsScreen()
+        option_list = mock.Mock()
+        screen.query_one = mock.Mock(return_value=option_list)
+        screen._show_auth_state(frozenset({"claude"}))
+        option_list.replace_option_prompt.assert_called_once_with(
+            "auth_claude", f"{AUTH_PROVIDERS['claude'].label}  ✓ authenticated"
+        )
+
+    def test_auth_screen_unreadable_vault_flags_subtitle(self) -> None:
+        """``None`` (vault unreadable) flags the state instead of faking 'no auth'."""
+        screens, _ = import_screens()
+        screen = screens.AuthActionsScreen()
+        dialog = mock.Mock()
+        screen.query_one = mock.Mock(return_value=dialog)
+        screen._show_auth_state(None)
+        assert "vault locked" in dialog.border_subtitle
+
+    def test_auth_screen_scopes_badge_query_to_project(self) -> None:
+        """The modal's project scope drives the vault badge query."""
+        screens, _ = import_screens()
+        screen = screens.AuthActionsScreen("myproj")
+        with mock.patch(
+            "terok.lib.api.agents.authenticated_entries", return_value=frozenset()
+        ) as mock_authed:
+            screen._fetch_auth_state()
+        mock_authed.assert_called_once_with("myproj")
+
     def test_opencode_config_screen_construction(self) -> None:
         """Verify OpenCodeConfigScreen can be instantiated."""
         screens, _ = import_screens()


### PR DESCRIPTION
Follow-ups to #1191 (this commit was originally pushed to that branch after the squash-merge, so it's re-landed here on its own PR).

## What

**1. The TUI auth modal shows the same `✓ authenticated` badge as the CLI menu.**

- The vault lookup does keyring + SQLCipher I/O, so it runs in a `thread=True` worker started from `on_mount` (same pattern as `ShieldStatusScreen`); badges are applied via `OptionList.replace_option_prompt` when the result lands. The modal renders instantly and the UI thread never blocks on vault access.
- An unreadable vault (fresh install, sealed) is flagged in the border subtitle ("vault locked — auth state unknown") instead of presenting every entry as unauthenticated.
- The badge query follows the fronted flow's credential scope: host-wide from the app-level modal, the project's credential set when opened from project details (matching `_run_auth_flow(provider, current_project_name)`).

**2. Single-shot `terok auth <provider>` prints a replace heads-up.** When the resolved entry already holds a stored credential: `Note: codex already has a stored credential — completing this flow replaces it.` on stderr (alias-resolved, so `terok auth openai` names `codex`). Silent when nothing is stored or the vault is unreadable.

## Verification

- `make check` green (2930 unit tests).
- Live in-container: the CLI note fires after `store_api_key`; a headless Textual pilot run shows `Claude  ✓ authenticated` in the modal once the worker completes.
- Tests: badge application, unreadable-vault subtitle, project scoping of the badge query, replace-note (including alias resolution) and its silent paths. The CLI test file now uses an autouse fixture so no unit test can reach a real vault.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Enhancements**
  - Authentication menus now show stored-credential badges scoped to the selected project.
  - Re-authenticating an existing credential now displays a warning that the credential will be replaced.
  - The authentication dialog now clearly reports when credential status is unavailable due to a locked vault.
  - Authentication provider lists now show authenticated-state indicators when available.
- **Documentation**
  - Updated authentication documentation to reflect project-scoped badge behavior and vault-locked handling.
- **Tests**
  - Expanded and centralized unit coverage for scoped badge logic, unreadable-vault messaging, and re-authentication warnings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->