### PR TITLE
ci: group dependabot GitHub Actions updates into coalesced PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -23,3 +23,9 @@ updates:
       day: "monday"
     commit-message:
       prefix: "ci"
+    groups:
+      internal-workflows:
+        patterns: ["terok-ai/*"]
+      external-actions:
+        patterns: ["*"]
+        exclude-patterns: ["terok-ai/*"]


### PR DESCRIPTION
The github-actions ecosystem had no groups block, so dependabot opened one
PR per referenced action *and* per referenced reusable-workflow file. Since
each terok-ai reusable workflow is keyed by its full path, a single sibling
release produced several near-identical PRs in every consumer.

Group them: first-party terok-ai reusable workflows in one PR, third-party
actions in another. This is the coalescing fix only — pins stay exact and
visible; it does not change what gets updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved automated dependency update management for GitHub Actions by grouping related workflow and external action updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->