### PR TITLE
fix(acp): READY classification never matched after the vault's v3 re-keying

### DIFF
--- a/src/terok/lib/domain/auth.py
+++ b/src/terok/lib/domain/auth.py
@@ -124,16 +124,33 @@ def resolve_credential_routing(project_name: str | None) -> tuple[Path, str]:
     return mounts_dir, project.credential_set
 
 
+def stored_credential_entries(credential_set: str) -> frozenset[str]:
+    """Auth entries whose credential is already stored in *credential_set*.
+
+    The vault keys credentials by the provider they authenticate to
+    (``anthropic``, ``github`` — terok-sandbox's v3 re-keying), while image
+    labels, rosters, and listings all speak in auth-entry / agent names
+    (``claude``, ``gh``).  This is the single translation point between the
+    two vocabularies: any code comparing vault contents against agent names
+    must go through here — intersecting raw vault keys with agent names is
+    provably always empty for every renamed provider.
+
+    Vault errors (e.g. [`NoPassphraseError`][terok_sandbox.NoPassphraseError])
+    propagate — callers own the unreadable-vault policy.
+    """
+    stored = set(list_authenticated_agents(scope=credential_set))
+    return frozenset(entry for entry in AUTH_PROVIDERS if credential_provider(entry) in stored)
+
+
 def authenticated_entries(project_name: str | None = None) -> frozenset[str] | None:
     """Auth entries that already hold a stored credential, or ``None`` when unknowable.
 
-    The vault stores credentials under provider keys (``anthropic``, ``github``);
-    this maps them back onto the auth entries that write them (``claude``,
-    ``gh``) so listings can badge already-authenticated entries.  The queried
-    credential set follows the same routing as
-    [`authenticate`][terok.lib.domain.auth.authenticate]: the host-wide bucket
+    Resolves the credential set with the same routing as
+    [`authenticate`][terok.lib.domain.auth.authenticate] — the host-wide bucket
     for ``project_name=None`` and shared-scope projects, the project's private
-    set for ``credentials.scope: project``.
+    set for ``credentials.scope: project`` — then maps the stored vault keys
+    back to entry names via
+    [`stored_credential_entries`][terok.lib.domain.auth.stored_credential_entries].
 
     Returns ``None`` when the vault cannot be read — not yet provisioned,
     sealed, or unlocking with a stale passphrase.  ``terok auth`` is often the
@@ -145,10 +162,9 @@ def authenticated_entries(project_name: str | None = None) -> frozenset[str] | N
 
     _, credential_set = resolve_credential_routing(project_name)
     try:
-        stored = set(list_authenticated_agents(scope=credential_set))
+        return stored_credential_entries(credential_set)
     except (NoPassphraseError, WrongPassphraseError):
         return None
-    return frozenset(entry for entry in AUTH_PROVIDERS if credential_provider(entry) in stored)
 
 
 def authenticate(
@@ -348,4 +364,5 @@ __all__ = [
     "find_host_auth_image",
     "resolve_auth_provider",
     "resolve_credential_routing",
+    "stored_credential_entries",
 ]

--- a/src/terok/lib/domain/project.py
+++ b/src/terok/lib/domain/project.py
@@ -54,7 +54,6 @@ from terok.lib.integrations.executor import (
     AGENTS_LABEL,
     ACPEndpointStatus,
     get_agent,
-    list_authenticated_agents,
     resolve_instructions,
 )
 from terok.lib.integrations.sandbox import GitGate, SSHManager
@@ -88,6 +87,7 @@ from ..orchestration.tasks import (
     task_new,
 )
 from ..util.fs import archive_timestamp, create_archive_file
+from .auth import stored_credential_entries
 from .task import Task
 from .vault import vault_db
 
@@ -332,8 +332,12 @@ def _task_has_any_authed_agent(
 
     The image label is the source of truth for "what agents could this
     task run"; intersecting with the live auth set tells us whether
-    ``acp connect`` would succeed.  Empty image labels surface as
-    ``unsupported`` rather than failing at connect time — that case
+    ``acp connect`` would succeed.  *authed* must therefore contain
+    auth-entry / agent names (``claude``, ``gh``) as produced by
+    [`stored_credential_entries`][terok.lib.domain.auth.stored_credential_entries]
+    — never raw vault provider keys (``anthropic``, ``github``), which
+    the label's vocabulary can never match.  Empty image labels surface
+    as ``unsupported`` rather than failing at connect time — that case
     is real for legacy task images pre-dating the agents label.
 
     *sandbox* and *label_cache* are threaded through from the listing
@@ -728,7 +732,10 @@ class Project:
         # ``credentials.scope: project`` reads its own vault row, not
         # the host-wide bucket — otherwise its tasks would be reported
         # READY on host-wide creds the container will never see.
-        authed = set(list_authenticated_agents(scope=self._config.credential_set))
+        # ``stored_credential_entries`` translates the vault's provider
+        # keys (anthropic, github) into the agent names the image label
+        # speaks — raw vault keys never intersect the label.
+        authed = set(stored_credential_entries(self._config.credential_set))
         sandbox = Sandbox(config=make_sandbox_config())
         label_cache: dict[str, set[str]] = {}
         out: list[ACPEndpoint] = []

--- a/tach.toml
+++ b/tach.toml
@@ -273,6 +273,7 @@ depends_on = [
 path = "terok.lib.domain.project"
 layer = "domain"
 depends_on = [
+    "terok.lib.domain.auth",
     "terok.lib.orchestration.agent_config",
     "terok.lib.orchestration.image",
     "terok.lib.domain.project_state",
@@ -966,10 +967,12 @@ from = ["terok.lib.domain.ssh"]
 expose = [
     "auth_provider_aliases",
     "authenticate",
+    "authenticated_entries",
     "available_auth_modes",
     "find_host_auth_image",
     "resolve_auth_provider",
     "resolve_credential_routing",
+    "stored_credential_entries",
 ]
 from = ["terok.lib.domain.auth"]
 

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -166,18 +166,28 @@ def _stub_credential_db(tmp_path_factory: pytest.TempPathFactory) -> Iterator[No
     a SQLCipher file with a known test passphrase — tests that mock
     deeper (``cfg.open_credential_db.return_value = MagicMock()``)
     override this stub.
+
+    The stub mirrors the real signature — ``open_credential_db(db_path=None,
+    *, prompt_on_tty=False)`` — because callers like
+    [`list_authenticated_agents`][terok_executor.list_authenticated_agents]
+    pass ``db_path`` positionally; a keyword-only stub raises ``TypeError``
+    on exactly the vault-backed code paths tests need to exercise.  The
+    ``db_path`` override is deliberately ignored: every test reads and
+    writes the one per-session vault file.
     """
     from terok_sandbox import CredentialDB
 
     db_path = tmp_path_factory.mktemp("unit-vault") / "credentials.db"
     test_passphrase = "unit-test-passphrase"  # nosec: B105 — fixture, not a real secret
 
-    def _open(*, prompt_on_tty: bool = False) -> CredentialDB:
+    def _open(_db_path: Path | None = None, *, prompt_on_tty: bool = False) -> CredentialDB:
         return CredentialDB(db_path, passphrase=test_passphrase)
 
     with patch(
         "terok_sandbox.config.SandboxConfig.open_credential_db",
-        new=lambda self, *, prompt_on_tty=False: _open(prompt_on_tty=prompt_on_tty),
+        new=lambda self, db_path=None, *, prompt_on_tty=False: _open(
+            db_path, prompt_on_tty=prompt_on_tty
+        ),
     ):
         yield
 

--- a/tests/unit/lib/domain/test_acp_endpoints.py
+++ b/tests/unit/lib/domain/test_acp_endpoints.py
@@ -7,12 +7,15 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
+from types import SimpleNamespace
 from unittest import mock
 
+import pytest
 from terok_executor import ACPEndpointStatus
 
 from terok.lib.domain.project import (
     ACPEndpoint,
+    Project,
     _read_bound_agent,
     _task_has_any_authed_agent,
 )
@@ -114,6 +117,95 @@ class TestTaskHasAnyAuthedAgent:
                 )
                 is False
             )
+
+
+class TestAuthedVocabulary:
+    """The auth set fed to the intersection must speak the image label's language.
+
+    The vault keys credentials by provider (``anthropic`` — sandbox's v3
+    re-keying); image labels list agent names (``claude``).  These tests pin
+    the whole pipeline against the *real* storage path — a hand-built authed
+    set can't catch a vocabulary drift between the two sibling packages.
+    """
+
+    def test_stored_credential_surfaces_under_agent_name(self) -> None:
+        """A credential stored the way ``terok auth`` stores it maps back to the agent name."""
+        from terok_executor import store_api_key
+
+        from terok.lib.domain.auth import stored_credential_entries
+
+        store_api_key("claude", "sk-unit-test")  # real path: lands under 'anthropic'
+        entries = stored_credential_entries("default")
+        assert "claude" in entries
+        assert "anthropic" not in entries  # vault vocabulary must not leak through
+
+    @pytest.mark.parametrize(
+        ("agent", "expected_vault_key"),
+        [("claude", "anthropic"), ("codex", "openai"), ("gh", "github")],
+    )
+    def test_vault_stores_under_provider_key(self, agent: str, expected_vault_key: str) -> None:
+        """Pin the executor-side keying this module's translation depends on.
+
+        If a future sibling release changes how credentials are keyed, this
+        fails loudly here instead of silently emptying the READY intersection.
+        """
+        from terok_executor import credential_provider
+
+        assert credential_provider(agent) == expected_vault_key
+
+    def test_running_task_with_stored_credential_is_ready(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """End-to-end regression for the v3 re-keying bug: READY must survive it.
+
+        Stores a claude credential through the executor's real storage path
+        (vault key ``anthropic``), then lists endpoints for a running task
+        whose image label declares ``claude``.  Before the fix the raw vault
+        key was intersected with the label and the endpoint degraded to
+        ``unsupported`` despite valid auth.
+        """
+        from terok_executor import store_api_key
+
+        store_api_key("claude", "sk-unit-test")
+        monkeypatch.setenv("XDG_RUNTIME_DIR", str(tmp_path))  # no live socket anywhere
+        project = Project(
+            SimpleNamespace(name="proj", security_class="online", credential_set="default")  # type: ignore[arg-type]
+        )
+        task = _FakeTask("t1", mode="cli")
+        with (
+            mock.patch.object(Project, "list_tasks", return_value=[task]),
+            mock.patch("terok.lib.domain.project.make_sandbox_config"),
+            mock.patch("terok.lib.integrations.sandbox.Sandbox"),
+            # Label side pinned to its real vocabulary: agent names, as
+            # written by the executor's L1 build into ``ai.terok.agents``.
+            mock.patch(
+                "terok.lib.domain.project._image_agents_for_task",
+                return_value={"claude", "gh"},
+            ),
+        ):
+            (endpoint,) = project.acp_endpoints()
+        assert endpoint.status is ACPEndpointStatus.READY
+
+    def test_running_task_without_credential_stays_unsupported(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """Empty vault ⇒ the same task classifies as ``unsupported``, not READY."""
+        monkeypatch.setenv("XDG_RUNTIME_DIR", str(tmp_path))
+        project = Project(
+            SimpleNamespace(name="proj", security_class="online", credential_set="default")  # type: ignore[arg-type]
+        )
+        task = _FakeTask("t1", mode="cli")
+        with (
+            mock.patch.object(Project, "list_tasks", return_value=[task]),
+            mock.patch("terok.lib.domain.project.make_sandbox_config"),
+            mock.patch("terok.lib.integrations.sandbox.Sandbox"),
+            mock.patch(
+                "terok.lib.domain.project._image_agents_for_task",
+                return_value={"claude", "gh"},
+            ),
+        ):
+            (endpoint,) = project.acp_endpoints()
+        assert endpoint.status is ACPEndpointStatus.UNSUPPORTED
 
 
 class TestACPEndpointDataclass:


### PR DESCRIPTION
## Bug

`terok acp list` can never report a socketless task as **ready** — every authenticated running task shows **unsupported**.

Root cause is a vocabulary mismatch between two sibling packages:

- terok-sandbox's **v2→v3 vault migration** re-keyed credentials from agent names to the providers they authenticate to (`_PROVIDER_RENAMES`: claude→anthropic, codex→openai, vibe→mistral, gh→github, glab→gitlab, sonar→sonarcloud), and all new writes go through `credential_provider()` to the same keys.
- `Project.acp_endpoints` intersected those **raw vault keys** with the image's `ai.terok.agents` label, which lists **agent names**.

The intersection is provably empty for every ACP-capable agent (claude/codex/vibe renamed; copilot/opencode never store anything), so READY was unreachable. The intersection code (#888, 2026-05-06) predates the re-keying and was correct for the old vault vocabulary; the sibling migration broke it silently. Reproduction:

```
vault returns:   {'anthropic'}
label declares:  {'claude', 'codex', 'opencode', 'gh'}
intersection:    set()   →  READY unreachable
```

Display-only blast radius: `acp connect` doesn't gate on this, and `environment.py`'s use of the same query only checks emptiness.

## Fix

New `stored_credential_entries(credential_set)` in the auth domain — the **single** vault-key→agent-name translation point (`authenticated_entries` now delegates to it, keeping its unreadable-vault→`None` policy on top). `acp_endpoints` routes its auth set through it; `_task_has_any_authed_agent`'s docstring now states the required vocabulary explicitly.

## Tests that would have caught this

The pre-existing intersection tests hand-built `authed={'claude'}` — enshrining the assumption instead of checking it. The new `TestAuthedVocabulary` pins the pipeline against the **real storage path**:

- `store_api_key('claude', …)` into a real SQLCipher vault (lands under `anthropic`) → `stored_credential_entries('default')` must yield `claude`, and the vault key must not leak through.
- End-to-end: same real store + running task whose label declares `claude` → `acp_endpoints()` must classify READY (plus the empty-vault → unsupported counterpart).
- A parametrized pin of the executor-side keying (claude→anthropic, codex→openai, gh→github) so a future re-keying fails loudly here instead of silently emptying the intersection again.

Verified both vault-backed tests **fail on master** and pass with the fix.

Enabling fix along the way: the unit conftest's credential-DB stub used a keyword-only lambda, so `list_authenticated_agents`'s positional `db_path` raised `TypeError` — no unit test could ever drive this pipeline for real. The stub now mirrors the real `open_credential_db(db_path=None, *, prompt_on_tty=False)` signature.

Also: `tach.toml` gains the `domain.project → domain.auth` edge and exposes `stored_credential_entries` / `authenticated_entries` on the domain.auth interface.

`make check` green — 2967 unit tests, lint, tach, import-linter, docstrings, reuse, bandit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)