### PR TITLE
feat(orchestration): log task-launch phase timings for startup profiling

### DIFF
--- a/src/terok/lib/orchestration/task_runners/cli.py
+++ b/src/terok/lib/orchestration/task_runners/cli.py
@@ -20,6 +20,7 @@ from ...core import runtime as _rt
 from ...core.images import project_cli_image
 from ...core.projects import load_project
 from ...util.ansi import green as _green, red as _red, supports_color as _supports_color
+from ...util.logging_utils import _log_debug, timed_phase
 from ..agent_config import resolve_agent_config
 from ..environment import build_task_env_and_volumes
 from ..hooks import run_hook
@@ -55,6 +56,7 @@ def task_run_cli(
     meta, meta_path = load_task_meta(project.name, task_id, "cli")
 
     cname = container_name(project.name, "cli", task_id)
+    _log_debug(f"cli run: start project={project.name} task={task_id} cname={cname}")
     # One resolve per launch — vault-expensive under krun.
     runtime = _rt.resolve_runtime(project)
     _refuse_existing_container(runtime, project.name, cname, task_id)
@@ -119,10 +121,11 @@ def task_run_cli(
     )
 
     # Stream initial logs until ready marker is seen (or timeout), then detach
-    runtime.container(cname).stream_initial_logs(
-        ready_check=lambda line: "__CLI_READY__" in line or ">> init complete" in line,
-        timeout_sec=60.0,
-    )
+    with timed_phase(f"launch[{cname}]: stream init logs"):
+        runtime.container(cname).stream_initial_logs(
+            ready_check=lambda line: "__CLI_READY__" in line or ">> init complete" in line,
+            timeout_sec=60.0,
+        )
 
     # Verify the container is still alive after log streaming
     _assert_running(project, cname)

--- a/src/terok/lib/orchestration/task_runners/container.py
+++ b/src/terok/lib/orchestration/task_runners/container.py
@@ -36,6 +36,7 @@ from ...core import runtime as _rt
 from ...core.config import make_sandbox_config
 from ...core.projects import load_project
 from ...util.ansi import blue as _blue, supports_color as _supports_color, yellow as _yellow
+from ...util.logging_utils import timed_phase
 from ..tasks import dossier_path, tasks_meta_dir
 
 if TYPE_CHECKING:
@@ -275,29 +276,30 @@ def _run_container(
     if project.perf:
         _maybe_warn_perf_restricted()
     try:
-        _agent_runner(project).launch_prepared(
-            env=env,
-            volumes=volumes,
-            image=image,
-            command=list(command or ()),
-            name=cname,
-            task_dir=task_dir,
-            gpus=project.gpus,
-            memory=project.memory,
-            cpus=project.cpus,
-            caps=("perfmon",) if project.perf else None,
-            unrestricted="TEROK_UNRESTRICTED" in env,
-            sealed=project.is_sealed,
-            hooks=hooks,
-            extra_args=merged_args,
-            runtime=project.runtime,
-            hostname=cname,
-            annotations=annotations,
-            project_id=project.name,  # executor API kwarg is ``project_id``; value is the project name
-            task_id=task_id,
-            dossier_path=task_dossier_path,
-            allow_debugger=allow_debugger,
-        )
+        with timed_phase(f"launch[{cname}]: podman run"):
+            _agent_runner(project).launch_prepared(
+                env=env,
+                volumes=volumes,
+                image=image,
+                command=list(command or ()),
+                name=cname,
+                task_dir=task_dir,
+                gpus=project.gpus,
+                memory=project.memory,
+                cpus=project.cpus,
+                caps=("perfmon",) if project.perf else None,
+                unrestricted="TEROK_UNRESTRICTED" in env,
+                sealed=project.is_sealed,
+                hooks=hooks,
+                extra_args=merged_args,
+                runtime=project.runtime,
+                hostname=cname,
+                annotations=annotations,
+                project_id=project.name,  # executor API kwarg is ``project_id``; value is the project name
+                task_id=task_id,
+                dossier_path=task_dossier_path,
+                allow_debugger=allow_debugger,
+            )
     except FileNotFoundError as exc:
         raise SystemExit(f"podman not found; please install podman ({exc})") from exc
     except BuildError as exc:

--- a/src/terok/lib/orchestration/task_runners/shield.py
+++ b/src/terok/lib/orchestration/task_runners/shield.py
@@ -27,6 +27,7 @@ from terok.lib.integrations.sandbox import ShieldManager
 
 from ...core import runtime as _rt
 from ...core.config import SHIELD_SECURITY_HINT, get_shield_bypass_firewall_no_protection
+from ...util.logging_utils import timed_phase
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -260,28 +261,33 @@ def _apply_shield_policy(
     if get_shield_bypass_firewall_no_protection():
         return
 
-    try:
-        if is_restart:
-            policy = project.shield_on_task_restart
-            if policy == "retain":
-                _restore_shield_state(cname, task_dir)
-            elif policy == "up":
-                pass  # already UP from OCI hook
+    with timed_phase(f"shield[{cname}]: apply policy"):
+        try:
+            if is_restart:
+                policy = project.shield_on_task_restart
+                if policy == "retain":
+                    _restore_shield_state(cname, task_dir)
+                elif policy == "up":
+                    pass  # already UP from OCI hook
+                else:
+                    raise ValueError(
+                        f"Unknown shield.on_task_restart value: {policy!r} "
+                        "(expected 'retain' or 'up')"
+                    )
+            elif project.shield_drop_on_task_run:
+                _drop_shield_on_creation(cname, task_dir)
             else:
-                raise ValueError(
-                    f"Unknown shield.on_task_restart value: {policy!r} (expected 'retain' or 'up')"
-                )
-        elif project.shield_drop_on_task_run:
-            _drop_shield_on_creation(cname, task_dir)
-        else:
-            _write_desired_shield_state(task_dir, "up")
+                _write_desired_shield_state(task_dir, "up")
 
-        _apply_auth_protect_denies(cname, task_dir)
-    except Exception:
-        # Any shield-application failure leaves a live, half-protected
-        # container.  Tear it down before surfacing the original error.
-        _stop_container_best_effort(project, cname)
-        raise
+            # Roster-driven denies resolve allowlist hostnames — the DNS-bound
+            # step, timed separately as the usual suspect for a slow shield-up.
+            with timed_phase(f"shield[{cname}]: auth-protect denies"):
+                _apply_auth_protect_denies(cname, task_dir)
+        except Exception:
+            # Any shield-application failure leaves a live, half-protected
+            # container.  Tear it down before surfacing the original error.
+            _stop_container_best_effort(project, cname)
+            raise
 
 
 __all__ = [

--- a/src/terok/lib/orchestration/task_runners/toad.py
+++ b/src/terok/lib/orchestration/task_runners/toad.py
@@ -32,6 +32,7 @@ from ...util.ansi import (
     supports_color as _supports_color,
     yellow as _yellow,
 )
+from ...util.logging_utils import timed_phase
 from ...util.net import url_host
 from ..agent_config import resolve_agent_config
 from ..environment import build_task_env_and_volumes
@@ -241,10 +242,11 @@ def task_run_toad(
         """Return True when the supervisor wrapper reports both listeners are up."""
         return "TEROK_READY" in line
 
-    ready = runtime.container(cname).stream_initial_logs(
-        ready_check=_toad_ready,
-        timeout_sec=None,
-    )
+    with timed_phase(f"launch[{cname}]: stream init logs"):
+        ready = runtime.container(cname).stream_initial_logs(
+            ready_check=_toad_ready,
+            timeout_sec=None,
+        )
 
     if not ready or not runtime.container(cname).running:
         print(f"Toad failed to start. Check logs: podman logs {cname}")

--- a/src/terok/lib/util/logging_utils.py
+++ b/src/terok/lib/util/logging_utils.py
@@ -16,6 +16,9 @@ operator's terminal (CWE-150).
 
 from __future__ import annotations
 
+import time
+from collections.abc import Iterator
+from contextlib import contextmanager
 from pathlib import Path
 
 from terok_util import BestEffortLogger, sanitize_tty
@@ -47,6 +50,29 @@ def _log_debug(message: str) -> None:
 def log_warning(message: str) -> None:
     """Append a WARNING line to the terok library log."""
     _logger.warning(message)
+
+
+@contextmanager
+def timed_phase(name: str) -> Iterator[None]:
+    """Bracket a launch/lifecycle phase with best-effort timing DEBUG lines.
+
+    Emits ``<name>: start`` on entry and ``<name>: done in N.NNs`` on
+    clean exit (``failed in N.NNs`` when the wrapped body raises), so a
+    slow ``terok task run`` is diagnosable from ``terok.log`` alone —
+    the shared file log only ever timestamps to the second, so the
+    monotonic delta is what resolves the sub-second phase boundaries.
+    The wrapped exception always propagates unchanged; logging never
+    masks it.
+    """
+    _log_debug(f"{name}: start")
+    started = time.monotonic()
+    ok = False
+    try:
+        yield
+        ok = True
+    finally:
+        elapsed = time.monotonic() - started
+        _log_debug(f"{name}: {'done' if ok else 'failed'} in {elapsed:.2f}s")
 
 
 def warn_user(component: str, message: str) -> None:

--- a/tests/unit/lib/util/test_logging_utils.py
+++ b/tests/unit/lib/util/test_logging_utils.py
@@ -1,0 +1,35 @@
+# SPDX-FileCopyrightText: 2026 Jiri Vyskocil
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the best-effort logging helpers."""
+
+from __future__ import annotations
+
+import pytest
+
+from terok.lib.util import logging_utils
+
+
+def test_timed_phase_logs_start_and_done(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A clean phase logs a start line and a ``done in N.NNs`` line."""
+    lines: list[str] = []
+    monkeypatch.setattr(logging_utils, "_log_debug", lines.append)
+
+    with logging_utils.timed_phase("launch[c1]: podman run"):
+        pass
+
+    assert lines[0] == "launch[c1]: podman run: start"
+    assert lines[1].startswith("launch[c1]: podman run: done in ")
+    assert lines[1].endswith("s")
+
+
+def test_timed_phase_logs_failed_and_reraises(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A raising body logs ``failed in N.NNs`` and propagates the exception."""
+    lines: list[str] = []
+    monkeypatch.setattr(logging_utils, "_log_debug", lines.append)
+
+    with pytest.raises(ValueError, match="boom"), logging_utils.timed_phase("shield[c1]: policy"):
+        raise ValueError("boom")
+
+    assert lines[0] == "shield[c1]: policy: start"
+    assert lines[1].startswith("shield[c1]: policy: failed in ")


### PR DESCRIPTION
Closes #1222.

## Problem

The task **delete** path is fully instrumented with `_log_debug`, so a slow
delete shows up as timestamped lines in `~/.local/share/terok/core/terok.log`.
The task **launch** path emitted *nothing* — a slow `terok task run` left no
on-disk trace, and the startup phases (podman-run vs shield vs in-container
init) could only be guessed at.

## Change

Add a small `timed_phase` context manager to `lib/util/logging_utils.py` — it
logs `<name>: start` on entry and `<name>: done in N.NNs` (`failed in N.NNs`
when the body raises) on exit. Elapsed time is a `time.monotonic()` delta,
because `BestEffortLogger` only timestamps to the second — the delta is what
resolves the sub-second phase boundaries. The wrapped exception always
propagates unchanged.

Bracket the three launch phases where the wall-clock actually goes:

- `_run_container` → `launch[<cname>]: podman run`
- `_apply_shield_policy` → `shield[<cname>]: apply policy`, with the DNS-bound
  roster denies timed separately as `shield[<cname>]: auth-protect denies`
  (the usual suspect for a slow shield-up)
- the CLI / toad init-log stream → `launch[<cname>]: stream init logs`

Instrumenting the shared `container.py` / `shield.py` helpers covers **every**
runner (cli, toad, headless, restart) at once; the cli runner also logs a
`cli run: start project=… task=… cname=…` anchor line.

Example `terok.log` for one CLI launch:

```
cli run: start project=terok-f task=n1xtj cname=terok-f_cli-n1xtj
launch[terok-f_cli-n1xtj]: podman run: start
launch[terok-f_cli-n1xtj]: podman run: done in 2.13s
shield[terok-f_cli-n1xtj]: apply policy: start
shield[terok-f_cli-n1xtj]: auth-protect denies: start
shield[terok-f_cli-n1xtj]: auth-protect denies: done in 4.71s
shield[terok-f_cli-n1xtj]: apply policy: done in 4.83s
launch[terok-f_cli-n1xtj]: stream init logs: done in 1.20s
```

## Relationship to #1188

Complementary, not a duplicate. #1188 persists the *visible* output stream
byte-for-byte ("what was printed"); this measures the *gaps between* phases,
which a raw byte-tee can't surface without violating its "live output is
sacred" constraint.

## Tests

New `tests/unit/lib/util/test_logging_utils.py` locks the start/done and
failed/re-raise behaviour. Full suite green (3211 passed), lint + tach clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added detailed debug timing information for container launches, startup log streaming, task initialization, and security policy application.
  * Timing entries report phase names, elapsed duration, and whether each phase completed or failed.

* **Tests**
  * Added coverage verifying timing logs for successful and failed operations, including exception propagation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->