### PR TITLE
chore: pre-alpha polish — roster classification, build/setup output persistence

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -76,7 +76,7 @@ Terok was started at the
 - **Python 3.12+**
 - **OpenSSH client** — for private git repos
 - Optional but recommended: **systemd** user session, **`dnsmasq`**
-  and **`dig`** (DNS plumbing for the egress firewall), a desktop
+  and **`dig`** or **`drill`** (DNS plumbing for the egress firewall), a desktop
   **notification daemon**
 
 ### Installation

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,9 +44,9 @@ dependencies = [
     "unique-namer~=1.6",
     "textual-serve~=1.1",
     "jinja2~=3.1",
-    "terok-executor @ https://github.com/terok-ai/terok-executor/releases/download/v0.4.0a27/terok_executor-0.4.0a27-py3-none-any.whl",
-    "terok-sandbox @ https://github.com/terok-ai/terok-sandbox/releases/download/v0.5.0a28/terok_sandbox-0.5.0a28-py3-none-any.whl",
-    "terok-shield @ https://github.com/terok-ai/terok-shield/releases/download/v0.8.0a12/terok_shield-0.8.0a12-py3-none-any.whl",
+    "terok-executor @ https://github.com/terok-ai/terok-executor/releases/download/v0.4.0a28/terok_executor-0.4.0a28-py3-none-any.whl",
+    "terok-sandbox @ https://github.com/terok-ai/terok-sandbox/releases/download/v0.5.0a29/terok_sandbox-0.5.0a29-py3-none-any.whl",
+    "terok-shield @ https://github.com/terok-ai/terok-shield/releases/download/v0.8.0a13/terok_shield-0.8.0a13-py3-none-any.whl",
     "terok-clearance @ https://github.com/terok-ai/terok-clearance/releases/download/v0.8.0a9/terok_clearance-0.8.0a9-py3-none-any.whl",
     "terok-util @ https://github.com/terok-ai/terok-util/releases/download/v0.3.1a6/terok_util-0.3.1a6-py3-none-any.whl",
 ]

--- a/src/terok/cli/commands/agents.py
+++ b/src/terok/cli/commands/agents.py
@@ -22,6 +22,10 @@ from __future__ import annotations
 
 import argparse
 import sys
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from terok.lib.api.agents import AgentRoster
 
 
 def register(subparsers: argparse._SubParsersAction[argparse.ArgumentParser]) -> None:
@@ -126,31 +130,7 @@ def _print_roster(*, show_all: bool) -> None:
         print("No agents registered.", file=sys.stderr)
         return
 
-    agents = roster.agents
-    providers = roster.providers
-    installs = roster.installs
-    auth_providers = roster.auth_providers
-    rows: list[tuple[str, str, str]] = []
-    for name in sorted(names):
-        agent = agents.get(name)
-        provider = providers.get(name)
-        auth = auth_providers.get(name)
-        if agent is not None:
-            label = agent.label
-        elif auth is not None:
-            label = auth.label
-        else:
-            label = name
-
-        if provider is not None and provider.serves:
-            entry_type = "harness" if name in installs else "endpoint"
-        elif agent is not None and agent.protocol and agent.provider_binding is None:
-            entry_type = "harness"
-        elif agent is not None:
-            entry_type = "agent"
-        else:
-            entry_type = "tool"
-        rows.append((name, entry_type, label))
+    rows = [_roster_row(name, roster) for name in sorted(names)]
 
     w_name = max(len("NAME"), max(len(r[0]) for r in rows))
     w_type = max(len("TYPE"), max(len(r[1]) for r in rows))
@@ -163,6 +143,35 @@ def _print_roster(*, show_all: bool) -> None:
             "\nSelect LLM endpoint providers with --provider. "
             "Do not add LLM endpoint providers to image.agents."
         )
+
+
+def _roster_row(name: str, roster: AgentRoster) -> tuple[str, str, str]:
+    """Classify one roster entry as a ``(name, type, label)`` table row.
+
+    The type names what the entry is to the operator: an installable
+    ``harness``, a selectable LLM ``endpoint``, a plain ``agent``, or an
+    auth-only ``tool``.
+    """
+    agent = roster.agents.get(name)
+    provider = roster.providers.get(name)
+    auth = roster.auth_providers.get(name)
+
+    if agent is not None:
+        label = agent.label
+    elif auth is not None:
+        label = auth.label
+    else:
+        label = name
+
+    if provider is not None and provider.serves:
+        entry_type = "harness" if name in roster.installs else "endpoint"
+    elif agent is not None and agent.protocol and agent.provider_binding is None:
+        entry_type = "harness"
+    elif agent is not None:
+        entry_type = "agent"
+    else:
+        entry_type = "tool"
+    return name, entry_type, label
 
 
 def _set_global_default(*, selection: str | None) -> None:

--- a/src/terok/cli/commands/image.py
+++ b/src/terok/cli/commands/image.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 import argparse
 
 from ...lib.api import find_orphaned_images, list_images, remove_images, require_project_exists
+from ...lib.util.output_capture import tee_output
 from . import _storage_view
 from ._completers import complete_project_names as _complete_project_names, set_completer
 
@@ -121,15 +122,16 @@ def dispatch(args: argparse.Namespace) -> bool:
 
     match args.image_cmd:
         case "build":
-            _cmd_build(
-                project_name=getattr(args, "project_name", None),
-                base=getattr(args, "base", None),
-                agents=getattr(args, "agents", None),
-                family=getattr(args, "family", None),
-                rebuild=getattr(args, "rebuild", False),
-                full_rebuild=getattr(args, "full_rebuild", False),
-                sidecar=getattr(args, "sidecar", False),
-            )
+            with tee_output("build", project=getattr(args, "project_name", None)):
+                _cmd_build(
+                    project_name=getattr(args, "project_name", None),
+                    base=getattr(args, "base", None),
+                    agents=getattr(args, "agents", None),
+                    family=getattr(args, "family", None),
+                    rebuild=getattr(args, "rebuild", False),
+                    full_rebuild=getattr(args, "full_rebuild", False),
+                    sidecar=getattr(args, "sidecar", False),
+                )
         case "list":
             _cmd_list(getattr(args, "project_name", None))
         case "cleanup":

--- a/src/terok/cli/commands/setup.py
+++ b/src/terok/cli/commands/setup.py
@@ -41,6 +41,7 @@ from ...lib.api import (
 )
 from ...lib.api.gate import summarize_gate_sync
 from ...lib.core.projects import require_project_exists
+from ...lib.util.output_capture import tee_output
 
 # ── CLI wiring ─────────────────────────────────────────────────────────
 
@@ -112,13 +113,14 @@ def dispatch(args: argparse.Namespace) -> bool:
     """Handle ``setup``.  Returns True if handled."""
     if args.cmd != "setup":
         return False
-    cmd_setup(
-        no_desktop_entry=getattr(args, "no_desktop_entry", False),
-        install_desktop_entry=getattr(args, "install_desktop_entry", False),
-        with_images=getattr(args, "with_images", None),
-        family=getattr(args, "family", None),
-        passphrase_tier=getattr(args, "passphrase_tier", None),
-    )
+    with tee_output("setup"):
+        cmd_setup(
+            no_desktop_entry=getattr(args, "no_desktop_entry", False),
+            install_desktop_entry=getattr(args, "install_desktop_entry", False),
+            with_images=getattr(args, "with_images", None),
+            family=getattr(args, "family", None),
+            passphrase_tier=getattr(args, "passphrase_tier", None),
+        )
     return True
 
 

--- a/src/terok/cli/commands/sickbay.py
+++ b/src/terok/cli/commands/sickbay.py
@@ -123,7 +123,7 @@ def _check_shield() -> _CheckResult:
         return ("warn", label, f"unexpected health: {ec.health}")
     dns = getattr(ec, "dns_tier", "unknown")
     detail = f"active ({ec.hooks}, {dns} DNS)"
-    # On a lower tier (dig/getent) surface shield's own reason: dnsmasq
+    # On a lower tier (lookup/getent) surface shield's own reason: dnsmasq
     # missing and dnsmasq AppArmor-confined need different fixes, and
     # shield reports the precise one (with any docs pointer) in ec.issues.
     if dns != "dnsmasq":

--- a/src/terok/lib/core/task_display.py
+++ b/src/terok/lib/core/task_display.py
@@ -102,15 +102,15 @@ def mode_info(mode: str | None) -> ModeInfo:
 #: DNS tiers that resolve the egress allowlist statically at launch, with no
 #: live IP-rotation handling.  A task on one of these gets an operator warning
 #: next to its shield posture.  The healthy tier is ``dnsmasq``.
-DEGRADED_DNS_TIERS = ("dig", "getent")
+DEGRADED_DNS_TIERS = ("lookup", "getent")
 
 
 @dataclass(frozen=True)
 class DnsTierWarning:
     """A degraded-DNS-tier warning for one task.
 
-    This task's egress allowlist resolved statically at launch (``dig`` or
-    ``getent``), so there is no live IP-rotation handling.  ``detail`` is
+    This task's egress allowlist resolved statically at launch (``lookup``
+    or ``getent``), so there is no live IP-rotation handling.  ``detail`` is
     the operator-facing explanation.
     """
 
@@ -126,7 +126,7 @@ class DnsTierWarning:
 def dns_tier_warning(task_tier: str | None) -> DnsTierWarning | None:
     """Flag a task on a degraded DNS tier, or ``None`` when it is healthy.
 
-    A degraded *task_tier* (``dig``/``getent``) means this task's egress
+    A degraded *task_tier* (``lookup``/``getent``) means this task's egress
     allowlist resolved statically at launch, with no live IP-rotation
     handling.  The healthy tier is ``dnsmasq``.  The warning is scoped to
     the task; why its tier degraded (e.g. AppArmor-confined dnsmasq) is in

--- a/src/terok/lib/util/output_capture.py
+++ b/src/terok/lib/util/output_capture.py
@@ -88,7 +88,7 @@ def tee_output(
     file-fallback path lazily under the core state dir.
 
     Args:
-        kind: Operation label — ``"build"`` or ``"run"``.
+        kind: Operation label — ``"build"``, ``"run"``, or ``"setup"``.
         project: Owning project name, when known.
         task_id: Owning task id, when known.
     """

--- a/src/terok/tui/screens.py
+++ b/src/terok/tui/screens.py
@@ -2338,7 +2338,7 @@ _SHIELD_HEALTH_STYLES: dict[str, str] = {
 def _shield_dns_line(dns_tier: str) -> Text:
     """The shield-status DNS line: the active tier, red when degraded.
 
-    A degraded tier (``dig``/``getent``) resolves the egress allowlist
+    A degraded tier (``lookup``/``getent``) resolves the egress allowlist
     statically, with no IP-rotation handling; its host-wide reason shows
     under Issues below.  The healthy tier is ``dnsmasq``.
     """

--- a/src/terok/tui/widgets/task_detail.py
+++ b/src/terok/tui/widgets/task_detail.py
@@ -167,7 +167,7 @@ def render_task_details(
                     )
                 )
     if task.dns_tier_warning:
-        # Degraded DNS tier (dig/getent): the task's egress allowlist resolves
+        # Degraded DNS tier (lookup/getent): the task's egress allowlist resolves
         # statically at launch, without IP-rotation handling.  Shown red, next
         # to the shield posture.
         warn = task.dns_tier_warning

--- a/tests/unit/cli/test_cli_image.py
+++ b/tests/unit/cli/test_cli_image.py
@@ -472,3 +472,30 @@ class TestCmdBuild:
                     full_rebuild=False,
                     sidecar=False,
                 )
+
+
+class TestBuildOutputPersistence:
+    """``image build`` runs under the output-capture tee (terok#1188)."""
+
+    def test_build_dispatch_tees_its_output(self) -> None:
+        import argparse
+
+        from terok.cli.commands.image import dispatch
+
+        args = argparse.Namespace(
+            cmd="image",
+            image_cmd="build",
+            project_name="proj",
+            base=None,
+            agents=None,
+            family=None,
+            rebuild=False,
+            full_rebuild=False,
+            sidecar=False,
+        )
+        with (
+            patch("terok.cli.commands.image.tee_output") as tee,
+            patch("terok.cli.commands.image._cmd_build"),
+        ):
+            assert dispatch(args) is True
+        tee.assert_called_once_with("build", project="proj")

--- a/tests/unit/cli/test_cli_setup_global.py
+++ b/tests/unit/cli/test_cli_setup_global.py
@@ -444,3 +444,20 @@ class TestCmdSetupStringExitCode:
         ):
             cmd_setup()
         assert "Sandbox aggregator reported failures (exit 2)." in capsys.readouterr().out
+
+
+class TestSetupOutputPersistence:
+    """``setup`` runs under the output-capture tee (terok#1188)."""
+
+    def test_setup_dispatch_tees_its_output(self) -> None:
+        import argparse
+
+        from terok.cli.commands.setup import dispatch
+
+        args = argparse.Namespace(cmd="setup")
+        with (
+            patch("terok.cli.commands.setup.tee_output") as tee,
+            patch("terok.cli.commands.setup.cmd_setup"),
+        ):
+            assert dispatch(args) is True
+        tee.assert_called_once_with("setup")

--- a/tests/unit/cli/test_sickbay.py
+++ b/tests/unit/cli/test_sickbay.py
@@ -415,11 +415,11 @@ class TestCheckShieldDnsTier:
         assert sev == "ok"
         assert "install dnsmasq" not in detail
 
-    def test_dig_tier_carries_hint(self) -> None:
-        """dig tier works but loses IP rotation — hint surfaces."""
+    def test_lookup_tier_carries_hint(self) -> None:
+        """lookup tier works but loses IP rotation — hint surfaces."""
         from terok.cli.commands.sickbay import _check_shield
 
-        with self._patch("dig"):
+        with self._patch("lookup"):
             sev, _, detail = _check_shield()
         assert sev == "ok"
         assert "install dnsmasq" in detail

--- a/tests/unit/lib/test_dns_tier_warning.py
+++ b/tests/unit/lib/test_dns_tier_warning.py
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: 2026 Jiri Vyskocil
 # SPDX-License-Identifier: Apache-2.0
 
-"""The degraded-DNS-tier warning: flag a task launched on dig/getent."""
+"""The degraded-DNS-tier warning: flag a task launched on lookup/getent."""
 
 from __future__ import annotations
 
@@ -16,7 +16,7 @@ def test_no_warning_when_task_tier_is_not_degraded(task_tier: str | None) -> Non
     assert dns_tier_warning(task_tier) is None
 
 
-@pytest.mark.parametrize("task_tier", ["dig", "getent"])
+@pytest.mark.parametrize("task_tier", ["lookup", "getent"])
 def test_degraded_tier_is_flagged_with_its_name(task_tier: str) -> None:
     """A static-allowlist tier is flagged, its headline naming the tier."""
     warn = dns_tier_warning(task_tier)
@@ -28,6 +28,6 @@ def test_degraded_tier_is_flagged_with_its_name(task_tier: str) -> None:
 
 def test_warning_is_frozen() -> None:
     """The warning value object is immutable."""
-    warn = DnsTierWarning(tier="dig", detail="x")
+    warn = DnsTierWarning(tier="lookup", detail="x")
     with pytest.raises((AttributeError, TypeError)):
         warn.tier = "getent"  # type: ignore[misc]

--- a/tests/unit/tui/test_detail_screens.py
+++ b/tests/unit/tui/test_detail_screens.py
@@ -433,10 +433,10 @@ class TestRenderHelpers:
         """A degraded DNS tier renders a DNS line naming the tier and its explanation."""
         from terok.lib.core.task_display import dns_tier_warning
 
-        warn = dns_tier_warning("dig")
+        warn = dns_tier_warning("lookup")
         assert_rendered_needles(
             render_task_details_text(task_id="99", shield_state="DOWN", dns_tier_warning=warn),
-            ["DNS:", "dig (degraded)", "resolved statically at launch"],
+            ["DNS:", "lookup (degraded)", "resolved statically at launch"],
             [],
         )
 
@@ -454,8 +454,8 @@ class TestRenderHelpers:
             "issues": [],
             "setup_hint": "",
         }
-        degraded = str(screens.render_shield_status(SimpleNamespace(dns_tier="dig", **base)))
-        assert "DNS:" in degraded and "dig (degraded)" in degraded
+        degraded = str(screens.render_shield_status(SimpleNamespace(dns_tier="lookup", **base)))
+        assert "DNS:" in degraded and "lookup (degraded)" in degraded
         healthy = str(screens.render_shield_status(SimpleNamespace(dns_tier="dnsmasq", **base)))
         assert "dnsmasq" in healthy and "degraded" not in healthy
 

--- a/tests/unit/tui/test_key_routing_screen.py
+++ b/tests/unit/tui/test_key_routing_screen.py
@@ -37,7 +37,7 @@ class _RoutingHost(App[None]):
         self.push_screen(KeyRoutingScreen())
 
 
-@pytest.fixture()
+@pytest.fixture
 def mint_calls(monkeypatch):
     """Serve one routed key and record every project passed to the minting API."""
     key = SimpleNamespace(

--- a/uv.lock
+++ b/uv.lock
@@ -2392,9 +2392,9 @@ requires-dist = [
     { name = "rich", specifier = "~=15.0" },
     { name = "ruamel-yaml", specifier = "==0.19.1" },
     { name = "terok-clearance", url = "https://github.com/terok-ai/terok-clearance/releases/download/v0.8.0a9/terok_clearance-0.8.0a9-py3-none-any.whl" },
-    { name = "terok-executor", url = "https://github.com/terok-ai/terok-executor/releases/download/v0.4.0a27/terok_executor-0.4.0a27-py3-none-any.whl" },
-    { name = "terok-sandbox", url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.5.0a28/terok_sandbox-0.5.0a28-py3-none-any.whl" },
-    { name = "terok-shield", url = "https://github.com/terok-ai/terok-shield/releases/download/v0.8.0a12/terok_shield-0.8.0a12-py3-none-any.whl" },
+    { name = "terok-executor", url = "https://github.com/terok-ai/terok-executor/releases/download/v0.4.0a28/terok_executor-0.4.0a28-py3-none-any.whl" },
+    { name = "terok-sandbox", url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.5.0a29/terok_sandbox-0.5.0a29-py3-none-any.whl" },
+    { name = "terok-shield", url = "https://github.com/terok-ai/terok-shield/releases/download/v0.8.0a13/terok_shield-0.8.0a13-py3-none-any.whl" },
     { name = "terok-util", url = "https://github.com/terok-ai/terok-util/releases/download/v0.3.1a6/terok_util-0.3.1a6-py3-none-any.whl" },
     { name = "textual", extras = ["syntax"], specifier = "~=8.2.8" },
     { name = "textual-serve", specifier = "~=1.1" },
@@ -2458,8 +2458,8 @@ requires-dist = [
 
 [[package]]
 name = "terok-executor"
-version = "0.4.0a27"
-source = { url = "https://github.com/terok-ai/terok-executor/releases/download/v0.4.0a27/terok_executor-0.4.0a27-py3-none-any.whl" }
+version = "0.4.0a28"
+source = { url = "https://github.com/terok-ai/terok-executor/releases/download/v0.4.0a28/terok_executor-0.4.0a28-py3-none-any.whl" }
 dependencies = [
     { name = "agent-client-protocol" },
     { name = "jinja2" },
@@ -2472,7 +2472,7 @@ dependencies = [
     { name = "tomli-w" },
 ]
 wheels = [
-    { url = "https://github.com/terok-ai/terok-executor/releases/download/v0.4.0a27/terok_executor-0.4.0a27-py3-none-any.whl", hash = "sha256:bc0e8c5e2bcd8ecef86e44ca588eef2fb0612e1b02435af52e48f0b9b431e4b6" },
+    { url = "https://github.com/terok-ai/terok-executor/releases/download/v0.4.0a28/terok_executor-0.4.0a28-py3-none-any.whl", hash = "sha256:1071055a7c232f660370c9166f0e035eee49d3244f42f1a8d7e10918f6826286" },
 ]
 
 [package.metadata]
@@ -2483,15 +2483,15 @@ requires-dist = [
     { name = "pydantic", specifier = "~=2.13" },
     { name = "rich", specifier = "~=15.0" },
     { name = "ruamel-yaml", specifier = "==0.19.1" },
-    { name = "terok-sandbox", url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.5.0a28/terok_sandbox-0.5.0a28-py3-none-any.whl" },
+    { name = "terok-sandbox", url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.5.0a29/terok_sandbox-0.5.0a29-py3-none-any.whl" },
     { name = "terok-util", url = "https://github.com/terok-ai/terok-util/releases/download/v0.3.1a6/terok_util-0.3.1a6-py3-none-any.whl" },
     { name = "tomli-w", specifier = "~=1.2" },
 ]
 
 [[package]]
 name = "terok-sandbox"
-version = "0.5.0a28"
-source = { url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.5.0a28/terok_sandbox-0.5.0a28-py3-none-any.whl" }
+version = "0.5.0a29"
+source = { url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.5.0a29/terok_sandbox-0.5.0a29-py3-none-any.whl" }
 dependencies = [
     { name = "aiohttp" },
     { name = "cryptography" },
@@ -2508,7 +2508,7 @@ dependencies = [
     { name = "terok-util" },
 ]
 wheels = [
-    { url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.5.0a28/terok_sandbox-0.5.0a28-py3-none-any.whl", hash = "sha256:700ab0d2a2af88aac0335023bc9abb8e0782129b00dc1a4906c44f256fb1901e" },
+    { url = "https://github.com/terok-ai/terok-sandbox/releases/download/v0.5.0a29/terok_sandbox-0.5.0a29-py3-none-any.whl", hash = "sha256:1e393681c57d5c75518b4bb0a4d9a33ef42f623ab27decf45d81d6a1c85ea438" },
 ]
 
 [package.metadata]
@@ -2524,21 +2524,21 @@ requires-dist = [
     { name = "ruamel-yaml", specifier = "==0.19.1" },
     { name = "sqlcipher3", specifier = "==0.6.2" },
     { name = "terok-clearance", url = "https://github.com/terok-ai/terok-clearance/releases/download/v0.8.0a9/terok_clearance-0.8.0a9-py3-none-any.whl" },
-    { name = "terok-shield", url = "https://github.com/terok-ai/terok-shield/releases/download/v0.8.0a12/terok_shield-0.8.0a12-py3-none-any.whl" },
+    { name = "terok-shield", url = "https://github.com/terok-ai/terok-shield/releases/download/v0.8.0a13/terok_shield-0.8.0a13-py3-none-any.whl" },
     { name = "terok-util", url = "https://github.com/terok-ai/terok-util/releases/download/v0.3.1a6/terok_util-0.3.1a6-py3-none-any.whl" },
 ]
 
 [[package]]
 name = "terok-shield"
-version = "0.8.0a12"
-source = { url = "https://github.com/terok-ai/terok-shield/releases/download/v0.8.0a12/terok_shield-0.8.0a12-py3-none-any.whl" }
+version = "0.8.0a13"
+source = { url = "https://github.com/terok-ai/terok-shield/releases/download/v0.8.0a13/terok_shield-0.8.0a13-py3-none-any.whl" }
 dependencies = [
     { name = "pydantic" },
     { name = "pyyaml" },
     { name = "terok-util" },
 ]
 wheels = [
-    { url = "https://github.com/terok-ai/terok-shield/releases/download/v0.8.0a12/terok_shield-0.8.0a12-py3-none-any.whl", hash = "sha256:f08c179686756ce4d1c725da051fb92acdc98177342395ca5cc5b048cc588d0a" },
+    { url = "https://github.com/terok-ai/terok-shield/releases/download/v0.8.0a13/terok_shield-0.8.0a13-py3-none-any.whl", hash = "sha256:a681fbac4f35b215903275af85ecec8823e9d4d1195eb1e1fd207df5a5601902" },
 ]
 
 [package.metadata]


### PR DESCRIPTION
🤖 Pre-alpha polish for the Manjaro-fix wheel (#1246); terok's one polish PR alongside terok-ai/terok-shield#435.

**Sonar polish.** `_roster_row` extracts the per-entry classification `_print_roster` performed inline (S3776 from the provider-simplification merge); the empty fixture-decorator parentheses go (S9083). SonarCloud new-code reports clean.

**Output persistence (closes #1188).** The unified-logging facility already persists `run`, `restart`, and project-triggered build output (journald-first, state-dir file fallback, live terminal byte-identical). Two producers still streamed to the terminal only: standalone `terok image build` and `terok setup` — the setup one being exactly the output the issue's Ubuntu/podman-3.4 forensic session was missing. Both dispatch sites now wrap in the existing `tee_output`; `"setup"` joins the operation labels; locking tests assert both dispatches enter the tee. No new mechanism, no layout decisions; the journald-first design dissolves the rotation question.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Build and setup command output is now captured for improved visibility and persistence.
* **Documentation**
  * Prerequisites now list `drill` as an alternative DNS utility.
  * DNS diagnostics and warnings now identify `lookup` and `getent` as degraded tiers.
* **Tests**
  * Added coverage for build and setup output capture.
  * Updated test fixture declaration syntax while preserving existing behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->