### PR TITLE
fix(tui): agent pickers offer only agents available in the task's image

### DIFF
--- a/src/terok/cli/commands/image.py
+++ b/src/terok/cli/commands/image.py
@@ -179,7 +179,7 @@ def _cmd_build(
         if project is not None:
             resolved_base = base or project.base_image or DEFAULT_BASE_IMAGE
             resolved_family = family or project.family
-            resolved_agents = AgentRoster.parse_selection(agents or ",".join(project.agents))
+            resolved_agents = AgentRoster.parse_selection(agents or project.agents)
         else:
             resolved_base = base or ExecutorConfigView.image_base_image() or DEFAULT_BASE_IMAGE
             resolved_family = family

--- a/src/terok/lib/core/images.py
+++ b/src/terok/lib/core/images.py
@@ -7,7 +7,6 @@ from __future__ import annotations
 
 import hashlib
 import re
-from functools import lru_cache
 from typing import TYPE_CHECKING
 
 from terok.lib.integrations.executor import AGENTS_LABEL
@@ -51,15 +50,15 @@ def project_dev_image(project_name: str) -> str:
     return f"{project_name}:l2-dev"
 
 
-@lru_cache(maxsize=64)
 def installed_agents(image_tag: str) -> frozenset[str]:
     """Return the set of agent names baked into *image_tag*.
 
     Reads the ``ai.terok.agents`` OCI label written by terok-executor's L1
     build (a sorted comma-separated list).  Derived images inherit the
-    label, so an L2 tag answers for the L1 it was built on.  Result is
-    cached per image tag, since the label is fixed for the life of an
-    image.
+    label, so an L2 tag answers for the L1 it was built on.  The label
+    is read fresh on every call — tags are repointed by rebuilds (from
+    this process or another terminal), so caching by tag would leave
+    long-running TUIs showing a previous agent set.
 
     When the image is not present locally, or the label is missing
     (e.g. a legacy image built before selectable agents), returns an

--- a/src/terok/lib/core/images.py
+++ b/src/terok/lib/core/images.py
@@ -56,8 +56,10 @@ def installed_agents(image_tag: str) -> frozenset[str]:
     """Return the set of agent names baked into *image_tag*.
 
     Reads the ``ai.terok.agents`` OCI label written by terok-executor's L1
-    build (a sorted comma-separated list).  Result is cached per image
-    tag, since the label is fixed for the life of an image.
+    build (a sorted comma-separated list).  Derived images inherit the
+    label, so an L2 tag answers for the L1 it was built on.  Result is
+    cached per image tag, since the label is fixed for the life of an
+    image.
 
     When the image is not present locally, or the label is missing
     (e.g. a legacy image built before selectable agents), returns an
@@ -73,41 +75,60 @@ def installed_agents(image_tag: str) -> frozenset[str]:
 
 
 def installed_agents_for_project(project: ProjectConfig) -> frozenset[str]:
-    """Return the agents installed in *project*'s L1 image.
+    """Return the agent names available in the image *project*'s tasks run.
 
-    Convenience over [`installed_agents`][terok.lib.core.images.installed_agents] for the very common
-    ``installed_agents(agent_cli_image(project.base_image))`` pattern.
+    Reads the ``ai.terok.agents`` label from the project's L2 CLI image —
+    the image a new task actually boots, which inherits the label from
+    the (agent-suffixed) L1 it was built on.  The unsuffixed L1 tag
+    ([`agent_cli_image`][terok.lib.core.images.agent_cli_image]) is
+    deliberately not consulted: it is a default alias pointing at the
+    user's *global* default selection, unrelated to what this project's
+    image contains.
+
+    When the L2 image is absent or unlabeled (not built yet, or built
+    before selectable agents), falls back to resolving the project
+    definition's ``image.agents`` selection — the set a rebuild would
+    install.  Only an unresolvable selection yields an empty set;
+    callers treat empty as "unknown / unrestricted".
     """
-    return installed_agents(agent_cli_image(project.base_image))
+    return installed_agents(project_cli_image(project.name)) or _agents_from_selection(
+        project.agents
+    )
 
 
-def is_installed(name: str, image_tag: str) -> bool:
-    """Return whether *name* is baked into *image_tag*.
+def _agents_from_selection(selection: str) -> frozenset[str]:
+    """Resolve an ``image.agents`` selection string into concrete roster names.
 
-    Treats an unknown / unlabeled image (empty [`installed_agents`][terok.lib.core.images.installed_agents]
-    result) as "unrestricted" — every name is considered installed —
-    so legacy images keep working until the user rebuilds.
+    Returns an empty set when the selection names unknown roster entries
+    (a stale or hand-edited project.yml) — an honest "unknown", not a
+    guess.
     """
-    installed = installed_agents(image_tag)
-    return not installed or name in installed
+    from terok.lib.integrations.executor import AgentRoster
+
+    roster = AgentRoster.shared()
+    try:
+        return frozenset(roster.resolve_selection(AgentRoster.parse_selection(selection)))
+    except ValueError:
+        return frozenset()
 
 
 def require_agent_installed(project: ProjectConfig, name: str, *, noun: str = "Agent") -> None:
-    """Fail fast if *name* is not baked into *project*'s L1 image.
+    """Fail fast if *name* is not available in the image *project*'s tasks run.
 
     Used at CLI / TUI / runtime entry points so the user sees a clear,
     actionable message instead of a deep ``command not found`` later.
-    Unlabeled (legacy) images are treated as unrestricted via
-    [`is_installed`][terok.lib.core.images.is_installed].
+    Checks the same source the TUI pickers offer from
+    ([`installed_agents_for_project`][terok.lib.core.images.installed_agents_for_project]),
+    so an agent the picker offered is never rejected here.  An empty
+    (unknown) result is treated as unrestricted.
     """
-    image = agent_cli_image(project.base_image)
-    if is_installed(name, image):
+    available = installed_agents_for_project(project)
+    if not available or name in available:
         return
-    available = ", ".join(sorted(installed_agents(image))) or "(none)"
     raise SystemExit(
-        f"{noun} {name!r} is not installed in the L1 image for "
-        f"project {project.name!r} ({image}).\n"
-        f"Installed: {available}\n"
+        f"{noun} {name!r} is not available in the image for "
+        f"project {project.name!r} ({project_cli_image(project.name)}).\n"
+        f"Available: {', '.join(sorted(available))}\n"
         f"Add it to image.agents and rebuild: "
         f"terok project build --agents {name} {project.name}"
     )

--- a/src/terok/tui/project_actions.py
+++ b/src/terok/tui/project_actions.py
@@ -278,7 +278,6 @@ class ProjectActionsMixin(_MixinBase):
             "terok.tui.worker_actions:build",
             pid,
             title=f"Building images for {pid}",
-            on_complete=self._invalidate_image_caches,
         )
 
     async def action_init_ssh(self) -> None:
@@ -303,7 +302,6 @@ class ProjectActionsMixin(_MixinBase):
             "terok.tui.worker_actions:build_agents",
             pid,
             title=f"Rebuilding {pid} from L1 with fresh agents",
-            on_complete=self._invalidate_image_caches,
         )
 
     async def _action_build_full(self) -> None:
@@ -316,20 +314,7 @@ class ProjectActionsMixin(_MixinBase):
             "terok.tui.worker_actions:build_full",
             pid,
             title=f"Rebuilding {pid} from L0 (no cache)",
-            on_complete=self._invalidate_image_caches,
         )
-
-    @staticmethod
-    def _invalidate_image_caches() -> None:
-        """Drop cached image-label lookups after an in-TUI rebuild.
-
-        The [`installed_agents`][terok.lib.core.images.installed_agents] lru_cache is keyed on the L1 tag,
-        which a rebuild reuses — so without this, the picker would keep
-        showing the previous agent set until the TUI restarts.
-        """
-        from ..lib.api import installed_agents
-
-        installed_agents.cache_clear()
 
     async def _action_project_init(self) -> None:
         """Re-run full project setup: ssh-init, generate, build, gate-sync.
@@ -349,7 +334,6 @@ class ProjectActionsMixin(_MixinBase):
         from .wizard_screens import InitProgressScreen
 
         def _on_init_done(_outcome: object) -> None:
-            self._invalidate_image_caches()
             self._refresh_project_state()
 
         await self.push_screen(InitProgressScreen(self.current_project_name), _on_init_done)

--- a/src/terok/tui/screens.py
+++ b/src/terok/tui/screens.py
@@ -115,9 +115,10 @@ _DETAIL_SCREEN_CSS = """
 def _visible_agents(installed: frozenset[str] | None) -> list[str]:
     """Provider names visible to the user given an *installed* filter.
 
-    Empty/``None`` *installed* (legacy or unlabeled image) → no filtering;
-    every known provider is shown.  Otherwise the registry is intersected
-    with the install set, preserving registry order.
+    Empty/``None`` *installed* (the lookup failed, so the set is
+    unknown) → no filtering; every known provider is shown as a last
+    resort.  Otherwise the registry is intersected with the install
+    set, preserving registry order.
     """
     from terok.lib.api.agents import AGENTS
 
@@ -940,10 +941,12 @@ class AgentSelectionScreen(screen.ModalScreen[str | None]):
         Args:
             default_agent: Name of the project's default agent (pre-highlighted
                 and marked with ``*``).
-            installed: Names baked into the project's L1 image (from the
-                ``ai.terok.agents`` label).  When provided and non-empty,
-                the picker hides agents not in the set.  ``None`` or empty
-                means no filtering — every known agent is shown.
+            installed: Names available in the image the task will run
+                (label of the project's L2 image, or the project
+                definition's ``image.agents`` selection).  When provided
+                and non-empty, the picker hides agents not in the set.
+                ``None`` or empty means the set is unknown — every known
+                agent is shown as a last resort.
         """
         super().__init__()
         self._installed = installed
@@ -1399,14 +1402,15 @@ class TaskLaunchScreen(
     ) -> None:
         """Create the launch screen with container context and default agent.
 
-        *installed* is the set of agents present in the project's L1 image
-        (from the ``ai.terok.agents`` label).  ``None`` means the lookup is
-        still in flight — the agent dropdown renders disabled with only
-        ``bash`` as a placeholder until the caller invokes
+        *installed* is the set of agents available in the image the task
+        will run (label of the project's L2 image, or the project
+        definition's ``image.agents`` selection).  ``None`` means the
+        lookup is still in flight — the agent dropdown renders disabled
+        with only ``bash`` as a placeholder until the caller invokes
         [`set_installed`][terok.tui.screens.TaskLaunchScreen.set_installed]
         with the resolved set.  A non-empty frozenset filters the dropdown
-        to those agents; an empty frozenset means no filter (legacy /
-        unlabeled images) — every known provider is shown.
+        to those agents; an empty frozenset means the set is unknown —
+        every known provider is shown as a last resort.
         """
         super().__init__()
         self._container_name = container_name

--- a/tach.toml
+++ b/tach.toml
@@ -901,7 +901,6 @@ expose = [
     "project_dev_image",
     "installed_agents",
     "installed_agents_for_project",
-    "is_installed",
     "require_agent_installed",
 ]
 from = ["terok.lib.core.images"]

--- a/tests/unit/cli/test_cli_image.py
+++ b/tests/unit/cli/test_cli_image.py
@@ -369,10 +369,12 @@ class TestCmdBuild:
 
         from terok.cli.commands.image import _cmd_build
 
+        # ``agents`` is a plain selection string on ProjectConfig — a list
+        # here would hide a re-join regression ("all" → "a,l,l").
         fake_project = MagicMock(
             base_image="fedora:43",
             family="rpm",
-            agents=["claude", "codex"],
+            agents="claude,codex",
         )
         fake_images = MagicMock(l0="L0", l1="L1")
         with (
@@ -402,6 +404,40 @@ class TestCmdBuild:
         assert kwargs["agents"] is sentinel.RESOLVED_AGENTS
         # Per-project builds must NOT clobber the user's host-wide default tag.
         assert kwargs["tag_as_default"] is False
+
+    def test_project_agents_selection_string_passes_through_verbatim(self) -> None:
+        """The project's ``agents`` string reaches the parser as-is.
+
+        Regression: a ``",".join(project.agents)`` over the *string* field
+        exploded it character-by-character (``"all"`` → ``"a,l,l"``), so
+        every project build without ``--agents`` died with "Unknown
+        roster entries".
+        """
+        from unittest.mock import MagicMock
+
+        from terok.cli.commands.image import _cmd_build
+
+        fake_project = MagicMock(base_image="fedora:43", family="rpm", agents="all")
+        fake_images = MagicMock(l0="L0", l1="L1")
+        with (
+            patch("terok.lib.core.projects.load_project", return_value=fake_project),
+            patch(
+                "terok.lib.integrations.executor.AgentRoster.parse_selection",
+                side_effect=lambda v: v,
+            ) as mock_parse,
+            patch("terok_executor.container.build.build_base_images", return_value=fake_images),
+        ):
+            _cmd_build(
+                project_name="myproj",
+                base=None,
+                agents=None,
+                family=None,
+                rebuild=False,
+                full_rebuild=False,
+                sidecar=False,
+            )
+
+        mock_parse.assert_called_once_with("all")
 
     def test_build_error_exits_cleanly(self) -> None:
         from terok_executor import BuildError

--- a/tests/unit/lib/test_images.py
+++ b/tests/unit/lib/test_images.py
@@ -137,12 +137,6 @@ def test_base_image_functions_reuse_the_same_long_tag() -> None:
 # ── installed_agents / installed_agents_for_project ──────────────────
 
 
-@pytest.fixture(autouse=True)
-def _clear_installed_agents_cache() -> None:
-    """Drop the lru_cache between tests so each test sees a fresh inspect."""
-    images.installed_agents.cache_clear()
-
-
 def _patch_labels(mock_runtime, labels: dict[str, str]) -> None:
     """Configure the autouse ``mock_runtime`` so ``Image.labels()`` returns *labels*.
 
@@ -150,15 +144,11 @@ def _patch_labels(mock_runtime, labels: dict[str, str]) -> None:
     unlabeled images — the distinction doesn't matter for the callers
     under test here.
     """
-    # ``installed_agents`` is ``@lru_cache``-d — clear the cache so each
-    # test sees the patched labels regardless of call order.
-    images.installed_agents.cache_clear()
     mock_runtime.image.return_value.labels.return_value = labels
 
 
 def _patch_labels_by_tag(mock_runtime, labels_by_tag: dict[str, dict[str, str]]) -> None:
     """Configure ``mock_runtime`` so each image tag answers with its own labels."""
-    images.installed_agents.cache_clear()
 
     def _image(tag: str):
         image = MagicMock(name=f"image[{tag}]")
@@ -261,15 +251,17 @@ def test_require_agent_installed_rejects_agent_missing_from_l2_label(mock_runtim
             "my-project:l2-cli": {"ai.terok.agents": "claude"},
         },
     )
+    project = _project()
     with pytest.raises(SystemExit, match="not available in the image"):
-        images.require_agent_installed(_project(), "vibe")
+        images.require_agent_installed(project, "vibe")
 
 
 def test_require_agent_installed_uses_project_selection_when_unlabeled(mock_runtime) -> None:
     _patch_labels(mock_runtime, {})
-    images.require_agent_installed(_project("claude"), "claude")
+    project = _project("claude")
+    images.require_agent_installed(project, "claude")
     with pytest.raises(SystemExit, match="not available in the image"):
-        images.require_agent_installed(_project("claude"), "codex")
+        images.require_agent_installed(project, "codex")
 
 
 def test_require_agent_installed_treats_unknown_set_as_unrestricted(mock_runtime) -> None:

--- a/tests/unit/lib/test_images.py
+++ b/tests/unit/lib/test_images.py
@@ -6,10 +6,13 @@
 from __future__ import annotations
 
 from collections.abc import Callable
+from unittest.mock import MagicMock
 
 import pytest
 
 from terok.lib.core import images
+from terok.lib.core.project_model import ProjectConfig
+from tests.testfs import MOCK_BASE
 
 BASE_IMAGE_FUNCS: list[tuple[Callable[[str], str], str]] = [
     (images.base_dev_image, "terok-l0"),
@@ -131,7 +134,7 @@ def test_base_image_functions_reuse_the_same_long_tag() -> None:
     assert len(tags) == 1
 
 
-# ── installed_agents / is_installed ───────────────────────────────────
+# ── installed_agents / installed_agents_for_project ──────────────────
 
 
 @pytest.fixture(autouse=True)
@@ -151,6 +154,35 @@ def _patch_labels(mock_runtime, labels: dict[str, str]) -> None:
     # test sees the patched labels regardless of call order.
     images.installed_agents.cache_clear()
     mock_runtime.image.return_value.labels.return_value = labels
+
+
+def _patch_labels_by_tag(mock_runtime, labels_by_tag: dict[str, dict[str, str]]) -> None:
+    """Configure ``mock_runtime`` so each image tag answers with its own labels."""
+    images.installed_agents.cache_clear()
+
+    def _image(tag: str):
+        image = MagicMock(name=f"image[{tag}]")
+        image.labels.return_value = labels_by_tag.get(tag, {})
+        return image
+
+    mock_runtime.image.side_effect = _image
+
+
+def _project(agents: str = "all") -> ProjectConfig:
+    """Minimal project whose L2 tag is ``my-project:l2-cli``."""
+    root = MOCK_BASE / "images" / "my-project"
+    return ProjectConfig(
+        name="my-project",
+        security_class="online",
+        upstream_url=None,
+        default_branch="main",
+        root=root,
+        tasks_root=root / "tasks",
+        gate_path=root / "gate",
+        staging_root=None,
+        base_image="ubuntu-24.04",
+        agents=agents,
+    )
 
 
 def test_installed_agents_parses_label(mock_runtime) -> None:
@@ -173,14 +205,75 @@ def test_installed_agents_missing_image_returns_empty(mock_runtime) -> None:
     assert images.installed_agents("terok-l1-cli:nope") == frozenset()
 
 
-def test_is_installed_treats_unlabeled_as_unrestricted(mock_runtime) -> None:
-    # Legacy / unlabeled image: every agent is considered installed so
-    # older builds keep working until the user rebuilds.
+def test_installed_agents_for_project_reads_the_l2_image_not_the_l1_alias(
+    mock_runtime,
+) -> None:
+    # The unsuffixed L1 tag is a default alias for the user's *global*
+    # agent selection, so the answer must come from the L2 image the
+    # task actually boots.
+    _patch_labels_by_tag(
+        mock_runtime,
+        {
+            "terok-l1-cli:ubuntu-24.04": {"ai.terok.agents": "claude,codex,vibe"},
+            "my-project:l2-cli": {"ai.terok.agents": "claude"},
+        },
+    )
+    assert images.installed_agents_for_project(_project()) == frozenset({"claude"})
+
+
+def test_installed_agents_for_project_falls_back_to_project_selection(mock_runtime) -> None:
+    # Unlabeled / absent L2 image: the offer comes from the project
+    # definition (what a rebuild would install), never "every known agent".
     _patch_labels(mock_runtime, {})
-    assert images.is_installed("anything", "terok-l1-cli:legacy") is True
+    assert images.installed_agents_for_project(_project("claude,codex")) == frozenset(
+        {"claude", "codex"}
+    )
 
 
-def test_is_installed_filters_by_label(mock_runtime) -> None:
-    _patch_labels(mock_runtime, {"ai.terok.agents": "claude,codex"})
-    assert images.is_installed("claude", "terok-l1-cli:test") is True
-    assert images.is_installed("vibe", "terok-l1-cli:test") is False
+def test_installed_agents_for_project_fallback_resolves_all(mock_runtime) -> None:
+    from terok.lib.integrations.executor import AgentRoster
+
+    _patch_labels(mock_runtime, {})
+    expected = frozenset(AgentRoster.shared().resolve_selection("all"))
+    assert images.installed_agents_for_project(_project("all")) == expected
+
+
+def test_installed_agents_for_project_unresolvable_selection_is_empty(mock_runtime) -> None:
+    _patch_labels(mock_runtime, {})
+    assert images.installed_agents_for_project(_project("no-such-agent")) == frozenset()
+
+
+# ── require_agent_installed ───────────────────────────────────────────
+
+
+def test_require_agent_installed_accepts_labeled_agent(mock_runtime) -> None:
+    _patch_labels_by_tag(mock_runtime, {"my-project:l2-cli": {"ai.terok.agents": "claude,codex"}})
+    images.require_agent_installed(_project(), "claude")
+
+
+def test_require_agent_installed_rejects_agent_missing_from_l2_label(mock_runtime) -> None:
+    # ``vibe`` is in the default-alias L1 label but not in this project's
+    # L2 image — the guard must agree with the picker and reject.
+    _patch_labels_by_tag(
+        mock_runtime,
+        {
+            "terok-l1-cli:ubuntu-24.04": {"ai.terok.agents": "claude,vibe"},
+            "my-project:l2-cli": {"ai.terok.agents": "claude"},
+        },
+    )
+    with pytest.raises(SystemExit, match="not available in the image"):
+        images.require_agent_installed(_project(), "vibe")
+
+
+def test_require_agent_installed_uses_project_selection_when_unlabeled(mock_runtime) -> None:
+    _patch_labels(mock_runtime, {})
+    images.require_agent_installed(_project("claude"), "claude")
+    with pytest.raises(SystemExit, match="not available in the image"):
+        images.require_agent_installed(_project("claude"), "codex")
+
+
+def test_require_agent_installed_treats_unknown_set_as_unrestricted(mock_runtime) -> None:
+    # No label anywhere and an unresolvable project selection: the set is
+    # unknown, so the guard stays permissive rather than blocking launches.
+    _patch_labels(mock_runtime, {})
+    images.require_agent_installed(_project("no-such-agent"), "claude")


### PR DESCRIPTION
## Problem

The agent selector in the new-CLI-task window (and the unattended-agent picker) offered agents that are not available in the image the task is about to run.

Root cause: `installed_agents_for_project()` read the `ai.terok.agents` label from the **unsuffixed L1 tag** (`terok-l1-cli:<base>`). Since the selectable-agents work, that tag is a *default alias* pointing at whichever L1 was last built with `tag_as_default=True` — i.e. the user's **global** default selection. Project builds produce only agent-suffixed L1 tags and never touch the alias, so the pickers reflected the global selection (or, when the alias was missing/unlabeled, fell back to *every known agent*), not the project's image.

## Fix

- `installed_agents_for_project()` now reads the label from the project's **L2 CLI image** — the image a new task actually boots. OCI labels are inherited, so the L2 answers for exactly the L1 it was built on.
- When the L2 image is absent or unlabeled (not built yet, or pre-selectable-agents), it falls back to resolving the **project definition's `image.agents` selection** via the executor roster — the set a rebuild would install — instead of widening to all known agents. Auth status is deliberately not consulted.
- `require_agent_installed()` now checks the same source, so an agent the picker offers is never rejected at launch (previously the guard consulted the L1 alias too, and could reject an agent that *is* in the project's image). Its message now lists the available set and the L2 tag.
- The now-orphaned `is_installed()` helper is removed (internal only — not part of `lib/api`), along with its tach interface entry.
- An empty/unknown result (podman failure, unresolvable selection) keeps the existing last-resort behaviour: pickers show all, the guard stays permissive.

## Tests

New regression tests (all fail on pre-fix code): L2-label-not-L1-alias source, project-definition fallback, `all` resolution, unresolvable-selection behaviour, and guard/picker agreement. Full `make check` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Also in this PR

`terok image build <project>` ran `",".join(project.agents)` over the plain selection **string**, exploding it character-by-character (`"all"` → `"a,l,l"`), so every per-project build without `--agents` died with "Unknown roster entries". The selection now passes through verbatim. The existing test masked this by mocking `agents` as a list; it now uses the real string shape, plus a regression test for the `"all"` case (fails pre-fix).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected project agent selection during image builds so configured selections are passed through accurately.
  * Improved detection of installed agents using project task images, with fallback to project configuration when image metadata is unavailable.
  * Updated agent availability checks to provide more accurate results for labeled, unlabeled, and unknown configurations.

* **Tests**
  * Added coverage for project-based agent selection, image metadata handling, fallback behavior, and agent availability validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->