### PR TITLE
feat(tui): show Debug line in task detail pane and screen

### DIFF
--- a/src/terok/tui/widgets/task_detail.py
+++ b/src/terok/tui/widgets/task_detail.py
@@ -11,7 +11,7 @@ from textual import events
 from textual.app import ComposeResult
 from textual.widgets import Static
 
-from ...lib.api import STATUS_DISPLAY, TaskMeta, get_config, mode_info
+from ...lib.api import DEBUG_BADGE, STATUS_DISPLAY, TaskMeta, get_config, mode_info
 from ...lib.util.emoji import render_emoji
 from ...lib.util.net import url_host
 from ...ui_utils.terminal import wrap_with_hanging_indent
@@ -77,6 +77,11 @@ def render_task_details(
         Text(f"Status:    {render_emoji(s_info)} {s_info.label}"),
         Text(type_line),
     ]
+    # Read-only debug marker (``terok task run --debug``) — surfaced here
+    # as well as the task-list badge so the relaxed hardening floor is
+    # visible from the detail pane and the details screen.
+    if task.debug:
+        lines.append(Text(f"Debug:     {render_emoji(DEBUG_BADGE)} enabled"))
     if task.work_status:
         work_text = task.work_status
         if task.work_message:

--- a/tests/unit/tui/test_detail_screens.py
+++ b/tests/unit/tui/test_detail_screens.py
@@ -227,6 +227,12 @@ class TestRenderHelpers:
         text_str = str(result)
         assert "42" in text_str
 
+    def test_render_task_details_shows_debug_line_when_debug(self) -> None:
+        assert_rendered_needles(render_task_details_text(debug=True), ["Debug:", "enabled"], [])
+
+    def test_render_task_details_omits_debug_line_by_default(self) -> None:
+        assert_rendered_needles(render_task_details_text(), [], ["Debug:"])
+
     def test_render_task_details_none_shows_empty_message(self) -> None:
         widgets = import_widgets()
 


### PR DESCRIPTION
## What

Surfaces the read-only **debug marker** (`terok task run --debug`) in the task
detail pane *and* the task details screen, not just the task-list cockroach
badge introduced in #1219.

```
Status:    ✅ running
Type:      🖥️ CLI
Debug:     🪳 enabled     ← only when task.debug
```

## Why

The badge told you a task was debug-mode from the list, but once you focused a
task the detail view gave no indication the hardening floor was relaxed. The
line closes that gap wherever a task is inspected.

## How

One edit to the shared `render_task_details()` in
`src/terok/tui/widgets/task_detail.py` — it backs both the `TaskDetails` pane
and `TaskDetailsScreen`, so a single change covers both surfaces. Reuses the
existing `DEBUG_BADGE` via `render_emoji` (same as the list badge). Renders only
when `task.debug` is set.

## Tests

Two locking tests added: the line is present when `debug=True` and absent by
default. Full `test_detail_screens.py` green (288 passed), lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Task details now display a “Debug: enabled” indicator when debug mode is active.

* **Bug Fixes**
  * Debug status is omitted when it is not enabled, keeping task details accurate and uncluttered.

* **Tests**
  * Added coverage to verify debug indicators appear only when applicable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->