### PR TITLE
fix(tui): restore SSH key minting

### DIFF
--- a/src/terok/lib/api/ssh_routing.py
+++ b/src/terok/lib/api/ssh_routing.py
@@ -99,13 +99,13 @@ def delete_key(key_id: int) -> None:
         db.delete_ssh_key(key_id)
 
 
-def mint_key(
-    project_name: str, *, key_type: str = "ed25519", comment: str | None = None
-) -> SSHInitResult:
+def mint_key(project_name: str, *, key_type: str = "ed25519", comment: str = "") -> SSHInitResult:
     """Generate a fresh keypair already linked to *project_name*.
 
     A key is born attached to a project (the vault holds no unlinked
-    keys), so minting always names the column it lands in.
+    keys), so minting always names the column it lands in.  The blank
+    comment deliberately selects additive provisioning; ``None`` means
+    "reuse the primary key" and therefore is not a mint operation.
     """
     return get_project(project_name).provision_ssh_key(key_type=key_type, comment=comment)
 

--- a/src/terok/tui/key_routing_screen.py
+++ b/src/terok/tui/key_routing_screen.py
@@ -86,6 +86,18 @@ class _BaseRoutingScreen(screen.Screen[None]):
         """Render *routing* into the subclass's widgets."""
         raise NotImplementedError
 
+    def _pick_project_to_mint(self) -> None:
+        """Ask which loaded project should receive a fresh key."""
+        if self._routing is not None:
+            self.app.push_screen(
+                _ProjectPickerScreen(self._routing.projects), self._mint_for_picked
+            )
+
+    def _mint_for_picked(self, scope: str | None) -> None:
+        """Mint for the picked project, or do nothing on cancel."""
+        if scope:
+            self._mint(scope)
+
     def _mint(self, scope: str) -> None:
         """Mint a key for *scope*."""
         self._apply(lambda: mint_key(scope), "Mint failed")
@@ -173,6 +185,7 @@ class KeyRoutingScreen(_BaseRoutingScreen):
         _modal_binding("escape", "dismiss_screen", "Back"),
         _modal_binding("q", "dismiss_screen", "Back"),
         _modal_binding("m", "toggle_mode", "Matrix / list"),
+        _modal_binding("n", "pick_project_to_mint", "Mint key"),
         _modal_binding("c", "rename_cursor_key", "Rename key"),
         _modal_binding("d", "delete_cursor_key", "Delete key"),
         _modal_binding("i", "show_inventory", "Inventory"),
@@ -280,6 +293,10 @@ class KeyRoutingScreen(_BaseRoutingScreen):
         if self._list_mode:
             self.query_one("#kr-projects").focus()
 
+    def action_pick_project_to_mint(self) -> None:
+        """Ask for a project when the focused list cannot infer one."""
+        self._pick_project_to_mint()
+
     def action_rename_cursor_key(self) -> None:
         """Rename the key the cursor points at (matrix or list)."""
         if (key_id := self._current_key_id()) is not None:
@@ -376,15 +393,7 @@ class KeyInventoryScreen(_BaseRoutingScreen):
 
     def action_mint(self) -> None:
         """Pick a project, then mint a key for it."""
-        if self._routing is not None:
-            self.app.push_screen(
-                _ProjectPickerScreen(self._routing.projects), self._mint_for_picked
-            )
-
-    def _mint_for_picked(self, scope: str | None) -> None:
-        """Mint for the picked project, or do nothing on cancel."""
-        if scope:
-            self._mint(scope)
+        self._pick_project_to_mint()
 
     def action_rename(self) -> None:
         """Rename the highlighted key's comment."""

--- a/tests/unit/lib/test_ssh_routing_api.py
+++ b/tests/unit/lib/test_ssh_routing_api.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 from contextlib import contextmanager
 from types import SimpleNamespace
+from unittest import mock
 
 import pytest
 
@@ -130,6 +131,16 @@ class TestMutations:
 
 class TestMint:
     """Verify minting routes through the project aggregate."""
+
+    def test_default_requests_additive_generation(self, monkeypatch):
+        """A bare mint requests a fresh side key instead of reusing the primary key."""
+        project = SimpleNamespace(provision_ssh_key=mock.Mock(return_value={"key_id": 8}))
+        monkeypatch.setattr(ssh_routing, "get_project", lambda _name: project)
+
+        result = ssh_routing.mint_key("foo")
+
+        project.provision_ssh_key.assert_called_once_with(key_type="ed25519", comment="")
+        assert result == {"key_id": 8}
 
     def test_mint_provisions_for_project(self, monkeypatch):
         """mint_key calls provision_ssh_key on the named project."""

--- a/tests/unit/tui/test_key_routing_screen.py
+++ b/tests/unit/tui/test_key_routing_screen.py
@@ -1,24 +1,104 @@
 # SPDX-FileCopyrightText: 2026 Jiri Vyskocil
 # SPDX-License-Identifier: Apache-2.0
 
-"""Tests for the pure label and hint helpers of the key-routing screens."""
+"""Verify SSH key routing labels, mutation guards, and minting shortcuts."""
 
 from __future__ import annotations
 
 from types import SimpleNamespace
 from unittest import mock
 
+import pytest
+from textual.app import App
+
+from terok.lib.api.ssh_routing import KeyRouting
+from terok.tui import key_routing_screen
 from terok.tui.key_routing_screen import (
+    KeyInventoryScreen,
+    KeyRoutingScreen,
     _BaseRoutingScreen,
     _hint,
     _inventory_label,
     _key_label,
+    _ProjectPickerScreen,
 )
 
 
 def _row(*, comment: str = "", key_type: str = "ed25519", fingerprint: str = "SHA256:abcdef"):
     """A stand-in key row carrying the fields the label helpers read."""
     return SimpleNamespace(comment=comment, key_type=key_type, fingerprint=fingerprint)
+
+
+class _RoutingHost(App[None]):
+    """Run the routing screen in the smallest app that can exercise its bindings."""
+
+    def on_mount(self) -> None:
+        """Open the routing screen."""
+        self.push_screen(KeyRoutingScreen())
+
+
+@pytest.fixture()
+def mint_calls(monkeypatch):
+    """Serve one routed key and record every project passed to the minting API."""
+    key = SimpleNamespace(
+        id=1,
+        comment="tk-main:alpha",
+        key_type="ed25519",
+        fingerprint="SHA256:abcdef",
+    )
+    routing = KeyRouting(
+        keys=(key,),
+        projects=("alpha", "beta"),
+        links=frozenset({("alpha", key.id)}),
+    )
+    calls: list[str] = []
+    monkeypatch.setattr(key_routing_screen, "load_key_routing", lambda: routing)
+    monkeypatch.setattr(key_routing_screen, "mint_key", calls.append)
+    return calls
+
+
+class TestMintShortcuts:
+    """Every advertised ``n`` path reaches the project-scoped minting API."""
+
+    @pytest.mark.asyncio
+    async def test_matrix_mints_for_cursor_project(self, mint_calls) -> None:
+        """Matrix mode derives the project from the cursor column."""
+        app = _RoutingHost()
+        async with app.run_test(size=(100, 30)) as pilot:
+            await pilot.pause()
+            await pilot.press("n")
+            await pilot.pause()
+
+        assert mint_calls == ["alpha"]
+
+    @pytest.mark.asyncio
+    async def test_list_mode_opens_picker_and_mints_selection(self, mint_calls) -> None:
+        """List mode asks for the otherwise ambiguous project and mints the selection."""
+        app = _RoutingHost()
+        async with app.run_test(size=(100, 30)) as pilot:
+            await pilot.pause()
+            await pilot.press("m", "n")
+            await pilot.pause()
+            assert isinstance(app.screen, _ProjectPickerScreen)
+            await pilot.press("enter")
+            await pilot.pause()
+
+        assert mint_calls == ["alpha"]
+
+    @pytest.mark.asyncio
+    async def test_inventory_picker_mints_selection(self, mint_calls) -> None:
+        """Inventory mode carries the project picker result into the minting API."""
+        app = _RoutingHost()
+        async with app.run_test(size=(100, 30)) as pilot:
+            await pilot.pause()
+            await pilot.press("i", "n")
+            await pilot.pause()
+            assert isinstance(app.screen, _ProjectPickerScreen)
+            await pilot.press("enter")
+            await pilot.pause()
+            assert isinstance(app.screen, KeyInventoryScreen)
+
+        assert mint_calls == ["alpha"]
 
 
 class TestKeyLabel:


### PR DESCRIPTION
The list view had no `n` binding, while matrix and inventory minting reused the existing primary key. Wire list mode to the project picker and request additive provisioning so every mint action creates a fresh key.

Tests: `make test`, `make lint`, `make tach`, `make lint-imports`, and `make typecheck`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an `n` shortcut to mint an SSH key for a manually selected project.
  * Unified project selection and key-minting flows across key routing screens.
  * New keys use Ed25519 encryption with a blank comment by default.

* **Bug Fixes**
  * Improved SSH key provisioning behavior for additive key generation.
  * Updated key inventory actions to use the shared minting flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->