### PR TITLE
fix(tui): rekey stale-holder modal — scrollable, concise, with progress

### DIFF
--- a/src/terok/cli/commands/vault_change.py
+++ b/src/terok/cli/commands/vault_change.py
@@ -113,16 +113,18 @@ def _clear_rekey_blockers() -> list[RunningTask]:
     holders = wait_for_db_release(timeout_s=15.0 if stopped else 0.0)
     if not holders:
         return stopped
-    listing = "\n".join(f"  • {h}" for h in holders)
     if any(not h.owned for h in holders):
+        listing = "\n".join(f"  • {h}" for h in holders if not h.owned)
         _restart_stopped(stopped)
         raise SystemExit(
             "processes outside terok are holding the credentials DB open —"
             f" close them and retry:\n{listing}\nnothing was changed."
         )
+    listing = "\n".join(f"  • {h.summary}" for h in holders)
     print(
-        "No running task explains these supervisor processes still holding"
-        f" the credentials DB (likely orphaned by an earlier stop):\n{listing}"
+        f"{len(holders)} supervisor process(es) still hold the credentials DB, but no"
+        " running task explains them — most likely orphaned by an earlier task stop"
+        f" (harmless to kill):\n{listing}"
     )
     _confirm_or_exit(
         "Kill them and continue?",
@@ -131,7 +133,7 @@ def _clear_rekey_blockers() -> list[RunningTask]:
     )
     survivors = terminate_stale_holders(holders)
     if survivors:
-        listing = "\n".join(f"  • {h}" for h in survivors)
+        listing = "\n".join(f"  • {h.summary}" for h in survivors)
         _restart_stopped(stopped)
         raise SystemExit(f"the credentials DB is still held open — nothing was changed:\n{listing}")
     return stopped

--- a/src/terok/lib/domain/vault_rekey.py
+++ b/src/terok/lib/domain/vault_rekey.py
@@ -89,10 +89,30 @@ class DbHolder:
     """``True`` when the argv marks it as sandbox's own supervisor family —
     the only holders [`terminate_stale_holders`][terok.lib.domain.vault_rekey.terminate_stale_holders]
     will signal."""
+    service: str | None = None
+    """The supervisor service (``vault`` / ``signer`` / …) parsed from a
+    ``supervise-child`` argv, or ``None`` for anything else."""
+    task_label: str | None = None
+    """The sidecar stem (e.g. ``alpaka-fedora-cli-v78t0``) that names the
+    task the holder belongs to, or ``None`` when it can't be derived."""
 
     def __str__(self) -> str:
-        """Render as ``pid NNN (argv…)`` for operator-facing listings."""
+        """Render as ``pid NNN (argv…)`` — the full form, for foreign holders."""
         return f"pid {self.pid} ({self.cmdline})"
+
+    @property
+    def summary(self) -> str:
+        """One concise line for the operator-facing listing.
+
+        A recognised ``supervise-child`` collapses to ``pid · service ·
+        task``; anything else keeps its (short) argv so a foreign holder
+        stays fully identifiable.
+        """
+        if self.service and self.task_label:
+            return f"pid {self.pid} · {self.service} · {self.task_label}"
+        if self.service:
+            return f"pid {self.pid} · {self.service}"
+        return str(self)
 
 
 def find_running_tasks() -> tuple[RunningTask, ...]:
@@ -272,9 +292,36 @@ def _describe_holder(pid: int) -> DbHolder:
     raw = b""
     with contextlib.suppress(OSError):
         raw = (_PROC / str(pid) / "cmdline").read_bytes()
+    args = raw.split(b"\0")
     cmdline = raw.replace(b"\0", b" ").decode(errors="replace").strip() or "?"
     owned = any(mark in raw for mark in _OWNED_CMDLINE_MARKS)
-    return DbHolder(pid=pid, cmdline=cmdline, owned=owned)
+    service, task_label = _parse_supervise_child(args)
+    return DbHolder(pid=pid, cmdline=cmdline, owned=owned, service=service, task_label=task_label)
+
+
+def _parse_supervise_child(args: list[bytes]) -> tuple[str | None, str | None]:
+    """Pull ``(service, task_label)`` out of a ``supervise-child`` argv.
+
+    The launcher spawns ``… supervise-child <service> <container_id>
+    <sidecar_path>``; the service is the token after the verb, and the
+    task label is the sidecar filename's stem (far friendlier than the
+    64-char container id).  Returns ``(None, None)`` for any argv that
+    isn't a supervise-child.
+    """
+    try:
+        verb = args.index(b"supervise-child")
+    except ValueError:
+        return None, None
+    service = args[verb + 1].decode(errors="replace") if verb + 1 < len(args) else None
+    label = next(
+        (
+            arg.rsplit(b"/", 1)[-1].removesuffix(b".json").decode(errors="replace")
+            for arg in args
+            if arg.endswith(b".json")
+        ),
+        None,
+    )
+    return service, label
 
 
 def _await_exits(pids: Sequence[int], *, grace_s: float) -> None:

--- a/src/terok/tui/app.py
+++ b/src/terok/tui/app.py
@@ -924,6 +924,11 @@ if _HAS_TEXTUAL:
                         timeout=8,
                     )
                     return None
+                self.notify(
+                    f"Stopping {len(running)} task(s) to free the credentials DB…",
+                    title="Passphrase change in progress",
+                    timeout=30,
+                )
                 results = await asyncio.to_thread(stop_tasks_for_rekey, running)
                 stopped = [task for task, error in results if error is None]
                 failed = [(task, error) for task, error in results if error is not None]
@@ -946,8 +951,8 @@ if _HAS_TEXTUAL:
             )
             if not holders:
                 return stopped
-            listing = "\n".join(f"  • {h}" for h in holders)
             if any(not h.owned for h in holders):
+                listing = "\n".join(f"  • {h}" for h in holders if not h.owned)
                 self.notify(
                     "Processes outside terok are holding the credentials DB"
                     f" open — close them and retry:\n{listing}\n\nNothing was changed.",
@@ -956,12 +961,15 @@ if _HAS_TEXTUAL:
                 )
                 await self._restart_stopped_tasks(stopped)
                 return None
+            listing = "\n".join(f"  • {h.summary}" for h in holders)
             proceed = await self.push_screen_wait(
                 ConfirmDestructiveScreen(
-                    "No running task explains these supervisor processes still"
-                    f" holding the credentials DB:\n\n{listing}\n\n"
-                    "They were likely orphaned by an earlier task stop."
-                    "  Kill them and continue?",
+                    f"{len(holders)} supervisor process(es) still hold the"
+                    " credentials DB open, but no running task explains them —"
+                    " they were most likely orphaned by an earlier task stop"
+                    " (harmless to kill):\n\n"
+                    f"{listing}\n\n"
+                    "Kill them and continue with the passphrase change?",
                     title="Stale vault DB holders",
                     confirm_label="Kill & continue",
                 )
@@ -970,9 +978,14 @@ if _HAS_TEXTUAL:
                 self.notify("Passphrase change cancelled.", severity="warning", timeout=8)
                 await self._restart_stopped_tasks(stopped)
                 return None
+            self.notify(
+                f"Terminating {len(holders)} stale holder(s)…",
+                title="Passphrase change in progress",
+                timeout=30,
+            )
             survivors = await asyncio.to_thread(terminate_stale_holders, holders)
             if survivors:
-                listing = "\n".join(f"  • {h}" for h in survivors)
+                listing = "\n".join(f"  • {h.summary}" for h in survivors)
                 self.notify(
                     f"The credentials DB is still held open — nothing was changed:\n{listing}",
                     severity="error",
@@ -1075,6 +1088,11 @@ if _HAS_TEXTUAL:
 
             cfg = make_sandbox_config()
             try:
+                self.notify(
+                    "Re-encrypting the credentials DB under the new passphrase…",
+                    title="Passphrase change in progress",
+                    timeout=30,
+                )
                 try:
                     result = await asyncio.to_thread(
                         change_passphrase, cfg, old=old, new=typed or None

--- a/src/terok/tui/screens.py
+++ b/src/terok/tui/screens.py
@@ -9,7 +9,7 @@ from typing import TYPE_CHECKING, Any
 
 from textual import events, screen
 from textual.app import ComposeResult
-from textual.containers import Horizontal, Vertical
+from textual.containers import Horizontal, Vertical, VerticalScroll
 from textual.widgets import Button, Static
 
 # Optional textual widget imports: TUI tests build a stub textual module
@@ -1729,9 +1729,9 @@ class ConfirmDestructiveScreen(screen.ModalScreen[bool]):
     }
 
     #confirm-dialog {
-        width: 60;
+        width: 72;
         height: auto;
-        max-height: 80%;
+        max-height: 90%;
         border: heavy $error;
         border-title-align: right;
         border-subtitle-align: left;
@@ -1739,11 +1739,16 @@ class ConfirmDestructiveScreen(screen.ModalScreen[bool]):
         padding: 1;
     }
 
-    #confirm-message {
+    /* The message scrolls; the buttons dock to the dialog's bottom edge so
+       they stay reachable no matter how long the message is (e.g. a rekey
+       stale-holder listing with many entries). */
+    #confirm-scroll {
+        height: auto;
         margin-bottom: 1;
     }
 
     #confirm-buttons {
+        dock: bottom;
         height: auto;
         align-horizontal: right;
     }
@@ -1766,9 +1771,10 @@ class ConfirmDestructiveScreen(screen.ModalScreen[bool]):
         self._confirm_label = confirm_label
 
     def compose(self) -> ComposeResult:
-        """Build the confirmation message and Yes/Cancel buttons."""
+        """Build the (scrollable) confirmation message and Yes/Cancel buttons."""
         with Vertical(id="confirm-dialog") as dialog:
-            yield Static(self._message, id="confirm-message", markup=False)
+            with VerticalScroll(id="confirm-scroll"):
+                yield Static(self._message, id="confirm-message", markup=False)
             with Horizontal(id="confirm-buttons"):
                 yield Button("Cancel", id="btn-cancel", variant="default")
                 yield Button(self._confirm_label, id="btn-confirm", variant="error")

--- a/tests/unit/lib/domain/test_vault_rekey.py
+++ b/tests/unit/lib/domain/test_vault_rekey.py
@@ -31,7 +31,10 @@ from terok.lib.domain.vault_rekey import (
     wait_for_db_release,
 )
 
-_SUPERVISOR_ARGV = b"/usr/bin/python\0-P\0-m\0terok_sandbox\0supervise-child\0vault\0abc123\0"
+_SUPERVISOR_ARGV = (
+    b"/usr/bin/python\0-P\0-m\0terok_sandbox\0supervise-child\0vault\0abc123"
+    b"\0/home/op/.local/share/terok/sandbox/sidecar/alpaka-fedora-cli-v78t0.json\0"
+)
 _FOREIGN_ARGV = b"/usr/bin/sqlitebrowser\0/home/op/creds.db\0"
 
 
@@ -75,6 +78,30 @@ class TestFindDbHolders:
 
         assert [(h.pid, h.owned) for h in holders] == [(4242, True)]
         assert "supervise-child" in holders[0].cmdline
+
+    def test_supervise_child_gets_a_concise_summary(
+        self, fake_proc: Path, fake_vault: SimpleNamespace
+    ) -> None:
+        """The listing line collapses to ``pid · service · task``, not the 200-char argv."""
+        _add_process(fake_proc, 4242, cmdline=_SUPERVISOR_ARGV, holds=fake_vault.db_path)
+
+        holder = find_db_holders(fake_vault)[0]
+
+        assert holder.service == "vault"
+        assert holder.task_label == "alpaka-fedora-cli-v78t0"
+        assert holder.summary == "pid 4242 · vault · alpaka-fedora-cli-v78t0"
+
+    def test_foreign_holder_summary_keeps_full_argv(
+        self, fake_proc: Path, fake_vault: SimpleNamespace
+    ) -> None:
+        """A non-supervise-child holder has no service, so its summary stays identifiable."""
+        _add_process(fake_proc, 99, cmdline=_FOREIGN_ARGV, holds=fake_vault.db_path)
+
+        holder = find_db_holders(fake_vault)[0]
+
+        assert holder.service is None
+        assert holder.summary == str(holder)
+        assert "sqlitebrowser" in holder.summary
 
     def test_wal_sidecar_counts_as_holding(
         self, fake_proc: Path, fake_vault: SimpleNamespace

--- a/tests/unit/tui/test_confirm_destructive_screen.py
+++ b/tests/unit/tui/test_confirm_destructive_screen.py
@@ -1,0 +1,86 @@
+# SPDX-FileCopyrightText: 2026 Jiri Vyskocil
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the shared destructive-confirmation modal.
+
+The regression these guard: a long message (e.g. a rekey stale-holder
+listing with many entries) used to push the confirm/cancel buttons past
+the dialog's ``max-height`` clip, leaving them unclickable.  The message
+now lives in its own scroll box so the buttons stay on screen — and the
+dismissal contract (confirm → ``True``, escape → ``False``) is pinned
+alongside it.
+"""
+
+from __future__ import annotations
+
+import pytest
+from textual.app import App
+from textual.containers import VerticalScroll
+from textual.widgets import Button
+
+from terok.tui.screens import ConfirmDestructiveScreen
+
+_PENDING = object()
+
+
+class _Host(App):
+    """Minimal app that pushes a [`ConfirmDestructiveScreen`][terok.tui.screens.ConfirmDestructiveScreen]."""
+
+    def __init__(self, message: str) -> None:
+        """Stash the message and a pending-result sentinel."""
+        super().__init__()
+        self._message = message
+        self.result: object = _PENDING
+
+    def on_mount(self) -> None:
+        """Push the modal and capture its dismissal value."""
+        self.push_screen(
+            ConfirmDestructiveScreen(self._message, title="T", confirm_label="Kill & continue"),
+            self._capture,
+        )
+
+    def _capture(self, result: object) -> None:
+        self.result = result
+
+
+_HUGE_MESSAGE = "Stale holders:\n" + "\n".join(f"  • pid {p} · vault · task-{p}" for p in range(60))
+
+
+class TestButtonsStayReachable:
+    """A message far taller than the dialog must not clip the buttons away."""
+
+    @pytest.mark.asyncio
+    async def test_message_is_scrollable_and_buttons_visible(self) -> None:
+        """The message sits in a VerticalScroll; both buttons render on screen."""
+        app = _Host(_HUGE_MESSAGE)
+        async with app.run_test(size=(90, 24)) as pilot:
+            await pilot.pause()
+            scroll = app.screen.query_one("#confirm-scroll", VerticalScroll)
+            # The long message is inside the scroll box, not a bare Static
+            # that would grow past the dialog and shove the buttons out.
+            assert scroll.query_one("#confirm-message") is not None
+            buttons = app.screen.query(Button)
+            assert {b.id for b in buttons} == {"btn-cancel", "btn-confirm"}
+            for button in buttons:
+                assert button.region.height > 0, f"{button.id} is clipped to zero height"
+                assert button.region.bottom <= app.size.height, f"{button.id} is below the screen"
+
+    @pytest.mark.asyncio
+    async def test_confirm_button_dismisses_true(self) -> None:
+        """Clicking the confirm button returns ``True`` even with a huge message."""
+        app = _Host(_HUGE_MESSAGE)
+        async with app.run_test(size=(90, 24)) as pilot:
+            await pilot.pause()
+            await pilot.click("#btn-confirm")
+            await pilot.pause()
+        assert app.result is True
+
+    @pytest.mark.asyncio
+    async def test_escape_dismisses_false(self) -> None:
+        """Escape cancels the destructive action."""
+        app = _Host(_HUGE_MESSAGE)
+        async with app.run_test(size=(90, 24)) as pilot:
+            await pilot.pause()
+            await pilot.press("escape")
+            await pilot.pause()
+        assert app.result is False


### PR DESCRIPTION
## Field report

Rekeying on a host with several orphaned supervisor children, the **Stale vault DB holders** modal was unusable:

- each holder was listed with its full ~200-char argv (`…/python3 -P -m terok_sandbox supervise-child vault <64-char id> …/sidecar/<name>.json`), wrapped across ~8 lines;
- 6 holders × 8 lines overflowed the dialog's `max-height`, pushing **"Kill & continue" off-screen** — the operator physically could not accept the offer, so the rekey dead-ended and no passphrase was changed.

The stop/re-encrypt windows were also silent, so the flow looked wedged between clicks.

## Fixes

1. **`ConfirmDestructiveScreen` buttons stay reachable.** The message scrolls (`VerticalScroll`) and the button row **docks to the dialog's bottom edge**, so confirm/cancel render on screen for a message of any length. Shared modal — every destructive confirm benefits. Pinned by a `run_test` regression that pushes a 60-entry message at an 80×24 screen and asserts both buttons are on-screen and clickable.
2. **Concise holder lines.** `DbHolder` gains a `summary` property (`pid 417002 · vault · alpaka-fedora-cli-v78t0`) parsed from the `supervise-child` argv — one line instead of a wrapped paragraph. Foreign (non-terok) holders keep their full argv, since there are few of them and identity matters. Used in both the TUI and CLI listings.
3. **Progress notifications.** The silent `to_thread` windows (stop tasks / terminate holders / re-encrypt) now emit "in progress" notifications so the operator sees the flow moving.

## About the orphans in the report

Those holders predate **terok-sandbox#465** (group-`killpg` reap + `PR_SET_PDEATHSIG` on service children), so nothing reaped them when their tasks stopped — exactly the leak #465 closes going forward. Killing them once through this now-usable offer clears them; tasks created on a 465-carrying sandbox won't orphan.

## Not in this PR (follow-up)

The report also suggested manual `task stop` run in the background instead of opening a full-screen log. That's a general change to the stop UX (every stop invocation), so I've kept it out of this focused modal fix — happy to do it as a separate PR.

## Tests

New `test_confirm_destructive_screen.py` (scroll + reachable-buttons + dismissal contract), extended `test_vault_rekey.py` (summary parsing, foreign fallback). Full suite green (3091), tach / import-linter / docstrings clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Improved vault passphrase-change guidance with clearer progress messages and diagnostics for active or orphaned processes.
  * Added concise details identifying supervisor services and tasks that are blocking credential database access.
  * Updated destructive confirmation dialogs to support scrolling long messages while keeping action buttons visible.
* **Bug Fixes**
  * Improved handling and cleanup of stale or foreign processes during vault re-encryption.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->