### PR TITLE
fix(cli): shield logs bridge crash, sickbay hint flag, stale-bundle visibility

### DIFF
--- a/src/terok/cli/commands/shield.py
+++ b/src/terok/cli/commands/shield.py
@@ -66,17 +66,30 @@ def _resolve_task(project_name: str, task_id: str) -> tuple[str, Path]:
     return cname, task_dir
 
 
+def _is_container_arg(name: str) -> bool:
+    """True when *name* is a registry command's container-reference arg.
+
+    The registry spells it ``container`` (positional), ``--container``
+    (``logs``' optional filter in shield's standalone CLI), or
+    ``--container-id`` (the hub-socket routing key).  The bridge resolves
+    the container itself, so no spelling may surface as a CLI flag or be
+    forwarded to a handler from parsed args — a forwarded ``container``
+    kwarg collides with the positionally-passed resolved name.
+    """
+    return name.lstrip("-") in {"container", "container-id"}
+
+
 def _extract_handler_kwargs(args: argparse.Namespace, cmd_def: CommandDef) -> dict:
     """Extract keyword arguments for a registry handler from parsed args.
 
-    Skips the positional ``container`` arg (the CLI resolves it from
-    ``project_name`` + ``task_id``) and ``--container-id``
-    (the orchestrator resolves it from the container's UUID — see
+    Skips the container-reference args, any spelling (the CLI resolves the
+    container from ``project_name`` + ``task_id``, and ``--container-id``
+    from the container's UUID — see
     [`resolve_container_uuid`][terok.lib.orchestration.task_runners.shield.resolve_container_uuid]).
     """
     kwargs: dict = {}
     for arg in cmd_def.args:
-        if arg.name in {"container", "--container-id"}:
+        if _is_container_arg(arg.name):
             continue
         key = arg.dest or arg.name.lstrip("-").replace("-", "_")
         if hasattr(args, key):
@@ -202,7 +215,7 @@ def register(subparsers: argparse._SubParsersAction[argparse.ArgumentParser]) ->
         if shield_needs_container(cmd):
             add_project_name(sp, help="Project name")
             add_task_id(sp, help="Task ID")
-        elif any(a.name == "container" for a in cmd.args):
+        elif any(_is_container_arg(a.name) for a in cmd.args):
             add_project_name(sp, nargs="?", help="Project name")
             add_task_id(sp, nargs="?", help="Task ID")
 
@@ -212,7 +225,7 @@ def register(subparsers: argparse._SubParsersAction[argparse.ArgumentParser]) ->
         # task runner), so we don't surface it as a CLI flag — the
         # dispatch function injects it from a ``podman inspect`` lookup.
         for arg in cmd.args:
-            if arg.name in {"container", "--container-id"}:
+            if _is_container_arg(arg.name):
                 continue
             _add_arg(sp, arg)
 

--- a/src/terok/cli/commands/sickbay.py
+++ b/src/terok/cli/commands/sickbay.py
@@ -61,6 +61,8 @@ from ...lib.util.check_reporter import CheckReporter
 # Type alias for check results: (severity, label, detail)
 _CheckResult = tuple[str, str, str]
 
+_INSTALL_HOOKS_HINT = "run 'terok shield install-hooks'"
+
 
 def register(subparsers: argparse._SubParsersAction[argparse.ArgumentParser]) -> None:
     """Register the ``sickbay`` subcommand."""
@@ -111,13 +113,9 @@ def _check_shield() -> _CheckResult:
     if ec.health == "disabled":
         return ("warn", label, "disable_firewall_no_protection is active — egress disabled")
     if ec.health == "stale-hooks":
-        return ("warn", label, "hooks outdated — run 'terok shield install-hooks --user'")
+        return ("warn", label, f"hooks outdated — {_INSTALL_HOOKS_HINT}")
     if ec.health == "setup-needed":
-        hint = (
-            ec.setup_hint.splitlines()[0]
-            if ec.setup_hint
-            else "run 'terok shield install-hooks --user'"
-        )
+        hint = ec.setup_hint.splitlines()[0] if ec.setup_hint else _INSTALL_HOOKS_HINT
         return ("warn", label, f"{ec.issues[0] if ec.issues else 'setup needed'} — {hint}")
     if ec.health != "ok":
         return ("warn", label, f"unexpected health: {ec.health}")
@@ -283,11 +281,15 @@ def _reconcile_post_stop(
 def _check_task_shield_annotation(
     pid: str, tid: str, project: ProjectConfig
 ) -> _CheckResult | None:
-    """Check that task_dir agrees with the container's ``terok.shield.state_dir``.
+    """Check a task container's shield bundle version and ``terok.shield.state_dir``.
 
-    Drift between the two sides sends a verdict dispatched from the hub or
+    A bundle from a different shield generation makes restart refuse
+    (fail-fast), so version drift is reported for stopped containers too —
+    the operator sees every task needing re-creation before hitting the
+    refusal.  State-dir drift sends a verdict dispatched from the hub or
     TUI (which only know the container name) to the wrong state dir, or to
-    nothing at all.  Non-shielded containers and stopped ones are skipped.
+    nothing at all — that only matters while the container runs.
+    Non-shielded and absent containers are skipped.
     """
     if not is_valid_project_name(pid) or not is_task_id(tid):
         return None
@@ -302,14 +304,14 @@ def _check_task_shield_annotation(
     if not mode:
         return None
     cname = container_name(pid, mode, tid)
-    if _rt.resolve_runtime(project).container(cname).state != "running":
-        return None
-
-    expected = (project.tasks_root / tid / "shield").resolve()
-    if not expected.is_dir():
-        return None  # task isn't shielded — nothing to compare against
+    state = _rt.resolve_runtime(project).container(cname).state
+    if state is None:
+        return None  # container absent (or podman unreachable) — nothing to inspect
 
     label = f"Task {pid}/{tid} shield"
+    # The version check reads only the container annotation — like restart's
+    # refusal gate — so it must not hide behind the shield-dir check: a task
+    # whose state dir is gone is still refused on resume.
     version = resolve_container_shield_version(cname)
     if version is not None and version != BUNDLE_VERSION:
         # Direction-neutral: a bundle *newer* than this terok (a downgrade)
@@ -321,6 +323,11 @@ def _check_task_shield_annotation(
             f"v{BUNDLE_VERSION} — restart refuses; re-create the task under this terok, "
             "or run the terok version that created it",
         )
+    if state != "running":
+        return None  # state-dir drift matters only for a live container
+    expected = (project.tasks_root / tid / "shield").resolve()
+    if not expected.is_dir():
+        return None  # task isn't shielded — nothing to compare against
     actual = resolve_container_state_dir(cname)
     if actual is None:
         return (
@@ -367,7 +374,7 @@ def _check_unfired_hooks(
 
 
 def _check_shield_annotations(project_name: str | None, task_id: str | None) -> list[_CheckResult]:
-    """Check that every running task's container carries the expected shield annotation."""
+    """Check every task container's shield bundle version and state-dir annotation."""
     results: list[_CheckResult] = []
 
     if project_name:

--- a/tests/integration/test_shield_hooks.py
+++ b/tests/integration/test_shield_hooks.py
@@ -3,7 +3,7 @@
 
 """Integration tests for shield hook installation and detection.
 
-These tests verify that ``terok shield install-hooks --user`` correctly installs
+These tests verify that ``terok shield install-hooks`` correctly installs
 global OCI hooks and that ``has_global_hooks()`` detects them.  No podman
 or nft is required — the tests only exercise filesystem operations.
 
@@ -22,12 +22,12 @@ pytestmark = [pytest.mark.needs_host_features, pytest.mark.needs_hooks]
 
 @hooks_unavailable
 class TestHooksInstalled:
-    """Verify global hooks are present after ``terok shield install-hooks --user``."""
+    """Verify global hooks are present after ``terok shield install-hooks``."""
 
     def test_global_hooks_detected(self) -> None:
         """has_global_hooks() returns True after user-level setup."""
         assert has_global_hooks(), (
-            "Global hooks not detected — expected terok shield install-hooks --user "
+            "Global hooks not detected — expected terok shield install-hooks "
             "to install hooks before running needs_hooks tests.\n"
             f"Searched dirs: {find_hooks_dirs()}"
         )

--- a/tests/unit/cli/test_cli_shield.py
+++ b/tests/unit/cli/test_cli_shield.py
@@ -109,12 +109,24 @@ def _stub_resolve_task_id() -> object:
         ),
         pytest.param(
             ["shield", "logs", "proj", "task1"],
-            {"shield_cmd": "logs", "project_name": "proj", "task_id": "task1", "n": 50},
+            {
+                "shield_cmd": "logs",
+                "project_name": "proj",
+                "task_id": "task1",
+                "n": 50,
+                "container": MISSING,
+            },
             id="logs",
         ),
         pytest.param(
             ["shield", "logs", "proj", "task1", "-n", "10"],
-            {"shield_cmd": "logs", "project_name": "proj", "task_id": "task1", "n": 10},
+            {
+                "shield_cmd": "logs",
+                "project_name": "proj",
+                "task_id": "task1",
+                "n": 10,
+                "container": MISSING,
+            },
             id="logs-custom-n",
         ),
     ],
@@ -283,6 +295,39 @@ def test_dispatch_task_scoped_commands(
 
     getattr(mock_shield, shield_method).assert_called_once_with("proj-cli-1")
     assert expected_text in out.getvalue()
+
+
+@patch("terok.cli.commands.shield._resolve_task", return_value=("proj-cli-1", MOCK_TASK_DIR_1))
+@patch("terok.cli.commands.shield.ShieldManager")
+def test_dispatch_logs_resolves_container_and_tails(
+    mock_mgr_cls: MagicMock,
+    _resolve: MagicMock,
+) -> None:
+    """``logs`` forwards only ``n`` — the resolved container rides positionally.
+
+    The registry spells logs' container arg ``--container`` (the standalone
+    CLI's optional filter); forwarding it from parsed args used to hand the
+    real handler ``container`` twice (TypeError: multiple values).
+    """
+    mock_shield = MagicMock()
+    mock_shield.tail_log.return_value = [{"verdict": "allow"}]
+    mock_mgr_cls.return_value.shield = mock_shield
+
+    # ``container=None`` mirrors the pre-fix parser namespace; the kwarg
+    # extraction must ignore the attribute whether or not argparse sets it.
+    args = argparse.Namespace(
+        cmd="shield",
+        shield_cmd="logs",
+        project_name="proj",
+        task_id="1",
+        container=None,
+        n=5,
+    )
+    with patch("sys.stdout", new_callable=StringIO) as out:
+        assert dispatch(args)
+
+    mock_shield.tail_log.assert_called_once_with(5)
+    assert "allow" in out.getvalue()
 
 
 @patch("terok.cli.commands.shield.ShieldManager")

--- a/tests/unit/cli/test_cli_sickbay.py
+++ b/tests/unit/cli/test_cli_sickbay.py
@@ -58,12 +58,12 @@ def _make_vault_snapshot(
             [],
             None,
             "warn",
-            "hooks outdated",
+            "hooks outdated — run 'terok shield install-hooks'",
             id="stale-hooks",
         ),
         pytest.param(
             "setup-needed",
-            "run 'terok shield install-hooks --user'",
+            "run 'terok shield install-hooks'",
             ["nft not found"],
             None,
             "warn",
@@ -76,7 +76,7 @@ def _make_vault_snapshot(
             [],
             None,
             "warn",
-            "setup needed",
+            "setup needed — run 'terok shield install-hooks'",
             id="setup-needed-no-hint",
         ),
         pytest.param(

--- a/tests/unit/cli/test_sickbay.py
+++ b/tests/unit/cli/test_sickbay.py
@@ -582,15 +582,39 @@ class TestCheckTaskShieldAnnotation:
         ):
             assert _check_task_shield_annotation("p", "g1abc", project) is None
 
-    def test_non_running_container_returns_none(self, tmp_path: Path, mock_runtime) -> None:
-        """Stopped container is post_stop's territory, not annotation-drift territory."""
+    def test_absent_container_returns_none(self, tmp_path: Path, mock_runtime) -> None:
+        """No container (or unreachable podman) → nothing to inspect."""
         from terok.cli.commands.sickbay import _check_task_shield_annotation
 
         _write_meta(tmp_path, "g1abc", {"mode": "cli"})
         project = self._project(tmp_path.parent)
-        mock_runtime.container.return_value.state = "exited"
+        mock_runtime.container.return_value.state = None
         with unittest.mock.patch(
             "terok.cli.commands.sickbay.tasks_meta_dir", return_value=tmp_path
+        ):
+            assert _check_task_shield_annotation("p", "g1abc", project) is None
+
+    def test_stopped_container_skips_drift_checks(self, tmp_path: Path, mock_runtime) -> None:
+        """State-dir drift on a stopped container is not reported — only a live
+        container dispatches verdicts, and post_stop owns the stopped-task story."""
+        from terok.cli.commands.sickbay import _check_task_shield_annotation
+
+        tasks_root = tmp_path / "tasks"
+        (tasks_root / "g1abc" / "shield").mkdir(parents=True)
+        meta_dir = tmp_path / "meta"
+        meta_dir.mkdir()
+        _write_meta(meta_dir, "g1abc", {"mode": "cli"})
+        project = self._project(tasks_root)
+        mock_runtime.container.return_value.state = "exited"
+        with (
+            unittest.mock.patch("terok.cli.commands.sickbay.tasks_meta_dir", return_value=meta_dir),
+            unittest.mock.patch(
+                "terok.cli.commands.sickbay.resolve_container_shield_version", return_value=None
+            ),
+            unittest.mock.patch(
+                "terok.cli.commands.sickbay.resolve_container_state_dir",
+                return_value=tmp_path / "elsewhere",
+            ),
         ):
             assert _check_task_shield_annotation("p", "g1abc", project) is None
 
@@ -601,13 +625,22 @@ class TestCheckTaskShieldAnnotation:
         _write_meta(tmp_path, "g1abc", {"mode": "cli"})
         project = self._project(tmp_path.parent)
         mock_runtime.container.return_value.state = "running"
-        with unittest.mock.patch(
-            "terok.cli.commands.sickbay.tasks_meta_dir", return_value=tmp_path
+        with (
+            unittest.mock.patch("terok.cli.commands.sickbay.tasks_meta_dir", return_value=tmp_path),
+            unittest.mock.patch(
+                "terok.cli.commands.sickbay.resolve_container_shield_version", return_value=None
+            ),
         ):
             assert _check_task_shield_annotation("p", "g1abc", project) is None
 
-    def test_stale_bundle_version_warns(self, tmp_path: Path, mock_runtime) -> None:
-        """A container prepared with an older shield bundle → re-create warning."""
+    @pytest.mark.parametrize("state", ["running", "exited"])
+    def test_stale_bundle_version_warns(self, tmp_path: Path, mock_runtime, state: str) -> None:
+        """A container prepared with an older shield bundle → re-create warning.
+
+        Stopped containers warn too: restart would refuse them (the upgrade
+        contract), so the operator must see the full re-create list before
+        hitting the refusal.
+        """
         from terok.cli.commands.sickbay import _check_task_shield_annotation
 
         tasks_root = tmp_path / "tasks"
@@ -616,7 +649,35 @@ class TestCheckTaskShieldAnnotation:
         meta_dir.mkdir()
         _write_meta(meta_dir, "g1abc", {"mode": "cli"})
         project = self._project(tasks_root)
-        mock_runtime.container.return_value.state = "running"
+        mock_runtime.container.return_value.state = state
+        with (
+            unittest.mock.patch("terok.cli.commands.sickbay.tasks_meta_dir", return_value=meta_dir),
+            unittest.mock.patch(
+                "terok.cli.commands.sickbay.resolve_container_shield_version", return_value=1
+            ),
+            unittest.mock.patch("terok.cli.commands.sickbay.BUNDLE_VERSION", 15),
+        ):
+            result = _check_task_shield_annotation("p", "g1abc", project)
+        assert result is not None
+        assert result[0] == "warn"
+        assert "does not match" in result[2]
+        assert "re-create" in result[2]
+
+    def test_stale_bundle_version_warns_without_shield_dir(
+        self, tmp_path: Path, mock_runtime
+    ) -> None:
+        """Version drift is reported even when the shield state dir is gone —
+        restart's refusal gate reads only the container annotation, so the
+        missing dir must not hide the re-create diagnosis."""
+        from terok.cli.commands.sickbay import _check_task_shield_annotation
+
+        tasks_root = tmp_path / "tasks"
+        (tasks_root / "g1abc").mkdir(parents=True)  # task dir without shield/
+        meta_dir = tmp_path / "meta"
+        meta_dir.mkdir()
+        _write_meta(meta_dir, "g1abc", {"mode": "cli"})
+        project = self._project(tasks_root)
+        mock_runtime.container.return_value.state = "exited"
         with (
             unittest.mock.patch("terok.cli.commands.sickbay.tasks_meta_dir", return_value=meta_dir),
             unittest.mock.patch(


### PR DESCRIPTION
# 🤖

## `terok shield logs <project> <task>` crashed with a TypeError

The registry spells `logs`' container arg `--container` — an *optional filter* in shield's standalone aggregated mode — while every other per-container verb spells it positional `container`. The bridge skipped only the `container` / `--container-id` spellings when extracting handler kwargs, so `--container` leaked through as `kwargs["container"]` and collided with the positionally-passed resolved name:

```
TypeError: _handle_logs() got multiple values for argument 'container'
```

The bridge now recognises the container-reference arg in any spelling (`_is_container_arg`), at all three sites: kwarg extraction, flag suppression, and the optional-container positional grant. Shield's registry is untouched — its `--container` spelling is correct for the standalone CLI.

## sickbay recommended a flag that does not parse

The shield rows said `run 'terok shield install-hooks --user'`; `terok shield install-hooks` takes no flags, so following the hint exits 2 with `unrecognized arguments: --user`. The hints (now one shared literal) and the integration-test prose that repeated them name the bare command.

## `terok sickbay` was silent about exactly the containers restart refuses

The bundle-version check ran only for *running* containers, but the containers the upgrade contract refuses to resume are typically stopped — the operator got no diagnosis until each individual restart attempt failed, despite the CHANGELOG's "`terok sickbay` diagnoses them". Version drift is now reported for any existing container, and — like restart's refusal gate, which reads only the container annotation — independently of whether the task's shield state dir still exists. After an upgrade, one sickbay run lists every task that needs re-creation. State-dir drift stays running-only (verdict dispatch only matters for a live container, and post_stop owns the stopped-task story).

## Tests

Each fix carries a locking test verified to fail against the previous code:

- `test_dispatch_logs_resolves_container_and_tails` reproduces the TypeError end-to-end through `dispatch()` with the real registry handler (a `MagicMock` handler swallows the duplicate kwarg — that is why the existing suite never caught it); the parse-shape params additionally pin that `container` no longer surfaces in the `logs` namespace.
- The `stale-hooks` / `setup-needed-no-hint` params now lock the full remedy strings.
- `test_stale_bundle_version_warns` is parametrized over running/exited (the claim is state-independence); `test_stale_bundle_version_warns_without_shield_dir` locks the missing-state-dir case, and `test_stopped_container_skips_drift_checks` / `test_absent_container_returns_none` pin the unchanged boundaries.

## Follow-up candidates (not in this PR)

- The container-arg spellings are a terok-shield registry fact hardcoded downstream; the cleaner home is a shield-exported predicate beside `needs_container` / `standalone_only`, consumed here at the next repin.
- The sickbay sweep pays one `podman inspect` per stopped shielded task for the version read (and separate inspects for state/version/state-dir on running ones); a batched `container_states()` + combined annotation resolver would make the walk cheaper on hosts with many retained tasks.
- The #1254 degraded-DNS-tier warning still has no CLI at-launch surface (TUI + sickbay only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved shield command parsing for all supported container argument formats.
  - Shield diagnostics now detect bundle-version mismatches in stopped containers.
  - Running-container state checks remain focused on relevant shielded containers.
  - Added clearer guidance for installing required shield hooks.
  - Improved shield log dispatch and container resolution behavior.

- **Tests**
  - Expanded coverage for stopped containers, version drift, hook installation guidance, and shield log handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
