### PR TITLE
fix(tui): GPU modal and SSH-key panel degrade gracefully on small terminals

### DIFF
--- a/src/terok/tui/gpu_screen.py
+++ b/src/terok/tui/gpu_screen.py
@@ -30,6 +30,7 @@ _GPU_ALL = "all"  # nosec: B105 — selector token, not a secret
 _MASTER_ID = "gpu-select-all"
 _ERROR_ID = "gpu-select-error"
 _DEVICES_ID = "gpu-select-devices"
+_SCROLL_ID = "gpu-select-scroll"
 _CUSTOM_ID = "gpu-select-custom"
 _PROBE_NOTE_ID = "gpu-select-probe-note"
 
@@ -61,7 +62,7 @@ class GpuSelectScreen(ModalScreen[str | None]):
         width: 70;
         max-width: 100%;
         height: auto;
-        max-height: 90%;
+        max-height: 100%;
         border: heavy $primary;
         border-title-align: right;
         background: $surface;
@@ -69,14 +70,30 @@ class GpuSelectScreen(ModalScreen[str | None]):
     }
 
     #gpu-select-scroll {
-        height: auto;
-        max-height: 16;
+        /* Explicit height, updated from content when detection lands —
+           an auto-height VerticalScroll greedily takes its max, which
+           in turn inflates the auto-sized dialog to the full screen. */
+        height: 3;
+        max-height: 8;
     }
 
     .gpu-select-list {
         border: round $primary-darken-2;
         padding: 0 1;
         height: auto;
+    }
+
+    /* Compact one-row toggles: the default bordered Checkbox is three
+       rows tall, which overflows small terminals and the scroll cap. */
+    GpuSelectScreen Checkbox {
+        border: none;
+        padding: 0 1;
+        height: auto;
+    }
+
+    GpuSelectScreen Checkbox:focus {
+        text-style: bold;
+        background: $boost;
     }
 
     .gpu-select-master {
@@ -86,7 +103,6 @@ class GpuSelectScreen(ModalScreen[str | None]):
     .gpu-select-help {
         color: $text-muted;
         height: auto;
-        margin-bottom: 1;
     }
 
     .gpu-select-error {
@@ -122,12 +138,10 @@ class GpuSelectScreen(ModalScreen[str | None]):
         dialog.border_title = "GPU passthrough"
         with dialog:
             yield Label(
-                "Pick 'All detected GPUs' to pass through every vendor the "
-                "host supports, or select individual devices.  Mixed setups "
-                "beyond what's listed can be typed as a custom selector.",
+                "Pass through all detected GPUs, or pick devices.",
                 classes="gpu-select-help",
             )
-            with VerticalScroll(id="gpu-select-scroll"):
+            with VerticalScroll(id=_SCROLL_ID):
                 with Vertical(classes="gpu-select-list"):
                     yield Checkbox(
                         "All detected GPUs",
@@ -141,9 +155,7 @@ class GpuSelectScreen(ModalScreen[str | None]):
                         yield Label(
                             "Detecting devices…", id=_PROBE_NOTE_ID, classes="gpu-select-help"
                         )
-            yield Label(
-                "Custom selector (optional, wins over checkboxes):", classes="gpu-select-help"
-            )
+            yield Label("Custom selector (wins over checkboxes):", classes="gpu-select-help")
             yield Input(
                 value="",
                 placeholder='e.g. "nvidia:0,amd" — vendors or vendor:N devices',
@@ -180,6 +192,9 @@ class GpuSelectScreen(ModalScreen[str | None]):
                     name=choice.token,
                 )
             )
+        # Master + rule + one row per device (compact checkboxes), capped
+        # by the stylesheet's max-height; scrolls only past the cap.
+        self.query_one(f"#{_SCROLL_ID}").styles.height = 2 + len(choices)
         known = {c.token for c in choices}
         self._pending_tokens -= known
         self._spill_pending_to_custom()

--- a/src/terok/tui/wizard_screens.py
+++ b/src/terok/tui/wizard_screens.py
@@ -653,9 +653,14 @@ class InitProgressScreen(ModalScreen[InitOutcome]):
         height: auto;
         border: round $warning;
         background: $surface;
-        padding: 1;
+        padding: 0 1;
         margin-bottom: 1;
         display: none;
+    }
+
+    #wizard-init-ssh-buttons {
+        height: auto;
+        margin-top: 1;
     }
 
     .wizard-init-ssh-spacer {
@@ -1016,11 +1021,13 @@ class InitProgressScreen(ModalScreen[InitOutcome]):
                 # the raw text the way TextArea.text does.
                 self._ssh_pub_line = result["public_line"]
                 self.query_one("#wizard-init-ssh-key").styles.display = "block"
+                self._apply_ssh_layout()
                 log.write(
                     "[yellow]Register the public key on the git remote, then click Continue.[/]"
                 )
                 await self._ssh_continue.wait()
                 self.query_one("#wizard-init-ssh-key").styles.display = "none"
+                self._apply_ssh_layout()
 
             # Silent stdout capture — the facade's summarise/print lines
             # land in the log instead of the terminal.  podman subprocess
@@ -1095,6 +1102,28 @@ class InitProgressScreen(ModalScreen[InitOutcome]):
         # ``_run_init_with_confirm`` finally — keeping it there prevents
         # the button from flashing enabled then disabled between the
         # two coroutines.
+
+    _SSH_COMPACT_HEIGHT = 30
+    """Terminal rows below which the SSH panel claims the log's space."""
+
+    def on_resize(self) -> None:
+        """Re-evaluate the SSH panel's space claim when the terminal changes."""
+        with contextlib.suppress(NoMatches):
+            self._apply_ssh_layout()
+
+    def _apply_ssh_layout(self) -> None:
+        """Give the SSH key panel room on short terminals — reactively.
+
+        While the panel is visible on a small screen, the log pane and
+        the Close row (disabled during init anyway) yield their rows and
+        the dialog stretches to the full height; everything returns when
+        the panel hides or the terminal grows.
+        """
+        panel = self.query_one("#wizard-init-ssh-key")
+        compact = panel.styles.display == "block" and self.size.height < self._SSH_COMPACT_HEIGHT
+        self.query_one("#wizard-init-log").display = not compact
+        self.query_one("#wizard-init-buttons").display = not compact
+        self.query_one("#wizard-init-dialog").styles.height = "100%" if compact else "80%"
 
     # ── Button handlers ───────────────────────────────────────────────
 

--- a/src/terok/tui/wizard_screens.py
+++ b/src/terok/tui/wizard_screens.py
@@ -709,6 +709,7 @@ class InitProgressScreen(ModalScreen[InitOutcome]):
         self._project_name = project_name
         self._rendered_yaml = rendered_yaml
         self._ssh_continue: Any = None  # an asyncio.Event, set when user clicks continue
+        self._running_step: str | None = None  # step key currently in "running" state
         # Default pessimistic — the worker flips this to SUCCESS on a clean
         # finish, DECLINED when the user opts out of overwriting, and leaves
         # it on FAILED when a step raises.
@@ -895,6 +896,10 @@ class InitProgressScreen(ModalScreen[InitOutcome]):
         return f"wizard-init-step-{key}"
 
     def _mark(self, key: str, status: str, detail: str = "") -> None:
+        # Track the in-flight step in state rather than reading it back
+        # out of the widget — Static's rendered-content attribute has
+        # changed names across Textual releases.
+        self._running_step = key if status == "running" else None
         self.query_one(f"#{self._step_id(key)}", Static).update(
             self._step_text(key, status, detail)
         )
@@ -1092,12 +1097,8 @@ class InitProgressScreen(ModalScreen[InitOutcome]):
             # out of the worker and vanishing silently.
             log.write(f"[red]Error: {exc}[/]")
             # Mark the currently-running step failed (whichever one raised).
-            for key in self._STEP_KEYS:
-                widget = self.query_one(f"#{self._step_id(key)}", Static)
-                # `renderable` is on Static at runtime but missing from textual stubs.
-                if "⋯" in str(widget.renderable):  # type: ignore[attr-defined]
-                    self._mark(key, "failed", str(exc))
-                    break
+            if self._running_step is not None:
+                self._mark(self._running_step, "failed", str(exc))
         # Close-button enabling is consolidated in the outer
         # ``_run_init_with_confirm`` finally — keeping it there prevents
         # the button from flashing enabled then disabled between the

--- a/tests/unit/tui/test_gpu_screen.py
+++ b/tests/unit/tui/test_gpu_screen.py
@@ -168,6 +168,34 @@ async def test_apply_before_detection_keeps_initial_tokens() -> None:
 
 
 @pytest.mark.asyncio
+async def test_fits_80x24_terminal() -> None:
+    """The whole modal — device list through Apply — fits an 80x24 screen.
+
+    Guards the compact-checkbox layout: the default three-row toggles
+    pushed the buttons off-screen (pilot clicks then raise OutOfBounds).
+    """
+    with _detected(_TRI_HOST):
+        app = _Host(GpuSelectScreen())
+        async with app.run_test(size=(80, 24)) as pilot:
+            await pilot.pause()
+            assert app.screen.query_one("#gpu-select-item-3", Checkbox).region.height == 1
+            await pilot.click("#gpu-select-apply")
+            await pilot.pause()
+    assert app.result == "all"
+
+
+@pytest.mark.asyncio
+async def test_dialog_hugs_content_on_large_terminals() -> None:
+    """No blank tail: the dialog auto-sizes to its content, not the screen."""
+    with _detected(_TRI_HOST):
+        app = _Host(GpuSelectScreen())
+        async with app.run_test(size=(120, 44)) as pilot:
+            await pilot.pause()
+            dialog = app.screen.query_one("#gpu-select-dialog")
+            assert dialog.region.height < 30
+
+
+@pytest.mark.asyncio
 async def test_cancel_returns_none() -> None:
     """Cancel dismisses with ``None`` — caller keeps the previous value."""
     with _detected(()):

--- a/tests/unit/tui/test_wizard_screens.py
+++ b/tests/unit/tui/test_wizard_screens.py
@@ -537,6 +537,34 @@ async def test_init_screen_decline_overwrite_distinguishes_from_failure() -> Non
             assert close_button.variant == "default"
 
 
+@pytest.mark.asyncio
+async def test_failed_step_is_marked_without_widget_readback() -> None:
+    """A step failure marks the running step via tracked state.
+
+    Regression: the old path read the step text back through
+    ``Static.renderable``, which newer Textual removed — every init
+    failure then added an 'Unexpected wizard error' line and left the
+    failed step showing the running spinner.
+    """
+    from terok.tui.wizard_screens import InitProgressScreen
+
+    fake_project = MagicMock()
+    fake_project.provision_ssh_key.side_effect = RuntimeError("boom")
+
+    with patch.object(InitProgressScreen, "on_mount", new=AsyncMock()):
+        app = _WizardHost(InitProgressScreen("demo"))
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            screen = app.screen
+            assert isinstance(screen, InitProgressScreen)
+            with patch("terok.lib.api.get_project", return_value=fake_project):
+                await screen._run_init()
+            await pilot.pause()
+            step = str(screen.query_one("#wizard-init-step-ssh", Static).render())
+            assert "boom" in step
+            assert "⋯" not in step
+
+
 # ── Form prefill (Back round-trip preservation) ──────────────────────
 
 

--- a/tests/unit/tui/test_wizard_screens.py
+++ b/tests/unit/tui/test_wizard_screens.py
@@ -417,6 +417,55 @@ def test_touched_wizard_yaml_survives_roundtrip() -> None:
         assert path.read_text() == rendered
 
 
+# ── InitProgressScreen — SSH panel layout ─────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_ssh_panel_usable_on_80x24() -> None:
+    """On short terminals the SSH panel claims the log's rows reactively —
+    the continue button stays on-screen and the panel border closes."""
+    from terok.tui.wizard_screens import InitProgressScreen
+
+    with patch.object(InitProgressScreen, "_run_init_with_confirm", lambda self: None):
+        app = _WizardHost(InitProgressScreen("demo"))
+        async with app.run_test(size=(80, 24)) as pilot:
+            await pilot.pause()
+            screen = app.screen
+            assert isinstance(screen, InitProgressScreen)
+            screen.query_one("#wizard-init-ssh-key").styles.display = "block"
+            screen._apply_ssh_layout()
+            await pilot.pause()
+            assert screen.query_one("#wizard-init-log").display is False
+            cont = screen.query_one("#wizard-init-ssh-continue")
+            assert cont.region.height > 0
+            assert cont.region.y + cont.region.height <= 24
+            panel = screen.query_one("#wizard-init-ssh-key")
+            buttons = screen.query_one("#wizard-init-ssh-buttons")
+            # The panel's bottom border renders below its last child.
+            assert buttons.region.y + buttons.region.height < panel.region.y + panel.region.height
+            screen.query_one("#wizard-init-ssh-key").styles.display = "none"
+            screen._apply_ssh_layout()
+            await pilot.pause()
+            assert screen.query_one("#wizard-init-log").display is True
+
+
+@pytest.mark.asyncio
+async def test_ssh_panel_keeps_log_on_tall_terminals() -> None:
+    """Plenty of rows: the log stays while the panel is up."""
+    from terok.tui.wizard_screens import InitProgressScreen
+
+    with patch.object(InitProgressScreen, "_run_init_with_confirm", lambda self: None):
+        app = _WizardHost(InitProgressScreen("demo"))
+        async with app.run_test(size=(100, 40)) as pilot:
+            await pilot.pause()
+            screen = app.screen
+            assert isinstance(screen, InitProgressScreen)
+            screen.query_one("#wizard-init-ssh-key").styles.display = "block"
+            screen._apply_ssh_layout()
+            await pilot.pause()
+            assert screen.query_one("#wizard-init-log").display is True
+
+
 # ── InitProgressScreen — error paths ──────────────────────────────────
 
 


### PR DESCRIPTION
Three hardware-pass TUI finds, verified by live region probes at 80x24 and large sizes plus regression tests at both.

**GPU picker modal**
- Compact one-row checkboxes (the default bordered toggles are three rows tall — they overflowed the scroll cap, clipping the last device's bottom border even on large terminals, and pushed Off/Cancel/Apply below an 80x24 screen).
- Blank-tail fix: an auto-height `VerticalScroll` greedily takes its `max-height`, which inflates the auto-sized dialog to the full screen. The scroll now gets an explicit height computed from the device count when detection lands (capped, scrolls past the cap).
- Regression tests: Apply clickable at 80x24 (pilot clicks raise OutOfBounds for off-screen targets, so the test is honest) and dialog hugging content on 120x44.

**Init screen SSH-key panel**
- The button row had no height rule — the fr-default `Horizontal` overflowed the auto-height panel, which is why the panel's bottom border never rendered at any size; on 80x24 the Copy/Show/Continue buttons were pushed out entirely.
- Reactive space claim: below 30 rows, while the panel is visible, the log pane and the Close row (disabled during init anyway) yield their rows and the dialog stretches to 100% height; everything restores on continue and re-evaluates on resize.
- Regression tests at 80x24 (continue visible, border closes, log yields and returns) and 100x40 (log stays).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **UI Improvements**
  * Improved GPU selection dialog sizing on compact and large terminals.
  * Simplified GPU passthrough guidance and selector labels.
  * Improved SSH-key panel layout in the project setup wizard.
  * Added responsive resizing behavior for short terminals while preserving log visibility on larger screens.

* **Bug Fixes**
  * Prevented excessive blank space and layout overflow in GPU and SSH panels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->


**Init screen failure marking** (third find): every init failure emitted `Unexpected wizard error: 'Static' object has no attribute 'renderable'` and left the failed step on the running spinner — the except path identified the in-flight step by reading step text back through `Static.renderable`, which newer Textual removed. `_mark` now tracks the running step in state and the failure path uses that; regression test drives a real `_run_init` failure and asserts the step shows the error, not the spinner.