### PR TITLE
fix(tui): probe the vault off the event loop

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,9 +44,9 @@ dependencies = [
     "unique-namer~=1.6",
     "textual-serve~=1.1",
     "jinja2~=3.1",
-    "terok-executor @ https://github.com/terok-ai/terok-executor/releases/download/v0.4.0a21/terok_executor-0.4.0a21-py3-none-any.whl",
-    "terok-sandbox @ https://github.com/terok-ai/terok-sandbox/releases/download/v0.5.0a22/terok_sandbox-0.5.0a22-py3-none-any.whl",
-    "terok-shield @ https://github.com/terok-ai/terok-shield/releases/download/v0.8.0a9/terok_shield-0.8.0a9-py3-none-any.whl",
+    "terok-executor @ https://github.com/terok-ai/terok-executor/releases/download/v0.4.0a22/terok_executor-0.4.0a22-py3-none-any.whl",
+    "terok-sandbox @ https://github.com/terok-ai/terok-sandbox/releases/download/v0.5.0a23/terok_sandbox-0.5.0a23-py3-none-any.whl",
+    "terok-shield @ https://github.com/terok-ai/terok-shield/releases/download/v0.8.0a10/terok_shield-0.8.0a10-py3-none-any.whl",
     "terok-clearance @ https://github.com/terok-ai/terok-clearance/releases/download/v0.8.0a8/terok_clearance-0.8.0a8-py3-none-any.whl",
     "terok-util @ https://github.com/terok-ai/terok-util/releases/download/v0.3.1a5/terok_util-0.3.1a5-py3-none-any.whl",
 ]

--- a/src/terok/tui/app.py
+++ b/src/terok/tui/app.py
@@ -5,6 +5,7 @@
 
 """Terok TUI application built on Textual."""
 
+import asyncio
 import getpass
 import inspect
 import os
@@ -321,6 +322,10 @@ if _HAS_TEXTUAL:
             self.ansi_theme_light = self.ansi_theme_dark
             # Snapshot the global config once; reuse via ``self._config``.
             self._config: Config = get_config()
+            # One vault probe at a time: the poll worker and the vault
+            # screen may otherwise race, and a slower probe would land a
+            # stale ``_last_vault_status`` over a newer one.
+            self._vault_probe_lock = asyncio.Lock()
             # Set dynamic title with version and branch info
             self._update_title()
 
@@ -2389,12 +2394,13 @@ if _HAS_TEXTUAL:
 
             from terok.lib.api.vault import load_vault_status
 
-            # Off the loop for the same reason as ``_refresh_vault_status``:
-            # the probe can stall on host facilities.
-            try:
-                self._last_vault_status = await asyncio.to_thread(load_vault_status)
-            except Exception:
-                self._last_vault_status = None
+            # Off the loop and under the shared lock for the same reasons
+            # as ``_refresh_vault_status``.
+            async with self._vault_probe_lock:
+                try:
+                    self._last_vault_status = await asyncio.to_thread(load_vault_status)
+                except Exception:
+                    self._last_vault_status = None
             await self.push_screen(
                 VaultScreen(self._last_vault_status),
                 self._on_vault_action_result,
@@ -2473,11 +2479,13 @@ if _HAS_TEXTUAL:
             # chain.  That is blocking I/O, and it can stall on host
             # facilities (a slow keyring, a wedged D-Bus).  The probe runs
             # on a thread, so the message pump keeps painting whatever the
-            # chain does.
-            try:
-                self._last_vault_status = await asyncio.to_thread(load_vault_status)
-            except Exception:
-                self._last_vault_status = None
+            # chain does.  The lock serializes concurrent probes, so a
+            # slower one cannot land a stale snapshot over a newer one.
+            async with self._vault_probe_lock:
+                try:
+                    self._last_vault_status = await asyncio.to_thread(load_vault_status)
+                except Exception:
+                    self._last_vault_status = None
 
             self._render_status_pill(self._last_vault_status)
 

--- a/src/terok/tui/app.py
+++ b/src/terok/tui/app.py
@@ -2390,17 +2390,7 @@ if _HAS_TEXTUAL:
 
         async def action_show_vault(self) -> None:
             """Open the vault management screen."""
-            import asyncio
-
-            from terok.lib.api.vault import load_vault_status
-
-            # Off the loop and under the shared lock for the same reasons
-            # as ``_refresh_vault_status``.
-            async with self._vault_probe_lock:
-                try:
-                    self._last_vault_status = await asyncio.to_thread(load_vault_status)
-                except Exception:
-                    self._last_vault_status = None
+            await self._probe_vault_status()
             await self.push_screen(
                 VaultScreen(self._last_vault_status),
                 self._on_vault_action_result,
@@ -2469,23 +2459,35 @@ if _HAS_TEXTUAL:
                 exit_on_error=False,
             )
 
-        async def _refresh_vault_status(self, *, push_modal_if_locked: bool = False) -> None:
-            """Read a fresh snapshot, update the pill, optionally push the unlock modal."""
-            import asyncio
+        async def _probe_vault_status(self, *, skip_if_inflight: bool = False) -> bool:
+            """Land a fresh snapshot in ``_last_vault_status``; return ``False`` on a skip.
 
-            from terok.lib.api.vault import VaultState, load_vault_status
+            The probe opens the credentials DB and walks the passphrase
+            chain.  That is blocking I/O, and it can stall on host
+            facilities (a slow keyring, a wedged D-Bus).  The probe runs
+            on a thread, so the message pump keeps painting whatever the
+            chain does.  The lock serializes concurrent probes, so a
+            slower one cannot land a stale snapshot over a newer one.
+            *skip_if_inflight* lets the poll drop its tick instead of
+            queueing a redundant probe behind a stalled one.
+            """
+            if skip_if_inflight and self._vault_probe_lock.locked():
+                return False
+            from terok.lib.api.vault import load_vault_status
 
-            # The probe opens the credentials DB and walks the passphrase
-            # chain.  That is blocking I/O, and it can stall on host
-            # facilities (a slow keyring, a wedged D-Bus).  The probe runs
-            # on a thread, so the message pump keeps painting whatever the
-            # chain does.  The lock serializes concurrent probes, so a
-            # slower one cannot land a stale snapshot over a newer one.
             async with self._vault_probe_lock:
                 try:
                     self._last_vault_status = await asyncio.to_thread(load_vault_status)
                 except Exception:
                     self._last_vault_status = None
+            return True
+
+        async def _refresh_vault_status(self, *, push_modal_if_locked: bool = False) -> None:
+            """Read a fresh snapshot, update the pill, optionally push the unlock modal."""
+            from terok.lib.api.vault import VaultState
+
+            if not await self._probe_vault_status(skip_if_inflight=True):
+                return  # the in-flight probe's caller renders the fresh pill
 
             self._render_status_pill(self._last_vault_status)
 

--- a/src/terok/tui/app.py
+++ b/src/terok/tui/app.py
@@ -2385,10 +2385,14 @@ if _HAS_TEXTUAL:
 
         async def action_show_vault(self) -> None:
             """Open the vault management screen."""
+            import asyncio
+
             from terok.lib.api.vault import load_vault_status
 
+            # Off the loop for the same reason as ``_refresh_vault_status``:
+            # the probe can stall on host facilities.
             try:
-                self._last_vault_status = load_vault_status()
+                self._last_vault_status = await asyncio.to_thread(load_vault_status)
             except Exception:
                 self._last_vault_status = None
             await self.push_screen(
@@ -2461,10 +2465,16 @@ if _HAS_TEXTUAL:
 
         async def _refresh_vault_status(self, *, push_modal_if_locked: bool = False) -> None:
             """Read a fresh snapshot, update the pill, optionally push the unlock modal."""
+            import asyncio
+
             from terok.lib.api.vault import VaultState, load_vault_status
 
+            # The probe opens the credentials DB and walks the passphrase
+            # chain — blocking I/O that can stall on host facilities (a
+            # slow keyring, a wedged D-Bus).  It runs on a thread so the
+            # message pump keeps painting whatever the chain does.
             try:
-                self._last_vault_status = load_vault_status()
+                self._last_vault_status = await asyncio.to_thread(load_vault_status)
             except Exception:
                 self._last_vault_status = None
 

--- a/src/terok/tui/app.py
+++ b/src/terok/tui/app.py
@@ -2470,9 +2470,10 @@ if _HAS_TEXTUAL:
             from terok.lib.api.vault import VaultState, load_vault_status
 
             # The probe opens the credentials DB and walks the passphrase
-            # chain — blocking I/O that can stall on host facilities (a
-            # slow keyring, a wedged D-Bus).  It runs on a thread so the
-            # message pump keeps painting whatever the chain does.
+            # chain.  That is blocking I/O, and it can stall on host
+            # facilities (a slow keyring, a wedged D-Bus).  The probe runs
+            # on a thread, so the message pump keeps painting whatever the
+            # chain does.
             try:
                 self._last_vault_status = await asyncio.to_thread(load_vault_status)
             except Exception:

--- a/src/terok/tui/app.py
+++ b/src/terok/tui/app.py
@@ -2480,6 +2480,10 @@ if _HAS_TEXTUAL:
                     self._last_vault_status = await asyncio.to_thread(load_vault_status)
                 except Exception:
                     self._last_vault_status = None
+            # The pill derives from the snapshot, so it updates wherever
+            # the snapshot lands — a skipped poll can then rely on the
+            # probe owner to have painted it.
+            self._render_status_pill(self._last_vault_status)
             return True
 
         async def _refresh_vault_status(self, *, push_modal_if_locked: bool = False) -> None:
@@ -2487,9 +2491,7 @@ if _HAS_TEXTUAL:
             from terok.lib.api.vault import VaultState
 
             if not await self._probe_vault_status(skip_if_inflight=True):
-                return  # the in-flight probe's caller renders the fresh pill
-
-            self._render_status_pill(self._last_vault_status)
+                return  # the in-flight probe renders the fresh pill itself
 
             # Only a genuinely LOCKED vault gets the unlock prompt.  An
             # UNPROVISIONED one has nothing to unlock — the modal would

--- a/tests/unit/tui/test_detail_screens.py
+++ b/tests/unit/tui/test_detail_screens.py
@@ -2969,6 +2969,9 @@ class TestRefreshVaultStatus:
         instance._render_status_pill = mock.Mock()
         instance.push_screen = mock.AsyncMock()
         instance._vault_probe_lock = asyncio.Lock()
+        # Route the probe to the real implementation so the refresh
+        # under test exercises the thread + lock mechanics.
+        instance._probe_vault_status = lambda **kw: app_class._probe_vault_status(instance, **kw)
         return instance
 
     def test_refresh_probes_and_stores_status(self) -> None:

--- a/tests/unit/tui/test_detail_screens.py
+++ b/tests/unit/tui/test_detail_screens.py
@@ -2963,9 +2963,12 @@ class TestRefreshVaultStatus:
     """[`_refresh_vault_status`][terok.tui.app.TerokTUI._refresh_vault_status] probe + modal trigger behaviour."""
 
     def _make_instance(self, app_class: type) -> object:
+        import asyncio
+
         instance = mock.Mock(spec=app_class)
         instance._render_status_pill = mock.Mock()
         instance.push_screen = mock.AsyncMock()
+        instance._vault_probe_lock = asyncio.Lock()
         return instance
 
     def test_refresh_probes_and_stores_status(self) -> None:

--- a/tests/unit/tui/test_vault_provisioning_flow.py
+++ b/tests/unit/tui/test_vault_provisioning_flow.py
@@ -184,6 +184,7 @@ class TestFreshInstallUnlockGuard:
             _on_vault_unlock_result=MagicMock(),
             _vault_probe_lock=asyncio.Lock(),
         )
+        stub._probe_vault_status = lambda **kw: TerokTUI._probe_vault_status(stub, **kw)
         with patch("terok.lib.api.vault.load_vault_status", return_value=status):
             await TerokTUI._refresh_vault_status(stub, push_modal_if_locked=True)
         stub.push_screen.assert_not_awaited()
@@ -197,6 +198,7 @@ class TestFreshInstallUnlockGuard:
             _on_vault_unlock_result=MagicMock(),
             _vault_probe_lock=asyncio.Lock(),
         )
+        stub._probe_vault_status = lambda **kw: TerokTUI._probe_vault_status(stub, **kw)
         with patch("terok.lib.api.vault.load_vault_status", return_value=status):
             await TerokTUI._refresh_vault_status(stub, push_modal_if_locked=True)
         stub.push_screen.assert_awaited_once()

--- a/tests/unit/tui/test_vault_provisioning_flow.py
+++ b/tests/unit/tui/test_vault_provisioning_flow.py
@@ -15,6 +15,7 @@ unbound-method-on-stub, same idiom as ``test_vault_unlock_flow.py``.
 
 from __future__ import annotations
 
+import asyncio
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -181,6 +182,7 @@ class TestFreshInstallUnlockGuard:
             _render_status_pill=MagicMock(),
             push_screen=AsyncMock(),
             _on_vault_unlock_result=MagicMock(),
+            _vault_probe_lock=asyncio.Lock(),
         )
         with patch("terok.lib.api.vault.load_vault_status", return_value=status):
             await TerokTUI._refresh_vault_status(stub, push_modal_if_locked=True)
@@ -193,6 +195,7 @@ class TestFreshInstallUnlockGuard:
             _render_status_pill=MagicMock(),
             push_screen=AsyncMock(),
             _on_vault_unlock_result=MagicMock(),
+            _vault_probe_lock=asyncio.Lock(),
         )
         with patch("terok.lib.api.vault.load_vault_status", return_value=status):
             await TerokTUI._refresh_vault_status(stub, push_modal_if_locked=True)

--- a/tests/unit/tui/test_vault_unlock_flow.py
+++ b/tests/unit/tui/test_vault_unlock_flow.py
@@ -236,6 +236,7 @@ class TestVaultProbeOffTheLoop:
                 _last_vault_status=None,
                 _vault_probe_lock=asyncio.Lock(),
             )
+            stub._probe_vault_status = lambda **kw: TerokTUI._probe_vault_status(stub, **kw)
             await TerokTUI._refresh_vault_status(stub)
             return stub
 
@@ -275,8 +276,8 @@ class TestVaultProbeOffTheLoop:
                 _vault_probe_lock=asyncio.Lock(),
             )
             await asyncio.gather(
-                TerokTUI._refresh_vault_status(stub),
-                TerokTUI._refresh_vault_status(stub),
+                TerokTUI._probe_vault_status(stub),
+                TerokTUI._probe_vault_status(stub),
             )
 
         asyncio.run(_drive())

--- a/tests/unit/tui/test_vault_unlock_flow.py
+++ b/tests/unit/tui/test_vault_unlock_flow.py
@@ -203,3 +203,35 @@ class TestVaultPoll:
         assert args[0] is sentinel
         assert kwargs["group"] == "vault-poll"
         assert kwargs["exclusive"] is True
+
+
+class TestVaultProbeOffTheLoop:
+    """The vault probe never runs on the message pump.
+
+    ``load_vault_status`` opens the credentials DB and walks the
+    passphrase chain, which can stall on host facilities (a locked OS
+    keyring's unlock prompt froze the whole TUI on a headless host).
+    The refresh must hand the probe to a thread so the loop keeps
+    painting whatever the chain does.
+    """
+
+    def test_refresh_probes_on_a_worker_thread(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        import asyncio
+        import threading
+
+        import terok.lib.api.vault as vault_api
+
+        probe_threads: list[threading.Thread] = []
+
+        def _probe() -> None:
+            probe_threads.append(threading.current_thread())
+            return None
+
+        monkeypatch.setattr(vault_api, "load_vault_status", _probe)
+        stub = SimpleNamespace(_render_status_pill=MagicMock(), _last_vault_status=None)
+
+        asyncio.run(TerokTUI._refresh_vault_status(stub))
+
+        assert probe_threads
+        assert probe_threads[0] is not threading.main_thread()
+        stub._render_status_pill.assert_called_once()

--- a/tests/unit/tui/test_vault_unlock_flow.py
+++ b/tests/unit/tui/test_vault_unlock_flow.py
@@ -209,10 +209,10 @@ class TestVaultProbeOffTheLoop:
     """The vault probe never runs on the message pump.
 
     ``load_vault_status`` opens the credentials DB and walks the
-    passphrase chain, which can stall on host facilities (a locked OS
-    keyring's unlock prompt froze the whole TUI on a headless host).
-    The refresh must hand the probe to a thread so the loop keeps
-    painting whatever the chain does.
+    passphrase chain, and the chain can stall on host facilities.  A
+    locked OS keyring's unlock prompt froze the whole TUI on a headless
+    host.  The refresh must hand the probe to a thread, so the loop
+    keeps painting whatever the chain does.
     """
 
     def test_refresh_probes_on_a_worker_thread(self, monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/unit/tui/test_vault_unlock_flow.py
+++ b/tests/unit/tui/test_vault_unlock_flow.py
@@ -216,6 +216,7 @@ class TestVaultProbeOffTheLoop:
     """
 
     def test_refresh_probes_on_a_worker_thread(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """The refresh hands ``load_vault_status`` to a thread, not the loop."""
         import asyncio
         import threading
 
@@ -228,10 +229,56 @@ class TestVaultProbeOffTheLoop:
             return None
 
         monkeypatch.setattr(vault_api, "load_vault_status", _probe)
-        stub = SimpleNamespace(_render_status_pill=MagicMock(), _last_vault_status=None)
 
-        asyncio.run(TerokTUI._refresh_vault_status(stub))
+        async def _drive() -> SimpleNamespace:
+            stub = SimpleNamespace(
+                _render_status_pill=MagicMock(),
+                _last_vault_status=None,
+                _vault_probe_lock=asyncio.Lock(),
+            )
+            await TerokTUI._refresh_vault_status(stub)
+            return stub
+
+        stub = asyncio.run(_drive())
 
         assert probe_threads
         assert probe_threads[0] is not threading.main_thread()
         stub._render_status_pill.assert_called_once()
+
+    def test_overlapping_probes_serialize_on_the_shared_lock(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A slower probe cannot land a stale snapshot over a newer one."""
+        import asyncio
+
+        import terok.lib.api.vault as vault_api
+
+        active = 0
+        peak = 0
+
+        def _probe() -> str:
+            nonlocal active, peak
+            active += 1
+            peak = max(peak, active)
+            import time
+
+            time.sleep(0.05)
+            active -= 1
+            return "snapshot"
+
+        monkeypatch.setattr(vault_api, "load_vault_status", _probe)
+
+        async def _drive() -> None:
+            stub = SimpleNamespace(
+                _render_status_pill=MagicMock(),
+                _last_vault_status=None,
+                _vault_probe_lock=asyncio.Lock(),
+            )
+            await asyncio.gather(
+                TerokTUI._refresh_vault_status(stub),
+                TerokTUI._refresh_vault_status(stub),
+            )
+
+        asyncio.run(_drive())
+
+        assert peak == 1  # the lock admits one probe at a time

--- a/uv.lock
+++ b/uv.lock
@@ -2396,9 +2396,9 @@ requires-dist = [
     { name = "rich", specifier = "~=15.0" },
     { name = "ruamel-yaml", specifier = "==0.19.1" },
     { name = "terok-clearance", url = "https://github.com/terok-ai/terok-clearance/releases/download/v0.8.0a8/terok_clearance-0.8.0a8-py3-none-any.whl" },
-    { name = "terok-executor", url = "https://github.com/terok-ai/terok-executor/releases/download/v0.4.0a21/terok_executor-0.4.0a21-py3-none-any.whl" },
-    { name = "terok-sandbox", url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.5.0a22/terok_sandbox-0.5.0a22-py3-none-any.whl" },
-    { name = "terok-shield", url = "https://github.com/terok-ai/terok-shield/releases/download/v0.8.0a9/terok_shield-0.8.0a9-py3-none-any.whl" },
+    { name = "terok-executor", url = "https://github.com/terok-ai/terok-executor/releases/download/v0.4.0a22/terok_executor-0.4.0a22-py3-none-any.whl" },
+    { name = "terok-sandbox", url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.5.0a23/terok_sandbox-0.5.0a23-py3-none-any.whl" },
+    { name = "terok-shield", url = "https://github.com/terok-ai/terok-shield/releases/download/v0.8.0a10/terok_shield-0.8.0a10-py3-none-any.whl" },
     { name = "terok-util", url = "https://github.com/terok-ai/terok-util/releases/download/v0.3.1a5/terok_util-0.3.1a5-py3-none-any.whl" },
     { name = "textual", extras = ["syntax"], specifier = "~=8.2.8" },
     { name = "textual-serve", specifier = "~=1.1" },
@@ -2462,8 +2462,8 @@ requires-dist = [
 
 [[package]]
 name = "terok-executor"
-version = "0.4.0a21"
-source = { url = "https://github.com/terok-ai/terok-executor/releases/download/v0.4.0a21/terok_executor-0.4.0a21-py3-none-any.whl" }
+version = "0.4.0a22"
+source = { url = "https://github.com/terok-ai/terok-executor/releases/download/v0.4.0a22/terok_executor-0.4.0a22-py3-none-any.whl" }
 dependencies = [
     { name = "agent-client-protocol" },
     { name = "jinja2" },
@@ -2476,7 +2476,7 @@ dependencies = [
     { name = "tomli-w" },
 ]
 wheels = [
-    { url = "https://github.com/terok-ai/terok-executor/releases/download/v0.4.0a21/terok_executor-0.4.0a21-py3-none-any.whl", hash = "sha256:e5f79f1e57f77dcf913fae59d0d566cf99adb86210a902a17f86ca1bfdb4f1d6" },
+    { url = "https://github.com/terok-ai/terok-executor/releases/download/v0.4.0a22/terok_executor-0.4.0a22-py3-none-any.whl", hash = "sha256:d4009453ac20fcb46dbd05a083e5d1b696688f6d82f39b1ee0181fb3627d25cb" },
 ]
 
 [package.metadata]
@@ -2487,15 +2487,15 @@ requires-dist = [
     { name = "pydantic", specifier = "~=2.13" },
     { name = "rich", specifier = "~=15.0" },
     { name = "ruamel-yaml", specifier = "==0.19.1" },
-    { name = "terok-sandbox", url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.5.0a22/terok_sandbox-0.5.0a22-py3-none-any.whl" },
+    { name = "terok-sandbox", url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.5.0a23/terok_sandbox-0.5.0a23-py3-none-any.whl" },
     { name = "terok-util", url = "https://github.com/terok-ai/terok-util/releases/download/v0.3.1a5/terok_util-0.3.1a5-py3-none-any.whl" },
     { name = "tomli-w", specifier = "~=1.2" },
 ]
 
 [[package]]
 name = "terok-sandbox"
-version = "0.5.0a22"
-source = { url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.5.0a22/terok_sandbox-0.5.0a22-py3-none-any.whl" }
+version = "0.5.0a23"
+source = { url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.5.0a23/terok_sandbox-0.5.0a23-py3-none-any.whl" }
 dependencies = [
     { name = "aiohttp" },
     { name = "cryptography" },
@@ -2512,7 +2512,7 @@ dependencies = [
     { name = "terok-util" },
 ]
 wheels = [
-    { url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.5.0a22/terok_sandbox-0.5.0a22-py3-none-any.whl", hash = "sha256:d51c13e2671de9a0b32b480edc3149e76047486bc3bfa59fe85236119d496018" },
+    { url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.5.0a23/terok_sandbox-0.5.0a23-py3-none-any.whl", hash = "sha256:e85f8565c35ab441bd508fac2e523b78d6bfc4ad1ba9424208547e1cd5ff16ab" },
 ]
 
 [package.metadata]
@@ -2528,21 +2528,21 @@ requires-dist = [
     { name = "ruamel-yaml", specifier = "==0.19.1" },
     { name = "sqlcipher3", specifier = "==0.6.2" },
     { name = "terok-clearance", url = "https://github.com/terok-ai/terok-clearance/releases/download/v0.8.0a8/terok_clearance-0.8.0a8-py3-none-any.whl" },
-    { name = "terok-shield", url = "https://github.com/terok-ai/terok-shield/releases/download/v0.8.0a9/terok_shield-0.8.0a9-py3-none-any.whl" },
+    { name = "terok-shield", url = "https://github.com/terok-ai/terok-shield/releases/download/v0.8.0a10/terok_shield-0.8.0a10-py3-none-any.whl" },
     { name = "terok-util", url = "https://github.com/terok-ai/terok-util/releases/download/v0.3.1a5/terok_util-0.3.1a5-py3-none-any.whl" },
 ]
 
 [[package]]
 name = "terok-shield"
-version = "0.8.0a9"
-source = { url = "https://github.com/terok-ai/terok-shield/releases/download/v0.8.0a9/terok_shield-0.8.0a9-py3-none-any.whl" }
+version = "0.8.0a10"
+source = { url = "https://github.com/terok-ai/terok-shield/releases/download/v0.8.0a10/terok_shield-0.8.0a10-py3-none-any.whl" }
 dependencies = [
     { name = "pydantic" },
     { name = "pyyaml" },
     { name = "terok-util" },
 ]
 wheels = [
-    { url = "https://github.com/terok-ai/terok-shield/releases/download/v0.8.0a9/terok_shield-0.8.0a9-py3-none-any.whl", hash = "sha256:f3425bdb9e9f01c65f10543bdc9a12306757ea98c1bd50dbbf01cb88340fb503" },
+    { url = "https://github.com/terok-ai/terok-shield/releases/download/v0.8.0a10/terok_shield-0.8.0a10-py3-none-any.whl", hash = "sha256:a589e80024e1e4336348eb19561a827c8f010825363075630a0f007bc22c7421" },
 ]
 
 [package.metadata]


### PR DESCRIPTION
🤖 `load_vault_status` opens the credentials DB and walks the passphrase chain. That is blocking I/O, and it can stall on host facilities. A locked OS keyring's unlock prompt blocked it indefinitely on a headless host and froze the whole TUI: `on_mount` and the adaptive vault poll both ran the probe on the message pump.

- `_refresh_vault_status` and `action_show_vault` hand the probe to `asyncio.to_thread`. A stalled chain degrades the vault pill, never the app.
- The locking test drives the refresh and asserts the probe runs off the loop thread. It fails on master.

The pins carry the full fix chain (terok-ai/terok-sandbox#522 → terok-ai/terok-executor#524 → this; shield via terok-ai/terok-shield#431). An install of this PR is a complete test of the freeze fix:

    pipx install --force 'terok @ git+https://github.com/sliwowitz/terok.git@fix/tui-vault-freeze'

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved vault status checking in the TUI by preventing overlapping checks from producing stale results.
  * Preserved responsive behavior, status displays, cached results, error handling, and locked-vault prompts.
  * Improved reliability when refreshing or viewing vault details during concurrent status checks.

* **Tests**
  * Added coverage verifying that concurrent vault status checks run sequentially and display the latest result correctly.
  * Expanded coverage for vault status refresh and provisioning flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
