### PR TITLE
feat(task): debug-mode task launch — CLI --debug flag + read-only TUI cockroach badge

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -794,6 +794,32 @@ terok task status myproj v9krt
 
 The TUI task detail panel also shows the permission mode.
 
+### Debug Mode
+
+Each container's services (vault proxy, clearance hub, SSH signer, gate) run as
+separate supervised child processes.  In production every child hardens itself —
+it clears the dumpable flag (`PR_SET_DUMPABLE=0`, so no `ptrace`, no core dump),
+zeroes `RLIMIT_CORE`, and `mlockall`s its memory.  That is exactly what you want
+in normal operation, but it also makes the split's other payoff — a debuggable
+per-service process you can attach to — unreachable.
+
+`--debug` relaxes that floor for one task launch:
+
+```bash
+terok task run myproj --debug                       # cli mode
+terok task run myproj --mode headless --prompt "…" --debug
+```
+
+Only the dumpable clear is skipped, so a debugger can attach
+(`py-spy dump --pid <child>`, `gdb -p <child>`); the core-file limit and
+`mlockall` still apply.  The choice is **fail-closed**: hardening is relaxed only
+when this explicit flag is set — it is never inferred from `-O` / `__debug__`.
+
+Debug mode is a **CLI-only** trigger — there is no TUI control to enable it
+(asking for it presumes you'll attach a debugger, so the launch stays in the
+terminal).  A debug-mode task is marked read-only in the TUI task list with a
+🪳 badge, and the choice is remembered across `task restart`.
+
 ### Native Claude Agents and MCPs
 
 Sub-agents, skills, and MCP servers are managed natively by Claude — terok

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,7 @@ dependencies = [
     "textual-serve~=1.1",
     "jinja2~=3.1",
     "terok-executor @ git+https://github.com/sliwowitz/terok-executor@feat/debug-mode-allow-debugger",
-    "terok-sandbox @ https://github.com/terok-ai/terok-sandbox/releases/download/v0.5.0a15/terok_sandbox-0.5.0a15-py3-none-any.whl",
+    "terok-sandbox @ https://github.com/terok-ai/terok-sandbox/releases/download/v0.5.0a16/terok_sandbox-0.5.0a16-py3-none-any.whl",
     "terok-shield @ https://github.com/terok-ai/terok-shield/releases/download/v0.8.0a6/terok_shield-0.8.0a6-py3-none-any.whl",
     "terok-clearance @ https://github.com/terok-ai/terok-clearance/releases/download/v0.8.0a6/terok_clearance-0.8.0a6-py3-none-any.whl",
     "terok-util @ https://github.com/terok-ai/terok-util/releases/download/v0.3.1a3/terok_util-0.3.1a3-py3-none-any.whl",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ dependencies = [
     "unique-namer~=1.6",
     "textual-serve~=1.1",
     "jinja2~=3.1",
-    "terok-executor @ git+https://github.com/sliwowitz/terok-executor@feat/debug-mode-allow-debugger",
+    "terok-executor @ https://github.com/terok-ai/terok-executor/releases/download/v0.4.0a16/terok_executor-0.4.0a16-py3-none-any.whl",
     "terok-sandbox @ https://github.com/terok-ai/terok-sandbox/releases/download/v0.5.0a16/terok_sandbox-0.5.0a16-py3-none-any.whl",
     "terok-shield @ https://github.com/terok-ai/terok-shield/releases/download/v0.8.0a6/terok_shield-0.8.0a6-py3-none-any.whl",
     "terok-clearance @ https://github.com/terok-ai/terok-clearance/releases/download/v0.8.0a6/terok_clearance-0.8.0a6-py3-none-any.whl",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ dependencies = [
     "unique-namer~=1.6",
     "textual-serve~=1.1",
     "jinja2~=3.1",
-    "terok-executor @ https://github.com/terok-ai/terok-executor/releases/download/v0.4.0a15/terok_executor-0.4.0a15-py3-none-any.whl",
+    "terok-executor @ git+https://github.com/sliwowitz/terok-executor@feat/debug-mode-allow-debugger",
     "terok-sandbox @ https://github.com/terok-ai/terok-sandbox/releases/download/v0.5.0a15/terok_sandbox-0.5.0a15-py3-none-any.whl",
     "terok-shield @ https://github.com/terok-ai/terok-shield/releases/download/v0.8.0a6/terok_shield-0.8.0a6-py3-none-any.whl",
     "terok-clearance @ https://github.com/terok-ai/terok-clearance/releases/download/v0.8.0a6/terok_clearance-0.8.0a6-py3-none-any.whl",

--- a/src/terok/cli/commands/task.py
+++ b/src/terok/cli/commands/task.py
@@ -156,6 +156,15 @@ def register(
     )
     t_run.add_argument("--name", help="Human-readable task name (slug-style, e.g. fix-auth-bug)")
     _add_restriction_flags(t_run)
+    t_run.add_argument(
+        "--debug",
+        action="store_true",
+        help=(
+            "Debug mode: launch with the hardening floor relaxed so a debugger can "
+            "attach to the supervised service processes (skips PR_SET_DUMPABLE only; "
+            "core-limit + mlockall still apply). Marked with a cockroach badge in the TUI."
+        ),
+    )
     # CLI-mode attach (default: attach when stdout is a TTY).  Headless
     # already streams/follows on its own; toad returns a URL + token.
     attach_group = t_run.add_mutually_exclusive_group()
@@ -506,6 +515,7 @@ def _cmd_task_run_interactive(args: argparse.Namespace, *, runner: Any, attach: 
         pid,
         tid,
         unrestricted=_resolve_unrestricted(args),
+        debug=getattr(args, "debug", False),
     )
     if attach:
         # ``task_login`` calls ``os.execvp`` and never returns on success.
@@ -540,6 +550,7 @@ def _cmd_task_run_headless(args: argparse.Namespace) -> None:
             provider=getattr(args, "provider", None),
             instructions=instructions_text,
             unrestricted=_resolve_unrestricted(args),
+            debug=getattr(args, "debug", False),
         )
     )
 

--- a/src/terok/lib/api/__init__.py
+++ b/src/terok/lib/api/__init__.py
@@ -177,6 +177,7 @@ if TYPE_CHECKING:
     )
     from terok.lib.api.task import (
         CONTAINER_MODES as CONTAINER_MODES,
+        DEBUG_BADGE as DEBUG_BADGE,
         GPU_DISPLAY as GPU_DISPLAY,
         SECURITY_CLASS_DISPLAY as SECURITY_CLASS_DISPLAY,
         STATUS_DISPLAY as STATUS_DISPLAY,
@@ -274,6 +275,7 @@ _LAZY: dict[str, str] = {
     "CommandDef": "terok_util",
     "CommandTree": "terok_util",
     "ContainerEventStream": "terok.lib.api.task",
+    "DEBUG_BADGE": "terok.lib.api.task",
     "DEFAULT_BASE_IMAGE": "terok.lib.api.agents",
     "DeleteProjectResult": "terok.lib.api.project",
     "EXECUTOR_COMMANDS": "terok.lib.api.agents",
@@ -513,6 +515,7 @@ __all__ = [
     "CommandTree",
     "Config",
     "ContainerEventStream",
+    "DEBUG_BADGE",
     "GPU_DISPLAY",
     "HeadlessRunRequest",
     "LogViewOptions",

--- a/src/terok/lib/api/task.py
+++ b/src/terok/lib/api/task.py
@@ -23,6 +23,7 @@ from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from terok.lib.core.task_display import (
+        DEBUG_BADGE as DEBUG_BADGE,
         GPU_DISPLAY as GPU_DISPLAY,
         SECURITY_CLASS_DISPLAY as SECURITY_CLASS_DISPLAY,
         STATUS_DISPLAY as STATUS_DISPLAY,
@@ -84,6 +85,7 @@ if TYPE_CHECKING:
 _LAZY: dict[str, str] = {
     "CONTAINER_MODES": "terok.lib.core.task_state",
     "ContainerEventStream": "terok.lib.orchestration.tasks",
+    "DEBUG_BADGE": "terok.lib.core.task_display",
     "GPU_DISPLAY": "terok.lib.core.task_display",
     "HeadlessRunRequest": "terok.lib.orchestration.task_runners",
     "LogViewOptions": "terok.lib.domain.task_logs",

--- a/src/terok/lib/core/task_display.py
+++ b/src/terok/lib/core/task_display.py
@@ -82,6 +82,14 @@ GPU_DISPLAY: dict[bool, ProjectBadge] = {
     False: ProjectBadge(emoji="\U0001f4bf", label="CPU"),
 }
 
+# Read-only marker on tasks launched with the hardening floor relaxed
+# (``terok task run --debug``): the supervisor children stay ptrace-able so
+# a debugger can attach.  Cockroach (U+1FAB3) is natively wide
+# (``East_Asian_Width=W``, no VS16), so it aligns without ``render_emoji``
+# padding.  The TUI shows it; there is no control to toggle debug mode there
+# — the trigger is CLI-only by design.
+DEBUG_BADGE = ProjectBadge(emoji="\U0001fab3", label="debug")
+
 
 def mode_info(mode: str | None) -> ModeInfo:
     """Return the display info for a task mode string."""

--- a/src/terok/lib/orchestration/task_runners/cli.py
+++ b/src/terok/lib/orchestration/task_runners/cli.py
@@ -43,6 +43,7 @@ def task_run_cli(
     project_name: str,
     task_id: str,
     unrestricted: bool | None = None,
+    debug: bool = False,
 ) -> None:
     """Launch a CLI-mode task container and wait for its readiness marker.
 
@@ -103,6 +104,7 @@ def task_run_cli(
         # Ensure init runs and then keep the container alive even without a TTY
         # init-ssh-and-repo.sh now prints a readiness marker we can watch for
         command=["bash", "-lc", "init-ssh-and-repo.sh && echo __CLI_READY__; tail -f /dev/null"],
+        allow_debugger=debug,
     )
     _apply_shield_policy(project, cname, task_dir, is_restart=False)
     run_hook(
@@ -138,6 +140,7 @@ def task_run_cli(
     meta["mode"] = "cli"
     meta["ready_at"] = datetime.now(UTC).isoformat()
     meta["unrestricted"] = unrestricted
+    meta["debug"] = debug
     write_task_meta(meta_path, meta)
 
     color_enabled = _supports_color()

--- a/src/terok/lib/orchestration/task_runners/container.py
+++ b/src/terok/lib/orchestration/task_runners/container.py
@@ -207,6 +207,7 @@ def _run_container(
     extra_args: list[str] | None = None,
     command: list[str] | None = None,
     hooks: LifecycleHooks | None = None,
+    allow_debugger: bool = False,
 ) -> None:
     """Launch a detached task container, annotated for clearance enrichment.
 
@@ -244,6 +245,12 @@ def _run_container(
             args (e.g. ``["-p", "127.0.0.1:8080:7860"]``).
         command: Optional command + args appended after the image name.
         hooks: Optional lifecycle callbacks fired around the launch.
+        allow_debugger: Launch in debug mode — the supervisor children
+            stay ptrace-able so a debugger can attach (only the
+            ``PR_SET_DUMPABLE`` clear is skipped; core-limit + mlockall
+            still apply).  Forwarded to
+            [`AgentRunner.launch_prepared`][terok_executor.AgentRunner.launch_prepared]'s
+            ``allow_debugger`` kwarg, which writes it into the sidecar.
     """
     # OCI annotation under the ``dossier.*`` namespace flows through to
     # the shield reader, which picks it up at hook spawn time and uses
@@ -289,6 +296,7 @@ def _run_container(
             project_id=project.name,  # executor API kwarg is ``project_id``; value is the project name
             task_id=task_id,
             dossier_path=task_dossier_path,
+            allow_debugger=allow_debugger,
         )
     except FileNotFoundError as exc:
         raise SystemExit(f"podman not found; please install podman ({exc})") from exc

--- a/src/terok/lib/orchestration/task_runners/headless.py
+++ b/src/terok/lib/orchestration/task_runners/headless.py
@@ -76,6 +76,9 @@ class HeadlessRunRequest:
     routes to at runtime; ``None`` → the agent's default provider."""
     instructions: str | None = None
     unrestricted: bool | None = None
+    debug: bool = False
+    """Launch with the hardening floor relaxed (``--debug``) so the
+    supervisor children stay ptrace-able for an attached debugger."""
 
 
 @dataclass(frozen=True)
@@ -289,6 +292,7 @@ def task_run_headless(request: HeadlessRunRequest) -> str:
         task_id=task_id,
         task_dir=task_dir,
         command=["bash", "-lc", headless_cmd],
+        allow_debugger=request.debug,
     )
     _apply_shield_policy(project, cname, task_dir, is_restart=False)
     run_hook(
@@ -309,6 +313,7 @@ def task_run_headless(request: HeadlessRunRequest) -> str:
     if request.provider:
         meta["provider"] = request.provider
     meta["unrestricted"] = unrestricted
+    meta["debug"] = request.debug
     write_task_meta(meta_path, meta)
 
     _report_headless_result(

--- a/src/terok/lib/orchestration/task_runners/restart.py
+++ b/src/terok/lib/orchestration/task_runners/restart.py
@@ -364,7 +364,9 @@ def _recreate_in_place(
     # Recreation rewrites the sidecar from scratch, so debug mode is not
     # inherited from the old one — carry the task's saved choice forward
     # so a recreated container keeps its relaxed hardening (and its badge).
-    debug = bool(meta.get("debug"))
+    # Strict ``is True``: this drives real hardening on the new container, so a
+    # malformed/legacy persisted value must fail closed (fully hardened).
+    debug = meta.get("debug") is True
     if mode == "cli":
         task_run_cli(project.name, task_id, unrestricted=unrestricted, debug=debug)
     else:  # toad — the refusal above keeps mode binary here

--- a/src/terok/lib/orchestration/task_runners/restart.py
+++ b/src/terok/lib/orchestration/task_runners/restart.py
@@ -361,10 +361,14 @@ def _recreate_in_place(
         _sandbox(project).rm([cname])
     if unrestricted is None:
         unrestricted = meta.get("unrestricted")
+    # Recreation rewrites the sidecar from scratch, so debug mode is not
+    # inherited from the old one — carry the task's saved choice forward
+    # so a recreated container keeps its relaxed hardening (and its badge).
+    debug = bool(meta.get("debug"))
     if mode == "cli":
-        task_run_cli(project.name, task_id, unrestricted=unrestricted)
+        task_run_cli(project.name, task_id, unrestricted=unrestricted, debug=debug)
     else:  # toad — the refusal above keeps mode binary here
-        task_run_toad(project.name, task_id, unrestricted=unrestricted)
+        task_run_toad(project.name, task_id, unrestricted=unrestricted, debug=debug)
 
 
 __all__ = [

--- a/src/terok/lib/orchestration/task_runners/toad.py
+++ b/src/terok/lib/orchestration/task_runners/toad.py
@@ -131,6 +131,7 @@ def task_run_toad(
     project_name: str,
     task_id: str,
     unrestricted: bool | None = None,
+    debug: bool = False,
 ) -> None:
     """Launch the Toad multi-agent TUI behind Caddy for token-gated browser access.
 
@@ -181,6 +182,7 @@ def task_run_toad(
 
     meta["mode"] = "toad"
     meta["unrestricted"] = unrestricted
+    meta["debug"] = debug
     write_task_meta(meta_path, meta)
 
     # Preserve the address family when the public host is a loopback — binding
@@ -220,6 +222,7 @@ def task_run_toad(
         task_dir=task_dir,
         extra_args=["-p", f"{bind_addr}:{port}:{_TOAD_PUBLIC_PORT}"],
         command=["bash", "-lc", toad_cmd],
+        allow_debugger=debug,
     )
     _apply_shield_policy(project, cname, task_dir, is_restart=False)
     run_hook(

--- a/src/terok/lib/orchestration/tasks/query.py
+++ b/src/terok/lib/orchestration/tasks/query.py
@@ -89,6 +89,12 @@ class TaskMeta(TaskState):
     name: str = ""
     agent: str | None = None
     unrestricted: bool | None = None
+    debug: bool = False
+    """Whether the task was launched with the hardening floor relaxed
+    (``terok task run --debug``): its supervisor children stay ptrace-able
+    so a debugger can attach.  Drives the read-only
+    [`DEBUG_BADGE`][terok.lib.core.task_display.DEBUG_BADGE] in the TUI —
+    there is no TUI control to toggle it (the trigger is CLI-only)."""
     work_status: str | None = None
     work_message: str | None = None
     shield_state: str | None = None
@@ -191,6 +197,7 @@ def get_task_meta(project_name: str, task_id: str) -> TaskMeta:
         name=raw["name"],
         agent=raw.get("agent"),
         unrestricted=raw.get("unrestricted"),
+        debug=bool(raw.get("debug")),
         work_status=ws_status,
         work_message=ws_message,
         created_at=raw.get("created_at"),
@@ -273,6 +280,7 @@ def _get_tasks(project_name: str, reverse: bool = False) -> list[TaskMeta]:
                     name=meta["name"],
                     agent=meta.get("agent"),
                     unrestricted=meta.get("unrestricted"),
+                    debug=bool(meta.get("debug")),
                     work_status=ws_status,
                     work_message=ws_message,
                     created_at=meta.get("created_at"),

--- a/src/terok/lib/orchestration/tasks/query.py
+++ b/src/terok/lib/orchestration/tasks/query.py
@@ -197,7 +197,10 @@ def get_task_meta(project_name: str, task_id: str) -> TaskMeta:
         name=raw["name"],
         agent=raw.get("agent"),
         unrestricted=raw.get("unrestricted"),
-        debug=bool(raw.get("debug")),
+        # Strict ``is True`` (not ``bool(...)``): debug mode relaxes container
+        # hardening, so a malformed/legacy persisted value must fail closed —
+        # only a canonical JSON ``true`` counts.
+        debug=raw.get("debug") is True,
         work_status=ws_status,
         work_message=ws_message,
         created_at=raw.get("created_at"),
@@ -280,7 +283,7 @@ def _get_tasks(project_name: str, reverse: bool = False) -> list[TaskMeta]:
                     name=meta["name"],
                     agent=meta.get("agent"),
                     unrestricted=meta.get("unrestricted"),
-                    debug=bool(meta.get("debug")),
+                    debug=meta.get("debug") is True,  # fail closed on malformed/legacy values
                     work_status=ws_status,
                     work_message=ws_message,
                     created_at=meta.get("created_at"),

--- a/src/terok/tui/widgets/task_list.py
+++ b/src/terok/tui/widgets/task_list.py
@@ -9,7 +9,7 @@ from textual import events
 from textual.message import Message
 from textual.widgets import ListItem, ListView, Static
 
-from ...lib.api import STATUS_DISPLAY, TaskMeta, mode_info
+from ...lib.api import DEBUG_BADGE, STATUS_DISPLAY, TaskMeta, mode_info
 from ...lib.util.emoji import render_emoji
 from ...ui_utils.terminal import wrap_with_hanging_indent
 
@@ -82,6 +82,9 @@ class TaskList(ListView):
         m_emoji = render_emoji(mode_info(task.mode))
         s_info = STATUS_DISPLAY.get(task.status, STATUS_DISPLAY["created"])
         s_emoji = render_emoji(s_info)
+        # Read-only marker on debug-mode tasks (``terok task run --debug``);
+        # no TUI control toggles it — the trigger is CLI-only by design.
+        d_badge = f"{render_emoji(DEBUG_BADGE)} " if task.debug else ""
 
         extra_parts: list[str] = []
         if task.work_status:
@@ -89,7 +92,7 @@ class TaskList(ListView):
         if task.web_port is not None:
             extra_parts.append(f"port={task.web_port}")
 
-        prefix = f"{task.task_id} {m_emoji} {s_emoji} "
+        prefix = f"{task.task_id} {m_emoji} {s_emoji} {d_badge}"
         suffix = f" [{'; '.join(extra_parts)}]" if extra_parts else ""
         return wrap_with_hanging_indent(prefix, task.name, suffix, width)
 

--- a/tests/unit/cli/test_cli_unattended.py
+++ b/tests/unit/cli/test_cli_unattended.py
@@ -77,6 +77,13 @@ def test_run_dispatches_to_task_run_headless() -> None:
     assert request.name is None
     assert request.provider is None
     assert request.instructions is None
+    assert request.debug is False
+
+
+def test_headless_debug_flag_sets_request_debug() -> None:
+    """``--debug`` on a headless run sets ``HeadlessRunRequest.debug``."""
+    assert capture_headless_request("myproject", "Fix it").debug is False
+    assert capture_headless_request("myproject", "Fix it", "--debug").debug is True
 
 
 def test_headless_without_prompt_exits() -> None:
@@ -223,7 +230,7 @@ def test_run_interactive_mode_creates_and_runs(mode: str, runner_target: str) ->
         run_cli("task", "run", "myproj", "--mode", mode, "--no-attach")
 
     mock_new.assert_called_once_with("myproj", name=None)
-    mock_runner.assert_called_once_with("myproj", "42", unrestricted=None)
+    mock_runner.assert_called_once_with("myproj", "42", unrestricted=None, debug=False)
     mock_login.assert_not_called()
 
 

--- a/tests/unit/cli/test_cli_workflows.py
+++ b/tests/unit/cli/test_cli_workflows.py
@@ -273,16 +273,22 @@ class TestTaskRunInteractive:
                 ["terok", "task", "run", "proj1"],
                 "42",
                 "terok.cli.commands.task.task_run_cli",
-                ("proj1", "42", {"unrestricted": None}),
+                ("proj1", "42", {"unrestricted": None, "debug": False}),
             ),
             (
                 ["terok", "task", "run", "proj1", "--mode", "toad"],
                 "10",
                 "terok.cli.commands.task.task_run_toad",
-                ("proj1", "10", {"unrestricted": None}),
+                ("proj1", "10", {"unrestricted": None, "debug": False}),
+            ),
+            (
+                ["terok", "task", "run", "proj1", "--debug"],
+                "42",
+                "terok.cli.commands.task.task_run_cli",
+                ("proj1", "42", {"unrestricted": None, "debug": True}),
             ),
         ],
-        ids=["default-cli-mode", "toad-mode"],
+        ids=["default-cli-mode", "toad-mode", "cli-debug-mode"],
     )
     def test_task_run_interactive_dispatch(
         self,

--- a/tests/unit/lib/test_container_lifecycle.py
+++ b/tests/unit/lib/test_container_lifecycle.py
@@ -367,6 +367,25 @@ def test_task_restart_recreate_preserves_debug_from_meta() -> None:
         run_cli.assert_called_once_with(project_name, task_id, unrestricted=None, debug=True)
 
 
+def test_task_restart_recreate_debug_fails_closed_on_malformed_meta() -> None:
+    """A malformed/legacy truthy debug value recreates fully hardened (fail-closed)."""
+    project_name = "proj_restart_debug_bad"
+    with project_env(project_config(project_name), project_name=project_name) as ctx:
+        task_id = create_task_with_mode(ctx, project_name)
+        update_task_meta(ctx, project_name, task_id, debug="yes")  # not a canonical bool
+
+        runtime_mock = _mock_runtime(_mock_container(state=None))
+        with (
+            mock_git_config(),
+            patch("terok.lib.core.runtime.resolve_runtime", return_value=runtime_mock),
+            patch("terok.lib.orchestration.task_runners.restart._sandbox"),
+            patch("terok.lib.orchestration.task_runners.restart.task_run_cli") as run_cli,
+        ):
+            capture_stdout(task_restart, project_name, task_id)
+
+        run_cli.assert_called_once_with(project_name, task_id, unrestricted=None, debug=False)
+
+
 def test_task_restart_missing_toad_container_recreates_via_toad_runner() -> None:
     """A gone toad container takes the recreate rung through the toad runner."""
     project_name = "proj_restart_toad_gone"

--- a/tests/unit/lib/test_container_lifecycle.py
+++ b/tests/unit/lib/test_container_lifecycle.py
@@ -345,7 +345,26 @@ def test_task_restart_missing_container_recreates_in_place() -> None:
 
         assert "Recreating" in output
         sandbox.return_value.rm.assert_not_called()  # nothing to remove
-        run_cli.assert_called_once_with(project_name, task_id, unrestricted=False)
+        run_cli.assert_called_once_with(project_name, task_id, unrestricted=False, debug=False)
+
+
+def test_task_restart_recreate_preserves_debug_from_meta() -> None:
+    """Recreation rewrites the sidecar, so debug mode is carried from saved meta."""
+    project_name = "proj_restart_debug"
+    with project_env(project_config(project_name), project_name=project_name) as ctx:
+        task_id = create_task_with_mode(ctx, project_name)
+        update_task_meta(ctx, project_name, task_id, debug=True)
+
+        runtime_mock = _mock_runtime(_mock_container(state=None))
+        with (
+            mock_git_config(),
+            patch("terok.lib.core.runtime.resolve_runtime", return_value=runtime_mock),
+            patch("terok.lib.orchestration.task_runners.restart._sandbox"),
+            patch("terok.lib.orchestration.task_runners.restart.task_run_cli") as run_cli,
+        ):
+            capture_stdout(task_restart, project_name, task_id)
+
+        run_cli.assert_called_once_with(project_name, task_id, unrestricted=None, debug=True)
 
 
 def test_task_restart_missing_toad_container_recreates_via_toad_runner() -> None:
@@ -367,7 +386,7 @@ def test_task_restart_missing_toad_container_recreates_via_toad_runner() -> None
             output = capture_stdout(task_restart, project_name, task_id)
 
         assert "Recreating" in output
-        run_toad.assert_called_once_with(project_name, task_id, unrestricted=None)
+        run_toad.assert_called_once_with(project_name, task_id, unrestricted=None, debug=False)
         run_cli.assert_not_called()
 
 
@@ -385,7 +404,7 @@ def test_ensure_task_running_launches_missing_container() -> None:
         ):
             capture_stdout(ensure_task_running, project_name, task_id, unrestricted=True)
 
-        run_cli.assert_called_once_with(project_name, task_id, unrestricted=True)
+        run_cli.assert_called_once_with(project_name, task_id, unrestricted=True, debug=False)
 
 
 def test_task_restart_fresh_skips_resume_and_recreates() -> None:

--- a/tests/unit/lib/test_emoji.py
+++ b/tests/unit/lib/test_emoji.py
@@ -11,6 +11,7 @@ import pytest
 from rich.cells import cell_len
 
 from terok.lib.core.task_display import (
+    DEBUG_BADGE,
     GPU_DISPLAY,
     MODE_DISPLAY,
     SECURITY_CLASS_DISPLAY,
@@ -34,6 +35,7 @@ EMOJI_COLLECTIONS = [
     pytest.param("security-class", SECURITY_CLASS_DISPLAY.values(), id="security-class"),
     pytest.param("gpu", GPU_DISPLAY.values(), id="gpu"),
     pytest.param("work-status", WORK_STATUS_DISPLAY.values(), id="work-status"),
+    pytest.param("debug-badge", [DEBUG_BADGE], id="debug-badge"),
 ]
 
 LABEL_COLLECTIONS = [
@@ -41,6 +43,7 @@ LABEL_COLLECTIONS = [
     pytest.param("security-class", SECURITY_CLASS_DISPLAY.values(), id="security-class"),
     pytest.param("gpu", GPU_DISPLAY.values(), id="gpu"),
     pytest.param("work-status", WORK_STATUS_DISPLAY.values(), id="work-status"),
+    pytest.param("debug-badge", [DEBUG_BADGE], id="debug-badge"),
 ]
 
 

--- a/tests/unit/lib/test_task_runner_internals.py
+++ b/tests/unit/lib/test_task_runner_internals.py
@@ -595,6 +595,26 @@ class TestRunContainer:
         assert spec.gpus is None
         assert spec.unrestricted is False  # FOO doesn't have TEROK_UNRESTRICTED
 
+    def test_allow_debugger_forwarded_to_launch_prepared(self) -> None:
+        """``allow_debugger`` reaches ``launch_prepared``; default is False."""
+        project = self._make_project()
+        for requested, expected in ((True, True), (False, False)):
+            with patch(
+                "terok.lib.orchestration.task_runners.container._agent_runner"
+            ) as sandbox_factory:
+                _run_container(
+                    task_id="t1",
+                    cname="test-ctr",
+                    image="alpine:latest",
+                    env={},
+                    volumes=[],
+                    project=project,
+                    task_dir=MOCK_TASK_DIR,
+                    allow_debugger=requested,
+                )
+            kwargs = sandbox_factory.return_value.launch_prepared.call_args.kwargs
+            assert kwargs["allow_debugger"] is expected
+
     def test_unrestricted_flag_from_env(self) -> None:
         """unrestricted is True when TEROK_UNRESTRICTED is in env."""
         project = self._make_project()

--- a/tests/unit/lib/test_tasks.py
+++ b/tests/unit/lib/test_tasks.py
@@ -2007,6 +2007,26 @@ class TestGetTaskMeta:
             assert tm.container_state is None
             mock_runtime.container.assert_not_called()
 
+    @pytest.mark.parametrize(
+        ("persisted", "expected"),
+        [(True, True), (False, False), ("true", False), (1, False), (None, False)],
+        ids=["true", "false", "truthy-string", "truthy-int", "absent"],
+    )
+    def test_debug_hydrates_fail_closed(self, mock_runtime, persisted, expected) -> None:
+        """Only a canonical JSON ``true`` enables debug; anything else fails closed."""
+        from terok.lib.orchestration.tasks import get_task_meta
+
+        pid = "proj_gtm_debug"
+        with project_env(f"project:\n  id: {pid}\n", project_name=pid), mock_git_config():
+            task_id = task_new(pid)
+            meta_dir = tasks_meta_dir(pid)
+            meta = read_task_meta(meta_dir, task_id)
+            if persisted is not None:
+                meta["debug"] = persisted
+            write_task_meta(dossier_path(meta_dir, task_id), meta)
+
+            assert get_task_meta(pid, task_id).debug is expected
+
 
 class TestDossierHandle:
     """_dossier_handle_to_dir_and_id decomposes a dossier-file handle."""

--- a/tests/unit/lib/test_unattended.py
+++ b/tests/unit/lib/test_unattended.py
@@ -401,6 +401,20 @@ class TestTaskRunHeadless:
             assert meta["mode"] == "run"
             assert meta["exit_code"] == 0
 
+    def test_headless_debug_flows_to_sidecar_and_meta(self) -> None:
+        """``--debug`` reaches ``launch_prepared`` and is persisted in task meta."""
+        with tempfile.TemporaryDirectory() as td:
+            base = Path(td)
+            result = run_headless_request(
+                base,
+                write_runner_project(base, "proj_dbg"),
+                HeadlessRunRequest("proj_dbg", "test", debug=True),
+            )
+
+            kwargs = result.run_mock.return_value.launch_prepared.call_args.kwargs
+            assert kwargs["allow_debugger"] is True
+            assert read_task_meta(base, "proj_dbg", result.task_id)["debug"] is True
+
     def test_headless_no_follow_mode(self) -> None:
         """task_run_headless with follow=False prints detach info."""
         with tempfile.TemporaryDirectory() as td:

--- a/tests/unit/tui/test_list_widgets.py
+++ b/tests/unit/tui/test_list_widgets.py
@@ -79,6 +79,21 @@ def test_task_list_preserves_live_state_and_posts_current_project() -> None:
     assert messages[-1].task.task_id == "t1"
 
 
+def test_task_label_shows_debug_badge_only_when_debug() -> None:
+    """A debug-mode task gets the cockroach badge; a normal one does not."""
+    widgets = import_widgets()
+    task_list = widgets.TaskList()
+    _wire_listview(task_list)
+    task_list._label_width = lambda: 80
+
+    cockroach = "\U0001fab3"
+    normal = widgets.TaskMeta(task_id="t1", mode="cli", workspace="", web_port=None)
+    debugged = widgets.TaskMeta(task_id="t2", mode="cli", workspace="", web_port=None, debug=True)
+
+    assert cockroach not in task_list._format_task_label(normal)
+    assert cockroach in task_list._format_task_label(debugged)
+
+
 def test_task_list_drops_stale_selection_messages() -> None:
     """Stale rows from another project cannot update the current selection."""
     widgets = import_widgets()

--- a/tests/unit/tui/test_list_widgets.py
+++ b/tests/unit/tui/test_list_widgets.py
@@ -80,7 +80,13 @@ def test_task_list_preserves_live_state_and_posts_current_project() -> None:
 
 
 def test_task_label_shows_debug_badge_only_when_debug() -> None:
-    """A debug-mode task gets the cockroach badge; a normal one does not."""
+    """A debug-mode task gets the cockroach badge; a normal one does not.
+
+    Covers both render modes: the native-wide emoji when enabled, and the
+    ``[debug]`` text fallback when emoji rendering is globally disabled.
+    """
+    from terok.lib.util.emoji import is_emoji_enabled, set_emoji_enabled
+
     widgets = import_widgets()
     task_list = widgets.TaskList()
     _wire_listview(task_list)
@@ -92,6 +98,14 @@ def test_task_label_shows_debug_badge_only_when_debug() -> None:
 
     assert cockroach not in task_list._format_task_label(normal)
     assert cockroach in task_list._format_task_label(debugged)
+
+    original = is_emoji_enabled()
+    set_emoji_enabled(False)
+    try:
+        assert "[debug]" not in task_list._format_task_label(normal)
+        assert "[debug]" in task_list._format_task_label(debugged)
+    finally:
+        set_emoji_enabled(original)
 
 
 def test_task_list_drops_stale_selection_messages() -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -2396,7 +2396,7 @@ requires-dist = [
     { name = "rich", specifier = "~=15.0" },
     { name = "ruamel-yaml", specifier = "==0.19.1" },
     { name = "terok-clearance", url = "https://github.com/terok-ai/terok-clearance/releases/download/v0.8.0a6/terok_clearance-0.8.0a6-py3-none-any.whl" },
-    { name = "terok-executor", url = "https://github.com/terok-ai/terok-executor/releases/download/v0.4.0a15/terok_executor-0.4.0a15-py3-none-any.whl" },
+    { name = "terok-executor", git = "https://github.com/sliwowitz/terok-executor?rev=feat%2Fdebug-mode-allow-debugger" },
     { name = "terok-sandbox", url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.5.0a15/terok_sandbox-0.5.0a15-py3-none-any.whl" },
     { name = "terok-shield", url = "https://github.com/terok-ai/terok-shield/releases/download/v0.8.0a6/terok_shield-0.8.0a6-py3-none-any.whl" },
     { name = "terok-util", url = "https://github.com/terok-ai/terok-util/releases/download/v0.3.1a3/terok_util-0.3.1a3-py3-none-any.whl" },
@@ -2462,8 +2462,8 @@ requires-dist = [
 
 [[package]]
 name = "terok-executor"
-version = "0.4.0a15"
-source = { url = "https://github.com/terok-ai/terok-executor/releases/download/v0.4.0a15/terok_executor-0.4.0a15-py3-none-any.whl" }
+version = "0.4.0a16.dev442+g996598ae8"
+source = { git = "https://github.com/sliwowitz/terok-executor?rev=feat%2Fdebug-mode-allow-debugger#996598ae8152c2cecebb2272aa4d506dbc2f8185" }
 dependencies = [
     { name = "agent-client-protocol" },
     { name = "jinja2" },
@@ -2474,22 +2474,6 @@ dependencies = [
     { name = "terok-sandbox" },
     { name = "terok-util" },
     { name = "tomli-w" },
-]
-wheels = [
-    { url = "https://github.com/terok-ai/terok-executor/releases/download/v0.4.0a15/terok_executor-0.4.0a15-py3-none-any.whl", hash = "sha256:8f222bbf47b15fcbcbaee2f90e9fab2d4ddc663a845361aba1346f85b48d01b4" },
-]
-
-[package.metadata]
-requires-dist = [
-    { name = "agent-client-protocol", specifier = "==0.11.0" },
-    { name = "jinja2", specifier = "~=3.1" },
-    { name = "prompt-toolkit", specifier = "~=3.0" },
-    { name = "pydantic", specifier = "~=2.13" },
-    { name = "rich", specifier = "~=15.0" },
-    { name = "ruamel-yaml", specifier = "==0.19.1" },
-    { name = "terok-sandbox", url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.5.0a15/terok_sandbox-0.5.0a15-py3-none-any.whl" },
-    { name = "terok-util", url = "https://github.com/terok-ai/terok-util/releases/download/v0.3.1a3/terok_util-0.3.1a3-py3-none-any.whl" },
-    { name = "tomli-w", specifier = "~=1.2" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -2397,7 +2397,7 @@ requires-dist = [
     { name = "ruamel-yaml", specifier = "==0.19.1" },
     { name = "terok-clearance", url = "https://github.com/terok-ai/terok-clearance/releases/download/v0.8.0a6/terok_clearance-0.8.0a6-py3-none-any.whl" },
     { name = "terok-executor", git = "https://github.com/sliwowitz/terok-executor?rev=feat%2Fdebug-mode-allow-debugger" },
-    { name = "terok-sandbox", url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.5.0a15/terok_sandbox-0.5.0a15-py3-none-any.whl" },
+    { name = "terok-sandbox", url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.5.0a16/terok_sandbox-0.5.0a16-py3-none-any.whl" },
     { name = "terok-shield", url = "https://github.com/terok-ai/terok-shield/releases/download/v0.8.0a6/terok_shield-0.8.0a6-py3-none-any.whl" },
     { name = "terok-util", url = "https://github.com/terok-ai/terok-util/releases/download/v0.3.1a3/terok_util-0.3.1a3-py3-none-any.whl" },
     { name = "textual", extras = ["syntax"], specifier = "~=8.2.8" },
@@ -2462,8 +2462,8 @@ requires-dist = [
 
 [[package]]
 name = "terok-executor"
-version = "0.4.0a16.dev443+g2cb7dd40c"
-source = { git = "https://github.com/sliwowitz/terok-executor?rev=feat%2Fdebug-mode-allow-debugger#2cb7dd40c397f3517e2e428105a6d1203de6591b" }
+version = "0.4.0a16.dev444+g3a846a735"
+source = { git = "https://github.com/sliwowitz/terok-executor?rev=feat%2Fdebug-mode-allow-debugger#3a846a735cbb7e79b81a57e6c6224b1103ad0013" }
 dependencies = [
     { name = "agent-client-protocol" },
     { name = "jinja2" },
@@ -2478,8 +2478,8 @@ dependencies = [
 
 [[package]]
 name = "terok-sandbox"
-version = "0.5.0a15"
-source = { url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.5.0a15/terok_sandbox-0.5.0a15-py3-none-any.whl" }
+version = "0.5.0a16"
+source = { url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.5.0a16/terok_sandbox-0.5.0a16-py3-none-any.whl" }
 dependencies = [
     { name = "aiohttp" },
     { name = "cryptography" },
@@ -2496,7 +2496,7 @@ dependencies = [
     { name = "terok-util" },
 ]
 wheels = [
-    { url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.5.0a15/terok_sandbox-0.5.0a15-py3-none-any.whl", hash = "sha256:789d565d3c79197002f0f7986207b9e2a7e5a6555577f791a464feda5b9a14aa" },
+    { url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.5.0a16/terok_sandbox-0.5.0a16-py3-none-any.whl", hash = "sha256:fb2bcec4afca6c5a8b4081170c7686d7e87b6058681b9264ecbd3cf573888dae" },
 ]
 
 [package.metadata]

--- a/uv.lock
+++ b/uv.lock
@@ -2462,8 +2462,8 @@ requires-dist = [
 
 [[package]]
 name = "terok-executor"
-version = "0.4.0a16.dev442+g996598ae8"
-source = { git = "https://github.com/sliwowitz/terok-executor?rev=feat%2Fdebug-mode-allow-debugger#996598ae8152c2cecebb2272aa4d506dbc2f8185" }
+version = "0.4.0a16.dev443+g2cb7dd40c"
+source = { git = "https://github.com/sliwowitz/terok-executor?rev=feat%2Fdebug-mode-allow-debugger#2cb7dd40c397f3517e2e428105a6d1203de6591b" }
 dependencies = [
     { name = "agent-client-protocol" },
     { name = "jinja2" },

--- a/uv.lock
+++ b/uv.lock
@@ -2396,7 +2396,7 @@ requires-dist = [
     { name = "rich", specifier = "~=15.0" },
     { name = "ruamel-yaml", specifier = "==0.19.1" },
     { name = "terok-clearance", url = "https://github.com/terok-ai/terok-clearance/releases/download/v0.8.0a6/terok_clearance-0.8.0a6-py3-none-any.whl" },
-    { name = "terok-executor", git = "https://github.com/sliwowitz/terok-executor?rev=feat%2Fdebug-mode-allow-debugger" },
+    { name = "terok-executor", url = "https://github.com/terok-ai/terok-executor/releases/download/v0.4.0a16/terok_executor-0.4.0a16-py3-none-any.whl" },
     { name = "terok-sandbox", url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.5.0a16/terok_sandbox-0.5.0a16-py3-none-any.whl" },
     { name = "terok-shield", url = "https://github.com/terok-ai/terok-shield/releases/download/v0.8.0a6/terok_shield-0.8.0a6-py3-none-any.whl" },
     { name = "terok-util", url = "https://github.com/terok-ai/terok-util/releases/download/v0.3.1a3/terok_util-0.3.1a3-py3-none-any.whl" },
@@ -2462,8 +2462,8 @@ requires-dist = [
 
 [[package]]
 name = "terok-executor"
-version = "0.4.0a16.dev444+g3a846a735"
-source = { git = "https://github.com/sliwowitz/terok-executor?rev=feat%2Fdebug-mode-allow-debugger#3a846a735cbb7e79b81a57e6c6224b1103ad0013" }
+version = "0.4.0a16"
+source = { url = "https://github.com/terok-ai/terok-executor/releases/download/v0.4.0a16/terok_executor-0.4.0a16-py3-none-any.whl" }
 dependencies = [
     { name = "agent-client-protocol" },
     { name = "jinja2" },
@@ -2474,6 +2474,22 @@ dependencies = [
     { name = "terok-sandbox" },
     { name = "terok-util" },
     { name = "tomli-w" },
+]
+wheels = [
+    { url = "https://github.com/terok-ai/terok-executor/releases/download/v0.4.0a16/terok_executor-0.4.0a16-py3-none-any.whl", hash = "sha256:b1ff837f7d41440dafefddc498e0ed70c959a57421ca9ec033d699d1a42d8f5a" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "agent-client-protocol", specifier = "==0.11.0" },
+    { name = "jinja2", specifier = "~=3.1" },
+    { name = "prompt-toolkit", specifier = "~=3.0" },
+    { name = "pydantic", specifier = "~=2.13" },
+    { name = "rich", specifier = "~=15.0" },
+    { name = "ruamel-yaml", specifier = "==0.19.1" },
+    { name = "terok-sandbox", url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.5.0a16/terok_sandbox-0.5.0a16-py3-none-any.whl" },
+    { name = "terok-util", url = "https://github.com/terok-ai/terok-util/releases/download/v0.3.1a3/terok_util-0.3.1a3-py3-none-any.whl" },
+    { name = "tomli-w", specifier = "~=1.2" },
 ]
 
 [[package]]


### PR DESCRIPTION
Closes #1176.

## What

Operator-facing UX for launching a task with the hardening floor relaxed so a debugger can attach to the split supervisor's per-service processes.

The supervisor process split (util#70 → sandbox#450) hardens every service child via `harden_self`: `PR_SET_DUMPABLE=0` (no ptrace, no core), `RLIMIT_CORE=0`, `mlockall`. Great for production, but it also makes the split's *other* payoff — a debuggable per-service process — unreachable. `terok task run --debug` lifts **only** the dumpable clear for one launch; the core-file limit and `mlockall` still apply.

## Changes

- **CLI** — `--debug` on `terok task run` (all three modes). Threads through the cli/toad/headless runners and `_run_container` into `AgentRunner.launch_prepared(allow_debugger=...)`, which writes it into the per-container supervisor sidecar. The explicit flag is the **sole hardening authority (fail-closed)** — never derived from `-O` / `__debug__`.
- **Persistence** — the choice is saved in task meta and carried forward when a container is recreated by `task restart` (recreation rewrites the sidecar from scratch).
- **TUI** — a read-only 🪳 badge (cockroach, U+1FAB3 — natively wide, no VS16) marks debug-mode tasks in the task list. **No TUI control enables it** — asking for debug mode presumes terminal dexterity, so the trigger stays CLI-only (per the design call on the issue).
- **Docs** — new *Debug Mode* section in `usage.md`.

## Design decisions (from the issue)

- Trigger = **CLI-only**; indicator = **TUI, read-only**.
- Hardening authority = the explicit sidecar flag, **fail-closed**. Not coupled to `-O`/`__debug__` (which would fail *open* if `-O` were forgotten).

## Dependency chain

Pins `terok-executor` to `sliwowitz:feat/debug-mode-allow-debugger` (terok-ai/terok-executor#493), which adds the `allow_debugger` pass-through to `launch_prepared` / the executor CLI. The sandbox mechanism (`SidecarConfig.allow_debugger`, child hardening opt-out) already shipped in the supervisor-split chain (sandbox 0.5.0a12+).

**Merge order:** land executor#493 → cut an executor alpha → repin terok to the release wheel + `uv lock` → merge here.

## Tests

- `_run_container` / headless runner forward `allow_debugger`; default is fully-hardened.
- `--debug` CLI dispatch across cli / toad / headless.
- Debug choice persists in meta and survives `task restart` recreation.
- Cockroach badge appears only for debug-mode tasks; width/no-VS16 hygiene covered.

Full unit suite green (3194 passed); lint, tach, import-linter, docstrings, reuse, bandit, mypy, `properdocs build --strict` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a `--debug` option for `terok task run` to relax only the dumpability hardening so debuggers can attach (other protections remain).
  * Added a read-only debug badge to the task list for debug-mode tasks.
  * Persisted debug mode in task metadata and honored it across task restarts/recreation.
  * Updated the usage documentation with “Debug Mode” guidance.
  * Refreshed pinned runtime dependency versions.

* **Tests**
  * Extended unit coverage for `--debug` across headless/interactive flows, metadata fail-closed behavior, restart/recreation, and badge rendering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->