### PR TITLE
fix(tui): avoid task label mount race

### DIFF
--- a/src/terok/tui/widgets/task_list.py
+++ b/src/terok/tui/widgets/task_list.py
@@ -19,7 +19,8 @@ class TaskListItem(ListItem):
 
     def __init__(self, project_name: str, task: TaskMeta, label: str, generation: int) -> None:
         """Create a task list item with its metadata and display label."""
-        super().__init__(Static(label, markup=False))
+        self.label = Static(label, markup=False)
+        super().__init__(self.label)
         self.project_name = project_name
         self.task_meta = task
         self.generation = generation
@@ -111,7 +112,7 @@ class TaskList(ListView):
         width = self._label_width()
         for item in self.query(TaskListItem):
             label = self._format_task_label(item.task_meta, width)
-            item.query_one(Static).update(label)
+            item.label.update(label)
 
     def on_resize(self, event: events.Resize) -> None:
         """Re-wrap labels only when the panel's content width changes."""
@@ -158,7 +159,7 @@ class TaskList(ListView):
                 continue
             item.task_meta.deleting = True
             label = self._format_task_label(item.task_meta, width)
-            item.query_one(Static).update(label)
+            item.label.update(label)
             found = True
 
         return found

--- a/tests/unit/tui/test_list_widgets.py
+++ b/tests/unit/tui/test_list_widgets.py
@@ -108,6 +108,25 @@ def test_task_label_shows_debug_badge_only_when_debug() -> None:
         set_emoji_enabled(original)
 
 
+def test_task_labels_refresh_before_rows_mount() -> None:
+    """Refreshing a newly appended row must not query its unmounted children."""
+    widgets = import_widgets()
+    task_list = widgets.TaskList()
+    rows, _messages = _wire_listview(task_list)
+    task_list._label_width = lambda: 80
+    task_list.query = lambda _widget_type: rows
+
+    task_list.set_tasks(
+        "alpha", [widgets.TaskMeta(task_id="t1", mode="cli", workspace="", web_port=None)]
+    )
+    updates: list[str] = []
+    rows[0].label.update = updates.append
+
+    task_list.refresh_labels()
+
+    assert len(updates) == 1
+
+
 def test_task_list_drops_stale_selection_messages() -> None:
     """Stale rows from another project cannot update the current selection."""
     widgets = import_widgets()


### PR DESCRIPTION
## Summary

- retain each `TaskListItem` label widget instead of querying for it during refreshes
- update task labels safely while Textual is still mounting newly appended rows
- add regression coverage for refreshing labels before row children mount

## Root cause

A resize can run after a `TaskListItem` becomes queryable but before its child `Static` is mounted. `refresh_labels()` then raised `NoMatches` while querying that child. Updating the retained widget reference avoids depending on mount timing.

## Verification

- `make check`
- 3,359 unit tests passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Task labels now refresh correctly immediately after tasks are added, including before row contents are fully mounted.
  * Deletion markings update reliably without depending on widget mounting timing.

* **Tests**
  * Added regression coverage for refreshing task labels before rows are mounted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->