### PR TITLE
fix(tests): the matrix expects a lookup tool, not one particular binary

### DIFF
--- a/tests/containers/matrix.yml
+++ b/tests/containers/matrix.yml
@@ -23,7 +23,7 @@
 
 image-prefix: terok-test
 flavor: podman
-expect: [podman, nft, dnsmasq, dig, getent, git, ssh-keygen, internet]
+expect: [podman, nft, dnsmasq, lookup, getent, git, ssh-keygen, internet]
 groups: [test, stories]
 
 slots:

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -145,7 +145,9 @@ _CAPABILITY_PROBES = {
     "podman": lambda: _has("podman"),
     "nft": lambda: bool(_find_nft()),
     "dnsmasq": lambda: binary_on_path("dnsmasq"),
-    "dig": lambda: _has("dig"),
+    # A lookup tool, not one particular binary: terok-shield's resolver takes
+    # dig or drill, and the Arch/Manjaro images ship the latter.
+    "lookup": lambda: _has("dig") or _has("drill"),
     "getent": lambda: _has("getent"),
     "git": lambda: _has("git"),
     "ssh-keygen": lambda: _has("ssh-keygen"),
@@ -213,7 +215,7 @@ class MockRunner:
                     "version": {"Version": "5.6.0"},
                 }
             )
-        if cmd[0] == "dig":
+        if cmd[0] in ("dig", "drill"):
             return f"{TEST_IP}\n"
         if cmd[0] == "nft" or cmd[:2] == ["podman", "inspect"]:
             return ""


### PR DESCRIPTION
`expect:` named `dig`, and the capability probe behind it asked for `dig` alone. terok-shield #435 made the lookup tier accept `dig` **or** `drill`, and drill is the Arch/Manjaro default — so a drill-only image would fail the capability contract before a single test ran. The platform that motivated the rename is the one this would have blocked.

The capability is `lookup` now, satisfied by either tool.

## Why both halves are in one commit

The names are repo-local: the matrix runner passes `expect:` through as `TEROK_EXPECT`, and `check_capability_contract` cross-checks it against the repo's own probe dict, rejecting any name the repo does not define. A half-applied rename therefore fails the session loudly rather than drifting quietly — which is the right failure, and the reason the two files move together.

Verified both directions:

```
TEROK_EXPECT=lookup  ->  holds
TEROK_EXPECT=dig     ->  TEROK_EXPECT names unknown capabilities: ['dig']
```

## Not changed

No image is drill-only today — every slot ships `dig`, which is why the Manjaro slot passed. This removes the barrier rather than exercising the path. A genuinely drill-only slot would be the way to cover it for real, and that belongs with the harness rather than here.

Also widens the MockRunner stub, which answered to `dig` alone: a code path reaching for `drill` would have died on "Unexpected MockRunner command" instead of resolving.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated DNS lookup checks to support environments using either `dig`, `drill`, or `lookup`.
  * Improved integration test compatibility across supported container environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->