### PR TITLE
fix(tui): the clearance screen says which keys give a verdict

### DIFF
--- a/src/terok/tui/clearance_screen.py
+++ b/src/terok/tui/clearance_screen.py
@@ -38,7 +38,7 @@ from textual.app import App, ComposeResult
 from textual.message import Message
 from textual.widgets import Footer, ListItem, ListView, RichLog, Static
 
-from .screens import _modal_binding
+from .screens import _footer_binding, _modal_binding
 
 try:  # pragma: no cover - optional import for test stubs
     from textual.css.query import NoMatches
@@ -146,11 +146,15 @@ def _render_notification(message: NotificationPosted) -> str:
 class ClearanceScreen(screen.Screen[None]):
     """Full-page screen for live D-Bus shield clearance verdicts."""
 
+    #: The keys *are* this screen's interface — a verdict is what the
+    #: operator came here to give — so they carry into the footer.  Only
+    #: one of the two "Back" keys is shown; both in the bar would spend a
+    #: third of it saying the same thing twice.
     BINDINGS = [
         _modal_binding("escape", "dismiss_screen", "Back"),
-        _modal_binding("q", "dismiss_screen", "Back"),
-        _modal_binding("a", "allow_selected", "Allow"),
-        _modal_binding("x", "deny_selected", "Deny"),
+        _footer_binding("q", "dismiss_screen", "Back"),
+        _footer_binding("a", "allow_selected", "Allow"),
+        _footer_binding("x", "deny_selected", "Deny"),
     ]
 
     CSS = """
@@ -309,6 +313,12 @@ class ClearanceScreen(screen.Screen[None]):
             item = ListItem(label)
             item.clearance_nid = message.nid  # type: ignore[attr-defined]
             pending_list.append(item)
+            # Highlight the first arrival.  ``append`` leaves ``index`` at
+            # ``None``, and every verdict action reads
+            # ``highlighted_child`` — so without this the operator sees a
+            # request, presses Allow, and is told nothing is selected.
+            if getattr(pending_list, "index", None) is None:
+                pending_list.index = 0
             # The style alone communicates "this is a block" — drop the redundant
             # "BLOCKED  " prefix that used to double up with the "Blocked:" title.
             log.write(Text(rendered, style=_STYLE_BLOCKED))

--- a/src/terok/tui/screens.py
+++ b/src/terok/tui/screens.py
@@ -83,6 +83,20 @@ def _modal_binding(key: str, action: str, description: str) -> Any:
     return Binding(key, action, description, show=False)
 
 
+def _footer_binding(key: str, action: str, description: str) -> Any:
+    """Like [`_modal_binding`][terok.tui.screens._modal_binding], but shown in the footer.
+
+    A screen whose keys are its whole interface has to advertise them:
+    the ``Footer`` renders only bindings with ``show=True``, so a screen
+    built entirely from ``_modal_binding`` presents an empty bar and
+    leaves the operator guessing.  Use this for the few keys that *are*
+    the screen's interface, and ``_modal_binding`` for the rest.
+    """
+    if Binding is None:
+        return (key, action, description)
+    return Binding(key, action, description, show=True)
+
+
 # ---------------------------------------------------------------------------
 # Shared CSS for full-page detail screens
 # ---------------------------------------------------------------------------

--- a/tests/unit/tui/test_clearance_screen.py
+++ b/tests/unit/tui/test_clearance_screen.py
@@ -255,6 +255,58 @@ class TestOnNotificationPosted:
         log.write.assert_called_once()
         assert "Pending (1)" in pending_list.border_title
 
+    def _blocked(self, mod: Any, nid: int = 42) -> Any:
+        """One blocked-connection notification, the kind that queues a request."""
+        return mod.NotificationPosted(
+            nid=nid,
+            summary="Blocked: seznam.cz:80",
+            body="Container: my-task\nProtocol: TCP",
+            actions=[("allow", "Allow"), ("deny", "Deny")],
+            replaces_id=0,
+            container_id="fa0905d97a1c",
+            container_name="my-task",
+        )
+
+    def test_the_verdict_keys_reach_the_footer(self) -> None:
+        """A ``Footer`` renders only ``show=True`` bindings, and these keys are the screen.
+
+        Every binding here used to be built with ``_modal_binding``
+        (``show=False``), so the bar came up empty and the operator was
+        left to guess that a verdict is given with ``a`` or ``x``.
+        """
+        mod = _import_clearance()
+        shown = {
+            binding._stub_args[0]: binding._stub_args[2]
+            for binding in mod.ClearanceScreen.BINDINGS
+            if binding._stub_kwargs.get("show")
+        }
+        assert shown == {"q": "Back", "a": "Allow", "x": "Deny"}
+
+    def test_first_pending_request_is_highlighted(self) -> None:
+        """Every verdict action reads ``highlighted_child``, so something must be highlighted.
+
+        ``ListView.append`` leaves ``index`` at ``None``.  Without this the
+        operator sees a request, presses Allow, and is told that nothing is
+        selected — with no cue that a selection was ever needed.
+        """
+        mod = _import_clearance()
+        screen, _log, pending_list = self._screen_with_mocked_queries(mod)
+        pending_list.index = None
+
+        screen.on_notification_posted(self._blocked(mod))
+
+        assert pending_list.index == 0
+
+    def test_a_standing_highlight_survives_a_new_request(self) -> None:
+        """A request arriving must not move the selection out from under a keypress."""
+        mod = _import_clearance()
+        screen, _log, pending_list = self._screen_with_mocked_queries(mod)
+        pending_list.index = 3
+
+        screen.on_notification_posted(self._blocked(mod, nid=43))
+
+        assert pending_list.index == 3
+
     def test_verdict_applied_clears_pending_and_logs(self) -> None:
         """A notification with ``replaces_id`` matching a pending entry resolves it."""
         mod = _import_clearance()


### PR DESCRIPTION
Add user-visible shortcuts to the Clearance TUI screen (both standalone and embedded in terok TUI).

---

# 🤖

The clearance screen is where an operator answers a blocked connection. It is a list and four keys, and it showed neither the keys nor a selection. An operator who opened it had nothing on screen to tell them what to do.

## The footer was empty

Every binding came from `_modal_binding`, which sets `show=False`. A `Footer` renders only the bindings that ask to be shown, so the bar was empty — in the host `terok-tui` (whose footer renders the pushed screen's bindings) and in the standalone `terok-clearance` app (which composes its own) alike.

The three keys that *are* this screen's interface now carry into the footer through a new `_footer_binding`. `escape` stays hidden: both Back keys in the bar would spend a third of it saying the same thing two times. `_modal_binding` keeps its meaning for every other screen, where the keys are shortcuts rather than the interface.

## Nothing was ever selected

`ListView.append` leaves `index` at `None`, and all three verdict actions read `highlighted_child`. So an operator who saw a pending request and pressed Allow got **"No pending request selected."** — with nothing on the screen to say that a selection was needed, or that arrow keys make one.

The first request to arrive is now highlighted. A later arrival leaves a standing highlight alone: a request that moves the selection under a keypress would take a verdict to the wrong connection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **User Interface**
  * Clearance screen actions for quit, allow, and deny are now displayed in the footer.
  * Newly added pending requests automatically highlight the first request when none is selected.
  * Existing selections remain unchanged when additional requests arrive.

* **Tests**
  * Added coverage for visible footer actions and pending-request selection behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
