### PR TITLE
docs: baked NVIDIA userland recipe; old-podman seccomp gotcha

### DIFF
--- a/docs/custom-images.md
+++ b/docs/custom-images.md
@@ -99,6 +99,40 @@ userlands — the wizard offers the common ones directly, and all three
 vendors' images are on the autodetection allowlist above.  See
 [GPU Passthrough](usage.md#gpu-passthrough) for granting the hardware.
 
+### Baking the NVIDIA userland (toolkit-less hosts)
+
+On raw-tier NVIDIA hosts (no Container Toolkit, no CDI) the image must
+carry a driver userland matching the host kernel module.  A proven
+snippet for `user_snippet_inline`/`user_snippet_file` — set `NV_DRIVER`
+to the host's driver version (`nvidia-smi` shows it):
+
+```dockerfile
+ENV NV_DRIVER=595.71.05
+RUN su dev -c 'cd /tmp \
+        && curl -fLO https://us.download.nvidia.com/tesla/$NV_DRIVER/NVIDIA-Linux-x86_64-$NV_DRIVER.run \
+        && sh NVIDIA-Linux-x86_64-$NV_DRIVER.run -x' \
+    && cd /tmp/NVIDIA-Linux-x86_64-$NV_DRIVER \
+    && install -D -m755 -t /usr/lib64/nvidia \
+        libcuda.so.$NV_DRIVER libnvidia-ml.so.$NV_DRIVER libnvidia-ptxjitcompiler.so.$NV_DRIVER \
+    && install -m755 nvidia-smi /usr/local/bin/ \
+    && ldconfig -n /usr/lib64/nvidia \
+    && ln -s libcuda.so.$NV_DRIVER /usr/lib64/nvidia/libcuda.so \
+    && rm -rf /tmp/NVIDIA-Linux-x86_64-$NV_DRIVER* \
+    && printf '%s\n' \
+        'if [ -e /dev/nvidiactl ] && ! ldconfig -p | grep -q "libcuda\.so\.1"; then' \
+        '    export LD_LIBRARY_PATH=/usr/lib64/nvidia${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}' \
+        'fi' \
+        > /etc/profile.d/nvidia-baked-fallback.sh
+```
+
+Notes: the profile.d guard prefers a host-injected userland when one
+appears (installing the toolkit later needs no rebuild); the extraction
+runs as `dev` deliberately — see
+[Building on old podman hosts](#building-on-old-podman-hosts-seccomp);
+and the baked version is **locked to the host driver** — a host driver
+upgrade requires bumping `NV_DRIVER` and rebuilding.  Installing the
+NVIDIA Container Toolkit (CDI) removes this whole requirement.
+
 ### Building on old podman hosts (seccomp)
 
 Old podman releases (Ubuntu 22.04's 3.4 era) ship a seccomp profile

--- a/docs/custom-images.md
+++ b/docs/custom-images.md
@@ -99,6 +99,30 @@ userlands — the wizard offers the common ones directly, and all three
 vendors' images are on the autodetection allowlist above.  See
 [GPU Passthrough](usage.md#gpu-passthrough) for granting the hardware.
 
+### Building on old podman hosts (seccomp)
+
+Old podman releases (Ubuntu 22.04's 3.4 era) ship a seccomp profile
+that returns `EPERM` — instead of `ENOSYS` — for syscalls newer than
+the profile.  glibc falls back gracefully on `ENOSYS` but treats
+`EPERM` as a real denial, so modern userlands inside the container can
+fail in surprising, often root-only ways (observed: NVIDIA's `.run`
+extractor dying in its permission sweep because root paths call
+`fchmodat2`).  Per-user fix on such hosts: drop a current
+[containers seccomp.json](https://github.com/containers/common/blob/main/pkg/seccomp/seccomp.json)
+somewhere stable and point at it in
+`~/.config/containers/containers.conf`:
+
+```toml
+[containers]
+seccomp_profile = "/home/<you>/.config/containers/seccomp.json"
+```
+
+The profile is read at container *creation* — recreate containers (and
+rerun builds) after changing it; restarts keep the old profile.
+Workarounds when you cannot touch the host config: run the failing
+build step as a non-root user (`su dev -c '…'`), whose code paths often
+avoid the new syscalls.
+
 ### Private registries
 
 Registry hosts and ports are handled (`localhost:5000/fedora:44`

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -1127,39 +1127,9 @@ image:
   # base_image: intel/oneapi-basekit:latest                         # Intel oneAPI/SYCL
 ```
 
-#### Baking the NVIDIA userland (toolkit-less hosts)
-
-On raw-tier NVIDIA hosts (no Container Toolkit, no CDI) the image must
-carry a driver userland matching the host kernel module.  A proven
-snippet for `user_snippet_inline`/`user_snippet_file` — set `NV_DRIVER`
-to the host's driver version (`nvidia-smi` shows it):
-
-```dockerfile
-ENV NV_DRIVER=595.71.05
-RUN su dev -c 'cd /tmp \
-        && curl -fLO https://us.download.nvidia.com/tesla/$NV_DRIVER/NVIDIA-Linux-x86_64-$NV_DRIVER.run \
-        && sh NVIDIA-Linux-x86_64-$NV_DRIVER.run -x' \
-    && cd /tmp/NVIDIA-Linux-x86_64-$NV_DRIVER \
-    && install -D -m755 -t /usr/lib64/nvidia \
-        libcuda.so.$NV_DRIVER libnvidia-ml.so.$NV_DRIVER libnvidia-ptxjitcompiler.so.$NV_DRIVER \
-    && install -m755 nvidia-smi /usr/local/bin/ \
-    && ldconfig -n /usr/lib64/nvidia \
-    && ln -s libcuda.so.$NV_DRIVER /usr/lib64/nvidia/libcuda.so \
-    && rm -rf /tmp/NVIDIA-Linux-x86_64-$NV_DRIVER* \
-    && printf '%s\n' \
-        'if [ -e /dev/nvidiactl ] && ! ldconfig -p | grep -q "libcuda\.so\.1"; then' \
-        '    export LD_LIBRARY_PATH=/usr/lib64/nvidia${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}' \
-        'fi' \
-        > /etc/profile.d/nvidia-baked-fallback.sh
-```
-
-Notes: the profile.d guard prefers a host-injected userland when one
-appears (installing the toolkit later needs no rebuild); the extraction
-runs as `dev` deliberately — see the seccomp note in
-[Custom Base Images](custom-images.md#building-on-old-podman-hosts-seccomp);
-and the baked version is **locked to the host driver** — a host driver
-upgrade requires bumping `NV_DRIVER` and rebuilding.  Installing the
-NVIDIA Container Toolkit (CDI) removes this whole requirement.
+For raw-tier NVIDIA hosts (no toolkit, no CDI) the image must carry a
+matching driver userland — a proven recipe lives in
+[Custom Base Images](custom-images.md#baking-the-nvidia-userland-toolkit-less-hosts).
 
 ### Selecting GPUs inside the container
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -1127,6 +1127,40 @@ image:
   # base_image: intel/oneapi-basekit:latest                         # Intel oneAPI/SYCL
 ```
 
+#### Baking the NVIDIA userland (toolkit-less hosts)
+
+On raw-tier NVIDIA hosts (no Container Toolkit, no CDI) the image must
+carry a driver userland matching the host kernel module.  A proven
+snippet for `user_snippet_inline`/`user_snippet_file` — set `NV_DRIVER`
+to the host's driver version (`nvidia-smi` shows it):
+
+```dockerfile
+ENV NV_DRIVER=595.71.05
+RUN su dev -c 'cd /tmp \
+        && curl -fLO https://us.download.nvidia.com/tesla/$NV_DRIVER/NVIDIA-Linux-x86_64-$NV_DRIVER.run \
+        && sh NVIDIA-Linux-x86_64-$NV_DRIVER.run -x' \
+    && cd /tmp/NVIDIA-Linux-x86_64-$NV_DRIVER \
+    && install -D -m755 -t /usr/lib64/nvidia \
+        libcuda.so.$NV_DRIVER libnvidia-ml.so.$NV_DRIVER libnvidia-ptxjitcompiler.so.$NV_DRIVER \
+    && install -m755 nvidia-smi /usr/local/bin/ \
+    && ldconfig -n /usr/lib64/nvidia \
+    && ln -s libcuda.so.$NV_DRIVER /usr/lib64/nvidia/libcuda.so \
+    && rm -rf /tmp/NVIDIA-Linux-x86_64-$NV_DRIVER* \
+    && printf '%s\n' \
+        'if [ -e /dev/nvidiactl ] && ! ldconfig -p | grep -q "libcuda\.so\.1"; then' \
+        '    export LD_LIBRARY_PATH=/usr/lib64/nvidia${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}' \
+        'fi' \
+        > /etc/profile.d/nvidia-baked-fallback.sh
+```
+
+Notes: the profile.d guard prefers a host-injected userland when one
+appears (installing the toolkit later needs no rebuild); the extraction
+runs as `dev` deliberately — see the seccomp note in
+[Custom Base Images](custom-images.md#building-on-old-podman-hosts-seccomp);
+and the baked version is **locked to the host driver** — a host driver
+upgrade requires bumping `NV_DRIVER` and rebuilding.  Installing the
+NVIDIA Container Toolkit (CDI) removes this whole requirement.
+
 ### Selecting GPUs inside the container
 
 Prefer selecting at the terok level (`gpus: "amd:1"`) — the container


### PR DESCRIPTION
Promotes two learnings from the mixed-GPU hardware passes into docs:

- **GPU Passthrough** gains the proven toolkit-less NVIDIA recipe (baked userland parameterized by `ENV NV_DRIVER`, profile.d guard that automatically prefers a host-injected userland if the toolkit arrives later, explicit driver-lockstep caveat, non-root extraction).
- **Custom Base Images** gains the old-podman seccomp gotcha: pre-4.x profiles answer unknown syscalls with `EPERM` instead of `ENOSYS`, which glibc does not fall back from — modern userlands fail in surprising root-only ways (`fchmodat2` class). Documents the per-user `containers.conf` `seccomp_profile` fix and that it applies at container creation.

Docs-only; no pins, no code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)