### PR TITLE
feat(cli): tee image-build and setup output like the task operations

### DIFF
--- a/src/terok/cli/commands/image.py
+++ b/src/terok/cli/commands/image.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 import argparse
 
 from ...lib.api import find_orphaned_images, list_images, remove_images, require_project_exists
+from ...lib.util.output_capture import tee_output
 from . import _storage_view
 from ._completers import complete_project_names as _complete_project_names, set_completer
 
@@ -121,15 +122,16 @@ def dispatch(args: argparse.Namespace) -> bool:
 
     match args.image_cmd:
         case "build":
-            _cmd_build(
-                project_name=getattr(args, "project_name", None),
-                base=getattr(args, "base", None),
-                agents=getattr(args, "agents", None),
-                family=getattr(args, "family", None),
-                rebuild=getattr(args, "rebuild", False),
-                full_rebuild=getattr(args, "full_rebuild", False),
-                sidecar=getattr(args, "sidecar", False),
-            )
+            with tee_output("build", project=getattr(args, "project_name", None)):
+                _cmd_build(
+                    project_name=getattr(args, "project_name", None),
+                    base=getattr(args, "base", None),
+                    agents=getattr(args, "agents", None),
+                    family=getattr(args, "family", None),
+                    rebuild=getattr(args, "rebuild", False),
+                    full_rebuild=getattr(args, "full_rebuild", False),
+                    sidecar=getattr(args, "sidecar", False),
+                )
         case "list":
             _cmd_list(getattr(args, "project_name", None))
         case "cleanup":

--- a/src/terok/cli/commands/setup.py
+++ b/src/terok/cli/commands/setup.py
@@ -41,6 +41,7 @@ from ...lib.api import (
 )
 from ...lib.api.gate import summarize_gate_sync
 from ...lib.core.projects import require_project_exists
+from ...lib.util.output_capture import tee_output
 
 # ── CLI wiring ─────────────────────────────────────────────────────────
 
@@ -112,13 +113,14 @@ def dispatch(args: argparse.Namespace) -> bool:
     """Handle ``setup``.  Returns True if handled."""
     if args.cmd != "setup":
         return False
-    cmd_setup(
-        no_desktop_entry=getattr(args, "no_desktop_entry", False),
-        install_desktop_entry=getattr(args, "install_desktop_entry", False),
-        with_images=getattr(args, "with_images", None),
-        family=getattr(args, "family", None),
-        passphrase_tier=getattr(args, "passphrase_tier", None),
-    )
+    with tee_output("setup"):
+        cmd_setup(
+            no_desktop_entry=getattr(args, "no_desktop_entry", False),
+            install_desktop_entry=getattr(args, "install_desktop_entry", False),
+            with_images=getattr(args, "with_images", None),
+            family=getattr(args, "family", None),
+            passphrase_tier=getattr(args, "passphrase_tier", None),
+        )
     return True
 
 

--- a/src/terok/lib/util/output_capture.py
+++ b/src/terok/lib/util/output_capture.py
@@ -88,7 +88,7 @@ def tee_output(
     file-fallback path lazily under the core state dir.
 
     Args:
-        kind: Operation label — ``"build"`` or ``"run"``.
+        kind: Operation label — ``"build"``, ``"run"``, or ``"setup"``.
         project: Owning project name, when known.
         task_id: Owning task id, when known.
     """

--- a/tests/unit/cli/test_cli_image.py
+++ b/tests/unit/cli/test_cli_image.py
@@ -472,3 +472,30 @@ class TestCmdBuild:
                     full_rebuild=False,
                     sidecar=False,
                 )
+
+
+class TestBuildOutputPersistence:
+    """``image build`` runs under the output-capture tee (terok#1188)."""
+
+    def test_build_dispatch_tees_its_output(self) -> None:
+        import argparse
+
+        from terok.cli.commands.image import dispatch
+
+        args = argparse.Namespace(
+            cmd="image",
+            image_cmd="build",
+            project_name="proj",
+            base=None,
+            agents=None,
+            family=None,
+            rebuild=False,
+            full_rebuild=False,
+            sidecar=False,
+        )
+        with (
+            patch("terok.cli.commands.image.tee_output") as tee,
+            patch("terok.cli.commands.image._cmd_build"),
+        ):
+            assert dispatch(args) is True
+        tee.assert_called_once_with("build", project="proj")

--- a/tests/unit/cli/test_cli_setup_global.py
+++ b/tests/unit/cli/test_cli_setup_global.py
@@ -444,3 +444,20 @@ class TestCmdSetupStringExitCode:
         ):
             cmd_setup()
         assert "Sandbox aggregator reported failures (exit 2)." in capsys.readouterr().out
+
+
+class TestSetupOutputPersistence:
+    """``setup`` runs under the output-capture tee (terok#1188)."""
+
+    def test_setup_dispatch_tees_its_output(self) -> None:
+        import argparse
+
+        from terok.cli.commands.setup import dispatch
+
+        args = argparse.Namespace(cmd="setup")
+        with (
+            patch("terok.cli.commands.setup.tee_output") as tee,
+            patch("terok.cli.commands.setup.cmd_setup"),
+        ):
+            assert dispatch(args) is True
+        tee.assert_called_once_with("setup")


### PR DESCRIPTION
🤖 Closes #1188. Alpha-polish item for the #1246 wheel.

The unified-logging facility already gives #1188 nearly everything it asked for: `run`, `restart`, and the project-triggered builds persist their bytes to journald (or the state-dir log fallback) with the live terminal untouched. Two producers still streamed to the terminal only: the standalone `terok image build` and `terok setup` (which builds images during first-time setup — exactly the output the issue's Ubuntu/podman-3.4 forensic session was missing).

- Both dispatch sites wrap in the existing `tee_output`; `"setup"` joins `"build"`/`"run"` as an operation label.
- No new mechanism, no layout decisions: journald-first with the documented `journalctl` hint, state-dir file fallback, exactly as the fleet facility already does it.
- Locking tests assert both dispatches enter the tee.

Remaining open questions from the issue (rotation policy, toad/ACP interactive traffic) are unchanged — the journald-first design largely dissolves the rotation question.