### PR TITLE
feat: unified logging — consume terok-util facility, configure() at entry points

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -144,6 +144,25 @@ Run `terok config paths` to check whether completions are detected as installed.
 | Override (whole tree) | `TEROK_ROOT=/path/to/root` or `paths.root` in config.yml |
 | Override (terok core state only) | `TEROK_STATE_DIR=/path/to/state` |
 
+### Build/run output logs
+
+Image builds and task launches stream their output to your terminal *and*
+persist it durably, so the diagnostic signal survives the terminal. The live
+output is byte-for-byte unchanged (colours and progress bars intact — the
+capture fronts the operation with a pseudo-terminal); the durable copy goes
+to one of two backends, chosen automatically:
+
+| Host | Backend | Retrieve | Retention |
+|------|---------|----------|-----------|
+| **systemd present** | journald | `journalctl -t terok TEROK_KIND=run` (add `TEROK_TASK=<id>` / `TEROK_PROJECT=<name>` to filter) | managed by journald |
+| **no systemd** | timestamped files under `…/terok/core/projects/<project>/logs/` (`build-*.log`, `run-<task>-*.log`) | unlimited (never auto-pruned) |
+
+Each operation prints a `↳ output …` pointer to stderr on completion so the
+location is discoverable. The file backend is deliberately unbounded; to cap
+growth on a non-systemd host, point logrotate at the glob — see
+[`examples/logrotate/terok.conf`](https://github.com/terok-ai/terok/blob/master/examples/logrotate/terok.conf).
+On systemd hosts nothing extra is needed — journald owns retention.
+
 ---
 
 ## Global Configuration

--- a/examples/logrotate/terok.conf
+++ b/examples/logrotate/terok.conf
@@ -1,0 +1,29 @@
+# logrotate configuration for terok build/run output logs.
+#
+# Only needed on NON-systemd hosts: when journald is present, terok routes
+# captured build/run output to the journal instead of to files, and journald
+# handles retention/rotation itself (SystemMaxUse=, MaxRetentionSec=, …).
+#
+# On non-systemd hosts terok writes one timestamped file per operation under
+# each project's state dir and never prunes them (unlimited by design). Point
+# logrotate at the glob below to bound that growth.
+#
+# terok is a rootless, per-user tool, so run logrotate as your own user rather
+# than dropping this into /etc/logrotate.d:
+#
+#   logrotate --state ~/.local/state/terok/logrotate.status \
+#             examples/logrotate/terok.conf
+#
+# Wire that command into a user cron entry or a systemd --user timer. Adjust
+# the path if you override XDG_DATA_HOME / TEROK_ROOT / TEROK_STATE_DIR.
+
+/home/*/.local/share/terok/core/projects/*/logs/*.log {
+    weekly
+    missingok
+    notifempty
+    rotate 8
+    maxage 60
+    compress
+    delaycompress
+    nocreate
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,11 +44,11 @@ dependencies = [
     "unique-namer~=1.6",
     "textual-serve~=1.1",
     "jinja2~=3.1",
-    "terok-executor @ git+https://github.com/sliwowitz/terok-executor@feat/unified-logging",
-    "terok-sandbox @ git+https://github.com/sliwowitz/terok-sandbox@feat/unified-logging",
-    "terok-shield @ git+https://github.com/sliwowitz/terok-shield@feat/unified-logging",
-    "terok-clearance @ git+https://github.com/sliwowitz/terok-clearance@feat/unified-logging",
-    "terok-util @ git+https://github.com/sliwowitz/terok-util@feat/unified-logging",
+    "terok-executor @ https://github.com/terok-ai/terok-executor/releases/download/v0.4.0a18/terok_executor-0.4.0a18-py3-none-any.whl",
+    "terok-sandbox @ https://github.com/terok-ai/terok-sandbox/releases/download/v0.5.0a19/terok_sandbox-0.5.0a19-py3-none-any.whl",
+    "terok-shield @ https://github.com/terok-ai/terok-shield/releases/download/v0.8.0a8/terok_shield-0.8.0a8-py3-none-any.whl",
+    "terok-clearance @ https://github.com/terok-ai/terok-clearance/releases/download/v0.8.0a7/terok_clearance-0.8.0a7-py3-none-any.whl",
+    "terok-util @ https://github.com/terok-ai/terok-util/releases/download/v0.3.1a4/terok_util-0.3.1a4-py3-none-any.whl",
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,11 +44,11 @@ dependencies = [
     "unique-namer~=1.6",
     "textual-serve~=1.1",
     "jinja2~=3.1",
-    "terok-executor @ https://github.com/terok-ai/terok-executor/releases/download/v0.4.0a17/terok_executor-0.4.0a17-py3-none-any.whl",
-    "terok-sandbox @ https://github.com/terok-ai/terok-sandbox/releases/download/v0.5.0a18/terok_sandbox-0.5.0a18-py3-none-any.whl",
-    "terok-shield @ https://github.com/terok-ai/terok-shield/releases/download/v0.8.0a7/terok_shield-0.8.0a7-py3-none-any.whl",
-    "terok-clearance @ https://github.com/terok-ai/terok-clearance/releases/download/v0.8.0a6/terok_clearance-0.8.0a6-py3-none-any.whl",
-    "terok-util @ https://github.com/terok-ai/terok-util/releases/download/v0.3.1a3/terok_util-0.3.1a3-py3-none-any.whl",
+    "terok-executor @ git+https://github.com/sliwowitz/terok-executor@feat/unified-logging",
+    "terok-sandbox @ git+https://github.com/sliwowitz/terok-sandbox@feat/unified-logging",
+    "terok-shield @ git+https://github.com/sliwowitz/terok-shield@feat/unified-logging",
+    "terok-clearance @ git+https://github.com/sliwowitz/terok-clearance@feat/unified-logging",
+    "terok-util @ git+https://github.com/sliwowitz/terok-util@feat/unified-logging",
 ]
 
 [project.urls]
@@ -70,7 +70,7 @@ terok-askpass = "terok.tui.askpass:main"
 
 [dependency-groups]
 dev = [
-    "ruff~=0.16.0",
+    "ruff>=0.15.21",
     "markdown-it-py>=4.0.0",
     "mdit-py-plugins>=0.5.0",
     "tach>=0.35.0,<0.36",

--- a/src/terok/cli/commands/project.py
+++ b/src/terok/cli/commands/project.py
@@ -24,6 +24,7 @@ from ...lib.api import (
 from ...lib.core.projects import list_projects, load_project, normalize_project_name
 from ...lib.domain.project import make_git_gate
 from ...lib.domain.wizards.new_project import offer_edit_then_init, run_wizard
+from ...lib.util.output_capture import tee_output
 from ._completers import complete_project_names as _complete_project_names, set_completer
 from .setup import cmd_project_init
 
@@ -279,13 +280,14 @@ def dispatch(args: argparse.Namespace) -> bool:
         case "generate":
             generate_dockerfiles(args.project_name)
         case "build":
-            build_images(
-                args.project_name,
-                include_dev=getattr(args, "dev", False),
-                refresh_agents=getattr(args, "refresh_agents", False),
-                full_rebuild=getattr(args, "full_rebuild", False),
-                agents=getattr(args, "agents", None),
-            )
+            with tee_output("build", project=args.project_name):
+                build_images(
+                    args.project_name,
+                    include_dev=getattr(args, "dev", False),
+                    refresh_agents=getattr(args, "refresh_agents", False),
+                    full_rebuild=getattr(args, "full_rebuild", False),
+                    agents=getattr(args, "agents", None),
+                )
         case "ssh-init":
             _cmd_ssh_init(args)
         case "gate-path":

--- a/src/terok/cli/commands/task.py
+++ b/src/terok/cli/commands/task.py
@@ -35,6 +35,7 @@ from ...lib.api import (
 )
 from ...lib.core.config import get_logs_partial_streaming as _get_logs_partial_streaming
 from ...lib.orchestration.tasks import resolve_task_id
+from ...lib.util.output_capture import tee_output
 from ._completers import add_project_name, add_task_id
 
 
@@ -511,12 +512,13 @@ def _cmd_task_run_interactive(args: argparse.Namespace, *, runner: Any, attach: 
     pid = args.project_name
     _ensure_project_image(pid)
     tid = task_new(pid, name=getattr(args, "name", None))
-    runner(
-        pid,
-        tid,
-        unrestricted=_resolve_unrestricted(args),
-        debug=getattr(args, "debug", False),
-    )
+    with tee_output("run", project=pid, task_id=tid):
+        runner(
+            pid,
+            tid,
+            unrestricted=_resolve_unrestricted(args),
+            debug=getattr(args, "debug", False),
+        )
     if attach:
         # ``task_login`` calls ``os.execvp`` and never returns on success.
         task_login(pid, tid)
@@ -537,22 +539,23 @@ def _cmd_task_run_headless(args: argparse.Namespace) -> None:
 
     _ensure_project_image(args.project_name)
 
-    task_run_headless(
-        HeadlessRunRequest(
-            project_name=args.project_name,
-            prompt=prompt,
-            config_path=getattr(args, "agent_config", None),
-            model=getattr(args, "model", None),
-            timeout=getattr(args, "timeout", None),
-            follow=not getattr(args, "no_follow", False),
-            name=getattr(args, "name", None),
-            agent=getattr(args, "agent", None),
-            provider=getattr(args, "provider", None),
-            instructions=instructions_text,
-            unrestricted=_resolve_unrestricted(args),
-            debug=getattr(args, "debug", False),
+    with tee_output("run", project=args.project_name):
+        task_run_headless(
+            HeadlessRunRequest(
+                project_name=args.project_name,
+                prompt=prompt,
+                config_path=getattr(args, "agent_config", None),
+                model=getattr(args, "model", None),
+                timeout=getattr(args, "timeout", None),
+                follow=not getattr(args, "no_follow", False),
+                name=getattr(args, "name", None),
+                agent=getattr(args, "agent", None),
+                provider=getattr(args, "provider", None),
+                instructions=instructions_text,
+                unrestricted=_resolve_unrestricted(args),
+                debug=getattr(args, "debug", False),
+            )
         )
-    )
 
 
 def _resolve_attach(args: argparse.Namespace) -> bool:
@@ -603,7 +606,8 @@ def _ensure_project_image(project_name: str) -> None:
     if answer in ("n", "no"):
         raise SystemExit(hint)
 
-    build_images(project_name)
+    with tee_output("build", project=project_name):
+        build_images(project_name)
 
 
 def _read_instructions(instructions_path: str | None) -> str | None:
@@ -757,7 +761,8 @@ def _dispatch_task_sub(args: argparse.Namespace) -> bool:
         task_stop(pid, tid, timeout=getattr(args, "timeout", None))
     elif args.task_cmd == "restart":
         _setup_verdict_or_exit()
-        task_restart(pid, tid, fresh=args.recreate)
+        with tee_output("run", project=pid, task_id=tid):
+            task_restart(pid, tid, fresh=args.recreate)
     elif args.task_cmd == "followup":
         _setup_verdict_or_exit()
         task_followup_headless(

--- a/src/terok/cli/main.py
+++ b/src/terok/cli/main.py
@@ -184,8 +184,13 @@ def main(prog: str = "terok") -> None:
     # stack.  Command modules are loaded lazily too — only the invoked verb's
     # module (see ``_load_own_commands``) — so ``terok <verb>`` imports one
     # command module instead of all fourteen.
+    from terok_util import configure
+
     from terok.lib.core.config import declare_setup_invocation, set_experimental
 
+    # One-time unified logging: routes every getLogger(__name__) under terok.*
+    # to journald (when present) or stderr, with no per-module wiring.
+    configure(identifier="terok")
     declare_setup_invocation()
     # Fast-path: bare ``terok`` in a terminal launches the TUI.  Scripts
     # piping ``terok`` get the argparse usage error instead — the TTY

--- a/src/terok/lib/util/output_capture.py
+++ b/src/terok/lib/util/output_capture.py
@@ -1,188 +1,29 @@
 # SPDX-FileCopyrightText: 2026 Jiri Vyskocil
 # SPDX-License-Identifier: Apache-2.0
 
-"""Tee build/run output to a durable sink while the live terminal stays intact.
+"""Persist build/run output — terok glue over the terok-util capture facility.
 
-[`tee_output`][terok.lib.util.output_capture.tee_output] wraps an operation
-(image build, task launch) and copies every byte its subprocesses write to
-stdout/stderr into a durable **sink**, without disturbing the live terminal:
-
-* a pseudo-terminal fronts the wrapped block when stdout is a TTY, so podman
-  still sees ``isatty(1) == True`` and keeps its colour + progress output —
-  the forwarded bytes are byte-for-byte what the operator would have seen;
-* a plain pipe is used when stdout is not a TTY (redirected / CI), matching
-  today's non-interactive behaviour while still capturing the stream.
-
-The sink is chosen by environment, not by the caller:
-
-* **journald** (native datagram protocol, no third-party binding) when its
-  socket is present — retention/rotation then belongs to journald, and the
-  entries are queryable with ``journalctl -t terok``;
-* an **unlimited per-project log file** otherwise, documented as the fallback
-  for non-systemd hosts (see ``examples/logrotate/terok.conf`` to cap growth).
-
-Only the capture seam lives here; the CLI command handlers decide *what* to
-wrap, so the TUI — which drives the same launch/build code through its own
-output capture — is never touched.
+The capture mechanism (pty tee, journald/file sinks) lives in
+[`terok_util.output_capture`][terok_util.output_capture]; this module adds
+only the terok-specific bits: the ``TEROK_KIND``/``PROJECT``/``TASK``
+journald fields and the file-fallback path under
+[`core_state_dir`][terok.lib.core.paths.core_state_dir].  The CLI command
+handlers wrap an operation with [`tee_output`][terok.lib.util.output_capture.tee_output];
+everything below the seam is shared with the rest of the fleet.
 """
 
 from __future__ import annotations
 
 import contextlib
 import os
-import signal
-import socket
-import struct
-import sys
-import threading
 from collections.abc import Iterator
 from datetime import UTC, datetime
 from pathlib import Path
-from typing import Protocol
 
-_JOURNALD_SOCKET = Path("/run/systemd/journal/socket")
-"""Local journald datagram socket — its presence is the systemd-is-here probe."""
+from terok_util import tee_output as _util_tee_output
 
-_SYSLOG_IDENTIFIER = "terok"
-"""``SYSLOG_IDENTIFIER`` stamped on every journald entry (``journalctl -t terok``)."""
-
-_PRIORITY_INFO = "6"
-"""syslog ``info`` priority for captured output lines."""
-
-_READ_CHUNK = 65536
-"""Bytes pulled per pump-thread read from the capture fd."""
-
-_LOG_FILE_MODE = 0o600
-"""Owner-only permissions for a bespoke log file (matches the terok log posture)."""
-
-_SIGWINCH = getattr(signal, "SIGWINCH", None)
-"""Terminal-resize signal, or ``None`` on platforms without it."""
-
-
-# ── journald native protocol ───────────────────────────────────────────
-
-
-def _encode_field(name: str, value: bytes) -> bytes:
-    """Encode one journal field in the native export format.
-
-    Newline-free values use the compact ``NAME=value\\n`` form; values that
-    contain a newline switch to the ``NAME\\n<64-bit LE length><value>\\n``
-    binary form journald mandates for multi-line data.
-    """
-    if b"\n" in value:
-        return name.encode() + b"\n" + struct.pack("<Q", len(value)) + value + b"\n"
-    return name.encode() + b"=" + value + b"\n"
-
-
-def _encode_fields(fields: dict[str, str]) -> bytes:
-    """Concatenate encoded journal fields into one datagram body."""
-    return b"".join(_encode_field(k, v.encode()) for k, v in fields.items())
-
-
-def _journald_available() -> bool:
-    """Return True when a local journald datagram socket is accepting."""
-    try:
-        return _JOURNALD_SOCKET.is_socket()
-    except OSError:
-        return False
-
-
-# ── sinks ──────────────────────────────────────────────────────────────
-
-
-class _Sink(Protocol):
-    """A durable destination for captured output bytes."""
-
-    def write(self, data: bytes) -> None:
-        """Absorb a chunk of captured bytes (never raises to the pump)."""
-
-    def close(self) -> None:
-        """Flush any buffered tail and release resources."""
-
-    def hint(self) -> str:
-        """One-line, operator-facing pointer to where the output landed."""
-
-
-class _FileSink:
-    """Append captured bytes verbatim to a per-operation log file."""
-
-    def __init__(self, path: Path) -> None:
-        """Create (truncating) the owner-only log file at *path*."""
-        path.parent.mkdir(parents=True, exist_ok=True)
-        self._path = path
-        self._fd = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, _LOG_FILE_MODE)
-
-    def write(self, data: bytes) -> None:
-        """Write *data* to the log file, ignoring partial-write short counts."""
-        _write_all(self._fd, data)
-
-    def close(self) -> None:
-        """Close the underlying file descriptor."""
-        os.close(self._fd)
-
-    def hint(self) -> str:
-        """Point the operator at the saved log file."""
-        return f"output saved to {self._path}"
-
-
-class _JournaldSink:
-    """Line-buffer captured bytes into structured journald entries.
-
-    Splits the byte stream on ``\\n`` and emits one entry per line;
-    carriage-return progress redraws collapse to their final rendered
-    segment so an in-place progress bar becomes a single tidy line rather
-    than a wall of overwrites.  Static fields (identifier, priority, the
-    terok project/task/kind) are encoded once and reused per line.
-    """
-
-    def __init__(self, static_fields: dict[str, str]) -> None:
-        """Connect the datagram socket and precompute the static field block."""
-        self._prefix = _encode_fields(static_fields)
-        self._task = static_fields.get("TEROK_TASK")
-        self._kind = static_fields.get("TEROK_KIND", "")
-        self._buf = bytearray()
-        self._sock = socket.socket(socket.AF_UNIX, socket.SOCK_DGRAM)
-        self._sock.connect(str(_JOURNALD_SOCKET))
-
-    def write(self, data: bytes) -> None:
-        """Buffer *data* and flush every complete line to the journal."""
-        self._buf += data
-        while (nl := self._buf.find(b"\n")) != -1:
-            line = bytes(self._buf[:nl])
-            del self._buf[: nl + 1]
-            self._emit(line)
-
-    def close(self) -> None:
-        """Emit any buffered tail (no trailing newline) and close the socket."""
-        if self._buf:
-            self._emit(bytes(self._buf))
-            self._buf.clear()
-        self._sock.close()
-
-    def hint(self) -> str:
-        """Point the operator at the matching ``journalctl`` query."""
-        query = f"journalctl -t {_SYSLOG_IDENTIFIER} TEROK_KIND={self._kind}"
-        if self._task:
-            query += f" TEROK_TASK={self._task}"
-        return f"output logged to journald — {query}"
-
-    def _emit(self, line: bytes) -> None:
-        """Send one line as a journal entry (best-effort; never raises)."""
-        if b"\r" in line:
-            line = line.rsplit(b"\r", 1)[-1]  # keep only the final redraw state
-        datagram = self._prefix + _encode_field("MESSAGE", line)
-        with contextlib.suppress(OSError):
-            self._sock.send(datagram)
-
-
-def _write_all(fd: int, data: bytes) -> None:
-    """Write every byte of *data* to *fd*, looping over short writes."""
-    view = memoryview(data)
-    while view:
-        view = view[os.write(fd, view) :]
-
-
-# ── sink selection + placement ─────────────────────────────────────────
+_IDENTIFIER = "terok"
+"""``SYSLOG_IDENTIFIER`` for captured build/run output in journald."""
 
 
 def _logs_dir(project: str | None) -> Path:
@@ -196,121 +37,39 @@ def _logs_dir(project: str | None) -> Path:
 
 
 def _log_file_path(kind: str, project: str | None, task_id: str | None) -> Path:
-    """Build a timestamped log-file path for one *kind* of operation."""
+    """Build a timestamped fallback log-file path for one *kind* of operation."""
     stamp = datetime.now(UTC).strftime("%Y%m%dT%H%M%SZ")
     stem = f"{kind}-{task_id}-{stamp}" if task_id else f"{kind}-{stamp}"
     return _logs_dir(project) / f"{stem}.log"
-
-
-def _make_sink(kind: str, project: str | None, task_id: str | None) -> _Sink:
-    """Pick the journald sink when systemd is present, else a bespoke file."""
-    if _journald_available():
-        fields = {
-            "SYSLOG_IDENTIFIER": _SYSLOG_IDENTIFIER,
-            "PRIORITY": _PRIORITY_INFO,
-            "TEROK_KIND": kind,
-        }
-        if project:
-            fields["TEROK_PROJECT"] = project
-        if task_id:
-            fields["TEROK_TASK"] = task_id
-        return _JournaldSink(fields)
-    return _FileSink(_log_file_path(kind, project, task_id))
-
-
-# ── capture seam ───────────────────────────────────────────────────────
-
-
-def _copy_winsize(src_fd: int, dst_fd: int) -> None:
-    """Copy the terminal window size from *src_fd* onto *dst_fd* (best-effort)."""
-    import fcntl
-    import termios
-
-    with contextlib.suppress(OSError):
-        packed = fcntl.ioctl(src_fd, termios.TIOCGWINSZ, b"\0" * 8)
-        fcntl.ioctl(dst_fd, termios.TIOCSWINSZ, packed)
-
-
-@contextlib.contextmanager
-def _capture(sink: _Sink) -> Iterator[None]:
-    """Redirect fd 1/2 through a pty (or pipe) and pump every byte to *sink*.
-
-    A reader thread copies bytes to both the real terminal (so the live
-    stream is unchanged) and *sink*.  A pty is used when the real stdout is
-    a TTY so downstream isatty checks still pass; a plain pipe otherwise.
-    """
-    sys.stdout.flush()
-    sys.stderr.flush()
-    saved_out, saved_err = os.dup(1), os.dup(2)
-    is_tty = os.isatty(saved_out)
-    if is_tty:
-        master, slave = os.openpty()
-        _copy_winsize(saved_out, slave)
-    else:
-        master, slave = os.pipe()
-
-    def _pump() -> None:
-        """Forward capture-fd bytes to the terminal and the sink until EOF."""
-        while True:
-            try:
-                data = os.read(master, _READ_CHUNK)
-            except OSError:
-                break  # EIO once the slave side is fully closed
-            if not data:
-                break
-            _write_all(saved_out, data)
-            with contextlib.suppress(Exception):
-                sink.write(data)  # a failing sink must never break live output
-
-    reader = threading.Thread(target=_pump, name="terok-output-tee", daemon=True)
-    prev_winch = None
-    try:
-        os.dup2(slave, 1)
-        os.dup2(slave, 2)
-        reader.start()
-        if is_tty and _SIGWINCH is not None:
-            with contextlib.suppress(ValueError):  # not in the main thread
-                prev_winch = signal.getsignal(_SIGWINCH)
-                signal.signal(_SIGWINCH, lambda *_: _copy_winsize(saved_out, slave))
-        yield
-    finally:
-        sys.stdout.flush()
-        sys.stderr.flush()
-        if prev_winch is not None and _SIGWINCH is not None:
-            signal.signal(_SIGWINCH, prev_winch)
-        os.dup2(saved_out, 1)
-        os.dup2(saved_err, 2)
-        os.close(slave)  # drop the last writer so the pump reads EOF
-        reader.join()
-        for fd in (master, saved_out, saved_err):
-            os.close(fd)
 
 
 @contextlib.contextmanager
 def tee_output(
     kind: str, *, project: str | None = None, task_id: str | None = None
 ) -> Iterator[None]:
-    """Capture the wrapped operation's output to journald or a log file.
+    """Capture a build/run operation's output to journald or a log file.
 
-    *kind* labels the operation (``"build"`` / ``"run"``) and, with
-    *project* / *task_id*, drives both the journald fields and the log
-    filename.  Capture is best-effort: if the pty/pipe seam cannot be set
-    up the operation still runs, un-teed, so logging never blocks a launch.
+    Thin wrapper over
+    [`terok_util.output_capture.tee_output`][terok_util.output_capture.tee_output]:
+    labels the stream with terok's journald fields and resolves the
+    file-fallback path lazily under the core state dir.
 
     Args:
         kind: Operation label — ``"build"`` or ``"run"``.
         project: Owning project name, when known.
         task_id: Owning task id, when known.
     """
-    try:
-        sink = _make_sink(kind, project, task_id)
-    except Exception:  # noqa: BLE001 — durability is a bonus, never a blocker
+    fields = {"TEROK_KIND": kind}
+    if project:
+        fields["TEROK_PROJECT"] = project
+    if task_id:
+        fields["TEROK_TASK"] = task_id
+    with _util_tee_output(
+        _IDENTIFIER,
+        fields=fields,
+        file_path_fn=lambda: _log_file_path(kind, project, task_id),
+    ):
         yield
-        return
-    try:
-        with _capture(sink):
-            yield
-    finally:
-        with contextlib.suppress(Exception):
-            sink.close()
-        print(f"↳ {sink.hint()}", file=sys.stderr)
+
+
+__all__ = ["tee_output"]

--- a/src/terok/lib/util/output_capture.py
+++ b/src/terok/lib/util/output_capture.py
@@ -1,0 +1,316 @@
+# SPDX-FileCopyrightText: 2026 Jiri Vyskocil
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tee build/run output to a durable sink while the live terminal stays intact.
+
+[`tee_output`][terok.lib.util.output_capture.tee_output] wraps an operation
+(image build, task launch) and copies every byte its subprocesses write to
+stdout/stderr into a durable **sink**, without disturbing the live terminal:
+
+* a pseudo-terminal fronts the wrapped block when stdout is a TTY, so podman
+  still sees ``isatty(1) == True`` and keeps its colour + progress output —
+  the forwarded bytes are byte-for-byte what the operator would have seen;
+* a plain pipe is used when stdout is not a TTY (redirected / CI), matching
+  today's non-interactive behaviour while still capturing the stream.
+
+The sink is chosen by environment, not by the caller:
+
+* **journald** (native datagram protocol, no third-party binding) when its
+  socket is present — retention/rotation then belongs to journald, and the
+  entries are queryable with ``journalctl -t terok``;
+* an **unlimited per-project log file** otherwise, documented as the fallback
+  for non-systemd hosts (see ``examples/logrotate/terok.conf`` to cap growth).
+
+Only the capture seam lives here; the CLI command handlers decide *what* to
+wrap, so the TUI — which drives the same launch/build code through its own
+output capture — is never touched.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import os
+import signal
+import socket
+import struct
+import sys
+import threading
+from collections.abc import Iterator
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Protocol
+
+_JOURNALD_SOCKET = Path("/run/systemd/journal/socket")
+"""Local journald datagram socket — its presence is the systemd-is-here probe."""
+
+_SYSLOG_IDENTIFIER = "terok"
+"""``SYSLOG_IDENTIFIER`` stamped on every journald entry (``journalctl -t terok``)."""
+
+_PRIORITY_INFO = "6"
+"""syslog ``info`` priority for captured output lines."""
+
+_READ_CHUNK = 65536
+"""Bytes pulled per pump-thread read from the capture fd."""
+
+_LOG_FILE_MODE = 0o600
+"""Owner-only permissions for a bespoke log file (matches the terok log posture)."""
+
+_SIGWINCH = getattr(signal, "SIGWINCH", None)
+"""Terminal-resize signal, or ``None`` on platforms without it."""
+
+
+# ── journald native protocol ───────────────────────────────────────────
+
+
+def _encode_field(name: str, value: bytes) -> bytes:
+    """Encode one journal field in the native export format.
+
+    Newline-free values use the compact ``NAME=value\\n`` form; values that
+    contain a newline switch to the ``NAME\\n<64-bit LE length><value>\\n``
+    binary form journald mandates for multi-line data.
+    """
+    if b"\n" in value:
+        return name.encode() + b"\n" + struct.pack("<Q", len(value)) + value + b"\n"
+    return name.encode() + b"=" + value + b"\n"
+
+
+def _encode_fields(fields: dict[str, str]) -> bytes:
+    """Concatenate encoded journal fields into one datagram body."""
+    return b"".join(_encode_field(k, v.encode()) for k, v in fields.items())
+
+
+def _journald_available() -> bool:
+    """Return True when a local journald datagram socket is accepting."""
+    try:
+        return _JOURNALD_SOCKET.is_socket()
+    except OSError:
+        return False
+
+
+# ── sinks ──────────────────────────────────────────────────────────────
+
+
+class _Sink(Protocol):
+    """A durable destination for captured output bytes."""
+
+    def write(self, data: bytes) -> None:
+        """Absorb a chunk of captured bytes (never raises to the pump)."""
+
+    def close(self) -> None:
+        """Flush any buffered tail and release resources."""
+
+    def hint(self) -> str:
+        """One-line, operator-facing pointer to where the output landed."""
+
+
+class _FileSink:
+    """Append captured bytes verbatim to a per-operation log file."""
+
+    def __init__(self, path: Path) -> None:
+        """Create (truncating) the owner-only log file at *path*."""
+        path.parent.mkdir(parents=True, exist_ok=True)
+        self._path = path
+        self._fd = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, _LOG_FILE_MODE)
+
+    def write(self, data: bytes) -> None:
+        """Write *data* to the log file, ignoring partial-write short counts."""
+        _write_all(self._fd, data)
+
+    def close(self) -> None:
+        """Close the underlying file descriptor."""
+        os.close(self._fd)
+
+    def hint(self) -> str:
+        """Point the operator at the saved log file."""
+        return f"output saved to {self._path}"
+
+
+class _JournaldSink:
+    """Line-buffer captured bytes into structured journald entries.
+
+    Splits the byte stream on ``\\n`` and emits one entry per line;
+    carriage-return progress redraws collapse to their final rendered
+    segment so an in-place progress bar becomes a single tidy line rather
+    than a wall of overwrites.  Static fields (identifier, priority, the
+    terok project/task/kind) are encoded once and reused per line.
+    """
+
+    def __init__(self, static_fields: dict[str, str]) -> None:
+        """Connect the datagram socket and precompute the static field block."""
+        self._prefix = _encode_fields(static_fields)
+        self._task = static_fields.get("TEROK_TASK")
+        self._kind = static_fields.get("TEROK_KIND", "")
+        self._buf = bytearray()
+        self._sock = socket.socket(socket.AF_UNIX, socket.SOCK_DGRAM)
+        self._sock.connect(str(_JOURNALD_SOCKET))
+
+    def write(self, data: bytes) -> None:
+        """Buffer *data* and flush every complete line to the journal."""
+        self._buf += data
+        while (nl := self._buf.find(b"\n")) != -1:
+            line = bytes(self._buf[:nl])
+            del self._buf[: nl + 1]
+            self._emit(line)
+
+    def close(self) -> None:
+        """Emit any buffered tail (no trailing newline) and close the socket."""
+        if self._buf:
+            self._emit(bytes(self._buf))
+            self._buf.clear()
+        self._sock.close()
+
+    def hint(self) -> str:
+        """Point the operator at the matching ``journalctl`` query."""
+        query = f"journalctl -t {_SYSLOG_IDENTIFIER} TEROK_KIND={self._kind}"
+        if self._task:
+            query += f" TEROK_TASK={self._task}"
+        return f"output logged to journald — {query}"
+
+    def _emit(self, line: bytes) -> None:
+        """Send one line as a journal entry (best-effort; never raises)."""
+        if b"\r" in line:
+            line = line.rsplit(b"\r", 1)[-1]  # keep only the final redraw state
+        datagram = self._prefix + _encode_field("MESSAGE", line)
+        with contextlib.suppress(OSError):
+            self._sock.send(datagram)
+
+
+def _write_all(fd: int, data: bytes) -> None:
+    """Write every byte of *data* to *fd*, looping over short writes."""
+    view = memoryview(data)
+    while view:
+        view = view[os.write(fd, view) :]
+
+
+# ── sink selection + placement ─────────────────────────────────────────
+
+
+def _logs_dir(project: str | None) -> Path:
+    """Return the log directory for *project* (or a global dir when None)."""
+    from ..core.paths import core_state_dir
+
+    base = core_state_dir()
+    if project and os.sep not in project and ".." not in project:
+        return base / "projects" / project / "logs"
+    return base / "logs"
+
+
+def _log_file_path(kind: str, project: str | None, task_id: str | None) -> Path:
+    """Build a timestamped log-file path for one *kind* of operation."""
+    stamp = datetime.now(UTC).strftime("%Y%m%dT%H%M%SZ")
+    stem = f"{kind}-{task_id}-{stamp}" if task_id else f"{kind}-{stamp}"
+    return _logs_dir(project) / f"{stem}.log"
+
+
+def _make_sink(kind: str, project: str | None, task_id: str | None) -> _Sink:
+    """Pick the journald sink when systemd is present, else a bespoke file."""
+    if _journald_available():
+        fields = {
+            "SYSLOG_IDENTIFIER": _SYSLOG_IDENTIFIER,
+            "PRIORITY": _PRIORITY_INFO,
+            "TEROK_KIND": kind,
+        }
+        if project:
+            fields["TEROK_PROJECT"] = project
+        if task_id:
+            fields["TEROK_TASK"] = task_id
+        return _JournaldSink(fields)
+    return _FileSink(_log_file_path(kind, project, task_id))
+
+
+# ── capture seam ───────────────────────────────────────────────────────
+
+
+def _copy_winsize(src_fd: int, dst_fd: int) -> None:
+    """Copy the terminal window size from *src_fd* onto *dst_fd* (best-effort)."""
+    import fcntl
+    import termios
+
+    with contextlib.suppress(OSError):
+        packed = fcntl.ioctl(src_fd, termios.TIOCGWINSZ, b"\0" * 8)
+        fcntl.ioctl(dst_fd, termios.TIOCSWINSZ, packed)
+
+
+@contextlib.contextmanager
+def _capture(sink: _Sink) -> Iterator[None]:
+    """Redirect fd 1/2 through a pty (or pipe) and pump every byte to *sink*.
+
+    A reader thread copies bytes to both the real terminal (so the live
+    stream is unchanged) and *sink*.  A pty is used when the real stdout is
+    a TTY so downstream isatty checks still pass; a plain pipe otherwise.
+    """
+    sys.stdout.flush()
+    sys.stderr.flush()
+    saved_out, saved_err = os.dup(1), os.dup(2)
+    is_tty = os.isatty(saved_out)
+    if is_tty:
+        master, slave = os.openpty()
+        _copy_winsize(saved_out, slave)
+    else:
+        master, slave = os.pipe()
+
+    def _pump() -> None:
+        """Forward capture-fd bytes to the terminal and the sink until EOF."""
+        while True:
+            try:
+                data = os.read(master, _READ_CHUNK)
+            except OSError:
+                break  # EIO once the slave side is fully closed
+            if not data:
+                break
+            _write_all(saved_out, data)
+            with contextlib.suppress(Exception):
+                sink.write(data)  # a failing sink must never break live output
+
+    reader = threading.Thread(target=_pump, name="terok-output-tee", daemon=True)
+    prev_winch = None
+    try:
+        os.dup2(slave, 1)
+        os.dup2(slave, 2)
+        reader.start()
+        if is_tty and _SIGWINCH is not None:
+            with contextlib.suppress(ValueError):  # not in the main thread
+                prev_winch = signal.getsignal(_SIGWINCH)
+                signal.signal(_SIGWINCH, lambda *_: _copy_winsize(saved_out, slave))
+        yield
+    finally:
+        sys.stdout.flush()
+        sys.stderr.flush()
+        if prev_winch is not None and _SIGWINCH is not None:
+            signal.signal(_SIGWINCH, prev_winch)
+        os.dup2(saved_out, 1)
+        os.dup2(saved_err, 2)
+        os.close(slave)  # drop the last writer so the pump reads EOF
+        reader.join()
+        for fd in (master, saved_out, saved_err):
+            os.close(fd)
+
+
+@contextlib.contextmanager
+def tee_output(
+    kind: str, *, project: str | None = None, task_id: str | None = None
+) -> Iterator[None]:
+    """Capture the wrapped operation's output to journald or a log file.
+
+    *kind* labels the operation (``"build"`` / ``"run"``) and, with
+    *project* / *task_id*, drives both the journald fields and the log
+    filename.  Capture is best-effort: if the pty/pipe seam cannot be set
+    up the operation still runs, un-teed, so logging never blocks a launch.
+
+    Args:
+        kind: Operation label — ``"build"`` or ``"run"``.
+        project: Owning project name, when known.
+        task_id: Owning task id, when known.
+    """
+    try:
+        sink = _make_sink(kind, project, task_id)
+    except Exception:  # noqa: BLE001 — durability is a bonus, never a blocker
+        yield
+        return
+    try:
+        with _capture(sink):
+            yield
+    finally:
+        with contextlib.suppress(Exception):
+            sink.close()
+        print(f"↳ {sink.hint()}", file=sys.stderr)

--- a/src/terok/lib/util/output_capture.py
+++ b/src/terok/lib/util/output_capture.py
@@ -26,18 +26,51 @@ _IDENTIFIER = "terok"
 """``SYSLOG_IDENTIFIER`` for captured build/run output in journald."""
 
 
+def _reject_unsafe_component(value: str, label: str) -> None:
+    """Raise ``ValueError`` if *value* cannot be a single path component safely.
+
+    ``project``, ``kind`` and ``task_id`` all land in the fallback log path —
+    ``project`` as a directory level under
+    [`core_state_dir`][terok.lib.core.paths.core_state_dir], ``kind``/``task_id``
+    interpolated into the filename.  A value carrying a NUL, a path separator,
+    or a bare ``.``/``..`` could escape that tree — ``task_id="../../etc/cron.d/x"``
+    or an absolute ``"/etc/passwd"`` would otherwise resolve a log path outside
+    the state dir.  Traversal is a bug or an attack, never a real component, so
+    every one of the three fails loud here rather than being silently rewritten.
+    """
+    separators = {"/", os.sep} | ({os.altsep} if os.altsep else set())
+    if "\0" in value or separators & set(value) or value in (os.curdir, os.pardir):
+        raise ValueError(f"unsafe {label} for log path: {value!r}")
+
+
 def _logs_dir(project: str | None) -> Path:
-    """Return the log directory for *project* (or a global dir when None)."""
+    """Return the log directory for *project* (or a global dir when None).
+
+    A supplied *project* is validated with
+    [`_reject_unsafe_component`][terok.lib.util.output_capture._reject_unsafe_component]
+    before it becomes a directory level, so the path stays under
+    [`core_state_dir`][terok.lib.core.paths.core_state_dir].
+    """
     from ..core.paths import core_state_dir
 
     base = core_state_dir()
-    if project and os.sep not in project and ".." not in project:
-        return base / "projects" / project / "logs"
-    return base / "logs"
+    if not project:
+        return base / "logs"
+    _reject_unsafe_component(project, "project")
+    return base / "projects" / project / "logs"
 
 
 def _log_file_path(kind: str, project: str | None, task_id: str | None) -> Path:
-    """Build a timestamped fallback log-file path for one *kind* of operation."""
+    """Build a timestamped fallback log-file path for one *kind* of operation.
+
+    *kind*, *project* and *task_id* are each validated with
+    [`_reject_unsafe_component`][terok.lib.util.output_capture._reject_unsafe_component]
+    (the latter two via [`_logs_dir`][terok.lib.util.output_capture._logs_dir])
+    before interpolation, so the returned path always stays under the state dir.
+    """
+    _reject_unsafe_component(kind, "kind")
+    if task_id:
+        _reject_unsafe_component(task_id, "task_id")
     stamp = datetime.now(UTC).strftime("%Y%m%dT%H%M%SZ")
     stem = f"{kind}-{task_id}-{stamp}" if task_id else f"{kind}-{stamp}"
     return _logs_dir(project) / f"{stem}.log"

--- a/src/terok/tui/app.py
+++ b/src/terok/tui/app.py
@@ -2793,7 +2793,18 @@ if _HAS_TEXTUAL:
         is already running; ``--new-session`` opts out and starts a parallel,
         tmux-named session instead.
         """
+        from terok_util import configure
+
         from terok.lib.core.config import declare_setup_invocation
+        from terok.lib.util.logging_utils import _terok_log_path
+
+        # Unified logging for the TUI process: journald when present, else the
+        # terok.log file — never a stderr StreamHandler, which would paint over
+        # the Textual screen.  (The file is the same one logging_utils appends
+        # its best-effort breadcrumbs to.)
+        _log_path = _terok_log_path()
+        _log_path.parent.mkdir(parents=True, exist_ok=True)
+        configure(identifier="terok", stream=_log_path.open("a", encoding="utf-8"))
 
         declare_setup_invocation()
         args = _build_arg_parser().parse_args()

--- a/tach.toml
+++ b/tach.toml
@@ -648,6 +648,13 @@ layer = "core"
 depends_on = ["terok.lib.core.paths"]
 utility = true
 
+# Tee build/run output to journald or a bespoke log file
+[[modules]]
+path = "terok.lib.util.output_capture"
+layer = "core"
+depends_on = ["terok.lib.core.paths"]
+utility = true
+
 # Emoji display-width utilities
 [[modules]]
 path = "terok.lib.util.emoji"

--- a/tests/unit/lib/util/test_output_capture.py
+++ b/tests/unit/lib/util/test_output_capture.py
@@ -1,150 +1,17 @@
 # SPDX-FileCopyrightText: 2026 Jiri Vyskocil
 # SPDX-License-Identifier: Apache-2.0
 
-"""Tests for build/run output capture (journald + file sinks, pty/pipe tee)."""
+"""Tests for the terok output-capture glue over terok_util.tee_output."""
 
 from __future__ import annotations
 
 import os
-import socket
-import struct
 import subprocess
 from pathlib import Path
 
 import pytest
 
 from terok.lib.util import output_capture as oc
-
-# ── native journald field encoding ─────────────────────────────────────
-
-
-def test_encode_field_compact_form() -> None:
-    assert oc._encode_field("MESSAGE", b"hello") == b"MESSAGE=hello\n"
-
-
-def test_encode_field_binary_form_for_multiline() -> None:
-    value = b"line1\nline2"
-    encoded = oc._encode_field("MESSAGE", value)
-    assert encoded == b"MESSAGE\n" + struct.pack("<Q", len(value)) + value + b"\n"
-
-
-# ── journald availability probe ────────────────────────────────────────
-
-
-def test_journald_available_true_for_socket(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    sock_path = tmp_path / "journal.sock"
-    receiver = socket.socket(socket.AF_UNIX, socket.SOCK_DGRAM)
-    receiver.bind(str(sock_path))
-    monkeypatch.setattr(oc, "_JOURNALD_SOCKET", sock_path)
-    try:
-        assert oc._journald_available() is True
-    finally:
-        receiver.close()
-
-
-def test_journald_available_false_for_plain_file(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    plain = tmp_path / "not-a-socket"
-    plain.write_text("")
-    monkeypatch.setattr(oc, "_JOURNALD_SOCKET", plain)
-    assert oc._journald_available() is False
-
-
-# ── file sink ──────────────────────────────────────────────────────────
-
-
-def test_file_sink_writes_bytes_owner_only(tmp_path: Path) -> None:
-    path = tmp_path / "logs" / "run.log"
-    sink = oc._FileSink(path)
-    sink.write(b"first\n")
-    sink.write(b"second\n")
-    sink.close()
-    assert path.read_bytes() == b"first\nsecond\n"
-    assert (path.stat().st_mode & 0o777) == 0o600
-
-
-# ── journald sink (real bound receiver) ────────────────────────────────
-
-
-def _bind_receiver(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> socket.socket:
-    sock_path = tmp_path / "journal.sock"
-    receiver = socket.socket(socket.AF_UNIX, socket.SOCK_DGRAM)
-    receiver.bind(str(sock_path))
-    receiver.settimeout(2.0)
-    monkeypatch.setattr(oc, "_JOURNALD_SOCKET", sock_path)
-    return receiver
-
-
-def test_journald_sink_emits_one_entry_per_line(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    receiver = _bind_receiver(tmp_path, monkeypatch)
-    try:
-        sink = oc._JournaldSink({"SYSLOG_IDENTIFIER": "terok", "TEROK_KIND": "run"})
-        sink.write(b"alpha\nbeta\n")
-        first = receiver.recv(65536)
-        second = receiver.recv(65536)
-        sink.close()
-    finally:
-        receiver.close()
-    assert b"MESSAGE=alpha\n" in first
-    assert b"TEROK_KIND=run\n" in first
-    assert b"MESSAGE=beta\n" in second
-
-
-def test_journald_sink_collapses_carriage_returns(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    receiver = _bind_receiver(tmp_path, monkeypatch)
-    try:
-        sink = oc._JournaldSink({"SYSLOG_IDENTIFIER": "terok"})
-        sink.write(b"10%\r55%\r100% done\n")
-        datagram = receiver.recv(65536)
-        sink.close()
-    finally:
-        receiver.close()
-    assert b"MESSAGE=100% done\n" in datagram
-    assert b"10%" not in datagram
-
-
-def test_journald_sink_flushes_unterminated_tail_on_close(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    receiver = _bind_receiver(tmp_path, monkeypatch)
-    try:
-        sink = oc._JournaldSink({"SYSLOG_IDENTIFIER": "terok"})
-        sink.write(b"no-newline-tail")
-        sink.close()
-        datagram = receiver.recv(65536)
-    finally:
-        receiver.close()
-    assert b"MESSAGE=no-newline-tail\n" in datagram
-
-
-# ── sink selection ─────────────────────────────────────────────────────
-
-
-def test_make_sink_prefers_journald_when_available(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setattr(oc, "_journald_available", lambda: True)
-    captured: dict[str, str] = {}
-    monkeypatch.setattr(oc, "_JournaldSink", lambda fields: captured.update(fields) or "J")
-    assert oc._make_sink("run", "proj", "t1") == "J"
-    assert captured["TEROK_PROJECT"] == "proj"
-    assert captured["TEROK_TASK"] == "t1"
-    assert captured["TEROK_KIND"] == "run"
-
-
-def test_make_sink_falls_back_to_file(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
-    monkeypatch.setattr(oc, "_journald_available", lambda: False)
-    monkeypatch.setattr(oc, "_log_file_path", lambda kind, project, task_id: tmp_path / "x.log")
-    sink = oc._make_sink("build", "proj", None)
-    try:
-        assert isinstance(sink, oc._FileSink)
-    finally:
-        sink.close()
 
 
 def test_log_file_path_shape(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
@@ -155,27 +22,27 @@ def test_log_file_path_shape(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) ->
     assert build_path.name.startswith("build-") and "None" not in build_path.name
 
 
-# ── end-to-end tee (non-tty pipe path, deterministic under capfd) ──────
+def test_logs_dir_scopes_by_project(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    monkeypatch.setattr("terok.lib.core.paths.core_state_dir", lambda: tmp_path)
+    assert oc._logs_dir("proj") == tmp_path / "projects" / "proj" / "logs"
+    assert oc._logs_dir(None) == tmp_path / "logs"
+    assert oc._logs_dir("../evil") == tmp_path / "logs"  # unsafe name falls back to global
 
 
-def test_tee_output_forwards_live_and_persists_to_file(
+def test_tee_output_delegates_and_persists(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capfd: pytest.CaptureFixture[str]
 ) -> None:
     log_path = tmp_path / "run.log"
-    monkeypatch.setattr(oc, "_journald_available", lambda: False)
     monkeypatch.setattr(oc, "_log_file_path", lambda kind, project, task_id: log_path)
+    from terok_util import output_capture as util_oc
+
+    monkeypatch.setattr(util_oc, "journald_available", lambda: False)
 
     with oc.tee_output("run", project="proj", task_id="t1"):
-        os.write(1, b"direct-fd-output\n")
-        subprocess.run(["printf", "subprocess-output\\n"], check=True)
+        os.write(1, b"hello-capture\n")
+        subprocess.run(["printf", "sub-line\\n"], check=True)
 
     live = capfd.readouterr()
     logged = log_path.read_text()
-    # Live stream still reached the terminal (pytest's captured fd)...
-    assert "direct-fd-output" in live.out
-    assert "subprocess-output" in live.out
-    # ...and the same bytes were persisted.
-    assert "direct-fd-output" in logged
-    assert "subprocess-output" in logged
-    # Discoverability hint names the saved file.
-    assert str(log_path) in live.err
+    assert "hello-capture" in live.out and "sub-line" in live.out
+    assert "hello-capture" in logged and "sub-line" in logged

--- a/tests/unit/lib/util/test_output_capture.py
+++ b/tests/unit/lib/util/test_output_capture.py
@@ -1,0 +1,181 @@
+# SPDX-FileCopyrightText: 2026 Jiri Vyskocil
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for build/run output capture (journald + file sinks, pty/pipe tee)."""
+
+from __future__ import annotations
+
+import os
+import socket
+import struct
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from terok.lib.util import output_capture as oc
+
+# ── native journald field encoding ─────────────────────────────────────
+
+
+def test_encode_field_compact_form() -> None:
+    assert oc._encode_field("MESSAGE", b"hello") == b"MESSAGE=hello\n"
+
+
+def test_encode_field_binary_form_for_multiline() -> None:
+    value = b"line1\nline2"
+    encoded = oc._encode_field("MESSAGE", value)
+    assert encoded == b"MESSAGE\n" + struct.pack("<Q", len(value)) + value + b"\n"
+
+
+# ── journald availability probe ────────────────────────────────────────
+
+
+def test_journald_available_true_for_socket(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    sock_path = tmp_path / "journal.sock"
+    receiver = socket.socket(socket.AF_UNIX, socket.SOCK_DGRAM)
+    receiver.bind(str(sock_path))
+    monkeypatch.setattr(oc, "_JOURNALD_SOCKET", sock_path)
+    try:
+        assert oc._journald_available() is True
+    finally:
+        receiver.close()
+
+
+def test_journald_available_false_for_plain_file(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    plain = tmp_path / "not-a-socket"
+    plain.write_text("")
+    monkeypatch.setattr(oc, "_JOURNALD_SOCKET", plain)
+    assert oc._journald_available() is False
+
+
+# ── file sink ──────────────────────────────────────────────────────────
+
+
+def test_file_sink_writes_bytes_owner_only(tmp_path: Path) -> None:
+    path = tmp_path / "logs" / "run.log"
+    sink = oc._FileSink(path)
+    sink.write(b"first\n")
+    sink.write(b"second\n")
+    sink.close()
+    assert path.read_bytes() == b"first\nsecond\n"
+    assert (path.stat().st_mode & 0o777) == 0o600
+
+
+# ── journald sink (real bound receiver) ────────────────────────────────
+
+
+def _bind_receiver(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> socket.socket:
+    sock_path = tmp_path / "journal.sock"
+    receiver = socket.socket(socket.AF_UNIX, socket.SOCK_DGRAM)
+    receiver.bind(str(sock_path))
+    receiver.settimeout(2.0)
+    monkeypatch.setattr(oc, "_JOURNALD_SOCKET", sock_path)
+    return receiver
+
+
+def test_journald_sink_emits_one_entry_per_line(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    receiver = _bind_receiver(tmp_path, monkeypatch)
+    try:
+        sink = oc._JournaldSink({"SYSLOG_IDENTIFIER": "terok", "TEROK_KIND": "run"})
+        sink.write(b"alpha\nbeta\n")
+        first = receiver.recv(65536)
+        second = receiver.recv(65536)
+        sink.close()
+    finally:
+        receiver.close()
+    assert b"MESSAGE=alpha\n" in first
+    assert b"TEROK_KIND=run\n" in first
+    assert b"MESSAGE=beta\n" in second
+
+
+def test_journald_sink_collapses_carriage_returns(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    receiver = _bind_receiver(tmp_path, monkeypatch)
+    try:
+        sink = oc._JournaldSink({"SYSLOG_IDENTIFIER": "terok"})
+        sink.write(b"10%\r55%\r100% done\n")
+        datagram = receiver.recv(65536)
+        sink.close()
+    finally:
+        receiver.close()
+    assert b"MESSAGE=100% done\n" in datagram
+    assert b"10%" not in datagram
+
+
+def test_journald_sink_flushes_unterminated_tail_on_close(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    receiver = _bind_receiver(tmp_path, monkeypatch)
+    try:
+        sink = oc._JournaldSink({"SYSLOG_IDENTIFIER": "terok"})
+        sink.write(b"no-newline-tail")
+        sink.close()
+        datagram = receiver.recv(65536)
+    finally:
+        receiver.close()
+    assert b"MESSAGE=no-newline-tail\n" in datagram
+
+
+# ── sink selection ─────────────────────────────────────────────────────
+
+
+def test_make_sink_prefers_journald_when_available(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(oc, "_journald_available", lambda: True)
+    captured: dict[str, str] = {}
+    monkeypatch.setattr(oc, "_JournaldSink", lambda fields: captured.update(fields) or "J")
+    assert oc._make_sink("run", "proj", "t1") == "J"
+    assert captured["TEROK_PROJECT"] == "proj"
+    assert captured["TEROK_TASK"] == "t1"
+    assert captured["TEROK_KIND"] == "run"
+
+
+def test_make_sink_falls_back_to_file(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    monkeypatch.setattr(oc, "_journald_available", lambda: False)
+    monkeypatch.setattr(oc, "_log_file_path", lambda kind, project, task_id: tmp_path / "x.log")
+    sink = oc._make_sink("build", "proj", None)
+    try:
+        assert isinstance(sink, oc._FileSink)
+    finally:
+        sink.close()
+
+
+def test_log_file_path_shape(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    monkeypatch.setattr(oc, "_logs_dir", lambda project: tmp_path)
+    run_path = oc._log_file_path("run", "proj", "t1")
+    build_path = oc._log_file_path("build", "proj", None)
+    assert run_path.name.startswith("run-t1-") and run_path.suffix == ".log"
+    assert build_path.name.startswith("build-") and "None" not in build_path.name
+
+
+# ── end-to-end tee (non-tty pipe path, deterministic under capfd) ──────
+
+
+def test_tee_output_forwards_live_and_persists_to_file(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capfd: pytest.CaptureFixture[str]
+) -> None:
+    log_path = tmp_path / "run.log"
+    monkeypatch.setattr(oc, "_journald_available", lambda: False)
+    monkeypatch.setattr(oc, "_log_file_path", lambda kind, project, task_id: log_path)
+
+    with oc.tee_output("run", project="proj", task_id="t1"):
+        os.write(1, b"direct-fd-output\n")
+        subprocess.run(["printf", "subprocess-output\\n"], check=True)
+
+    live = capfd.readouterr()
+    logged = log_path.read_text()
+    # Live stream still reached the terminal (pytest's captured fd)...
+    assert "direct-fd-output" in live.out
+    assert "subprocess-output" in live.out
+    # ...and the same bytes were persisted.
+    assert "direct-fd-output" in logged
+    assert "subprocess-output" in logged
+    # Discoverability hint names the saved file.
+    assert str(log_path) in live.err

--- a/tests/unit/lib/util/test_output_capture.py
+++ b/tests/unit/lib/util/test_output_capture.py
@@ -22,11 +22,78 @@ def test_log_file_path_shape(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) ->
     assert build_path.name.startswith("build-") and "None" not in build_path.name
 
 
+@pytest.mark.parametrize(
+    "task_id",
+    [
+        pytest.param("../../etc/cron.d/x", id="relative-traversal"),
+        pytest.param("..", id="bare-parent"),
+        pytest.param(".", id="bare-dot"),
+        pytest.param("/etc/passwd", id="absolute-path"),
+        pytest.param("a/b", id="embedded-separator"),
+        pytest.param("has\0nul", id="nul-byte"),
+    ],
+)
+def test_log_file_path_rejects_traversal_task_id(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, task_id: str
+) -> None:
+    """A *task_id* that could escape the log tree is rejected, not interpolated."""
+    monkeypatch.setattr(oc, "_logs_dir", lambda project: tmp_path)
+    with pytest.raises(ValueError, match="unsafe task_id"):
+        oc._log_file_path("run", "proj", task_id)
+
+
+@pytest.mark.parametrize(
+    "kind",
+    [
+        pytest.param("../evil", id="relative-traversal"),
+        pytest.param("..", id="bare-parent"),
+        pytest.param("/abs", id="absolute-path"),
+        pytest.param("build\0", id="nul-byte"),
+    ],
+)
+def test_log_file_path_rejects_unsafe_kind(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, kind: str
+) -> None:
+    """An unsafe *kind* label is rejected the same way as *task_id*."""
+    monkeypatch.setattr(oc, "_logs_dir", lambda project: tmp_path)
+    with pytest.raises(ValueError, match="unsafe kind"):
+        oc._log_file_path(kind, "proj", "t1")
+
+
+def test_log_file_path_stays_within_logs_dir(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Valid components resolve strictly under ``_logs_dir`` — no escape."""
+    logs = tmp_path / "logs"
+    monkeypatch.setattr(oc, "_logs_dir", lambda project: logs)
+    path = oc._log_file_path("run", "proj", "t1")
+    assert path.parent == logs
+    assert logs in path.resolve().parents
+
+
 def test_logs_dir_scopes_by_project(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     monkeypatch.setattr("terok.lib.core.paths.core_state_dir", lambda: tmp_path)
     assert oc._logs_dir("proj") == tmp_path / "projects" / "proj" / "logs"
     assert oc._logs_dir(None) == tmp_path / "logs"
-    assert oc._logs_dir("../evil") == tmp_path / "logs"  # unsafe name falls back to global
+
+
+@pytest.mark.parametrize(
+    "project",
+    [
+        pytest.param("../evil", id="relative-traversal"),
+        pytest.param("..", id="bare-parent"),
+        pytest.param("/abs", id="absolute-path"),
+        pytest.param("a/b", id="embedded-separator"),
+        pytest.param("has\0nul", id="nul-byte"),
+    ],
+)
+def test_logs_dir_rejects_unsafe_project(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, project: str
+) -> None:
+    """An unsafe *project* now fails loud too — same guard as kind/task_id."""
+    monkeypatch.setattr("terok.lib.core.paths.core_state_dir", lambda: tmp_path)
+    with pytest.raises(ValueError, match="unsafe project"):
+        oc._logs_dir(project)
 
 
 def test_tee_output_delegates_and_persists(

--- a/tests/unit/tui/test_app_main_logging.py
+++ b/tests/unit/tui/test_app_main_logging.py
@@ -1,0 +1,56 @@
+# SPDX-FileCopyrightText: 2026 Jiri Vyskocil
+# SPDX-License-Identifier: Apache-2.0
+
+"""The TUI entry point wires unified logging to a file, never stderr.
+
+[`main`][terok.tui.app.main] must route logging through
+[`configure`][terok_util.configure] with a ``stream=`` pointed at the
+``terok.log`` file — a stderr ``StreamHandler`` would paint over the Textual
+screen.  These smoke tests stub the actual launch (`_run_tui`) so no TUI or
+tmux session ever starts.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from terok.lib.util.logging_utils import _terok_log_path
+from terok.tui import app
+
+pytestmark = pytest.mark.skipif(not app._HAS_TEXTUAL, reason="requires textual")
+
+
+def test_main_configures_logging_to_file_then_runs() -> None:
+    """``main`` sends logging to the terok.log file stream, then launches the TUI."""
+    with (
+        patch("sys.argv", ["terok"]),
+        patch("terok_util.configure") as configure,
+        patch.object(app, "_run_tui") as run_tui,
+        patch.object(app, "_launch_in_tmux") as launch_tmux,
+    ):
+        app.main()
+
+    run_tui.assert_called_once()
+    launch_tmux.assert_not_called()
+    configure.assert_called_once()
+    kwargs = configure.call_args.kwargs
+    assert kwargs["identifier"] == "terok"
+    # Routed to the terok.log file — a real writable stream, not stderr.
+    assert kwargs["stream"].name == str(_terok_log_path())
+
+
+def test_main_creates_the_log_parent_directory() -> None:
+    """The log directory is materialised before the stream opens."""
+    log_path = _terok_log_path()
+    assert not log_path.parent.exists()  # isolated tmp HOME starts clean
+
+    with (
+        patch("sys.argv", ["terok"]),
+        patch.object(app, "_run_tui"),
+        patch.object(app, "_launch_in_tmux"),
+    ):
+        app.main()
+
+    assert log_path.parent.is_dir()

--- a/uv.lock
+++ b/uv.lock
@@ -4,14 +4,14 @@ requires-python = ">=3.12, <3.15"
 
 [[package]]
 name = "agent-client-protocol"
-version = "0.11.1"
+version = "0.11.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pydantic" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ae/a3/0af4ac4cdb943d0daffd214c02dc5f79596d71d1db40248ee4d54ac596b2/agent_client_protocol-0.11.1.tar.gz", hash = "sha256:96b02a94de53e05ec20f64cedd1b83744b64f3f94dd2b82ae5d0af88388239ea", size = 100326, upload-time = "2026-07-27T18:47:29.298Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/6c/93/396d02c91b387b2678f23081869ca47bd495fc6c78789022c683180cf5f1/agent_client_protocol-0.11.0.tar.gz", hash = "sha256:8920a3b27bdcc852fd7c73066f47ab53257dbfbe57b505e20a40c69f80a5391c", size = 87402, upload-time = "2026-07-05T17:07:56.803Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/18/28/cc93079c418b03de7a778cabbf66ceac5add98592f5daf30cf6f4b8f9096/agent_client_protocol-0.11.1-py3-none-any.whl", hash = "sha256:42790f0a25b8fd24f5c9b27b7e0c34123fc1a980024ad8ef965d1d169a5e42d4", size = 68122, upload-time = "2026-07-27T18:47:28.27Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/48/a1367dded7765f5489f9840389949d5aeac53a73aeb1b4e6c0ab61e1617a/agent_client_protocol-0.11.0-py3-none-any.whl", hash = "sha256:2d8570cd4911f8af9fbab4808f7b05f09204a756f346c7409ecdcae3f37cdb2f", size = 68089, upload-time = "2026-07-05T17:07:55.518Z" },
 ]
 
 [[package]]
@@ -444,58 +444,58 @@ wheels = [
 
 [[package]]
 name = "complexipy"
-version = "6.2.0"
+version = "6.0.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "tomli" },
     { name = "typer" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/f2/82/6a5c35b7c31ef56ed3d5fc94cd84d066ac1affb2484fc94afa0dbb15c127/complexipy-6.2.0.tar.gz", hash = "sha256:c90db418f1a3e885ebe75537e5930e2ad98543e3302b55f59684db343d30de2b", size = 355624, upload-time = "2026-07-23T03:44:13.721Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b3/5b/8ad2d572e42e222d8127b37cad8595d6b7bb1d1d8e0a5bd3cb378f0f1d2c/complexipy-6.0.1.tar.gz", hash = "sha256:ab0ab0c38962a3f58062a16badfb30b88c4a68029040fc5333e1d644b41dc744", size = 352346, upload-time = "2026-07-03T03:25:52.548Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d5/81/59d3cfe82ae5e604e141d9818aefec38d8aaf2135b487fb8d617273eae08/complexipy-6.2.0-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:fba9cd689ac9e5b64ea293ff0c116c5b9604135e9254beff6a94e38cd4143d1a", size = 2318663, upload-time = "2026-07-23T03:42:21.46Z" },
-    { url = "https://files.pythonhosted.org/packages/a9/34/02d286db0ed86a62cac0d922b7711b82d2f829e443eee63db91e4e2f02a1/complexipy-6.2.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:a6ec8a85df7247c9b64c9a9a3b01fd0912b5f8ab882aebd2864e98a127b82442", size = 2260436, upload-time = "2026-07-23T03:42:22.754Z" },
-    { url = "https://files.pythonhosted.org/packages/ca/9a/dbb27707e468c8328fe081232d1e5faa79d6ff423b71ec5cbfee65c191c4/complexipy-6.2.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0bfc712f41774a4f753a1860c5538d1235aa29b1a166c429722cf2ea367b5bad", size = 2463028, upload-time = "2026-07-23T03:42:23.905Z" },
-    { url = "https://files.pythonhosted.org/packages/70/0c/ea72103f64823d3320cca0ae19c8332cf4f3a7717fdd4210da5440c96e75/complexipy-6.2.0-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:3fcdbe5d947da0f8fb6d6b20c5d314671ecca6be5801cfdb4319f784a940bbe6", size = 2394585, upload-time = "2026-07-23T03:42:25.333Z" },
-    { url = "https://files.pythonhosted.org/packages/38/7c/0ae87725ae80e0abd17aaeb180017e59d68d83b4917c1cbb7ddfeff4f5d4/complexipy-6.2.0-cp312-cp312-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:dec6d86f4781e02339364828af9e0fc9063ba4e48f618470992947b385b89677", size = 2611760, upload-time = "2026-07-23T03:42:26.611Z" },
-    { url = "https://files.pythonhosted.org/packages/ae/e3/7973f54b785991f072fb097bfcd711da1d93858ba3e2cf864737bebdda58/complexipy-6.2.0-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:8487d25288f2e4c13e0fde79d7e896adea7cd23cbe2a8084c796c3b877e23650", size = 2848458, upload-time = "2026-07-23T03:42:27.906Z" },
-    { url = "https://files.pythonhosted.org/packages/56/9f/202f6fc146a942064d797744dd24f62a7655b902548e457f1ccc0d28a3c3/complexipy-6.2.0-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:0b57cd3804071d3faa00a2ea7e70f5c9c4c7d051666b9a2b5a2199e630ae006d", size = 2524478, upload-time = "2026-07-23T03:42:29.201Z" },
-    { url = "https://files.pythonhosted.org/packages/04/62/d349bca4df2e1d0b80b77141cc1639a8f89c39775b782658952b053d2007/complexipy-6.2.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:001651eff2f8c223d5763714a1ff79949de743d98c14c69894a90ebed1453b70", size = 2486988, upload-time = "2026-07-23T03:42:30.448Z" },
-    { url = "https://files.pythonhosted.org/packages/5d/d3/0e49f8945e8b6c0b313a8b0be610ee8af196bf17e9b5c86b1faec2dc87c1/complexipy-6.2.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:d7180fffb12f644c8672751764698cc09561643911b77d4940e7d8ca54778575", size = 2642157, upload-time = "2026-07-23T03:42:31.769Z" },
-    { url = "https://files.pythonhosted.org/packages/49/5d/159d49784c7a495aff708f03fb07792b56f9c3172354ef71ae5c77d2cbc3/complexipy-6.2.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:12d169d90d3b6341c363bd92a6c53b575b8de56b8adcf68070326f9a0bdeb3fe", size = 2738241, upload-time = "2026-07-23T03:42:33.11Z" },
-    { url = "https://files.pythonhosted.org/packages/7a/0b/2efbca058d0daeb7634debfb6176a9fd81f959c52cc07c7d1e851188fbde/complexipy-6.2.0-cp312-cp312-win32.whl", hash = "sha256:d95852e9ec89519d911cabd692966ce46d43ba367a981d20ed23e5affbb9fc4d", size = 2036394, upload-time = "2026-07-23T03:42:34.642Z" },
-    { url = "https://files.pythonhosted.org/packages/0a/47/1da2632de465d9f347e0fd22b1224e8941acc6a681ff8fbfaea34e90c5d3/complexipy-6.2.0-cp312-cp312-win_amd64.whl", hash = "sha256:cc10f24ee67ff51c46868cc7672179b23114e3c8a98c321c7b7711ed9bb45433", size = 2188314, upload-time = "2026-07-23T03:42:36.023Z" },
-    { url = "https://files.pythonhosted.org/packages/af/75/27c11d3921bbd575b9e398fcec895444b7dcacc28500c54e642a56198a28/complexipy-6.2.0-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:f926157cdeada0bb3e8729429bea928ca210b2cf6249ac70a2fb09548a606f50", size = 2318369, upload-time = "2026-07-23T03:42:37.268Z" },
-    { url = "https://files.pythonhosted.org/packages/77/80/ad38a2afa6a7f1878935493b725b7f33db94b748458224948b21a807f9d6/complexipy-6.2.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:18ec1d43b40fa5c32288b137c7516814afb73843dce7019ba6280d5f6666240f", size = 2260208, upload-time = "2026-07-23T03:42:38.563Z" },
-    { url = "https://files.pythonhosted.org/packages/c5/a4/b97e3cd5f338bcc77f0fcd8914bd2fa1deb14aeb62027e2f14d92109f9d1/complexipy-6.2.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:eaa51743c27f6a7ff00f6cf19be871903bd101318b0eb1aa9ba958e6c1922898", size = 2462929, upload-time = "2026-07-23T03:42:39.757Z" },
-    { url = "https://files.pythonhosted.org/packages/f5/0d/178f6a0e2dca3c2acdb0a4108c5942fd9ee6c5e76379a5aa9ddfc4564cb4/complexipy-6.2.0-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:9d6a561815bff1cad0c43649ec1b6d501b8c0a0ebc4c84ab34fabcd5b35b78ad", size = 2394705, upload-time = "2026-07-23T03:42:41.112Z" },
-    { url = "https://files.pythonhosted.org/packages/ae/e4/00921335f5f43fe5160b4b31763df55b53daa7dcd00fe11787975f9c941e/complexipy-6.2.0-cp313-cp313-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:cec2b4dc54e6b8ecc993a6e66652816ba93c3bc99729b28ed5d3410e39e713b8", size = 2611667, upload-time = "2026-07-23T03:42:42.314Z" },
-    { url = "https://files.pythonhosted.org/packages/1a/3c/e0d65a1e20da7c7fdb6da365119bc7de32e3cad946d97aea96e87291ac69/complexipy-6.2.0-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:5bd3ccc2fda92ebfd82ffa53498df1783d809a0c6ad56941eed42fcf312d0acc", size = 2848850, upload-time = "2026-07-23T03:42:43.748Z" },
-    { url = "https://files.pythonhosted.org/packages/87/cf/1d939868ae311c004ebeaf19403e03375f38edcf1037822216592bcc17e6/complexipy-6.2.0-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:1dfc7145be69fad1a828b4d92391a4e70299d8cdc0d74541a9b0d02daf05c67b", size = 2524160, upload-time = "2026-07-23T03:42:45.008Z" },
-    { url = "https://files.pythonhosted.org/packages/72/69/964a50dd8de47eedea4a05405fe2a2d7037fcc59702a5488c36234d39fe7/complexipy-6.2.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1b3077f387b7c225d1a5416e42dd005a9bd61031494608b768fe9fe62f67e662", size = 2487218, upload-time = "2026-07-23T03:42:46.216Z" },
-    { url = "https://files.pythonhosted.org/packages/3c/ed/a6304b3519bbdefc3fe3b68926be11e14708f4724be6668e9c81f5e56058/complexipy-6.2.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:2d426720668664fb79f04c271da5fa2c0293ffb1e19ed4db0a8de134ad16d550", size = 2641994, upload-time = "2026-07-23T03:42:47.54Z" },
-    { url = "https://files.pythonhosted.org/packages/a0/4f/9805118d69a7ab3dc5bce00ab6d1c1207f4619777b50981a0179979ecf39/complexipy-6.2.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:54c00af2b42d14ba0e94c812b33c018c386013128de584f8cbc3124567d28c7e", size = 2737925, upload-time = "2026-07-23T03:42:49.301Z" },
-    { url = "https://files.pythonhosted.org/packages/fd/80/749ec64ef80b3863efb6b8cef03071a0054c1041e1082059c7d0d4f23d54/complexipy-6.2.0-cp313-cp313-win32.whl", hash = "sha256:338359fb31b928f1a49063106b2cecd8e6f827897cf348efadc6fbd12719b961", size = 2036290, upload-time = "2026-07-23T03:42:50.645Z" },
-    { url = "https://files.pythonhosted.org/packages/1c/7d/31122b321a5647512af1d748e689556112d3b381da78ed7f1d982a5884ea/complexipy-6.2.0-cp313-cp313-win_amd64.whl", hash = "sha256:624762987e37db3da602996f9190a33cf995f1768a6652d6d21f6170767750ad", size = 2187968, upload-time = "2026-07-23T03:42:51.973Z" },
-    { url = "https://files.pythonhosted.org/packages/f7/fb/9d0f90e32d1a2462ed4f4012ea922a759e708cd8816506486e4347249957/complexipy-6.2.0-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:498018df8448124247880fb7d824130401a8ac18a8b17aca7ebd54b91c5502bf", size = 2319799, upload-time = "2026-07-23T03:42:53.242Z" },
-    { url = "https://files.pythonhosted.org/packages/af/60/4f0b620afb20ed0a78356325d7dc5835b8c3610847d7adda3237e80cffb3/complexipy-6.2.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:8077354d21cd7256347af67e33d0d0c2965a2512a9e174dfa01d6935a6a2c8ef", size = 2261117, upload-time = "2026-07-23T03:42:54.618Z" },
-    { url = "https://files.pythonhosted.org/packages/96/ca/1843e382dc4b4f612ada7b8a3ebf2bd4e4584f3acf99fce243ed735dc883/complexipy-6.2.0-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f954e8d62891b85c0f279c335dda7df24638fa83efe3c1d5f4752100c61b4494", size = 2463571, upload-time = "2026-07-23T03:42:55.895Z" },
-    { url = "https://files.pythonhosted.org/packages/b2/53/24cf69643ab14d7070ce243f504c63624dec13c916bb8bae99ccaf2a3fde/complexipy-6.2.0-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:0341b7d7ebc67a5e7b500007df2195f4f92d4e24e21a85fd954ff77f4dc6af18", size = 2394587, upload-time = "2026-07-23T03:42:57.158Z" },
-    { url = "https://files.pythonhosted.org/packages/b5/f1/c70bc68ad4bd57af77991dd3d85f27bfaf27e5263e3afea7862d0d63e561/complexipy-6.2.0-cp314-cp314-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:8e9c615f1910c7436e9dfc7680e79399a89bded1c554b9c0a37b94db1e6def55", size = 2612999, upload-time = "2026-07-23T03:42:58.531Z" },
-    { url = "https://files.pythonhosted.org/packages/2c/eb/db02f3f6cd1c3d047aac8b10b1ff95c98af4f538e07c1d32c9ff9cf757dc/complexipy-6.2.0-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:7285614c6be583ea702d22a19c09ec235b81bd11d9e754c9a940493e008a7e10", size = 2850798, upload-time = "2026-07-23T03:42:59.959Z" },
-    { url = "https://files.pythonhosted.org/packages/6d/41/d3f1eef665f9833adaee9aff1232bcba43451244fbf1ab4a180365236aff/complexipy-6.2.0-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:708c80d46ac70dbfa17bf82742d89852aeb679b0d7c05379314930327841ce3f", size = 2525119, upload-time = "2026-07-23T03:43:01.331Z" },
-    { url = "https://files.pythonhosted.org/packages/98/6a/bed199004647f134deafeff21afefde4e180694a58d11dd14e7287b28985/complexipy-6.2.0-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:12064f3e210243c532a3734fc87c149dbb4806ac171ce42843ee816d25387def", size = 2487604, upload-time = "2026-07-23T03:43:02.689Z" },
-    { url = "https://files.pythonhosted.org/packages/e7/b8/0a2b482ba94f744a54a09e54a77563c1bc22847664d7af5349d4f4940199/complexipy-6.2.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:d78cbea32ad23dcc6ab2d5589712e9a9493f1295d13ae3bb96268f8427cea6ed", size = 2642190, upload-time = "2026-07-23T03:43:04.321Z" },
-    { url = "https://files.pythonhosted.org/packages/cb/7b/1ec6e25c7b0a5706c20c6a06d92fdbe768d103c80ccd37a8755b85c41525/complexipy-6.2.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:579450cf61ff04e59149e1901cb27de3d80cd4815a227ad24c2e92ebdf4b449c", size = 2738474, upload-time = "2026-07-23T03:43:05.749Z" },
-    { url = "https://files.pythonhosted.org/packages/9a/d1/80f4cc44d489db0c256f05fa1bb468c80d5db0e7309bba6260218f59e167/complexipy-6.2.0-cp314-cp314-win32.whl", hash = "sha256:3a22f5f2a6843a8d9652076368b457102a0c9e95b63769b5a50ef3686427fd96", size = 2036901, upload-time = "2026-07-23T03:43:07.289Z" },
-    { url = "https://files.pythonhosted.org/packages/ed/f0/16db165c81e6b2246e9a765bbb4ce4a1929a9ca151aee0637cf78092f8b9/complexipy-6.2.0-cp314-cp314-win_amd64.whl", hash = "sha256:89fabd582ed95cb0bae44f065b40a6afbc045d8717acbaf693ba3eafa50baaa8", size = 2190135, upload-time = "2026-07-23T03:43:08.691Z" },
-    { url = "https://files.pythonhosted.org/packages/20/22/1d27d7d75d32c49d0bcabe2e118ef7f1491b9bdfe02c7043b62a574f9409/complexipy-6.2.0-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:51a318d2bb83a766c5b7a1adc9d123df9fd822cee8df648c925b698506469e58", size = 2462244, upload-time = "2026-07-23T03:43:10.155Z" },
-    { url = "https://files.pythonhosted.org/packages/5f/6c/680f1dc9a671f4c3aa50c4922f0cfa5605a34bbbb5861725101580d8b45a/complexipy-6.2.0-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:50555b34bc069c8e06832b42755a93939215e21734891bad910ef0b6eb1e18fa", size = 2399189, upload-time = "2026-07-23T03:43:11.824Z" },
-    { url = "https://files.pythonhosted.org/packages/7a/c0/5ed9f7815c5abb4c91b2d0d78df7996c182ab61ac233f40fc92a907e23de/complexipy-6.2.0-cp314-cp314t-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:1348392bf58532653bf3583f18fb655b058e680432c23264a6ffc8f27451cc01", size = 2615954, upload-time = "2026-07-23T03:43:13.417Z" },
-    { url = "https://files.pythonhosted.org/packages/58/56/fb835163c4af2119539875b3d9c7ce09fd1c02cb952968fd9b71b54e2916/complexipy-6.2.0-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:de886742128d50e8100a8cee3b4596be2ec4b55cdedfce4ac8f9f45fbe8fbd85", size = 2850104, upload-time = "2026-07-23T03:43:15.148Z" },
-    { url = "https://files.pythonhosted.org/packages/dc/5a/3b50eb8c2d6b6016379825cf330fd7ba45a5859500000bb50586e1e008e0/complexipy-6.2.0-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:f50e3496d9dcc547d9c5d515bf297c87c9c57afe33cbb6df341e614fa57b1738", size = 2524210, upload-time = "2026-07-23T03:43:16.562Z" },
-    { url = "https://files.pythonhosted.org/packages/51/0e/c7f061240d82abed2d34a6e5fd4165fd97f6c7d0c90dadeff1fc4a93366b/complexipy-6.2.0-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:28914d763c03d3a662ac2d666bc4151852788e6e767f52dd07c94e8332a4b265", size = 2487720, upload-time = "2026-07-23T03:43:17.882Z" },
-    { url = "https://files.pythonhosted.org/packages/98/0a/ed66cc8d14d8cd0d76154f30e36b05a9bb058b462541056666f5f1bd7880/complexipy-6.2.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:63eed569ba56d2e90a167a38f241fa06de99ee9f96ec950c55a2aa22694e4ce0", size = 2641145, upload-time = "2026-07-23T03:43:19.273Z" },
-    { url = "https://files.pythonhosted.org/packages/81/2e/eb2a778b9ce6bfae57f41eb8f042df3167174d2627bf1eec37b6bf64eb44/complexipy-6.2.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:cbbefd1fc3e72da8016647176de792a579a276b1308f0822b5b1585f16eaf5a2", size = 2737833, upload-time = "2026-07-23T03:43:20.692Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/a8/ee7a6bfe3d54a62f604918b2de7e66f342a33414aa38d0584531762b3286/complexipy-6.0.1-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:a00a018244c5e6f0b6e145517ff59f40c8455775cf0be1337e47d8ba8fc08478", size = 2333561, upload-time = "2026-07-03T03:23:31.696Z" },
+    { url = "https://files.pythonhosted.org/packages/74/42/07aba6c0fcf8db82027d3f915d121c52cdf6927722489bc2c8f81ee31f5b/complexipy-6.0.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:6a4a6158431bbccfc5d033c46cafe683b204090a7d62e2d708fc3e7ff0009c09", size = 2270718, upload-time = "2026-07-03T03:23:33.5Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/1e/5b869db5eb6213623b9d6f8e0a97c7f53bec0963d8ea2a66ac4ce63b772b/complexipy-6.0.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:dc2fd8ed07086b9f1d669da6f901733984721800854807ecead2bdc79414bfac", size = 2452189, upload-time = "2026-07-03T03:23:35.067Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/a7/a6c2c0d28da6caa292a44ffe6bb99bc8217c5222511fdb773de60c6e70e8/complexipy-6.0.1-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:02d4045421fc5f1fb5cfb04ba3a7dac705be76fd45e80da5c699a98735d0b3fe", size = 2381579, upload-time = "2026-07-03T03:23:36.753Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/21/fca14853331bd5ce966db33bbda982a6c0b640d14f53c0281e1c81f72cdd/complexipy-6.0.1-cp312-cp312-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:e7a4b4058b19b832a43ca4bf370ce8c618489fa3bc5354c247a4d9a9f7593e37", size = 2598711, upload-time = "2026-07-03T03:23:38.862Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/01/1686158d43bd8397171a3c2f0e7a7938b861fc822c6346b02bb72e305dd8/complexipy-6.0.1-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:cbfa2957ea052d3749bed14b0ef78b93c8b443b2fd558a1cb585f574d2f68e3c", size = 2837911, upload-time = "2026-07-03T03:23:40.491Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/8c/19f4a3ca2cf4245fefb681a872ebca4a52ab2ebb1d94893da97c1bad684d/complexipy-6.0.1-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:7df5faeb40b1d3b9020fb42acb29370571661715d3cb853f98aa5d6a242d545a", size = 2514337, upload-time = "2026-07-03T03:23:42.044Z" },
+    { url = "https://files.pythonhosted.org/packages/62/39/81423ffe22709d8f4c3918f03cbf9e3d7e0dffaf73cc1c167769bc08a06e/complexipy-6.0.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f3aa9b1efec9dd32714a40af3ff545bd6024def2dcef37940c91643fc35486f4", size = 2496146, upload-time = "2026-07-03T03:23:43.68Z" },
+    { url = "https://files.pythonhosted.org/packages/59/c8/438b45da13ed43a44135da34abdb9e48ba8d3332ee1166bd58c59cd03675/complexipy-6.0.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:15bdef5eff10cd801f5fa44243b5e110bc4f44d194f62b80c196245e798a896c", size = 2628582, upload-time = "2026-07-03T03:23:45.594Z" },
+    { url = "https://files.pythonhosted.org/packages/36/47/f5fa4218d0acd80f1a17fb4dca64c8c7a278bcef40755c8340a68e546e9c/complexipy-6.0.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:f7e89d0f286c3d327e257b2e874c646e9726f9e09caa59b903a9f9f15b46d962", size = 2728422, upload-time = "2026-07-03T03:23:47.486Z" },
+    { url = "https://files.pythonhosted.org/packages/69/dc/94feddb3cc37c6bdcc445b37e7ee1e99151644511a07bdd03c98fc8103d5/complexipy-6.0.1-cp312-cp312-win32.whl", hash = "sha256:3513b6b6afe73f71ca8c1ff52c5b1a8d1aaebb9934d2279bd002e9fc4b6fbf8b", size = 2031415, upload-time = "2026-07-03T03:23:49.124Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/8e/ea9b294b9fca952076a1edd826f6ff964913f36b28654f757587a7207273/complexipy-6.0.1-cp312-cp312-win_amd64.whl", hash = "sha256:0ba9cf20affaa91979cc9a664d833f29fc0c02c44b91a889930c434e4c3e8f65", size = 2185216, upload-time = "2026-07-03T03:23:50.845Z" },
+    { url = "https://files.pythonhosted.org/packages/97/b5/8cbadf95c24c08c784ecb6c965d6fda10f332cddf7ba6a5221af1c835a33/complexipy-6.0.1-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:b51ef6cc39fb678d417a2145a65596ad5904a4e87137089e32d409ec38e13eff", size = 2332682, upload-time = "2026-07-03T03:23:52.525Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/a4/78dda753999d5706a05489ed37fc11f1140fce93ea6db993a4ec738bd7ed/complexipy-6.0.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:d7b2c57c166fc72d8f5fcd2f84b2577201ec3546b2c95c2a637b074d2e462c14", size = 2270641, upload-time = "2026-07-03T03:23:54.157Z" },
+    { url = "https://files.pythonhosted.org/packages/32/b2/3621279ba8ffe008dd7d6ab77132a4a9d9c7f5558eecbdb9c06f689a1cb4/complexipy-6.0.1-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:01970de229707df12d78e2b0dcd4227e863d8224790ed0cb43a5501821736a6a", size = 2451874, upload-time = "2026-07-03T03:23:55.698Z" },
+    { url = "https://files.pythonhosted.org/packages/91/d0/ca2b5d3d0e7ea098c8171ca4c14e791a5d47e3cca2fa1067b4bce83c0610/complexipy-6.0.1-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:f300897b20ab75c8bb5c26aafc69a6feff022355be0af59d8c8314b1d408a4e3", size = 2381901, upload-time = "2026-07-03T03:23:57.512Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/72/b8d11386924ee291f86d60a58bc5e9cae50c739a569b9abab3be23d6e477/complexipy-6.0.1-cp313-cp313-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:a9b65d9673d15e372629f9b564fbb4ce46f9293cba721c9be3def490aa8b1eb7", size = 2597418, upload-time = "2026-07-03T03:23:59.361Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/60/bec4001c8f384d636aa8489309278d59e1699c8864bef321703238f2d872/complexipy-6.0.1-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:13c51a3ee518011a554624ded5bb8665eac3c9080636c3cc08efd7282eb718b2", size = 2837794, upload-time = "2026-07-03T03:24:00.953Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/33/158945d9fec78d854c15147b2cf1ecd8ea6f6410ff75ca2aa0d8e79f2784/complexipy-6.0.1-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:71549e2b14a3fbdc73c3d87f2b8afea86a196d727ac0d9b07c0c3edf92b6afef", size = 2514715, upload-time = "2026-07-03T03:24:02.546Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/55/10689195791286c69a6dc5d15e75675d4dd5aa3682f330b7239bbd63c182/complexipy-6.0.1-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e4199549e08ba3e8d40877da74225efcad39caf7eb35f07ff3cc4ba8a6bbcc00", size = 2496272, upload-time = "2026-07-03T03:24:04.178Z" },
+    { url = "https://files.pythonhosted.org/packages/57/3a/9bd04f1985686f926ee146a78749e08363ba2a7c6d101d49d4a358f719c0/complexipy-6.0.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:9ad6516ede6ba71d8b68cee1b8f670d6ac6d9de88cebd82951d2f893587f4ae5", size = 2628251, upload-time = "2026-07-03T03:24:05.998Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/e4/b338966c3106344e49cd9abe650840f67969a8abf5d6445e185e1019bc84/complexipy-6.0.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:3d86e41ca6264778344fc7bf9ad101de740d94ec0e51bc1c7d5eb06b29d62f56", size = 2727617, upload-time = "2026-07-03T03:24:07.804Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/a4/f4b756595968ddf76c70219a253271eaab83ddedc7000296b7410dbb090b/complexipy-6.0.1-cp313-cp313-win32.whl", hash = "sha256:3ad75ba1918af0b88dee5aa5e35c99d3aae705e0fb55b9c518dffbd9bbf5cab1", size = 2031258, upload-time = "2026-07-03T03:24:09.5Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/ed/a4a55b9cefec4f8e5b0630614e0fdd6f854d96ad2afe5fd6a5c67cad10da/complexipy-6.0.1-cp313-cp313-win_amd64.whl", hash = "sha256:914da63e59780fd28f29ad84d51473ddfb4d35cfa600d9231eb92f1ccc3c83d5", size = 2184770, upload-time = "2026-07-03T03:24:10.991Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/15/819f85bc6598b3228461e3e0870300fe93b989ad02d59a25a7e647af0203/complexipy-6.0.1-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:9cdd4b30b7f2151a16f5827dae20ac4be8544c13ced4a9fdb4daf37bd38c7b82", size = 2334443, upload-time = "2026-07-03T03:24:12.733Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/2e/84ebf2c02f65d9e518a364f58779c46e118ca8b2ad8a39f342cee932811b/complexipy-6.0.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:dd7656fe1c3e6bd5ea2ad3e042e2de4e26c2fb60e6f8ec1871ed75d9d1adef7d", size = 2271854, upload-time = "2026-07-03T03:24:14.606Z" },
+    { url = "https://files.pythonhosted.org/packages/43/34/ad2b796d21b05f0b9ae2507c9c4cf57a3abbe4c4806c856f5f12e1bda274/complexipy-6.0.1-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:83c790634d70faaaa90f01124e305ed0db6f30668e260fb578d7db3c35a106e0", size = 2451616, upload-time = "2026-07-03T03:24:17.044Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/d6/da63d7b1557546c14294a47ee7617838b5d35508738c5cf65b37b38e0df1/complexipy-6.0.1-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:cbad719a6a74db3cb952abed96c5ea172ffb78416a143271e2736c3660b3e354", size = 2381811, upload-time = "2026-07-03T03:24:18.684Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/d7/cf08b7155f38fda311aef87b67ed6f47bb74f56f878bf1af7635e074f6db/complexipy-6.0.1-cp314-cp314-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:cf32d9bde0fe90b7c0c36c56fcb8adf7810d4b0eda0ee1d37019ff31ced33c3a", size = 2598714, upload-time = "2026-07-03T03:24:20.687Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/57/c363a9a6b3efd98b775fb9bf138dfdc5cc035edc15f501f2865f189aa0cd/complexipy-6.0.1-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:cf4602eb9896cd21145fd6dbe40c101dfd45b9d55a316e93dca256b2939738cc", size = 2840964, upload-time = "2026-07-03T03:24:22.804Z" },
+    { url = "https://files.pythonhosted.org/packages/92/b9/50d536bf67323e0abe2ae5ac929750402ea48dc0275ef826e604230a4356/complexipy-6.0.1-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:3d4903b4cf14bce2e5b51e417c1875cd64b72d03c1886dd959da00ce69772fee", size = 2514328, upload-time = "2026-07-03T03:24:24.616Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/6b/635c0291acb531cb15ce138d976c8ecc021c9d8c84286da4efa66e4f68d1/complexipy-6.0.1-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6f7fa5e803bcece8e95f98570e03a11455c889ab780c6b43108aee0c48340191", size = 2496921, upload-time = "2026-07-03T03:24:26.292Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/39/fb86363098388a4c93bedbe4fa1e1ccb250e8f3d3ca3dd5aae0b1e147ed4/complexipy-6.0.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:fac0f09da5c831ead52c060c49b0cfdfa9f59b9f7d76648f00d8aa320cd598da", size = 2626855, upload-time = "2026-07-03T03:24:27.964Z" },
+    { url = "https://files.pythonhosted.org/packages/45/0b/2f23cf237eb8b948494e1cf323c3d8b25ff570aede04d0ddbb4465dda604/complexipy-6.0.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:4cee67c6fb1e98bbc30ba44dceff10f64822449d7ee46d71aaa4239f381e6825", size = 2728611, upload-time = "2026-07-03T03:24:29.783Z" },
+    { url = "https://files.pythonhosted.org/packages/06/34/e5bcd00f0581430f7ff10a5a0b21e7bee5ee385a2bc6c19fdbf1404075a7/complexipy-6.0.1-cp314-cp314-win32.whl", hash = "sha256:f50d2b62383715f88e6e9a28705ce341e6c8b4d80ec699a823c6b079a8c7ca03", size = 2031432, upload-time = "2026-07-03T03:24:31.815Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/e9/d474bcc4de54bc972088069c66a20be78ea0bd080d2b0b971897dfd77a3b/complexipy-6.0.1-cp314-cp314-win_amd64.whl", hash = "sha256:d5e31cc445a9fc787a47b438f495069a303072b03608e649900b4c0865f4f6c4", size = 2185680, upload-time = "2026-07-03T03:24:33.587Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/f7/a00bad292745623d1b16fcdc3f5b933fda31b1f69ff8c2bdc5c3922cf996/complexipy-6.0.1-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:635bc9fe5aa26ab07599872ce529da7770af1870417712f8954e0ca7e08a2de5", size = 2451689, upload-time = "2026-07-03T03:24:35.189Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/70/5021c3f8dd6645e00ff8b6f9da549ab3f1d75dd036b1517acb790cf2b261/complexipy-6.0.1-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:92697f7536418244c4d0286c0cf4aa76c86b37835aea438a530956e5fc53c7ec", size = 2378153, upload-time = "2026-07-03T03:24:36.803Z" },
+    { url = "https://files.pythonhosted.org/packages/96/2a/cd42a9a4d7b6c488fa1bf1f0f030da87931fb770a3ea0aef13d5cd614839/complexipy-6.0.1-cp314-cp314t-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:1a69df4a46b79dce380979e07d4c6e87d0aaf7943669c20672635d45c612e7bf", size = 2597988, upload-time = "2026-07-03T03:24:39.429Z" },
+    { url = "https://files.pythonhosted.org/packages/53/d6/ea382f6f43f79a25264813de5ba90f20edd654063403123fe5b8013afd1c/complexipy-6.0.1-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:be35712c7d5ebdcc91fcfc8c986540f40c22c7fe08d8233df5406e91a08b5918", size = 2836822, upload-time = "2026-07-03T03:24:41.209Z" },
+    { url = "https://files.pythonhosted.org/packages/56/3c/44d0191e59f6f65477b5c7f8940cecc498574b2f34067fbc83be08452df5/complexipy-6.0.1-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:87a19d4baac23883198867e48f3f84af8bb5d87b3e0a6d67e34e328576a7aafe", size = 2513728, upload-time = "2026-07-03T03:24:44.073Z" },
+    { url = "https://files.pythonhosted.org/packages/06/f3/58e50e2b4031be7b0ca09a44d013d7b367888a4d5e74fc16daa3b09b49fb/complexipy-6.0.1-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6a15c2167caa2d187c060869dc20b9cacb2bcfccd557cced4326b4696ad2941a", size = 2496613, upload-time = "2026-07-03T03:24:45.782Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/a0/1aad33f322c7f25f0bfa168c19ee0df9e95423c01827c7f4f9b89666c9bf/complexipy-6.0.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:c9232716d9314f12165b32b5ef533af0526b2ee64fd768dd7c816e3bc020a385", size = 2628105, upload-time = "2026-07-03T03:24:47.59Z" },
+    { url = "https://files.pythonhosted.org/packages/df/27/4d1ad63f222d218f8513cd5bf88baf2388a4cdc00488d0b4f22e461fe57e/complexipy-6.0.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:3c57db8b2b4150cf5ee6738d2048f4cee0d674f18ff1d124f063cdba6ae4ac67", size = 2727809, upload-time = "2026-07-03T03:24:49.844Z" },
 ]
 
 [[package]]
@@ -1637,11 +1637,11 @@ wheels = [
 
 [[package]]
 name = "platformdirs"
-version = "4.11.0"
+version = "4.10.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/78/9b/560e4be8e26f6fd133a03630a8df0c663b9e8d61b4ade152b72005aec83b/platformdirs-4.11.0.tar.gz", hash = "sha256:0555d18370482847566ffabcaa53ad7c6c1c29f195989ae1ed634a05f76ea1e0", size = 31953, upload-time = "2026-07-21T13:09:36.565Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/52/cd/4f25b2f95b23f5d2c9c1fe43e49841bff5800562149b2666afc09309aa8f/platformdirs-4.10.1.tar.gz", hash = "sha256:ceab4084426fe6319ce18e86deada8ab1b7487c7aee7040c55e277c9ae793695", size = 31678, upload-time = "2026-07-18T03:53:43.808Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7d/68/d8d58938dfb1370b266a1a729e6d77a985be23689a0496498ee17b2cbf90/platformdirs-4.11.0-py3-none-any.whl", hash = "sha256:360ccded2b7fce0af0ff80cc8f5942a1c5d99b0e856033acb030bfc634709e74", size = 23247, upload-time = "2026-07-21T13:09:35.422Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/73/6fd0bb9ce84138c3857f12e9de63bc901852975a092d545f18087a204aa2/platformdirs-4.10.1-py3-none-any.whl", hash = "sha256:0e4eff26be2d75293977f7cddc153fd9b8eaa7fb0c7b64ffe4076cb443117443", size = 22906, upload-time = "2026-07-18T03:53:42.576Z" },
 ]
 
 [[package]]
@@ -1655,7 +1655,7 @@ wheels = [
 
 [[package]]
 name = "pre-commit"
-version = "4.6.1"
+version = "4.6.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cfgv" },
@@ -1664,9 +1664,9 @@ dependencies = [
     { name = "pyyaml" },
     { name = "virtualenv" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/25/3a/ddb78f32a0814e66b18a099377a106a2dcdce92d86a034d69d65df9b256e/pre_commit-4.6.1.tar.gz", hash = "sha256:03e809865c7d178b9979d06c761fcbfe6808fdaded8581a745bb110e52050421", size = 198646, upload-time = "2026-07-21T20:56:58.225Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/8e/22/2de9408ac81acbb8a7d05d4cc064a152ccf33b3d480ebe0cd292153db239/pre_commit-4.6.0.tar.gz", hash = "sha256:718d2208cef53fdc38206e40524a6d4d9576d103eb16f0fec11c875e7716e9d9", size = 198525, upload-time = "2026-04-21T20:31:41.613Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/fb/49/bc925106abcdac498074f2cbe6137e94e09f418dd2b7775df5b577dc0313/pre_commit-4.6.1-py2.py3-none-any.whl", hash = "sha256:0e3b2942510d1fb34eec167a3ec57331bf8442122f1153a9fb8b58f5c49b2717", size = 226186, upload-time = "2026-07-21T20:56:57.064Z" },
+    { url = "https://files.pythonhosted.org/packages/80/6e/4b28b62ecb6aae56769c34a8ff1d661473ec1e9519e2d5f8b2c150086b26/pre_commit-4.6.0-py2.py3-none-any.whl", hash = "sha256:e2cf246f7299edcabcf15f9b0571fdce06058527f0a06535068a86d38089f29b", size = 226472, upload-time = "2026-04-21T20:31:40.092Z" },
 ]
 
 [[package]]
@@ -2162,27 +2162,27 @@ wheels = [
 
 [[package]]
 name = "ruff"
-version = "0.16.0"
+version = "0.15.22"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/4d/94/1e5e4967626faf12fa56999cd6222dff6992ceb086ad7945756baf70c7a7/ruff-0.16.0.tar.gz", hash = "sha256:e460aafd5495ec89efaa6ced2e4a9a581116451e1c88b9d37ef497e0f8e93982", size = 4790557, upload-time = "2026-07-23T19:11:30.981Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/3a/06/ae069393fc66e8ff33036d4b368003833bf6e88ccf182e17e7a2f1c754fd/ruff-0.15.22.tar.gz", hash = "sha256:3f15175b1fb580126f58285a5dae6b2ea89000136d980c64499211f116b54809", size = 4785063, upload-time = "2026-07-16T15:14:13.244Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/4b/81/1c8818fee7ce1a04cd7d1b3172e0a8f8e4f1dc4feb7fc390e16daa8af323/ruff-0.16.0-py3-none-linux_armv6l.whl", hash = "sha256:e5115729eb08c585e5121978ba5d5b60caeae394ce21b9fb5e6cd33a1c6c9b1e", size = 10754633, upload-time = "2026-07-23T19:10:46.415Z" },
-    { url = "https://files.pythonhosted.org/packages/23/df/beaf59c09d68db84304d555f188b276a77132a5d5b0b67a5c762aa143628/ruff-0.16.0-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:3c954b1d580bfa035b41654f7858cc7e71d5fc3ac5b723dd62bd9133830ed522", size = 10969164, upload-time = "2026-07-23T19:10:50.271Z" },
-    { url = "https://files.pythonhosted.org/packages/42/ce/741cd197496a1abbf51352710fd15ed995d2a2be87189c1da26a450d6e83/ruff-0.16.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:e01c21d10eb1b29f47b7454e1f4056db9a3f0260c646aa88457c610291db9f81", size = 10488846, upload-time = "2026-07-23T19:10:52.639Z" },
-    { url = "https://files.pythonhosted.org/packages/52/2a/a2db8e88cade358f5cdcb05674a917751074109315d014eb6352d9a893f7/ruff-0.16.0-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6e364e5ed22ed8dc05082fd78e35308618260907ac2d3c1d637b2e682415b6c9", size = 10889729, upload-time = "2026-07-23T19:10:54.89Z" },
-    { url = "https://files.pythonhosted.org/packages/42/65/62a771694ebd63029dc953e27dbad40e1588bd4860ff9fe881018fddaa49/ruff-0.16.0-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:d327b8fc113a1d4421a04f3839d3752057c8dd1ee320223a6f3f52d04ada462a", size = 10568275, upload-time = "2026-07-23T19:10:56.993Z" },
-    { url = "https://files.pythonhosted.org/packages/3f/e2/ced249fe8af5f086c5c58cc21cc3356d50f32f7401c5df87050c999620a7/ruff-0.16.0-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:a9b50c55e263103586b3dcf5f73d479eb8cb5fdb6098fec59a62891dab653717", size = 11385112, upload-time = "2026-07-23T19:10:59.615Z" },
-    { url = "https://files.pythonhosted.org/packages/87/0b/05154977a8fd69eeb6c103271f55403bfd8711f5c0f8ed07489d95a504e7/ruff-0.16.0-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:0ff4a79ce3ec0172f3241943835de1c4cb4e2dcd07f0f8c2d02603dbbbee4b17", size = 12207008, upload-time = "2026-07-23T19:11:02.154Z" },
-    { url = "https://files.pythonhosted.org/packages/fb/29/98225831a3a1eab0e02f4acc6ca6559a98611dcc68b6965ff4b7234627c1/ruff-0.16.0-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:e95c448fca1fb2a18372a9440926c5a6ee789639bb975c72e7ae6d0b04218ab4", size = 11650842, upload-time = "2026-07-23T19:11:04.557Z" },
-    { url = "https://files.pythonhosted.org/packages/91/66/6bd3cf90500653d55dc0ffc8507aa8300bd49d0214b2e8cb4d3fef2943ba/ruff-0.16.0-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4f11a8d11010301d0a398a2fdef67691feca7294da6aef55e2150e8fa2cd520b", size = 11400718, upload-time = "2026-07-23T19:11:09.233Z" },
-    { url = "https://files.pythonhosted.org/packages/8e/a2/a54eb4eae05d66364050a5d3b8a9c5ef88196531b3cbe7109d873f87f819/ruff-0.16.0-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:48044c678e9cb8698246c99b14aaccfa6601dea7379eb48a6f8f73f7a6d86cd0", size = 11426177, upload-time = "2026-07-23T19:11:11.994Z" },
-    { url = "https://files.pythonhosted.org/packages/1a/be/16e3eea4b2a478a496919f5e36f17c4559e54620bd3bbac5d6affa068006/ruff-0.16.0-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:7aa0959bad8eb8bef50340154fc9b58678dae31fa4293afa38b44b6e552c0213", size = 10856126, upload-time = "2026-07-23T19:11:14.221Z" },
-    { url = "https://files.pythonhosted.org/packages/a2/84/252eb8b868a16eec7257c14f504f77537e734b2d69c762e639e588e304a3/ruff-0.16.0-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:28ea2b7df8ebf7f9da6b7d47b230ab48f387c0a29be3b474c4d0740e197bb9af", size = 10571208, upload-time = "2026-07-23T19:11:16.378Z" },
-    { url = "https://files.pythonhosted.org/packages/21/09/817a482f542f7570cbb4554b26e896610c7114f539b1d9e2d2145bf6bef6/ruff-0.16.0-py3-none-musllinux_1_2_i686.whl", hash = "sha256:33a3dfac8c35f81498dea9181bccc2f4c4bc8f1521a1dd9406e77643e0f0fb09", size = 11063329, upload-time = "2026-07-23T19:11:19.173Z" },
-    { url = "https://files.pythonhosted.org/packages/2e/23/9403c180ca1cb9b1f7335f5c3e5305c09d49ea5b345196682a36028bde4a/ruff-0.16.0-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:a5237a0bda500d30d81b8e07a6973a5cbc772864cbf746ae2f4e8a2e01c9f4ed", size = 11489751, upload-time = "2026-07-23T19:11:21.74Z" },
-    { url = "https://files.pythonhosted.org/packages/b2/1d/1b2ef7bcde851c78d7f17f1cca13fd6dc695fc4b3d6197941e72cae5b132/ruff-0.16.0-py3-none-win32.whl", hash = "sha256:7fab76fa065c873f41ff744347c6e77bcc3dfec4bcc754dc26b63d23c0f7f5fb", size = 10785885, upload-time = "2026-07-23T19:11:23.947Z" },
-    { url = "https://files.pythonhosted.org/packages/b2/a3/d5e4ef7a56be3f928ffb90b94c25ba7d3cb9c7fe0736aeaaedf361770712/ruff-0.16.0-py3-none-win_amd64.whl", hash = "sha256:429c117f022bf481fabd9d551e7a3952b24c65e6ef44337ea09d90bebef14472", size = 11923141, upload-time = "2026-07-23T19:11:26.409Z" },
-    { url = "https://files.pythonhosted.org/packages/cb/9a/8415f2657cbe200f41a4531ccededf135505a92d4a012229121f885b26f9/ruff-0.16.0-py3-none-win_arm64.whl", hash = "sha256:14296fedcd2705c77ab8235439278bbb38f285cf7da5528b00b3e330c3d4872d", size = 11273407, upload-time = "2026-07-23T19:11:28.705Z" },
+    { url = "https://files.pythonhosted.org/packages/23/18/ee54b7ae1e121be7a28ea6da4b67564ebb0530e183a54415ab7e3bcd2c4e/ruff-0.15.22-py3-none-linux_armv6l.whl", hash = "sha256:44423e73493737f5e7c5b41d475483898ff37afcdae38bc3da5085e29af1c2d8", size = 10781258, upload-time = "2026-07-16T15:13:19.452Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/d2/2520cb14761ddbeaf57642a76942fc36adcbdbe53b4532241995f6fc485c/ruff-0.15.22-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:b82c6482946e9eda7ff2e091d25b8bad3f718684e1916d41bd56873cee05b697", size = 10999477, upload-time = "2026-07-16T15:13:23.318Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/10/74e53572aa758dfaa678c2a2646b5c5515d884b7ca56be4d2ce03ca4b560/ruff-0.15.22-py3-none-macosx_11_0_arm64.whl", hash = "sha256:11c1c715af53a09f714e011106bffc419751ec8232fcb5da42173284ea3fec6f", size = 10466716, upload-time = "2026-07-16T15:13:26.162Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/cc/44eaaf0844e028182f2d0a8f2190d0f359159aed0a9e5ab861d892f1ae2a/ruff-0.15.22-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:742a29cf29bddb7c8327895d6a10e0e6c5b38a96dd407af9b5d0857f809c0576", size = 10892644, upload-time = "2026-07-16T15:13:29.229Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/21/8edf559014d2b0f82beea19cfb713993ad802ccda16868769979c6090a84/ruff-0.15.22-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:72af58b951b0ae395935ae79763dc349bc0eb706319d28f7a33ad2cfb3cfc178", size = 10576719, upload-time = "2026-07-16T15:13:32.35Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/1e/3a13abd392a3b50b62e5938a831f9ab6e588358cacad5c18545b716d2182/ruff-0.15.22-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:62d425005c1835eb24e2ee4161cb90e8db263415f4a71c8c72c33abaa6c0c224", size = 11376494, upload-time = "2026-07-16T15:13:35.958Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/3e/422d3d95bcf04dd78e1aeac22184d4f9a8fb2c01865d39d44618484a0317/ruff-0.15.22-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:e8b9b3f8779a4f08c969defc3c8c35abffaa757e601ed5ae66d6d1db6519969a", size = 12208370, upload-time = "2026-07-16T15:13:39.185Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/91/5d065a0e0a02bf4813f5119ad278462eed081d2b832eb7c021ade0ec9e65/ruff-0.15.22-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:1e0dd1b2e4d3d585f897a0d137cbf4eaf6223bef4e8ce34d6bb12556c5f9249e", size = 11581098, upload-time = "2026-07-16T15:13:42.132Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/f9/a0d4871d12fae702eb1f41b686caf05f1f8b124dc6db6f784f53d74918fa/ruff-0.15.22-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:365523eb91d9224e1bcb03b022fbf0facb8f9e23792a2c53d9d4b3924bdbdebb", size = 11399422, upload-time = "2026-07-16T15:13:45.2Z" },
+    { url = "https://files.pythonhosted.org/packages/18/80/c843a5176cddbceb0b7e8dd41cf9993490796c1c469348d384f5a5c13c56/ruff-0.15.22-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:fabfd168afdf29fee5be98b831efa9683c94d7c5a3b58b9ce5a2e38444589a74", size = 11381683, upload-time = "2026-07-16T15:13:48.46Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/00/8485de0ae92239438a36cfc51350db9b9e85c9ebdfaea91b18e422706662/ruff-0.15.22-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:225dbf095a87f1d9f90f5fd7924d2613ee452a75a4308c63a8f50f761787aa7c", size = 10850295, upload-time = "2026-07-16T15:13:51.655Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/91/24977ec2ec72eaf15e4394ace2959fdff2dd1e14f03e005e838023407169/ruff-0.15.22-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:1877d63b9d24ed278744f1523fd11b85540566d54641f97c566d7d9dc5ca5296", size = 10579640, upload-time = "2026-07-16T15:13:54.79Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/47/9b51216951974df1f263ac19da550d34252e0ed7218c25f10c5ef9ed7517/ruff-0.15.22-py3-none-musllinux_1_2_i686.whl", hash = "sha256:a1606c510bd7215680d32efab38965f7cdec3ef69f5170a3f4791404ffdd5262", size = 11105077, upload-time = "2026-07-16T15:13:57.915Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/47/20e9d4a3b8016778acea5fc32bb50d35d207500a17ddb529ffa6996feef8/ruff-0.15.22-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:630479b18625f5ffc373f77603a22a9f8ac0acd7ff0501178b5db28ec71e9c64", size = 11490980, upload-time = "2026-07-16T15:14:01.032Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/76/3f72d8fc38c1cb77b38c56a70da9d0c17700cc1cc50f9649c9d3c8f5ba71/ruff-0.15.22-py3-none-win32.whl", hash = "sha256:e5ba0e4a13fd14abbed2a77b517a3911290c6c6c59ef67784328d1668fab76cf", size = 10789165, upload-time = "2026-07-16T15:14:04.16Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/46/4965251734c2b6fcdca1b1b187d20bcac3af0ee5b083b89c910bb961ce3a/ruff-0.15.22-py3-none-win_amd64.whl", hash = "sha256:9be63ba1eb936acd2d1342fb8337c356353706fce233b2a15a09a97037e6acde", size = 11938297, upload-time = "2026-07-16T15:14:07.316Z" },
+    { url = "https://files.pythonhosted.org/packages/57/c9/e69b1ff4c8b69093ef08b8919ab767af0569666865b39c30a8795d88d3c6/ruff-0.15.22-py3-none-win_arm64.whl", hash = "sha256:e1168075b72158510839f250027659cdd78476f40507dd517892304c41318661", size = 11298172, upload-time = "2026-07-16T15:14:10.51Z" },
 ]
 
 [[package]]
@@ -2395,11 +2395,11 @@ requires-dist = [
     { name = "requests", specifier = "~=2.34" },
     { name = "rich", specifier = "~=15.0" },
     { name = "ruamel-yaml", specifier = "==0.19.1" },
-    { name = "terok-clearance", url = "https://github.com/terok-ai/terok-clearance/releases/download/v0.8.0a6/terok_clearance-0.8.0a6-py3-none-any.whl" },
-    { name = "terok-executor", url = "https://github.com/terok-ai/terok-executor/releases/download/v0.4.0a17/terok_executor-0.4.0a17-py3-none-any.whl" },
-    { name = "terok-sandbox", url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.5.0a18/terok_sandbox-0.5.0a18-py3-none-any.whl" },
-    { name = "terok-shield", url = "https://github.com/terok-ai/terok-shield/releases/download/v0.8.0a7/terok_shield-0.8.0a7-py3-none-any.whl" },
-    { name = "terok-util", url = "https://github.com/terok-ai/terok-util/releases/download/v0.3.1a3/terok_util-0.3.1a3-py3-none-any.whl" },
+    { name = "terok-clearance", git = "https://github.com/sliwowitz/terok-clearance?rev=feat%2Funified-logging" },
+    { name = "terok-executor", git = "https://github.com/sliwowitz/terok-executor?rev=feat%2Funified-logging" },
+    { name = "terok-sandbox", git = "https://github.com/sliwowitz/terok-sandbox?rev=feat%2Funified-logging" },
+    { name = "terok-shield", git = "https://github.com/sliwowitz/terok-shield?rev=feat%2Funified-logging" },
+    { name = "terok-util", git = "https://github.com/sliwowitz/terok-util?rev=feat%2Funified-logging" },
     { name = "textual", extras = ["syntax"], specifier = "~=8.2.8" },
     { name = "textual-serve", specifier = "~=1.1" },
     { name = "unique-namer", specifier = "~=1.6" },
@@ -2416,7 +2416,7 @@ dev = [
     { name = "mypy", specifier = ">=2.2.0,<3.0" },
     { name = "pre-commit", specifier = ">=4.0" },
     { name = "reuse", specifier = ">=6.2.0,<7" },
-    { name = "ruff", specifier = "~=0.16.0" },
+    { name = "ruff", specifier = ">=0.15.21" },
     { name = "tach", specifier = ">=0.35.0,<0.36" },
     { name = "textual-dev", specifier = ">=1.8.0,<2" },
     { name = "vulture", specifier = ">=2.12" },
@@ -2440,30 +2440,19 @@ test = [
 
 [[package]]
 name = "terok-clearance"
-version = "0.8.0a6"
-source = { url = "https://github.com/terok-ai/terok-clearance/releases/download/v0.8.0a6/terok_clearance-0.8.0a6-py3-none-any.whl" }
+version = "0.8.0a7.dev215+g8c785cf67"
+source = { git = "https://github.com/sliwowitz/terok-clearance?rev=feat%2Funified-logging#8c785cf671031bdab6673b1bbc7337ffc00ca540" }
 dependencies = [
     { name = "asyncvarlink" },
     { name = "dbus-fast" },
     { name = "pyyaml" },
     { name = "terok-util" },
 ]
-wheels = [
-    { url = "https://github.com/terok-ai/terok-clearance/releases/download/v0.8.0a6/terok_clearance-0.8.0a6-py3-none-any.whl", hash = "sha256:8c23580825510e1b46bd799838178c6245898b9794e1701dc952d812d9e147f5" },
-]
-
-[package.metadata]
-requires-dist = [
-    { name = "asyncvarlink", specifier = "==0.3.2" },
-    { name = "dbus-fast", specifier = "~=5.0" },
-    { name = "pyyaml", specifier = "~=6.0" },
-    { name = "terok-util", url = "https://github.com/terok-ai/terok-util/releases/download/v0.3.1a3/terok_util-0.3.1a3-py3-none-any.whl" },
-]
 
 [[package]]
 name = "terok-executor"
-version = "0.4.0a17"
-source = { url = "https://github.com/terok-ai/terok-executor/releases/download/v0.4.0a17/terok_executor-0.4.0a17-py3-none-any.whl" }
+version = "0.4.0a17.dev457+gd8a39e2a5"
+source = { git = "https://github.com/sliwowitz/terok-executor?rev=feat%2Funified-logging#d8a39e2a5274743f9668b0b59c425ca05197eb09" }
 dependencies = [
     { name = "agent-client-protocol" },
     { name = "jinja2" },
@@ -2475,27 +2464,11 @@ dependencies = [
     { name = "terok-util" },
     { name = "tomli-w" },
 ]
-wheels = [
-    { url = "https://github.com/terok-ai/terok-executor/releases/download/v0.4.0a17/terok_executor-0.4.0a17-py3-none-any.whl", hash = "sha256:26995f5cd154cebb8efc34f0203b97355a16d281b2e1e3adc31d9141f3bc9202" },
-]
-
-[package.metadata]
-requires-dist = [
-    { name = "agent-client-protocol", specifier = "==0.11.1" },
-    { name = "jinja2", specifier = "~=3.1" },
-    { name = "prompt-toolkit", specifier = "~=3.0" },
-    { name = "pydantic", specifier = "~=2.13" },
-    { name = "rich", specifier = "~=15.0" },
-    { name = "ruamel-yaml", specifier = "==0.19.1" },
-    { name = "terok-sandbox", url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.5.0a18/terok_sandbox-0.5.0a18-py3-none-any.whl" },
-    { name = "terok-util", url = "https://github.com/terok-ai/terok-util/releases/download/v0.3.1a3/terok_util-0.3.1a3-py3-none-any.whl" },
-    { name = "tomli-w", specifier = "~=1.2" },
-]
 
 [[package]]
 name = "terok-sandbox"
-version = "0.5.0a18"
-source = { url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.5.0a18/terok_sandbox-0.5.0a18-py3-none-any.whl" }
+version = "0.5.0a17.dev448+g49ccf7b68"
+source = { git = "https://github.com/sliwowitz/terok-sandbox?rev=feat%2Funified-logging#49ccf7b68bc61e57fdfe7d3930288be1c8fb17e9" }
 dependencies = [
     { name = "aiohttp" },
     { name = "cryptography" },
@@ -2511,65 +2484,25 @@ dependencies = [
     { name = "terok-shield" },
     { name = "terok-util" },
 ]
-wheels = [
-    { url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.5.0a18/terok_sandbox-0.5.0a18-py3-none-any.whl", hash = "sha256:801e1adedd9094392d9a54fd205750c928f44ac7781c5bd19b3cb6c63c48a0ca" },
-]
-
-[package.metadata]
-requires-dist = [
-    { name = "aiohttp", specifier = "~=3.14.1" },
-    { name = "cryptography", specifier = "~=49.0" },
-    { name = "jinja2", specifier = "~=3.1" },
-    { name = "keyring", specifier = "~=25.7" },
-    { name = "packaging", specifier = "~=26.2" },
-    { name = "platformdirs", specifier = "~=4.10" },
-    { name = "prompt-toolkit", specifier = "~=3.0" },
-    { name = "pydantic", specifier = "~=2.13" },
-    { name = "ruamel-yaml", specifier = "==0.19.1" },
-    { name = "sqlcipher3", specifier = "==0.6.2" },
-    { name = "terok-clearance", url = "https://github.com/terok-ai/terok-clearance/releases/download/v0.8.0a6/terok_clearance-0.8.0a6-py3-none-any.whl" },
-    { name = "terok-shield", url = "https://github.com/terok-ai/terok-shield/releases/download/v0.8.0a7/terok_shield-0.8.0a7-py3-none-any.whl" },
-    { name = "terok-util", url = "https://github.com/terok-ai/terok-util/releases/download/v0.3.1a3/terok_util-0.3.1a3-py3-none-any.whl" },
-]
 
 [[package]]
 name = "terok-shield"
-version = "0.8.0a7"
-source = { url = "https://github.com/terok-ai/terok-shield/releases/download/v0.8.0a7/terok_shield-0.8.0a7-py3-none-any.whl" }
+version = "0.8.0a8.dev351+g583f8870d"
+source = { git = "https://github.com/sliwowitz/terok-shield?rev=feat%2Funified-logging#583f8870d03577e7fef3eb1e686547611a129955" }
 dependencies = [
     { name = "pydantic" },
     { name = "pyyaml" },
     { name = "terok-util" },
 ]
-wheels = [
-    { url = "https://github.com/terok-ai/terok-shield/releases/download/v0.8.0a7/terok_shield-0.8.0a7-py3-none-any.whl", hash = "sha256:6b9f508caba11c443cab1f2c95bc1475347d342436574bef45bb4b6c3e852329" },
-]
-
-[package.metadata]
-requires-dist = [
-    { name = "pydantic", specifier = "~=2.13" },
-    { name = "pyyaml", specifier = "~=6.0" },
-    { name = "terok-util", url = "https://github.com/terok-ai/terok-util/releases/download/v0.3.1a3/terok_util-0.3.1a3-py3-none-any.whl" },
-]
 
 [[package]]
 name = "terok-util"
-version = "0.3.1a3"
-source = { url = "https://github.com/terok-ai/terok-util/releases/download/v0.3.1a3/terok_util-0.3.1a3-py3-none-any.whl" }
+version = "0.3.1a4.dev87+g969a358c4"
+source = { git = "https://github.com/sliwowitz/terok-util?rev=feat%2Funified-logging#969a358c451e44128c3cb5f59b4f50a7bc003a7d" }
 dependencies = [
     { name = "jinja2" },
     { name = "platformdirs" },
     { name = "ruamel-yaml" },
-]
-wheels = [
-    { url = "https://github.com/terok-ai/terok-util/releases/download/v0.3.1a3/terok_util-0.3.1a3-py3-none-any.whl", hash = "sha256:dc579905a4c9d815ccadb8370834002a9f2f0c0f2fd35d42e58140e7563799c1" },
-]
-
-[package.metadata]
-requires-dist = [
-    { name = "jinja2", specifier = "~=3.1" },
-    { name = "platformdirs", specifier = "~=4.10" },
-    { name = "ruamel-yaml", specifier = "==0.19.1" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -2395,11 +2395,11 @@ requires-dist = [
     { name = "requests", specifier = "~=2.34" },
     { name = "rich", specifier = "~=15.0" },
     { name = "ruamel-yaml", specifier = "==0.19.1" },
-    { name = "terok-clearance", git = "https://github.com/sliwowitz/terok-clearance?rev=feat%2Funified-logging" },
-    { name = "terok-executor", git = "https://github.com/sliwowitz/terok-executor?rev=feat%2Funified-logging" },
-    { name = "terok-sandbox", git = "https://github.com/sliwowitz/terok-sandbox?rev=feat%2Funified-logging" },
-    { name = "terok-shield", git = "https://github.com/sliwowitz/terok-shield?rev=feat%2Funified-logging" },
-    { name = "terok-util", git = "https://github.com/sliwowitz/terok-util?rev=feat%2Funified-logging" },
+    { name = "terok-clearance", url = "https://github.com/terok-ai/terok-clearance/releases/download/v0.8.0a7/terok_clearance-0.8.0a7-py3-none-any.whl" },
+    { name = "terok-executor", url = "https://github.com/terok-ai/terok-executor/releases/download/v0.4.0a18/terok_executor-0.4.0a18-py3-none-any.whl" },
+    { name = "terok-sandbox", url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.5.0a19/terok_sandbox-0.5.0a19-py3-none-any.whl" },
+    { name = "terok-shield", url = "https://github.com/terok-ai/terok-shield/releases/download/v0.8.0a8/terok_shield-0.8.0a8-py3-none-any.whl" },
+    { name = "terok-util", url = "https://github.com/terok-ai/terok-util/releases/download/v0.3.1a4/terok_util-0.3.1a4-py3-none-any.whl" },
     { name = "textual", extras = ["syntax"], specifier = "~=8.2.8" },
     { name = "textual-serve", specifier = "~=1.1" },
     { name = "unique-namer", specifier = "~=1.6" },
@@ -2440,19 +2440,30 @@ test = [
 
 [[package]]
 name = "terok-clearance"
-version = "0.8.0a7.dev215+g8c785cf67"
-source = { git = "https://github.com/sliwowitz/terok-clearance?rev=feat%2Funified-logging#8c785cf671031bdab6673b1bbc7337ffc00ca540" }
+version = "0.8.0a7"
+source = { url = "https://github.com/terok-ai/terok-clearance/releases/download/v0.8.0a7/terok_clearance-0.8.0a7-py3-none-any.whl" }
 dependencies = [
     { name = "asyncvarlink" },
     { name = "dbus-fast" },
     { name = "pyyaml" },
     { name = "terok-util" },
 ]
+wheels = [
+    { url = "https://github.com/terok-ai/terok-clearance/releases/download/v0.8.0a7/terok_clearance-0.8.0a7-py3-none-any.whl", hash = "sha256:12e357db2049850312571ab15615b61cac74a3e33d0746bcda8addaf4ca308b8" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "asyncvarlink", specifier = "==0.3.2" },
+    { name = "dbus-fast", specifier = "~=5.0" },
+    { name = "pyyaml", specifier = "~=6.0" },
+    { name = "terok-util", url = "https://github.com/terok-ai/terok-util/releases/download/v0.3.1a4/terok_util-0.3.1a4-py3-none-any.whl" },
+]
 
 [[package]]
 name = "terok-executor"
-version = "0.4.0a17.dev457+gd8a39e2a5"
-source = { git = "https://github.com/sliwowitz/terok-executor?rev=feat%2Funified-logging#d8a39e2a5274743f9668b0b59c425ca05197eb09" }
+version = "0.4.0a18"
+source = { url = "https://github.com/terok-ai/terok-executor/releases/download/v0.4.0a18/terok_executor-0.4.0a18-py3-none-any.whl" }
 dependencies = [
     { name = "agent-client-protocol" },
     { name = "jinja2" },
@@ -2464,11 +2475,27 @@ dependencies = [
     { name = "terok-util" },
     { name = "tomli-w" },
 ]
+wheels = [
+    { url = "https://github.com/terok-ai/terok-executor/releases/download/v0.4.0a18/terok_executor-0.4.0a18-py3-none-any.whl", hash = "sha256:3d50bc60d7f670b4bb65645094e7f6e9b390450433081f3d7752ea40464a7bfc" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "agent-client-protocol", specifier = "==0.11.0" },
+    { name = "jinja2", specifier = "~=3.1" },
+    { name = "prompt-toolkit", specifier = "~=3.0" },
+    { name = "pydantic", specifier = "~=2.13" },
+    { name = "rich", specifier = "~=15.0" },
+    { name = "ruamel-yaml", specifier = "==0.19.1" },
+    { name = "terok-sandbox", url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.5.0a19/terok_sandbox-0.5.0a19-py3-none-any.whl" },
+    { name = "terok-util", url = "https://github.com/terok-ai/terok-util/releases/download/v0.3.1a4/terok_util-0.3.1a4-py3-none-any.whl" },
+    { name = "tomli-w", specifier = "~=1.2" },
+]
 
 [[package]]
 name = "terok-sandbox"
-version = "0.5.0a17.dev448+g49ccf7b68"
-source = { git = "https://github.com/sliwowitz/terok-sandbox?rev=feat%2Funified-logging#49ccf7b68bc61e57fdfe7d3930288be1c8fb17e9" }
+version = "0.5.0a19"
+source = { url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.5.0a19/terok_sandbox-0.5.0a19-py3-none-any.whl" }
 dependencies = [
     { name = "aiohttp" },
     { name = "cryptography" },
@@ -2484,25 +2511,65 @@ dependencies = [
     { name = "terok-shield" },
     { name = "terok-util" },
 ]
+wheels = [
+    { url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.5.0a19/terok_sandbox-0.5.0a19-py3-none-any.whl", hash = "sha256:94d05fbbe8a299079561b2082a9ce9ef57e065a6d9b7cedb5d13146c15db017d" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "aiohttp", specifier = "~=3.14.1" },
+    { name = "cryptography", specifier = "~=49.0" },
+    { name = "jinja2", specifier = "~=3.1" },
+    { name = "keyring", specifier = "~=25.7" },
+    { name = "packaging", specifier = "~=26.2" },
+    { name = "platformdirs", specifier = "~=4.10" },
+    { name = "prompt-toolkit", specifier = "~=3.0" },
+    { name = "pydantic", specifier = "~=2.13" },
+    { name = "ruamel-yaml", specifier = "==0.19.1" },
+    { name = "sqlcipher3", specifier = "==0.6.2" },
+    { name = "terok-clearance", url = "https://github.com/terok-ai/terok-clearance/releases/download/v0.8.0a7/terok_clearance-0.8.0a7-py3-none-any.whl" },
+    { name = "terok-shield", url = "https://github.com/terok-ai/terok-shield/releases/download/v0.8.0a8/terok_shield-0.8.0a8-py3-none-any.whl" },
+    { name = "terok-util", url = "https://github.com/terok-ai/terok-util/releases/download/v0.3.1a4/terok_util-0.3.1a4-py3-none-any.whl" },
+]
 
 [[package]]
 name = "terok-shield"
-version = "0.8.0a8.dev351+g583f8870d"
-source = { git = "https://github.com/sliwowitz/terok-shield?rev=feat%2Funified-logging#583f8870d03577e7fef3eb1e686547611a129955" }
+version = "0.8.0a8"
+source = { url = "https://github.com/terok-ai/terok-shield/releases/download/v0.8.0a8/terok_shield-0.8.0a8-py3-none-any.whl" }
 dependencies = [
     { name = "pydantic" },
     { name = "pyyaml" },
     { name = "terok-util" },
 ]
+wheels = [
+    { url = "https://github.com/terok-ai/terok-shield/releases/download/v0.8.0a8/terok_shield-0.8.0a8-py3-none-any.whl", hash = "sha256:e966d2de3cd15c2649ceaa68e45a96debe54de6eae980d54df058bf8489d6d3e" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "pydantic", specifier = "~=2.13" },
+    { name = "pyyaml", specifier = "~=6.0" },
+    { name = "terok-util", url = "https://github.com/terok-ai/terok-util/releases/download/v0.3.1a4/terok_util-0.3.1a4-py3-none-any.whl" },
+]
 
 [[package]]
 name = "terok-util"
-version = "0.3.1a4.dev87+g969a358c4"
-source = { git = "https://github.com/sliwowitz/terok-util?rev=feat%2Funified-logging#969a358c451e44128c3cb5f59b4f50a7bc003a7d" }
+version = "0.3.1a4"
+source = { url = "https://github.com/terok-ai/terok-util/releases/download/v0.3.1a4/terok_util-0.3.1a4-py3-none-any.whl" }
 dependencies = [
     { name = "jinja2" },
     { name = "platformdirs" },
     { name = "ruamel-yaml" },
+]
+wheels = [
+    { url = "https://github.com/terok-ai/terok-util/releases/download/v0.3.1a4/terok_util-0.3.1a4-py3-none-any.whl", hash = "sha256:8878f21e8101c5d70e17c7c44737ea5ea1390226738c0e9221f91d7dedfb38b3" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "jinja2", specifier = "~=3.1" },
+    { name = "platformdirs", specifier = "~=4.10" },
+    { name = "ruamel-yaml", specifier = "==0.19.1" },
 ]
 
 [[package]]


### PR DESCRIPTION
Top of the fleet-wide logging unification chain (terok-util terok-ai/terok-util#85; siblings terok-shield#407, terok-clearance#214, terok-sandbox#492, terok-executor#498). Supersedes the original #1188 bespoke output-capture on this branch.

## What

- **`output_capture.py` → thin glue over `terok_util.tee_output`.** The native journald protocol, the pty/pipe capture seam, and the file/journald sinks all moved **down** into terok-util. Only terok's `TEROK_KIND`/`PROJECT`/`TASK` fields and the `core_state_dir` file-fallback path remain here. The two importers (`project.py`, `task.py`) are unchanged.
- **`configure(identifier="terok")` at `cli/main.py` and `tui/app.py`.** Routes every `getLogger(__name__)` under `terok.*` to journald when present. The **TUI** routes its fallback to the `terok.log` file, never a stderr `StreamHandler` — a stderr handler would paint over the Textual screen.

## Chain pinning

Pins all five siblings to their `feat/unified-logging` branches, each **rebased onto current upstream/master** (util `5dac55a`, shield `4bebeff`, clearance `3334506`, sandbox `902137a`, executor `c108f86`). This branch sits on master's #1227 (executor egress projection at task launch), so terok and the siblings now share the same released+master egress behaviour — the earlier release-tag basing (which withheld shield #352/#397/#406 and drove the dnsmasq-fixture failures) is gone. GitHub's three-dot diff shows only the logging change per sibling (merge-base = master). Repin bottom-up to release wheels as the chain lands.

## Tests

`test_output_capture.py` slimmed to the terok glue (path shape, project scoping, delegate-and-persist); the sink/protocol tests now live in terok-util. Full unit suite green (**3264 passed**); lint / tach / import-linter / bandit (0 med/high) / docstrings (96.3%) / reuse all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Build and task-run output is streamed live and persisted for later review, with phase/project/task labeling.
  * Operations now show a completion pointer to the saved output logs.
* **Documentation**
  * Added usage guidance for “Build/run output logs,” including journald vs file retention and filtering behavior.
* **Bug Fixes**
  * Strengthened safety for persisted log filenames to prevent path traversal/escaping.
* **Tests**
  * Added unit and TUI smoke tests covering log capture, persistence, and logging setup.
* **Chores**
  * Added an example logrotate configuration for file-based output logs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->